### PR TITLE
Bump the minimum pytest version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
 
 tests_require =
     pytest-xvfb
-    pytest>=5.0,!=5.23
+    pytest>=8.0
 
 # Be explicit as something doesn't seem quite right when using find.
 #

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,3 @@
-pytest>=5.0,!=5.2.3
+pytest>=8.0
 pytest-xvfb
 pytest-doctestplus


### PR DESCRIPTION
Pytest occasionally changes behavior and it does not seem worth our time to maintain backwards compatibility with old versions of pytest - see https://github.com/sherpa/sherpa/issues/1960

closes #1960