### PR TITLE
Remove Conda build 3.25 pin from deployments 

### DIFF
--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -4,6 +4,7 @@ name: Conda Deployments
 #With check-skip job, we skip build on main/ciaox if directly tagged as a release.
 # (To only build releases on the release branch)
 on:
+  pull_request:
   push:
     branches:
     - main

--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -4,7 +4,6 @@ name: Conda Deployments
 #With check-skip job, we skip build on main/ciaox if directly tagged as a release.
 # (To only build releases on the release branch)
 on:
-  pull_request:
   push:
     branches:
     - main

--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -83,7 +83,7 @@ jobs:
         curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-${CONDA_OS}.sh -o conda-installer.sh
         bash conda-installer.sh -b -p ${conda_loc}
         source ${conda_loc}/etc/profile.d/conda.sh
-        conda create -yq -n builder conda-build=3.25 conda-verify
+        conda create -yq -n builder conda-build conda-verify
 
     #Checkout the code with a depth of 0 to grab the tags/branches as well
     - name: Checkout Code
@@ -140,7 +140,7 @@ jobs:
         curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-${CONDA_OS}.sh -o conda-installer.sh
         bash conda-installer.sh -b -p ${conda_loc}
         source ${conda_loc}/etc/profile.d/conda.sh
-        conda create -yq -n builder conda-build=3.25 conda-verify
+        conda create -yq -n builder conda-build conda-verify
 
     - name: macOS 10.14 SDK
       if: ${{ matrix.conda-os == 'MacOSX-x86_64' }}
@@ -221,7 +221,7 @@ jobs:
         curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-${CONDA_OS}.sh -o conda-installer.sh
         bash conda-installer.sh -b -p ${conda_loc}
         source ${conda_loc}/etc/profile.d/conda.sh
-        conda install conda-build=3.25
+        conda install conda-build
         echo "Packages downloaded here: ${{steps.download.outputs.download-path}}"
         echo "ls packages/*/sherpa*.bz2"
         ls packages/*/sherpa*.bz2


### PR DESCRIPTION
We no longer need to specify conda-build=3.25 (as newer versions of mamba and others are out). Keeping this now causes compatibility issues. This PR just removed the version specification