### PR TITLE
Pick up latest Python micro version in conda workflow

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -51,7 +51,7 @@ fi
 echo "dependencies: ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC}"
 
 # Create and activate conda build environment
-conda create --yes -n build python="=${PYTHONVER}.*=*cpython*" pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${compilers}
+conda create --yes -n build python"=${PYTHONVER}.*=*cpython*" pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${compilers}
 
 conda activate build
 

--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -51,7 +51,7 @@ fi
 echo "dependencies: ${MATPLOTLIB} ${NUMPY} ${FITS} ${XSPEC}"
 
 # Create and activate conda build environment
-conda create --yes -n build python="=${PYTHONVER}=*cpython*" pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${compilers}
+conda create --yes -n build python="=${PYTHONVER}.*=*cpython*" pip ${MATPLOTLIB} ${NUMPY} ${XSPEC} ${FITSBUILD} ${compilers}
 
 conda activate build
 


### PR DESCRIPTION
This resolves the missing crypt.h issue being seen in the conda test workflow by picking up the latest micro version of the python packages for the conda test build workflows.