### PR TITLE
Improve the error message when a plot backend is not available.

### DIFF
--- a/sherpa/plot/backends.py
+++ b/sherpa/plot/backends.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2020, 2021, 2022, 2023
+#  Copyright (C) 2007, 2015, 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -142,7 +142,6 @@ uses the backend-specific default.'''],
               'levels': ['array-like', 'Levels at which to draw the contours'],
               'aspect': ['str or float', 'Aspect ratio of the plot. Strings "equal" or "auto" are accepted.'],
               'label': ['str', 'Label this dataset for use in a legend'],
-              'levels': ['array-like', 'Levels at which to draw the contours'],
               'ymin' : ['float', '''Beginning of the vertical line in axes coordinates,
 i.e. from 0 (bottom) to 1 (top).'''],
               'ymax' : ['float', '''End of the vertical line in axes coordinates,
@@ -191,7 +190,8 @@ class MetaBaseBackend(type):
             PLOT_BACKENDS[n] = cls
         else:
             warning(
-                f'{n} is already a registered name for {PLOT_BACKENDS[n]}: Not adding {cls}.')
+                '%s is already a registered name for %s: Not adding %s.',
+                n, PLOT_BACKENDS[n], cls)
 
 
 class BaseBackend(metaclass=MetaBaseBackend):
@@ -597,7 +597,7 @@ class BaseBackend(metaclass=MetaBaseBackend):
             will be displayed properly.
 
         """
-        return "${}$".format(txt)
+        return f"${txt}$"
 
     # HTML representation as tabular data
     #
@@ -626,7 +626,7 @@ class BaseBackend(metaclass=MetaBaseBackend):
             try:
                 val = getattr(data, name)
             except Exception as e:
-                lgr.debug("Skipping field {}: {}".format(name, e))
+                lgr.debug("Skipping field %s: %s", name, e)
                 continue
 
             meta.append((name, val))
@@ -865,8 +865,8 @@ class BasicBackend(BaseBackend):
         if 'ratioline' in kwargs:
             warning('Keyword "ratioline" is deprecated and has no effect. Ratio lines are always drawn for ratio plots.')
 
-        warning(f'{self.__class__} does not implement line/symbol plotting. ' +
-                'No plot will be produced.')
+        warning('%s does not implement line/symbol plotting. '
+                'No plot will be produced.', self.name)
 
     @translate_args
     def histo(self, xlo, xhi, y, *,
@@ -894,8 +894,8 @@ class BasicBackend(BaseBackend):
            No output will be produced by this backend, since the implementation
            is incomplete.
         '''
-        warning(f'{self.__class__} does not implement histogram plotting. ' +
-                'No histogram will be produced.')
+        warning('%s does not implement histogram plotting. '
+                'No histogram will be produced.', self.name)
 
     @translate_args
     def contour(self, x0, x1, y, *,
@@ -915,8 +915,8 @@ class BasicBackend(BaseBackend):
            No output will be produced by this backend, since the implementation
            is incomplete.
         '''
-        warning(f'{self.__class__} does not implement contour plotting. ' +
-                'No contour will be produced.')
+        warning('%s does not implement contour plotting. '
+                'No contour will be produced.', self.name)
 
     @add_kwargs_to_doc(kwargs_doc)
     @translate_args
@@ -940,8 +940,8 @@ class BasicBackend(BaseBackend):
             x position of the vertical line in data units
         {kwargs}
         """
-        warning(f'{self.__class__} does not implement line plotting. ' +
-                'No line will be produced.')
+        warning('%s does not implement line plotting. '
+                'No line will be produced.', self.name)
 
     @add_kwargs_to_doc(kwargs_doc)
     @translate_args
@@ -965,8 +965,8 @@ class BasicBackend(BaseBackend):
             x position of the vertical line in data units
         {kwargs}
            """
-        warning(f'{self.__class__} does not implement line plotting. ' +
-                'No line will be produced.')
+        warning('%s does not implement line plotting. '
+                'No line will be produced.', self.name)
 
 
 class IndepOnlyBackend(BasicBackend):

--- a/sherpa/plot/tests/test_backend.py
+++ b/sherpa/plot/tests/test_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2022, 2023
+#  Copyright (C) 2022 - 2024
 #  MIT
 #
 #
@@ -131,3 +131,21 @@ def test_colorlist():
     clist = back.colorlist(25)
     assert len(clist) == 25
     assert all([c in backend_indep_colors for c in clist])
+
+
+def test_dummy_backend_warning(caplog):
+    """Check we get a warning message that no plotting is available.
+
+    This is related to #1964. We could check all methods but that
+    seems excessive.
+    """
+
+    with TemporaryPlottingBackend(IndepOnlyBackend):
+        assert len(caplog.record_tuples) == 0
+        plot.backend.plot(1, 1)
+        assert len(caplog.record_tuples) == 1
+
+    (lname, llevel, lmsg) = caplog.record_tuples[0]
+    assert lname == "sherpa.plot.backends"
+    assert llevel == logging.WARNING
+    assert lmsg == "<class 'sherpa.plot.backends.IndepOnlyBackend'> does not implement line/symbol plotting. No plot will be produced."

--- a/sherpa/plot/tests/test_backend.py
+++ b/sherpa/plot/tests/test_backend.py
@@ -148,4 +148,4 @@ def test_dummy_backend_warning(caplog):
     (lname, llevel, lmsg) = caplog.record_tuples[0]
     assert lname == "sherpa.plot.backends"
     assert llevel == logging.WARNING
-    assert lmsg == "<class 'sherpa.plot.backends.IndepOnlyBackend'> does not implement line/symbol plotting. No plot will be produced."
+    assert lmsg == "IndepOnlyBackend does not implement line/symbol plotting. No plot will be produced."


### PR DESCRIPTION
# Summary

Improve the error message when a plot backend is not available. Fix #1964 

# Details

There is some minor code-cleanup here, but the main change is that the warning message that gets displayed uses the `self.name` attribute of the backend rather than `self.__class__`, which is a little-more-readable and doesn't contain `<>` characters (which then can get caught in our helpdesk system, leading to the text being lost in error reports).
