### PR TITLE
Support logarithmic axes for 1D and 2D confidence plots

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -51,7 +51,7 @@ fi
 echo "dependencies: ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC}"
 
 # Create and activate conda build environment
-conda create --yes -n build python="=${PYTHONVER}=*cpython*" pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${compilers}
+conda create --yes -n build python"=${PYTHONVER}.*=*cpython*" pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${compilers}
 
 conda activate build
 

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -2434,7 +2434,8 @@ class Confidence1D(DataPlot):
     """The base class for 1D confidence plots.
 
     .. versionchanged:: 4.16.1
-       Handling of log-scaled axes has been improved.
+       Handling of log-scaled axes has been improved and the string
+       output now includes the parameter value (if available).
 
     """
 
@@ -2476,22 +2477,15 @@ class Confidence1D(DataPlot):
             y = numpy.array2string(self.y, separator=',', precision=4,
                                    suppress_small=False)
 
-        return (('x     = %s\n' +
-                 'y     = %s\n' +
-                 'min   = %s\n' +
-                 'max   = %s\n' +
-                 'nloop = %s\n' +
-                 'delv  = %s\n' +
-                 'fac   = %s\n' +
-                 'log   = %s') %
-                (x,
-                 y,
-                 self.min,
-                 self.max,
-                 self.nloop,
-                 self.delv,
-                 self.fac,
-                 self.log))
+        return (f'x      = {x}\n' +
+                f'y      = {y}\n' +
+                f'min    = {self.min}\n' +
+                f'max    = {self.max}\n' +
+                f'nloop  = {self.nloop}\n' +
+                f'delv   = {self.delv}\n' +
+                f'fac    = {self.fac}\n' +
+                f'log    = {self.log}\n' +
+                f'parval = {self.parval}')
 
     def _repr_html_(self):
         """Return a HTML (string) representation of the confidence 1D plot."""
@@ -2730,32 +2724,19 @@ class Confidence2D(DataContour, Point):
             y = numpy.array2string(self.y, separator=',', precision=4,
                                    suppress_small=False)
 
-        return (('x0      = %s\n' +
-                 'x1      = %s\n' +
-                 'y       = %s\n' +
-                 'min     = %s\n' +
-                 'max     = %s\n' +
-                 'nloop   = %s\n' +
-                 'fac     = %s\n' +
-                 'delv    = %s\n' +
-                 'log     = %s\n' +
-                 'sigma   = %s\n' +
-                 'parval0 = %s\n' +
-                 'parval1 = %s\n' +
-                 'levels  = %s') %
-                (x0,
-                 x1,
-                 y,
-                 self.min,
-                 self.max,
-                 self.nloop,
-                 self.fac,
-                 self.delv,
-                 self.log,
-                 self.sigma,
-                 self.parval0,
-                 self.parval1,
-                 self.levels))
+        return (f'x0      = {x0}\n' +
+                f'x1      = {x1}\n' +
+                f'y       = {y}\n' +
+                f'min     = {self.min}\n' +
+                f'max     = {self.max}\n' +
+                f'nloop   = {self.nloop}\n' +
+                f'fac     = {self.fac}\n' +
+                f'delv    = {self.delv}\n' +
+                f'log     = {self.log}\n' +
+                f'sigma   = {self.sigma}\n' +
+                f'parval0 = {self.parval0}\n' +
+                f'parval1 = {self.parval1}\n' +
+                f'levels  = {self.levels}')
 
     def _repr_html_(self):
         """Return a HTML (string) representation of the confidence 2D plot."""
@@ -3017,7 +2998,8 @@ class IntervalProjection(Confidence1D):
     other thawed parameters to be fit.
 
     .. versionchanged:: 4.16.1
-       Support for logarithmically-spaced grids has been improved.
+       Handling of log-scaled axes has been improved and the string
+       output now includes the parameter value (if available).
 
     See Also
     --------
@@ -3132,7 +3114,8 @@ class IntervalUncertainty(Confidence1D):
     thawed parameters are *not* changed from their current values.
 
     .. versionchanged:: 4.16.1
-       Support for logarithmically-spaced grids has been improved.
+       Handling of log-scaled axes has been improved and the string
+       output now includes the parameter value (if available).
 
     See Also
     --------

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -2469,8 +2469,10 @@ def calc_par_range(minval: float,
     """
 
     if delv is not None:
+        # This assumes that delv > eps, but this should be safe.
+        #
         eps = numpy.finfo(numpy.float32).eps
-        maxval = maxval + delv - eps
+        maxval = maxval + eps
 
     if log:
         if minval <= 0.0 or maxval <= 0.0:
@@ -2483,9 +2485,6 @@ def calc_par_range(minval: float,
     if delv is None:
         x = numpy.linspace(minval, maxval, nloop)
     else:
-        # TODO: should we filter out any value > self.maxval
-        # (would have to be done after converting from a log, if set)
-        #
         x = numpy.arange(minval, maxval, delv)
 
     if log:

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -835,4 +835,12 @@ def test_confidence1d_log(cls, expected):
             fmdl.fwhm_g = x
             expected.append(fit.calc_stat())
 
-    assert plotobj.y == pytest.approx(expected)
+    # During testing the tolerance had to be relaxed for macOS. As
+    # this test is a bit "unusual" (synthetic data with no noise), and
+    # because we just want to check the code is doing something
+    # reasonable (i.e. this is not a test of the confidence routine
+    # but that the parameter under test is drawn from a log, rather
+    # than linear, distribution) we allow the relaxation in the
+    # tolerance.
+    #
+    assert plotobj.y == pytest.approx(expected, rel=4e-4)

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -766,7 +766,6 @@ def test_region_xxx_set_vars(ptype, kwargs, setup_confidence):
                                        35.90482971, 35.85479384], abs=1e-4)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("cls,expected",
                          [(sherpaplot.IntervalProjection,
                            [265.94960651707015, 267.00393711532496, 201.42206132760674, 36.51066189551196]),

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2018, 2019, 2020, 2021, 2022
+#  Copyright (C) 2007, 2015, 2018 - 2022, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -25,6 +25,7 @@ import pytest
 
 import sherpa.all as sherpa
 from sherpa.ui.utils import Session as BaseSession
+from sherpa.astro.models import Voigt1D
 from sherpa.astro.ui.utils import Session as AstroSession
 from sherpa.models import basic
 from sherpa import plot as sherpaplot
@@ -763,3 +764,76 @@ def test_region_xxx_set_vars(ptype, kwargs, setup_confidence):
     #
     assert plotobj.y == pytest.approx([36.82967813, 35.94869461,
                                        35.90482971, 35.85479384], abs=1e-4)
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize("cls,expected",
+                         [(sherpaplot.IntervalProjection,
+                           [265.94960651707015, 267.00393711532496, 201.42206132760674, 36.51066189551196]),
+                          (sherpaplot.IntervalUncertainty, None)
+                          ])
+def test_confidence1d_log(cls, expected):
+    """Check out Confidence1D plots with a log scale. Issue #1561."""
+
+    omdl = basic.Gauss1D('ideal')
+    omdl.fwhm = 10.1
+    omdl.pos = 31.05
+    omdl.ampl = 20.2
+
+    x = numpy.linspace(20, 40, 50)
+    y = omdl(x)
+    data = Data1D('temp', x, y)
+
+    # I want a model that is similar to, but not the same as, gauss1d
+    # (alternatively we could have added noise to the fit).
+    #
+    fmdl = Voigt1D('fit')
+    fmdl.fwhm_l = fmdl.fwhm_g / numpy.sqrt(2 * numpy.log(2))
+
+    # as this is not a test of fitting
+    #
+    fmdl.fwhm_g = 6
+    fmdl.pos = 31
+    fmdl.ampl = 250
+
+    fit = sherpa.Fit(data, fmdl)
+    fit.fit()
+
+    # We want to check the Confidence1D call doesn't change
+    # the results. We could just store these values and then check
+    # again later, but we can also add an explicit check that things
+    # are behaving as expected.
+    #
+    assert fmdl.fwhm_g.val == pytest.approx(5.989888868679278)
+    assert fmdl.pos.val == pytest.approx(31.09649448167323)
+    assert fmdl.ampl.val == pytest.approx(256.1058145890131)
+
+    # The range is chosen to make the values easy to check.  If we
+    # bump up to max=100 then the analysis fails because at some point
+    # the IntervalX call hits an upper limit on fwhm_g. Which is not
+    # relevant here.
+    #
+    plotobj = cls()
+    plotobj.prepare(min=0.01, max=10, nloop=4, log=True)
+    plotobj.calc(fit, fmdl.fwhm_g)
+
+    # Values are unchanged
+    assert fmdl.fwhm_g.val == pytest.approx(5.989888868679278)
+    assert fmdl.pos.val == pytest.approx(31.09649448167323)
+    assert fmdl.ampl.val == pytest.approx(256.1058145890131)
+
+    assert plotobj.log
+    assert plotobj.min == pytest.approx(0.01)
+    assert plotobj.max == pytest.approx(10)
+    assert plotobj.x == pytest.approx([0.01, 0.1, 1, 10])
+
+    if expected is None:
+        # For IntUnc we can calculate the expected values since only
+        # the fwhm_g value changes.
+        #
+        expected = []
+        for x in plotobj.x:
+            fmdl.fwhm_g = x
+            expected.append(fit.calc_stat())
+
+    assert plotobj.y == pytest.approx(expected)

--- a/sherpa/ui/tests/test_get_int_proj.py
+++ b/sherpa/ui/tests/test_get_int_proj.py
@@ -112,14 +112,11 @@ def test_get_reg_xxx_nloop_not_scalar(setUp, method):
                max=(0, -1.5), nloop=1)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
 @pytest.mark.parametrize("val", [[10], (2, 3, 4)])
 def test_get_reg_xxx_nloop_size_2(setUp, method, val):
     """nloop must contain 2 elements"""
 
-    # XFAIL: currently raises an IndexError or does not appear to fail
-    #
     with pytest.raises(ConfidenceErr,
                        match="Nloop parameter must be a list of size 2"):
         method(poly.c0, poly.c1, recalc=True, min=(-20, -3.5),
@@ -185,7 +182,6 @@ def test_get_reg_xxx_limits_not_scalar(setUp, method, minval, maxval):
                nloop=(3, 3))
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
 @pytest.mark.parametrize("minval,maxval",
                          [([-20], (0, -1.5)),
@@ -197,8 +193,6 @@ def test_get_reg_xxx_limits_not_scalar(setUp, method, minval, maxval):
 def test_get_reg_xxx_limits_size_2(setUp, method, minval, maxval):
     """max and min must contain 2 elements each"""
 
-    # XFAIL: currently raises an IndexError or does not appear to fail
-    #
     with pytest.raises(ConfidenceErr,
                        match="Parameter limits must be a list of size 2"):
         method(poly.c0, poly.c1, recalc=True, min=minval, max=maxval,
@@ -242,30 +236,23 @@ def test_get_int_xxx_delv_positive(setUp, method):
         method(poly.c1, recalc=True, min=-5, max=-1, delv=-0.1)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
 @pytest.mark.parametrize("delv", [(-5, 0.5), (5, -0.5), (0, 0.5),
                                   (5, 0), (0, 0)])
 def test_get_reg_xxx_delv_positive(setUp, method, delv):
     """delv must be positive"""
 
-    # XFAIL: this actually fails with one of
-    #        ValueError: Maximum allowed size exceeded
-    #        ZeroDivisionError
     with pytest.raises(ConfidenceErr,
                        match="delv parameter must be a list with elements > 0"):
         method(poly.c0, poly.c1, recalc=True, min=(-20, -3.5),
                max=(0, -1.5), nloop=(5, 5), delv=delv)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
 @pytest.mark.parametrize("delv", [[5], (2, 3, 4)])
 def test_get_reg_xxx_delv_list_2(setUp, method, delv):
     """delv must contain 2 elements"""
 
-    # XFAIL: currently raises an IndexError or does not appear to fail
-    #
     with pytest.raises(ConfidenceErr,
                        match="delv parameter must be a list of size 2"):
         method(poly.c0, poly.c1, recalc=True, min=(-20, -3.5),
@@ -616,7 +603,6 @@ def test_get_reg_unc(setUp):
     assert result.y == pytest.approx(expected, abs=1.0e-4)
 
 
-@pytest.mark.xfail
 def test_get_reg_unc_log(setUp):
     """Use log scaling to check. See issue #1561
 
@@ -649,7 +635,6 @@ def test_get_reg_unc_log(setUp):
     assert result.y == pytest.approx(expected, abs=1.0e-4)
 
 
-@pytest.mark.xfail
 def test_get_reg_proj_log(setUp):
     """Use log scaling to check. See issue #1561
 
@@ -704,7 +689,6 @@ def test_reg_xxx_delv(setUp, method):
     assert result.x1 == pytest.approx([-5] * 4 + [-4.5] * 4 + [-4] * 4)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
 def test_reg_xxx_delv_log(setUp, method):
     """What happens if we set delv and log?"""

--- a/sherpa/ui/tests/test_get_int_proj.py
+++ b/sherpa/ui/tests/test_get_int_proj.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2019 - 2021, 2024
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -22,6 +23,7 @@ import pytest
 import numpy as np
 
 from sherpa import ui
+from sherpa.utils.err import ConfidenceErr
 
 
 def cmp_args(result):
@@ -41,7 +43,159 @@ def cmp_x(result):
     assert result.x == pytest.approx(expected)
 
 
-def cmp_proj(result):
+def cmp_args_log(result):
+    assert result.min == 0.1
+    assert result.max == 0.9
+    assert result.nloop == 10
+    assert result.delv is None
+    assert result.fac == 1
+    assert result.log is True
+
+
+def cmp_x_log(result):
+
+    expected = np.logspace(-1, np.log10(0.9), 10)
+    assert result.x == pytest.approx(expected)
+
+
+# Also used in the log tests, hence a global.
+#
+X = [-13, -5, -3, 2, 7, 12]
+
+@pytest.fixture
+def setUp(clean_ui, hide_logging):
+
+    y = [102.3, 16.7, -0.6, -6.7, -9.9, 33.2]
+    dy = np.ones(6) * 5
+    ui.load_arrays(1, X, y, dy)
+    ui.set_source(ui.polynom1d.poly)
+    ui.thaw(poly.c1, poly.c2)
+    ui.fit()
+    # Just check we are fitting 6 data points with 3 parameters
+    assert ui.get_fit_results().dof == 3
+
+
+@pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
+@pytest.mark.parametrize("val", [-1, 0, 1])
+def test_get_int_xxx_positive_nloop(setUp, method, val):
+    """nloop must be > 1"""
+
+    with pytest.raises(ConfidenceErr,
+                       match="Nloop parameter must be > 1"):
+        method(poly.c1, recalc=True, min=-5, max=0, nloop=val)
+
+
+@pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
+def test_get_int_xxx_limits_sensible(setUp, method):
+    """max must be > min"""
+
+    with pytest.raises(ConfidenceErr,
+                       match="Bad parameter limits"):
+        method(poly.c1, recalc=True, min=0, max=0, nloop=10)
+
+
+@pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
+def test_get_int_xxx_limits_scalar(setUp, method):
+    """max and min must be scalars"""
+
+    with pytest.raises(ConfidenceErr,
+                       match="Parameter limits must be scalars"):
+        method(poly.c1, recalc=True, min=(-5, 2), max=(0, 4), nloop=10)
+
+
+@pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
+@pytest.mark.parametrize("minval,maxval", [(0, 1), (-2, -1), (-2, 0)])
+def test_get_int_xxx_limits_positive_when_log(setUp, method, minval, maxval):
+    """max and min must be positive when log scale"""
+
+    with pytest.raises(ConfidenceErr,
+                       match="Log scale must be on positive boundaries"):
+        method(poly.c1, recalc=True, min=minval, max=maxval, nloop=10,
+               log=True)
+
+
+# FAIL: this currently fails with ZeroDivisionError.
+@pytest.mark.xfail
+@pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
+def test_get_int_xxx_delv_positive(setUp, method):
+    """delv must be positive"""
+
+    with pytest.raises(ConfidenceErr,
+                       match="delv parameter must be > 0"):
+        method(poly.c1, recalc=True, min=-5, max=-1, delv=-0.1)
+
+
+@pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
+def test_get_int_xxx_not_leastsq(setUp, method):
+    """can not use the least-square statistic"""
+
+    ui.set_stat("leastsq")
+    with pytest.raises(ConfidenceErr,
+                       match="leastsq is inappropriate for confidence limit estimation"):
+        method(poly.c1, recalc=True, min=-5, max=0, nloop=10)
+
+
+@pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
+def test_get_int_xxx_not_thawed(setUp, method):
+    """can not use on a frozen parameter"""
+
+    with pytest.raises(ConfidenceErr,
+                       match="Frozen parameter poly.c4 cannot be used for interval "):
+        method(poly.c4, recalc=True, min=1, max=3, nloop=10)
+
+
+@pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
+def test_get_int_xxx_no_recalc(setUp, method, check_str):
+    """what is the output like when recalc=False (the default)?"""
+
+    res = method(poly.c1, min=-2, max=-1, nloop=5, recalc=False)
+    assert res.x is None
+    assert res.y is None
+    assert res.min is None
+    assert res.max is None
+    assert res.nloop == 20
+    assert res.delv is None
+    assert res.fac == 1
+    assert not res.log
+
+    check_str(str(res),
+              ["x     = None",
+               "y     = None",
+               "min   = None",
+               "max   = None",
+               "nloop = 20",
+               "delv  = None",
+               "fac   = 1",
+               "log   = False"
+               ])
+
+
+@pytest.mark.parametrize("method,expected",
+                         [(ui.get_int_unc, "[ 6.7979,17.4686,36.1392]"),
+                          (ui.get_int_proj, "[ 6.7782,17.3734,35.9119]")
+                          ])
+def test_get_int_xxx_show(setUp, method, expected, check_str):
+    """Check string output"""
+
+    res = method(poly.c1, min=-2, max=-1, nloop=3, recalc=True)
+    check_str(str(res),
+              ["x     = [-2. ,-1.5,-1. ]",
+               f"y     = {expected}  # doctest: +FLOAT_CMP",
+               "min   = -2",
+               "max   = -1",
+               "nloop = 3",
+               "delv  = None",
+               "fac   = 1",
+               "log   = False"
+               ])
+
+
+def test_get_int_proj(setUp):
+    # check we get the poly.c1 results with recalc=True
+    ui.int_proj(poly.c0)
+    result = ui.get_int_proj(poly.c1, recalc=True, min=-5, max=0, nloop=21)
+    cmp_args(result)
+    cmp_x(result)
 
     expected = np.array([110.0185, 90.493, 72.9534, 57.3995, 43.8316,
                          32.2494, 22.6531, 15.0427, 9.4181, 5.7794, 4.1265,
@@ -50,8 +204,12 @@ def cmp_proj(result):
     assert result.y == pytest.approx(expected, abs=1.0e-4)
 
 
-
-def cmp_unc(result):
+def test_get_int_unc(setUp):
+    # check we get the poly.c1 results with recalc=True
+    ui.int_unc(poly.c0)
+    result = ui.get_int_unc(poly.c1, recalc=True, min=-5, max=0, nloop=21)
+    cmp_args(result)
+    cmp_x(result)
 
     expected = np.array([110.774, 91.1094, 73.4447, 57.78, 44.1153, 32.4507,
                          22.786, 15.1213, 9.4566, 5.7919, 4.1273, 4.4626,
@@ -60,30 +218,82 @@ def cmp_unc(result):
     assert result.y == pytest.approx(expected, abs=1.0e-4)
 
 
+@pytest.mark.xfail
+def test_get_int_unc_log(setUp):
+    """Use log scaling to check. See issue #1561
 
-@pytest.fixture
-def setUp(clean_ui, hide_logging):
+    Note that c2 is the only positive parameter we can test with.
+    """
 
-    x = [-13, -5, -3, 2, 7, 12]
-    y = [102.3, 16.7, -0.6, -6.7, -9.9, 33.2]
-    dy = np.ones(6) * 5
-    ui.load_arrays(1, x, y, dy)
-    ui.set_source(ui.polynom1d.poly)
-    poly.c1.thaw()
-    poly.c2.thaw()
-    ui.int_proj(poly.c0)
-    ui.fit()
+    result = ui.get_int_unc(poly.c2, recalc=True, log=True,
+                            min=0.1, max=0.9, nloop=10)
+
+    cmp_args_log(result)
+    cmp_x_log(result)
+
+    # We can work out the expected vaues as we know all the parameter
+    # values.
+    #
+    expected = []
+    for x in result.x:
+        poly.c2 = x
+        expected.append(ui.calc_stat(1))
+
+    assert result.y == pytest.approx(expected, abs=1.0e-4)
 
 
-def test_get_int_proj(setUp):
-    result = ui.get_int_proj(poly.c1, recalc=True, min=-5, max=0, nloop=21)
-    cmp_args(result)
-    cmp_x(result)
-    cmp_proj(result)
+@pytest.mark.xfail
+def test_get_int_proj_log(setUp):
+    """Use log scaling to check. See issue #1561
+
+    Note that c2 is the only positive parameter we can test with.
+    """
+
+    result = ui.get_int_proj(poly.c2, recalc=True, log=True,
+                            min=0.1, max=0.9, nloop=10)
+
+    cmp_args_log(result)
+    cmp_x_log(result)
+
+    # Unlike the int_unc command it's harder to a-priori know the
+    # expected values, so treat as a regression test. We can compare
+    # to the linear case to check that they make sense.
+    #
+    expected = np.asarray([150.37621233, 129.76054302, 105.71703208,
+                           78.72851931, 50.31198137, 23.87142974,
+                           6.14353848, 9.62456249, 56.61597458,
+                           185.932959])
+    assert result.y == pytest.approx(expected, abs=1.0e-4)
 
 
-def test_get_int_unc(setUp):
-    result = ui.get_int_unc(poly.c1, recalc=True, min=-5, max=0, nloop=21)
-    cmp_args(result)
-    cmp_x(result)
-    cmp_unc(result)
+@pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
+@pytest.mark.parametrize("fac", [1, 3])
+def test_int_xxx_fac(setUp, method, fac):
+    """What happens if we use fac to calculate the limits"""
+
+    c = 0.47827334
+    dc = 0.0312677
+    expected = [c - fac * dc, c, c + fac * dc]
+
+    result = method(poly.c2, recalc=True, fac=fac, nloop=3)
+    assert result.x == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
+def test_int_xxx_delv(setUp, method):
+    """What happens if we set delv"""
+
+    result = method(poly.c2, recalc=True, min=0.1, max=0.9, delv=0.3)
+    assert result.x == pytest.approx([0.1, 0.4, 0.7, 1])
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
+def test_int_xxx_delv_log(setUp, method):
+    """What happens if we set delv and log?"""
+
+    result = method(poly.c2, recalc=True, log=True, min=0.1, max=0.9,
+                    delv=0.3)
+
+    expected = 10**np.asarray([-1, -0.7, -0.4, -0.1])
+    assert result.x == pytest.approx(expected)

--- a/sherpa/ui/tests/test_get_int_proj.py
+++ b/sherpa/ui/tests/test_get_int_proj.py
@@ -511,7 +511,7 @@ def test_get_int_unc_log(setUp):
     cmp_int_args_log(result)
     cmp_int_x_log(result)
 
-    # We can work out the expected vaues as we know all the parameter
+    # We can work out the expected values as we know all the parameter
     # values.
     #
     expected = []
@@ -633,7 +633,7 @@ def test_get_reg_unc_log(setUp):
     assert result.x0 == pytest.approx([0.1, 0.3, 0.9, 0.1, 0.3, 0.9])
     assert result.x1 == pytest.approx([-5, -5, -5, -4, -4, -4])
 
-    # We can work out the expected vaues as we know all the parameter
+    # We can work out the expected values as we know all the parameter
     # values.
     #
     expected = []

--- a/sherpa/ui/tests/test_get_int_proj.py
+++ b/sherpa/ui/tests/test_get_int_proj.py
@@ -18,15 +18,17 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+"""Simple tests int_proj/unc and reg_proj/unc."""
+
 import pytest
 
 import numpy as np
 
 from sherpa import ui
-from sherpa.utils.err import ConfidenceErr
+from sherpa.utils.err import ArgumentTypeErr, ConfidenceErr
 
 
-def cmp_args(result):
+def cmp_int_args(result):
     assert result.min == -5
     assert result.max == 0
     assert result.nloop == 21
@@ -35,7 +37,16 @@ def cmp_args(result):
     assert result.log is False
 
 
-def cmp_x(result):
+def cmp_reg_args(result):
+    assert result.min == [0.5, -5]
+    assert result.max == [0.6, -4]
+    assert result.nloop == (2, 3)
+    assert result.delv is None
+    assert result.fac == 4
+    assert result.log == (False, False)
+
+
+def cmp_int_x(result):
 
     expected = np.array([-5., -4.75, -4.5, -4.25, -4., -3.75, -3.5, -3.25, -3.,
                          -2.75, -2.5, -2.25, -2., -1.75, -1.5, -1.25, -1., -0.75,
@@ -43,7 +54,13 @@ def cmp_x(result):
     assert result.x == pytest.approx(expected)
 
 
-def cmp_args_log(result):
+def cmp_reg_x(result):
+
+    assert result.x0 == pytest.approx([0.5, 0.6, 0.5, 0.6, 0.5, 0.6])
+    assert result.x1 == pytest.approx([-5, -5, -4.5, -4.5, -4, -4])
+
+
+def cmp_int_args_log(result):
     assert result.min == 0.1
     assert result.max == 0.9
     assert result.nloop == 10
@@ -52,7 +69,7 @@ def cmp_args_log(result):
     assert result.log is True
 
 
-def cmp_x_log(result):
+def cmp_int_x_log(result):
 
     expected = np.logspace(-1, np.log10(0.9), 10)
     assert result.x == pytest.approx(expected)
@@ -85,6 +102,41 @@ def test_get_int_xxx_positive_nloop(setUp, method, val):
         method(poly.c1, recalc=True, min=-5, max=0, nloop=val)
 
 
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+def test_get_reg_xxx_nloop_not_scalar(setUp, method):
+    """nloop must contain 2 elements not a scalar"""
+
+    with pytest.raises(ConfidenceErr,
+                       match="Nloop parameter must be a list"):
+        method(poly.c0, poly.c1, recalc=True, min=(-20, -3.5),
+               max=(0, -1.5), nloop=1)
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+@pytest.mark.parametrize("val", [[10], (2, 3, 4)])
+def test_get_reg_xxx_nloop_size_2(setUp, method, val):
+    """nloop must contain 2 elements"""
+
+    # XFAIL: currently raises an IndexError or does not appear to fail
+    #
+    with pytest.raises(ConfidenceErr,
+                       match="Nloop parameter must be a list of size 2"):
+        method(poly.c0, poly.c1, recalc=True, min=(-20, -3.5),
+               max=(0, -1.5), nloop=val)
+
+
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+@pytest.mark.parametrize("val", [(0, 2), (2, 1), (1, 1)])
+def test_get_reg_xxx_positive_nloop(setUp, method, val):
+    """nloop must be > 1"""
+
+    with pytest.raises(ConfidenceErr,
+                       match="Nloop parameter must be a list with elements > 1"):
+        method(poly.c0, poly.c1, recalc=True, min=(-20, -3.5),
+               max=(0, -1.5), nloop=val)
+
+
 @pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
 def test_get_int_xxx_limits_sensible(setUp, method):
     """max must be > min"""
@@ -94,6 +146,21 @@ def test_get_int_xxx_limits_sensible(setUp, method):
         method(poly.c1, recalc=True, min=0, max=0, nloop=10)
 
 
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+@pytest.mark.parametrize("minval,maxval",
+                         [((0, -3.5), (-20, -1.5)),
+                          ((-20, -1.5), (0, -3.5)),
+                          ((0, 0), (0, 0))
+                         ])
+def test_get_reg_xxx_limits_sensible(setUp, method, minval, maxval):
+    """max must be > min"""
+
+    with pytest.raises(ConfidenceErr,
+                       match="Bad parameter limits"):
+        method(poly.c0, poly.c1, recalc=True, min=minval, max=maxval,
+               nloop=(5, 5))
+
+
 @pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
 def test_get_int_xxx_limits_scalar(setUp, method):
     """max and min must be scalars"""
@@ -101,6 +168,41 @@ def test_get_int_xxx_limits_scalar(setUp, method):
     with pytest.raises(ConfidenceErr,
                        match="Parameter limits must be scalars"):
         method(poly.c1, recalc=True, min=(-5, 2), max=(0, 4), nloop=10)
+
+
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+@pytest.mark.parametrize("minval,maxval",
+                         [(-20, (0, -1.5)),
+                          ((-20, -3.5), 0),
+                          (-20, 0)
+                         ])
+def test_get_reg_xxx_limits_not_scalar(setUp, method, minval, maxval):
+    """max and min must not be scalars"""
+
+    with pytest.raises(ConfidenceErr,
+                       match="Parameter limits must be a list"):
+        method(poly.c0, poly.c1, recalc=True, min=minval, max=maxval,
+               nloop=(3, 3))
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+@pytest.mark.parametrize("minval,maxval",
+                         [([-20], (0, -1.5)),
+                          ([1, 2, 3], [4, 5, 6]),
+                          ((-20, -3.5), [0]),
+                          ((-20, -3.5), [0, 2, 4]),
+                          ([-20], [0])
+                         ])
+def test_get_reg_xxx_limits_size_2(setUp, method, minval, maxval):
+    """max and min must contain 2 elements each"""
+
+    # XFAIL: currently raises an IndexError or does not appear to fail
+    #
+    with pytest.raises(ConfidenceErr,
+                       match="Parameter limits must be a list of size 2"):
+        method(poly.c0, poly.c1, recalc=True, min=minval, max=maxval,
+               nloop=(3, 3))
 
 
 @pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
@@ -114,6 +216,23 @@ def test_get_int_xxx_limits_positive_when_log(setUp, method, minval, maxval):
                log=True)
 
 
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+@pytest.mark.parametrize("minval,maxval",
+                         [((-1, 1), (0, 2)),
+                          ((0, 1), (1, 2)),
+                          ((1, -1), (2, 0)),
+                          ((1, 0), (2, 2)),
+                          ((-1, -1), (0, 0))
+                          ])
+def test_get_reg_xxx_limits_positive_when_log(setUp, method, minval, maxval):
+    """max and min must be positive when log scale"""
+
+    with pytest.raises(ConfidenceErr,
+                       match="Log scale must be on positive boundaries"):
+        method(poly.c0, poly.c1, recalc=True, min=minval, max=maxval,
+               nloop=(3, 3), log=(True, True))
+
+
 # FAIL: this currently fails with ZeroDivisionError.
 @pytest.mark.xfail
 @pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
@@ -123,6 +242,36 @@ def test_get_int_xxx_delv_positive(setUp, method):
     with pytest.raises(ConfidenceErr,
                        match="delv parameter must be > 0"):
         method(poly.c1, recalc=True, min=-5, max=-1, delv=-0.1)
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+@pytest.mark.parametrize("delv", [(-5, 0.5), (5, -0.5), (0, 0.5),
+                                  (5, 0), (0, 0)])
+def test_get_reg_xxx_delv_positive(setUp, method, delv):
+    """delv must be positive"""
+
+    # XFAIL: this actually fails with one of
+    #        ValueError: Maximum allowed size exceeded
+    #        ZeroDivisionError
+    with pytest.raises(ConfidenceErr,
+                       match="delv parameter must be a list with elements > 0"):
+        method(poly.c0, poly.c1, recalc=True, min=(-20, -3.5),
+               max=(0, -1.5), nloop=(5, 5), delv=delv)
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+@pytest.mark.parametrize("delv", [[5], (2, 3, 4)])
+def test_get_reg_xxx_delv_list_2(setUp, method, delv):
+    """delv must contain 2 elements"""
+
+    # XFAIL: currently raises an IndexError or does not appear to fail
+    #
+    with pytest.raises(ConfidenceErr,
+                       match="delv parameter must be a list of size 2"):
+        method(poly.c0, poly.c1, recalc=True, min=(-20, -3.5),
+               max=(0, -1.5), nloop=(5, 5), delv=delv)
 
 
 @pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
@@ -135,6 +284,27 @@ def test_get_int_xxx_not_leastsq(setUp, method):
         method(poly.c1, recalc=True, min=-5, max=0, nloop=10)
 
 
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+def test_get_reg_xxx_not_leastsq(setUp, method):
+    """can not use the least-square statistic"""
+
+    ui.set_stat("leastsq")
+    with pytest.raises(ConfidenceErr,
+                       match="leastsq is inappropriate for confidence limit estimation"):
+        method(poly.c0, poly.c1, recalc=True, min=(-20, -3.5),
+               max=(0, -1.5), nloop=(4, 4))
+
+
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+def test_get_reg_xxx_sigma_not_scalar(setUp, method):
+    """sigma can not be a scalar"""
+
+    with pytest.raises(ConfidenceErr,
+                       match="Please provide a list of sigma bounds"):
+        method(poly.c0, poly.c1, recalc=True, min=(-20, -3.5),
+               max=(0, -1.5), nloop=(4, 4), sigma=3)
+
+
 @pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
 def test_get_int_xxx_not_thawed(setUp, method):
     """can not use on a frozen parameter"""
@@ -142,6 +312,35 @@ def test_get_int_xxx_not_thawed(setUp, method):
     with pytest.raises(ConfidenceErr,
                        match="Frozen parameter poly.c4 cannot be used for interval "):
         method(poly.c4, recalc=True, min=1, max=3, nloop=10)
+
+
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+@pytest.mark.parametrize("name1,name2", [("c1", "c4"),
+                                         ("c4", "c1"),
+                                         ("c4", "c4")])
+def test_get_reg_xxx_not_thawed(setUp, method, name1, name2):
+    """can not use on a frozen parameter"""
+
+    par1 = getattr(poly, name1)
+    par2 = getattr(poly, name2)
+    with pytest.raises(ConfidenceErr,
+                       match="Frozen parameter poly.c4 cannot be used for region "):
+        method(par1, par2, recalc=True)
+
+
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+def test_get_reg_xxx_need_two_params(setUp, method):
+    """we need to provide two parameters"""
+
+    # Could break into two tests but not worth it.
+    #
+    with pytest.raises(ArgumentTypeErr,
+                       match="'par0' must be a parameter object or parameter expression string"):
+        method(recalc=True)
+
+    with pytest.raises(ArgumentTypeErr,
+                       match="'par1' must be a parameter object or parameter expression string"):
+        method(poly.c2, recalc=True)
 
 
 @pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
@@ -170,6 +369,46 @@ def test_get_int_xxx_no_recalc(setUp, method, check_str):
                ])
 
 
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+def test_get_reg_xxx_no_recalc(setUp, method, check_str):
+    """what is the output like when recalc=False (the default)?"""
+
+    # The arguments are ignored, so the fact they are not correct is
+    # technically not an issue (although we may decide to change this
+    # behaviour).
+    #
+    res = method(poly.c1, min=-2, max=-1, nloop=5, recalc=False)
+    assert res.x0 is None
+    assert res.x1 is None
+    assert res.y is None
+    assert res.min is None
+    assert res.max is None
+    assert res.nloop == (10, 10)
+    assert res.fac == 4
+    assert res.delv is None
+    assert res.log == (False, False)
+    assert res.sigma == (1, 2, 3)
+    assert res.parval0 is None
+    assert res.parval1 is None
+    assert res.levels is None
+
+    check_str(str(res),
+              ["x0      = None",
+               "x1      = None",
+               "y       = None",
+               "min     = None",
+               "max     = None",
+               "nloop   = (10, 10)",
+               "fac     = 4",
+               "delv    = None",
+               "log     = (False, False)",
+               "sigma   = (1, 2, 3)",
+               "parval0 = None",
+               "parval1 = None",
+               "levels  = None"
+               ])
+
+
 @pytest.mark.parametrize("method,expected",
                          [(ui.get_int_unc, "[ 6.7979,17.4686,36.1392]"),
                           (ui.get_int_proj, "[ 6.7782,17.3734,35.9119]")
@@ -190,12 +429,40 @@ def test_get_int_xxx_show(setUp, method, expected, check_str):
                ])
 
 
+@pytest.mark.parametrize("method,expected",
+                         [(ui.get_reg_unc,
+                           "[31.8653,18.0281,46.1268,51.3813,36.4641,63.4828]"),
+                          (ui.get_reg_proj,
+                           "[25.3301,17.5245,30.3216,44.8461,35.9605,47.6776]")
+                          ])
+def test_get_reg_xxx_show(setUp, method, expected, check_str):
+    """Check string output"""
+
+    res = method(poly.c2, poly.c1, min=(0.4, -1.5), max=(0.6, -1),
+                 nloop=(3, 2), recalc=True)
+    check_str(str(res),
+              ["x0      = [0.4,0.5,0.6,0.4,0.5,0.6]",
+               "x1      = [-1.5,-1.5,-1.5,-1. ,-1. ,-1. ]",
+               f"y       = {expected}  # doctest: +FLOAT_CMP",
+               "min     = [0.4, -1.5]",
+               "max     = [0.6, -1]",
+               "nloop   = (3, 2)",
+               "fac     = 4",
+               "delv    = None",
+               "log     = (False, False)",
+               "sigma   = (1, 2, 3)",
+               "parval0 = 0.4782733426103955  # doctest: +FLOAT_CMP",
+               "parval1 = -2.4169154937340127  # doctest: +FLOAT_CMP",
+               "levels  = [ 6.31257048 10.19689586 15.84597963]  # doctest: +FLOAT_CMP"
+               ])
+
+
 def test_get_int_proj(setUp):
     # check we get the poly.c1 results with recalc=True
     ui.int_proj(poly.c0)
     result = ui.get_int_proj(poly.c1, recalc=True, min=-5, max=0, nloop=21)
-    cmp_args(result)
-    cmp_x(result)
+    cmp_int_args(result)
+    cmp_int_x(result)
 
     expected = np.array([110.0185, 90.493, 72.9534, 57.3995, 43.8316,
                          32.2494, 22.6531, 15.0427, 9.4181, 5.7794, 4.1265,
@@ -208,8 +475,8 @@ def test_get_int_unc(setUp):
     # check we get the poly.c1 results with recalc=True
     ui.int_unc(poly.c0)
     result = ui.get_int_unc(poly.c1, recalc=True, min=-5, max=0, nloop=21)
-    cmp_args(result)
-    cmp_x(result)
+    cmp_int_args(result)
+    cmp_int_x(result)
 
     expected = np.array([110.774, 91.1094, 73.4447, 57.78, 44.1153, 32.4507,
                          22.786, 15.1213, 9.4566, 5.7919, 4.1273, 4.4626,
@@ -228,8 +495,8 @@ def test_get_int_unc_log(setUp):
     result = ui.get_int_unc(poly.c2, recalc=True, log=True,
                             min=0.1, max=0.9, nloop=10)
 
-    cmp_args_log(result)
-    cmp_x_log(result)
+    cmp_int_args_log(result)
+    cmp_int_x_log(result)
 
     # We can work out the expected vaues as we know all the parameter
     # values.
@@ -252,8 +519,8 @@ def test_get_int_proj_log(setUp):
     result = ui.get_int_proj(poly.c2, recalc=True, log=True,
                             min=0.1, max=0.9, nloop=10)
 
-    cmp_args_log(result)
-    cmp_x_log(result)
+    cmp_int_args_log(result)
+    cmp_int_x_log(result)
 
     # Unlike the int_unc command it's harder to a-priori know the
     # expected values, so treat as a regression test. We can compare
@@ -297,3 +564,132 @@ def test_int_xxx_delv_log(setUp, method):
 
     expected = 10**np.asarray([-1, -0.7, -0.4, -0.1])
     assert result.x == pytest.approx(expected)
+
+
+def test_get_reg_proj(setUp):
+    """Basic check"""
+
+    result = ui.get_reg_proj(poly.c2, poly.c1, recalc=True,
+                             min=(0.5, -5), max=(0.6, -4),
+                             nloop=(2, 3))
+    cmp_reg_args(result)
+    cmp_reg_x(result)
+
+    expected = np.array([112.47253333, 132.8296, 74.90853333,
+                         94.1856, 45.34453333, 63.5416])
+    assert result.y == pytest.approx(expected, abs=1.0e-4)
+
+
+def test_get_reg_unc(setUp):
+    """Basic check"""
+
+    result = ui.get_reg_unc(poly.c2, poly.c1, recalc=True,
+                            min=(0.5, -5), max=(0.6, -4),
+                            nloop=(2, 3))
+    cmp_reg_args(result)
+    cmp_reg_x(result)
+
+    expected = np.array([112.97605082, 148.63480439, 75.41205082,
+                         109.99080439, 45.84805082, 79.34680439])
+    assert result.y == pytest.approx(expected, abs=1.0e-4)
+
+
+@pytest.mark.xfail
+def test_get_reg_unc_log(setUp):
+    """Use log scaling to check. See issue #1561
+
+    Note that c2 is the only positive parameter we can test with.
+    """
+
+    result = ui.get_reg_unc(poly.c2, poly.c0, recalc=True,
+                            log=(True, False), min=(0.1, -5),
+                            max=(0.9, -4), nloop=(3, 2))
+
+    assert result.min == [0.1, -5]
+    assert result.max == [0.9, -4]
+    assert result.nloop == (3, 2)
+    assert result.delv is None
+    assert result.fac == 4
+    assert result.log == (True, False)
+
+    assert result.x0 == pytest.approx([0.1, 0.3, 0.9, 0.1, 0.3, 0.9])
+    assert result.x1 == pytest.approx([-5, -5, -5, -4, -4, -4])
+
+    # We can work out the expected vaues as we know all the parameter
+    # values.
+    #
+    expected = []
+    for x0, x1 in zip(result.x0, result.x1):
+        poly.c2 = x0
+        poly.c0 = x1
+        expected.append(ui.calc_stat(1))
+
+    assert result.y == pytest.approx(expected, abs=1.0e-4)
+
+
+@pytest.mark.xfail
+def test_get_reg_proj_log(setUp):
+    """Use log scaling to check. See issue #1561
+
+    Note that c2 is the only positive parameter we can test with.
+    """
+
+    result = ui.get_reg_proj(poly.c0, poly.c2, recalc=True,
+                             log=(False, True), min=(-5, 0.1),
+                             max=(-4, 0.9), nloop=(2, 3))
+
+    assert result.min == [-5, 0.1]
+    assert result.max == [-4, 0.9]
+    assert result.nloop == (2, 3)
+    assert result.delv is None
+    assert result.fac == 4
+    assert result.log == (False, True)
+
+    assert result.x0 == pytest.approx([-5, -4, -5, -4, -5, -4])
+    assert result.x1 == pytest.approx([0.1, 0.1, 0.3, 0.3, 0.9, 0.9])
+
+    # Unlike the int_unc command it's harder to a-priori know the
+    # expected values, so treat as a regression test. We can compare
+    # to the linear case to check that they make sense.
+    #
+    expected = np.asarray([254.542879, 244.782879, 50.024199,
+                           46.664199, 439.432959, 455.272959])
+    assert result.y == pytest.approx(expected, abs=1.0e-4)
+
+
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+@pytest.mark.parametrize("fac", [1, 3])
+def test_reg_xxx_fac(setUp, method, fac):
+    """What happens if we use fac to calculate the limits"""
+
+    c = 0.47827334
+    dc = 0.0312677
+    expected = [c - fac * dc, c, c + fac * dc] * 2
+
+    result = method(poly.c2, poly.c0, recalc=True, fac=fac,
+                    nloop=(3, 2))
+    assert result.x0 == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+def test_reg_xxx_delv(setUp, method):
+    """What happens if we set delv"""
+
+    result = method(poly.c2, poly.c0, recalc=True,
+                    min=(0.1, -5), max=(0.9, -4), delv=(0.3, 0.5))
+
+    assert result.x0 == pytest.approx([0.1, 0.4, 0.7, 1] * 3)
+    assert result.x1 == pytest.approx([-5] * 4 + [-4.5] * 4 + [-4] * 4)
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+def test_reg_xxx_delv_log(setUp, method):
+    """What happens if we set delv and log?"""
+
+    result = method(poly.c0, poly.c2, recalc=True, log=(False, True),
+                    min=(-5, 0.1), max=(-4, 0.9), delv=(1, 0.3))
+
+    assert result.x0 == pytest.approx([-5, -4] * 4)
+    expected = 10**np.asarray([-1, -1, -0.7, -0.7, -0.4, -0.4, -0.1, -0.1])
+    assert result.x1 == pytest.approx(expected)

--- a/sherpa/ui/tests/test_get_int_proj.py
+++ b/sherpa/ui/tests/test_get_int_proj.py
@@ -328,6 +328,33 @@ def test_get_reg_xxx_not_thawed(setUp, method, name1, name2):
         method(par1, par2, recalc=True)
 
 
+@pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
+def test_get_int_xxx_must_be_fitted_parameter(setUp, method):
+    """We must use a parameter that is part of the fitted model"""
+
+    const = ui.create_model_component("const1d", "other")
+    with pytest.raises(ConfidenceErr,
+                       match="Thawed parameter other.c0 not found in polynom1d.poly"):
+        method(const.c0, recalc=True, min=1, max=3, nloop=10)
+
+
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+def test_get_reg_xxx_must_be_fitted_parameter(setUp, method):
+    """We must use a parameter that is part of the fitted model"""
+
+    const = ui.create_model_component("const1d", "other")
+
+    # Could break into two tests but not worth it.
+    #
+    with pytest.raises(ConfidenceErr,
+                       match="Thawed parameter other.c0 not found in polynom1d.poly"):
+        method(const.c0, poly.c2, recalc=True)
+
+    with pytest.raises(ConfidenceErr,
+                       match="Thawed parameter other.c0 not found in polynom1d.poly"):
+        method(poly.c2, const.c0, recalc=True)
+
+
 @pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
 def test_get_reg_xxx_need_two_params(setUp, method):
     """we need to provide two parameters"""

--- a/sherpa/ui/tests/test_get_int_proj.py
+++ b/sherpa/ui/tests/test_get_int_proj.py
@@ -560,10 +560,18 @@ def test_int_xxx_fac(setUp, method, fac):
 
 @pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
 def test_int_xxx_delv(setUp, method):
-    """What happens if we set delv"""
+    """What happens if we set delv (max not included)"""
 
     result = method(poly.c2, recalc=True, min=0.1, max=0.9, delv=0.3)
-    assert result.x == pytest.approx([0.1, 0.4, 0.7, 1])
+    assert result.x == pytest.approx([0.1, 0.4, 0.7])
+
+
+@pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
+def test_int_xxx_delv_exact(setUp, method):
+    """What happens if we set delv (max is included)"""
+
+    result = method(poly.c2, recalc=True, min=0.1, max=0.9, delv=0.2)
+    assert result.x == pytest.approx([0.1, 0.3, 0.5, 0.7, 0.9])
 
 
 @pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
@@ -682,13 +690,24 @@ def test_reg_xxx_fac(setUp, method, fac):
 
 @pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
 def test_reg_xxx_delv(setUp, method):
-    """What happens if we set delv"""
+    """What happens if we set delv (max not included)"""
+
+    result = method(poly.c2, poly.c0, recalc=True,
+                    min=(0.1, -5), max=(0.9, -4), delv=(0.3, 0.4))
+
+    assert result.x0 == pytest.approx([0.1, 0.4, 0.7] * 3)
+    assert result.x1 == pytest.approx([-5] * 3 + [-4.6] * 3 + [-4.2] * 3)
+
+
+@pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])
+def test_reg_xxx_delv_exact(setUp, method):
+    """What happens if we set delv (max is included, at least for one)"""
 
     result = method(poly.c2, poly.c0, recalc=True,
                     min=(0.1, -5), max=(0.9, -4), delv=(0.3, 0.5))
 
-    assert result.x0 == pytest.approx([0.1, 0.4, 0.7, 1] * 3)
-    assert result.x1 == pytest.approx([-5] * 4 + [-4.5] * 4 + [-4] * 4)
+    assert result.x0 == pytest.approx([0.1, 0.4, 0.7] * 3)
+    assert result.x1 == pytest.approx([-5] * 3 + [-4.5] * 3 + [-4] * 3)
 
 
 @pytest.mark.parametrize("method", [ui.get_reg_unc, ui.get_reg_proj])

--- a/sherpa/ui/tests/test_get_int_proj.py
+++ b/sherpa/ui/tests/test_get_int_proj.py
@@ -233,8 +233,6 @@ def test_get_reg_xxx_limits_positive_when_log(setUp, method, minval, maxval):
                nloop=(3, 3), log=(True, True))
 
 
-# FAIL: this currently fails with ZeroDivisionError.
-@pytest.mark.xfail
 @pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
 def test_get_int_xxx_delv_positive(setUp, method):
     """delv must be positive"""
@@ -512,7 +510,6 @@ def test_get_int_unc(setUp):
     assert result.y == pytest.approx(expected, abs=1.0e-4)
 
 
-@pytest.mark.xfail
 def test_get_int_unc_log(setUp):
     """Use log scaling to check. See issue #1561
 
@@ -536,7 +533,6 @@ def test_get_int_unc_log(setUp):
     assert result.y == pytest.approx(expected, abs=1.0e-4)
 
 
-@pytest.mark.xfail
 def test_get_int_proj_log(setUp):
     """Use log scaling to check. See issue #1561
 
@@ -581,7 +577,6 @@ def test_int_xxx_delv(setUp, method):
     assert result.x == pytest.approx([0.1, 0.4, 0.7, 1])
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("method", [ui.get_int_unc, ui.get_int_proj])
 def test_int_xxx_delv_log(setUp, method):
     """What happens if we set delv and log?"""

--- a/sherpa/ui/tests/test_get_int_proj.py
+++ b/sherpa/ui/tests/test_get_int_proj.py
@@ -370,14 +370,15 @@ def test_get_int_xxx_no_recalc(setUp, method, check_str):
     assert not res.log
 
     check_str(str(res),
-              ["x     = None",
-               "y     = None",
-               "min   = None",
-               "max   = None",
-               "nloop = 20",
-               "delv  = None",
-               "fac   = 1",
-               "log   = False"
+              ["x      = None",
+               "y      = None",
+               "min    = None",
+               "max    = None",
+               "nloop  = 20",
+               "delv   = None",
+               "fac    = 1",
+               "log    = False",
+               "parval = None"
                ])
 
 
@@ -430,14 +431,15 @@ def test_get_int_xxx_show(setUp, method, expected, check_str):
 
     res = method(poly.c1, min=-2, max=-1, nloop=3, recalc=True)
     check_str(str(res),
-              ["x     = [-2. ,-1.5,-1. ]",
-               f"y     = {expected}  # doctest: +FLOAT_CMP",
-               "min   = -2",
-               "max   = -1",
-               "nloop = 3",
-               "delv  = None",
-               "fac   = 1",
-               "log   = False"
+              ["x      = [-2. ,-1.5,-1. ]",
+               f"y      = {expected}  # doctest: +FLOAT_CMP",
+               "min    = -2",
+               "max    = -1",
+               "nloop  = 3",
+               "delv   = None",
+               "fac    = 1",
+               "log    = False",
+               "parval = -2.4169154937340127  # doctest: +FLOAT_CMP"
                ])
 
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2010, 2015 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -15605,6 +15605,9 @@ class Session(NoNewAttributesAfterInit):
         are ignored and the results of the last `int_proj` call are
         returned.
 
+        .. versionchanged:: 4.16.1
+           The log parameter can now be set to `True`.
+
         Parameters
         ----------
         par
@@ -15716,6 +15719,9 @@ class Session(NoNewAttributesAfterInit):
         parameter is `False` (the default value) then all other parameters
         are ignored and the results of the last `int_unc` call are
         returned.
+
+        .. versionchanged:: 4.16.1
+           The log parameter can now be set to `True`.
 
         Parameters
         ----------
@@ -16081,6 +16087,9 @@ class Session(NoNewAttributesAfterInit):
         after a successful fit, so that the parameter values identify
         the best-fit location.
 
+        .. versionchanged:: 4.16.1
+           The log parameter can now be set to `True`.
+
         Parameters
         ----------
         par
@@ -16199,6 +16208,9 @@ class Session(NoNewAttributesAfterInit):
         the statistic evaluated while holding the other parameters
         fixed. It is expected that this is run after a successful fit,
         so that the parameter values identify the best-fit location.
+
+        .. versionchanged:: 4.16.1
+           The log parameter can now be set to `True`.
 
         Parameters
         ----------

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -15831,6 +15831,10 @@ class Session(NoNewAttributesAfterInit):
         are ignored and the results of the last `reg_proj` call are
         returned.
 
+        .. versionchanged:: 4.16.1
+           The log parameter can now be set to `True` for one or both
+           parameters.
+
         Parameters
         ----------
         par0, par1
@@ -15956,6 +15960,10 @@ class Session(NoNewAttributesAfterInit):
         parameter is `False` (the default value) then all other parameters
         are ignored and the results of the last `reg_unc` call are
         returned.
+
+        .. versionchanged:: 4.16.1
+           The log parameter can now be set to `True` for one or both
+           parameters.
 
         Parameters
         ----------


### PR DESCRIPTION
# Summary

The projection and uncertainty plots, for both interval (1D) and region (2D), now correctly create a logarithmic scale when requested. Fix #1561.

# Details

The int-unc and int-proj routines rely on the behaviour of Confidence1D._interval_init to set up the grid of points to use (the `x` attribute) and before this change

- the `minval` and `maxval` fields were logged
- `x` was set to a linear spacing (`numpy.linspace`) between the logged min/max fields
- this `x` array was returned but `self.x` wasn't updated, which means it isn't clear what was being done
- it wasn't clear how the log option worked when delv was set

We now

- add a bunch of tests to cover this behaviour and some lines (generally error handling) that weren't being tested
- the logic for creating the array of values is now more linear, in that it tries to use the same code for generating
  the arrays whether the log setting is given or not rther than having a lot of deeply-nested if statements. There is
  still some choice over the delv setting, but it is hopefully now a bit clearer
- the implementation classes (so `IntervalProjection` and `IntervalUncertainty` now care a lot less about the `log` setting,
  as this is all taken care of in the base class. This means that the worker class no longer has to worry about the log
  setting (which makes sense)
- some documentation (but not a lot)

This is repeated for the 2D case, which is similar.

There is then some re-working of the internal code to use a more-common structure, and a fix for when `delv` is set: it
used to allow a parameter value greater than the requested maximum value. We could view this as just part of the
interface, but given how the limits work I think it better if we fix the code (which appears to be from a mis-understanding
of the numpy arange command, coupled with poor testing that never tested this part of the code).

# Notes

We could move the generation code (e.g. calculating the parameter ranges and the statistic values for uncertainty and projection methods) out of the plot code (I thought I had an issue about that but I couldn't find it) and into some other module, since *technically* it could be of use. However, without an **actual** use case I don't think it's worth it here. 

# Example

## CIAO 4.16

With CIAO 4.16 I get (this is based on the simple test data used in `sherpa/ui/tests/test_get_int_proj.py`):

```
sherpa In [1]: x = [-13, -5, -3, 2, 7, 12]

sherpa In [2]: y =
SyntaxError: invalid syntax (<ipython-input-2-3042731917eb>, line 1)

sherpa In [3]: y = [102.3, 16.7, -0.6, -6.7, -9.9, 33.2]

sherpa In [4]: dy = np.ones(6) * 5

sherpa In [5]: load_arrays(1, x, y, dy)

sherpa In [6]: set_source(polynom1d.poly)

sherpa In [7]: thaw(poly.c1, poly.c2)

sherpa In [8]: fit()
Dataset               = 1
Method                = levmar
Statistic             = chi2
Initial fit statistic = 469.027
Final fit statistic   = 4.01682 at function evaluation 8
Data points           = 6
Degrees of freedom    = 3
Probability [Q-value] = 0.259653
Reduced statistic     = 1.33894
Change in statistic   = 465.01
   poly.c0        -9.38489     +/- 2.91751     
   poly.c1        -2.41692     +/- 0.250889    
   poly.c2        0.478273     +/- 0.0312677   

sherpa In [9]: int_proj(poly.c2, min=0.1, max=0.9)

sherpa In [10]: int_proj(poly.c2, min=0.1, max=0.9, log=True, overplot=True)
```

![sherpa](https://github.com/sherpa/sherpa/assets/224638/5df0b2d2-5357-48ac-84cf-ccf838208bc1)

The blue line is the linear run and the orange line the log pplot (since I used `overplot=True` we use a linear scale for the X axis). From this we can see that the first and last points agree, but the ones between are wrong (this is because it doesn't use the correct X value when setting the `poly.c2` parameter for each iteration). 

```
sherpa In [12]: res = get_int_proj(poly.c2, min=0.1, max=0.9, log=True, recalc=True)

sherpa In [13]: res.x
Out[13]: 
array([0.1       , 0.14210526, 0.18421053, 0.22631579, 0.26842105,
       0.31052632, 0.35263158, 0.39473684, 0.43684211, 0.47894737,
       0.52105263, 0.56315789, 0.60526316, 0.64736842, 0.68947368,
       0.73157895, 0.77368421, 0.81578947, 0.85789474, 0.9       ])

sherpa In [14]: res.y
Out[14]: 
array([150.37621233, 141.04315148, 130.93220937, 120.04334265,
       108.40130721,  96.06515319,  83.14056354,  69.79582204,
        56.28240639,  42.96146765,  30.33779233,  19.10326697,
        10.1923994 ,   4.85312564,   4.73698263,  12.01380174,
        29.51743305,  60.93072075, 111.02010662, 185.932959  ])
```

## This PR

```
In [1]: from sherpa.astro.ui import *
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'

In [2]: x = [-13, -5, -3, 2, 7, 12]

In [3]: y = [102.3, 16.7, -0.6, -6.7, -9.9, 33.2]

In [4]: dy = [1] * 6

In [5]: load_arrays(1, x, y, dy)

In [6]: set_source(polynom1d.poly)

In [7]: thaw(poly.c1, poly.c2)

In [8]: fit()
Dataset               = 1
Method                = levmar
Statistic             = chi2
Initial fit statistic = 11725.7
Final fit statistic   = 100.421 at function evaluation 8
Data points           = 6
Degrees of freedom    = 3
Probability [Q-value] = 1.26203e-21
Reduced statistic     = 33.4735
Change in statistic   = 11625.3
   poly.c0        -9.38489     +/- 0.583502    
   poly.c1        -2.41692     +/- 0.0501779   
   poly.c2        0.478273     +/- 0.00625353  

In [9]: int_proj(poly.c2, min=0.1, max=0.9)

In [10]: int_proj(poly.c2, min=0.1, max=0.9, log=True, overplot=True)
```

Here the two curves are very similar (thanks to the relatively large number of points used the interpolation differences are not huge).

![sherpa](https://github.com/sherpa/sherpa/assets/224638/47d05a6d-f7d2-4c33-8820-f12f5f0363e9)

Note that I accidentally set the error values smaller in this than the CIAO 4.16 run (using a value of 1 rather than 5per bin) which is why the fit statistic, and hence Y axis, is different between the two (but the best-fit parameters are the same).

Since I called `get_int_proj` for CIAO 4.16, here's the version now:

```
In [15]: res = get_int_proj(poly.c2, min=0.1, max=0.9, log=10, recalc=True)

In [16]: print(res)
x     = [0.1   ,0.1123,0.126 ,0.1415,0.1588,0.1783,0.2001,0.2247,0.2522,0.2831,
 0.3179,0.3568,0.4006,0.4497,0.5048,0.5667,0.6362,0.7142,0.8017,0.9   ]
y     = [3759.4053,3526.0788,3273.3052,3001.0836,2710.0327,2401.6288,2078.5141,
 1744.8956,1407.0602,1074.0367, 758.4448, 477.5817, 254.81  , 121.3281,
  118.4246, 300.345 , 737.9358,1523.268 ,2775.5027,4648.324 ]
min   = 0.1
max   = 0.9
nloop = 20
delv  = None
fac   = 1
log   = 10
```

For reference, here's the `log` plot on its own

A) CIAO 4.16 - obviously wrong since the best-fit value is not close to the minimum

```
sherpa In [15]: int_proj(poly.c2, min=0.1, max=0.9, log=True)
```

![sherpa](https://github.com/sherpa/sherpa/assets/224638/4b22b44d-3a23-4559-a96c-6b81d8e1c21b)


B) this PR - just perfect ...

```
In [13]: int_proj(poly.c2, min=0.1, max=0.9, log=True)
```

![sherpa](https://github.com/sherpa/sherpa/assets/224638/1f9f5179-3e37-4ac5-94b2-ce38ccdd2809)

## delv example

Here's the current (CIAO 4.16) behavior when `delv` is set:

```
sherpa-4.16.0> x = [-13, -5, -3, 2, 7, 12]

sherpa-4.16.0> y = [102.3, 16.7, -0.6, -6.7, -9.9, 33.2]

sherpa-4.16.0> load_arrays(1, x, y, np.ones(6) * 5)

sherpa-4.16.0> set_source(polynom1d.poly)

sherpa-4.16.0> thaw(poly.c1, poly.c2)

sherpa-4.16.0> fit()
Dataset               = 1
Method                = levmar
Statistic             = chi2
Initial fit statistic = 469.027
Final fit statistic   = 4.01682 at function evaluation 8
Data points           = 6
Degrees of freedom    = 3
Probability [Q-value] = 0.259653
Reduced statistic     = 1.33894
Change in statistic   = 465.01
   poly.c0        -9.38489     +/- 2.91751     
   poly.c1        -2.41692     +/- 0.250889    
   poly.c2        0.478273     +/- 0.0312677   

sherpa-4.16.0> ip1 = get_int_proj(poly.c2, min=0.1, max=0.9, nloop=9, recalc=True)

sherpa-4.16.0> ip1.x
array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])

sherpa-4.16.0> ip2 = get_int_proj(poly.c2, min=0.1, max=0.9, delv=0.2, recalc=True)

sherpa-4.16.0> ip2.x
array([0.1, 0.3, 0.5, 0.7, 0.9])

sherpa-4.16.0> ip3 = get_int_proj(poly.c2, min=0.1, max=0.9, delv=0.3, recalc=True)

sherpa-4.16.0> ip3.x
array([0.1, 0.4, 0.7, 1. ])
```

Note that `ip3.x` ends at `1`, which is larger than the `max` value (0.9 in this case).

With the PR we get

```
>>> import numpy as np
>>> from sherpa.astro.ui import *
WARNING: failed to import sherpa.astro.xspec; XSPEC models will not be available
>>> x = [-13, -5, -3, 2, 7, 12]
>>> y = [102.3, 16.7, -0.6, -6.7, -9.9, 33.2]
>>> load_arrays(1, x, y, np.ones(6) * 5)
>>> set_source(polynom1d.poly)
>>> thaw(poly.c1, poly.c2)
>>> fit()
Dataset               = 1
Method                = levmar
Statistic             = chi2
Initial fit statistic = 469.027
Final fit statistic   = 4.01682 at function evaluation 8
Data points           = 6
Degrees of freedom    = 3
Probability [Q-value] = 0.259653
Reduced statistic     = 1.33894
Change in statistic   = 465.01
   poly.c0        -9.38489     +/- 2.91751     
   poly.c1        -2.41692     +/- 0.250889    
   poly.c2        0.478273     +/- 0.0312677   
>>> ip3 = get_int_proj(poly.c2, min=0.1, max=0.9, delv=0.3, recalc=True)
>>> ip3.x
array([0.1, 0.4, 0.7])
```

Note that the x values are limited to within the min/max bounds.

If the `delv` value leads to the max value being included then it is:

```
>>> ip4 = get_int_proj(poly.c2, min=0.1, max=0.9, delv=0.2, recalc=True)
>>> ip4.x
array([0.1, 0.3, 0.5, 0.7, 0.9])
```