### PR TITLE
Remove excess brackets in model names

### DIFF
--- a/docs/model_classes/index.rst
+++ b/docs/model_classes/index.rst
@@ -48,6 +48,7 @@ contains the classes that implement various models.
 
    model
    parameters
+   op
    regrid
    instrument
    template

--- a/docs/model_classes/op.rst
+++ b/docs/model_classes/op.rst
@@ -1,0 +1,26 @@
+***************************
+The sherpa.models.op module
+***************************
+
+.. currentmodule:: sherpa.models.op
+
+.. automodule:: sherpa.models.op
+
+   .. rubric:: Symbols
+
+   .. autosummary::
+      :toctree: api
+
+      NO_PRECEDENCE
+      lprec
+      rprec
+
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree: api
+
+      get_precedences_op
+      get_precedence_expr
+      get_precedence_lhs
+      get_precedence_rhs

--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2020, 2021, 2022, 2023
+#  Copyright (C) 2017, 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -62,8 +62,8 @@ def validate_zero_replacement(ws, rtype, label, ethresh):
     w = ws[0]
     assert w.category == UserWarning
 
-    emsg = "The minimum ENERG_LO in the {} '{}' ".format(rtype, label) + \
-           "was 0 and has been replaced by {}".format(ethresh)
+    emsg = f"The minimum ENERG_LO in the {rtype} '{label}' " + \
+           f"was 0 and has been replaced by {ethresh}"
     assert str(w.message) == emsg
 
 
@@ -1213,10 +1213,10 @@ def test_rsp_matrix_call(analysis, arfexp, phaexp):
 
     if phaexp:
         exposure = pha_exposure
-        mdl_label = '({} * flat)'.format(exposure)
+        mdl_label = f'{exposure} * flat'
     elif arfexp:
         exposure = arf_exposure
-        mdl_label = '({} * flat)'.format(exposure)
+        mdl_label = f'{exposure} * flat'
     else:
         exposure = 1.0
         mdl_label = 'flat'
@@ -1251,7 +1251,7 @@ def test_rsp_matrix_call(analysis, arfexp, phaexp):
 
     assert isinstance(wrapped, ArithmeticModel)
 
-    expname = 'apply_rmf(apply_arf({}))'.format(mdl_label)
+    expname = f'apply_rmf(apply_arf({mdl_label}))'
     assert wrapped.name == expname
 
     modvals = exposure * constant * specresp
@@ -1290,10 +1290,10 @@ def test_rsp_normf_call(arfexp, phaexp):
 
     if phaexp:
         exposure = pha_exposure
-        mdl_label = '({} * flat)'.format(exposure)
+        mdl_label = f'{exposure} * flat'
     elif arfexp:
         exposure = arf_exposure
-        mdl_label = '({} * flat)'.format(exposure)
+        mdl_label = f'{exposure} * flat'
     else:
         exposure = 1.0
         mdl_label = 'flat'
@@ -1328,7 +1328,7 @@ def test_rsp_normf_call(arfexp, phaexp):
 
     assert isinstance(wrapped, ArithmeticModel)
 
-    expname = 'apply_arf({})'.format(mdl_label)
+    expname = f'apply_arf({mdl_label})'
     assert wrapped.name == expname
 
     expected = exposure * constant * specresp
@@ -1355,7 +1355,7 @@ def test_rsp_no_arf_matrix_call(analysis, phaexp):
 
     if phaexp:
         exposure = pha_exposure
-        mdl_label = '({} * flat)'.format(exposure)
+        mdl_label = f'{exposure} * flat'
     else:
         exposure = 1.0
         mdl_label = 'flat'
@@ -1384,7 +1384,7 @@ def test_rsp_no_arf_matrix_call(analysis, phaexp):
 
     assert isinstance(wrapped, ArithmeticModel)
 
-    expname = 'apply_rmf({})'.format(mdl_label)
+    expname = f'apply_rmf({mdl_label})'
     assert wrapped.name == expname
 
     modvals = exposure * constant * np.ones(rdata.energ_lo.size)

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -473,7 +473,7 @@ def test_sourceplot_component_stringification(make_basic_datapha):
     sp1.prepare(data, src)
     sp2.prepare(data, src)
 
-    mstr = "Source model component: (((100.0 * bgnd) * (1.0 - abs1)) * 10000.0)"
+    mstr = "Source model component: 100.0 * bgnd * (1.0 - abs1) * 10000.0"
     assert sp2.title == mstr
 
     sp1.title = ""

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2020, 2021, 2022, 2023
+#  Copyright (C) 2016, 2018, 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1185,7 +1185,7 @@ def test_show_bkg_source_output():
 
     toks = out.getvalue().split("\n")
     assert toks[0] == "Background Model: 1:1"
-    assert toks[1] == "apply_rmf((200.0 * lorentz1d.other))"
+    assert toks[1] == "apply_rmf(200.0 * lorentz1d.other)"
     assert toks[2] == "   Param        Type          Value          Min          Max      Units"
     assert toks[3] == "   -----        ----          -----          ---          ---      -----"
     assert toks[4] == "   other.fwhm   thawed           10            0  3.40282e+38           "
@@ -1202,7 +1202,7 @@ def test_show_bkg_source_output():
 
     toks = out.getvalue().split("\n")
     assert toks[0] == "Background Model: 1:1"
-    assert toks[1] == "apply_rmf((200.0 * lorentz1d.other))"
+    assert toks[1] == "apply_rmf(200.0 * lorentz1d.other)"
     assert toks[2] == "   Param        Type          Value          Min          Max      Units"
     assert toks[3] == "   -----        ----          -----          ---          ---      -----"
     assert toks[4] == "   other.fwhm   thawed           10            0  3.40282e+38           "
@@ -3403,8 +3403,8 @@ def test_check_get_source_and_model_with_background():
     # the models are not normalized by area. Hence the inclusion of
     # the backscal ratio (i.e. 2 / 8) in the model expression.
     #
-    assert s.get_model().name == "apply_rmf((100.0 * (gauss1d.g1 + (0.25 * polynom1d.g2))))"
-    assert s.get_bkg_model().name == "apply_rmf((200.0 * polynom1d.g2))"
+    assert s.get_model().name == "apply_rmf(100.0 * (gauss1d.g1 + 0.25 * polynom1d.g2))"
+    assert s.get_bkg_model().name == "apply_rmf(200.0 * polynom1d.g2)"
 
 
 def test_calc_model_sum_of_bkg():

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -1389,7 +1389,7 @@ def test_pileup_model(make_data_path, clean_astro_ui):
     # Check pileup is added to get_model
     #
     mlines = str(ui.get_model('pileup')).split('\n')
-    assert mlines[0] == 'apply_rmf(jdpileup.jdp((xswabs.amdl * powlaw1d.pl)))'
+    assert mlines[0] == 'apply_rmf(jdpileup.jdp(xswabs.amdl * powlaw1d.pl))'
     assert mlines[3].strip() == 'jdp.alpha    thawed         0.95            0            1'
     assert mlines[5].strip() == 'jdp.f        thawed         0.91          0.9            1'
     assert mlines[11].strip() == 'pl.gamma     thawed         1.97          -10           10'
@@ -1423,11 +1423,11 @@ def test_pileup_model(make_data_path, clean_astro_ui):
 
     toks = mlines[0].split()
     assert len(toks) == 5
-    assert toks[0].startswith('apply_rmf(apply_arf((38564.608')
+    assert toks[0].startswith('apply_rmf(apply_arf(38564.608')
     assert toks[1] == '*'
-    assert toks[2] == '(xswabs.amdl'
+    assert toks[2] == 'xswabs.amdl'
     assert toks[3] == '*'
-    assert toks[4] == 'powlaw1d.pl))))'
+    assert toks[4] == 'powlaw1d.pl))'
 
     assert mlines[4].strip() == 'pl.gamma     thawed         1.97          -10           10'
 

--- a/sherpa/astro/ui/tests/test_astro_ui_background.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_background.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2022, 2023
+#  Copyright (C) 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -173,11 +173,11 @@ def test_setup_pha1_file_models(id, make_data_path, clean_astro_ui, hide_logging
     assert ui.list_model_components() == ['bpl', 'pl']
 
     smdl = ui.get_model(id)
-    assert smdl.name == 'apply_rmf(apply_arf((1234.5 * (powlaw1d.pl + (0.5 * powlaw1d.bpl)))))'
+    assert smdl.name == 'apply_rmf(apply_arf(1234.5 * (powlaw1d.pl + 0.5 * powlaw1d.bpl)))'
     assert ui.list_model_components() == ['bpl', 'pl']
 
     bmdl = ui.get_bkg_model(id)
-    assert bmdl.name == 'apply_rmf(apply_arf((5432.1 * powlaw1d.bpl)))'
+    assert bmdl.name == 'apply_rmf(apply_arf(5432.1 * powlaw1d.bpl))'
     assert ui.list_model_components() == ['bpl', 'pl']
 
 
@@ -251,41 +251,31 @@ def test_setup_pha1_file_models_two(id, make_data_path, clean_astro_ui, hide_log
         ui.get_model(id)
 
     bmdl = ui.get_bkg_model(id)
-    assert bmdl.name == 'apply_rmf(apply_arf((1000.0 * powlaw1d.bpl)))'
+    assert bmdl.name == 'apply_rmf(apply_arf(1000.0 * powlaw1d.bpl))'
 
     ui.set_bkg_source(id, ui.polynom1d.bpl2, bkg_id=2)
 
     bmdl = ui.get_bkg_model(id, bkg_id=1)
-    assert bmdl.name == 'apply_rmf(apply_arf((1000.0 * powlaw1d.bpl)))'
+    assert bmdl.name == 'apply_rmf(apply_arf(1000.0 * powlaw1d.bpl))'
 
     bmdl = ui.get_bkg_model(id, bkg_id=2)
-    assert bmdl.name == 'apply_rmf(apply_arf((2000.0 * polynom1d.bpl2)))'
+    assert bmdl.name == 'apply_rmf(apply_arf(2000.0 * polynom1d.bpl2))'
 
     smdl = ui.get_model(id)
 
-    # The string representation can depend on Python version, so break
-    # it up so we can check terms separately.
-    #
     toks = smdl.name.split('(')
     assert toks[0] == 'apply_rmf'
     assert toks[1] == 'apply_arf'
-    assert toks[2] == ''
-    assert toks[3] == '100.0 * '
-    assert toks[4] == ''
-    assert toks[5] == 'powlaw1d.pl + '
+    assert toks[2] == '100.0 * '
 
-    # The scale factors here are half of the values above, as there are
-    # now two background components.
+    # The scale factors here are half of the values above, as there
+    # are now two background components. The ordering used to depend
+    # on the Python version but this should no-longer be an issue.
     #
-    x1 = '0.125 * powlaw1d.bpl)) + '
-    x2 = '0.0625 * polynom1d.bpl2)))))'
+    x1 = 'powlaw1d.pl + 0.125 * powlaw1d.bpl + 0.0625 * polynom1d.bpl2)))'
+    assert toks[3] == x1
 
-    y1 = '0.0625 * polynom1d.bpl2)) + '
-    y2 = '0.125 * powlaw1d.bpl)))))'
-
-    assert toks[6] in [x1, y1]
-    assert toks[7] in [x2, y2]
-    assert len(toks) == 8
+    assert len(toks) == 4
 
     assert ui.list_model_components() == ['bpl', 'bpl2', 'pl']
 
@@ -324,13 +314,13 @@ def test_setup_pha1_file_models_two_single(id, make_data_path, clean_astro_ui, h
     ui.set_bkg_source(id, ui.powlaw1d.bpl, bkg_id=2)
 
     bmdl = ui.get_bkg_model(id, bkg_id=1)
-    assert bmdl.name == 'apply_rmf(apply_arf((1000.0 * powlaw1d.bpl)))'
+    assert bmdl.name == 'apply_rmf(apply_arf(1000.0 * powlaw1d.bpl))'
 
     bmdl = ui.get_bkg_model(id, bkg_id=2)
-    assert bmdl.name == 'apply_rmf(apply_arf((2000.0 * powlaw1d.bpl)))'
+    assert bmdl.name == 'apply_rmf(apply_arf(2000.0 * powlaw1d.bpl))'
 
     smdl = ui.get_model(id)
-    assert smdl.name == 'apply_rmf(apply_arf((100.0 * (powlaw1d.pl + (0.1875 * powlaw1d.bpl)))))'
+    assert smdl.name == 'apply_rmf(apply_arf(100.0 * (powlaw1d.pl + 0.1875 * powlaw1d.bpl)))'
 
     assert ui.list_model_components() == ['bpl', 'pl']
 
@@ -746,14 +736,14 @@ def test_pha1_eval_vector_show(clean_astro_ui):
     assert ui.list_model_components() == ['bmdl1', 'smdl']
 
     bmdl = ui.get_bkg_model()
-    assert bmdl.name == 'apply_arf((1000.0 * box1d.bmdl1))'
+    assert bmdl.name == 'apply_arf(1000.0 * box1d.bmdl1)'
 
     assert ui.list_model_components() == ['bmdl1', 'smdl']
 
     smdl = ui.get_model()
 
-    src = '(apply_arf((100.0 * box1d.smdl))'
-    src += ' + (scale1 * apply_arf((100.0 * box1d.bmdl1))))'
+    src = 'apply_arf(100.0 * box1d.smdl)' + \
+        ' + scale1 * apply_arf(100.0 * box1d.bmdl1)'
 
     assert smdl.name == src
 
@@ -876,17 +866,17 @@ def test_pha1_eval_vector_show_two(clean_astro_ui):
     assert ui.list_model_components() == ['bmdl1', 'smdl']
 
     bmdl = ui.get_bkg_model()
-    assert bmdl.name == 'apply_arf((1000.0 * box1d.bmdl1))'
+    assert bmdl.name == 'apply_arf(1000.0 * box1d.bmdl1)'
 
     bmdl = ui.get_bkg_model(bkg_id=2)
-    assert bmdl.name == 'apply_arf((750.0 * box1d.bmdl1))'
+    assert bmdl.name == 'apply_arf(750.0 * box1d.bmdl1)'
 
     assert ui.list_model_components() == ['bmdl1', 'smdl']
 
     smdl = ui.get_model()
 
-    src = '(apply_arf((100.0 * box1d.smdl))'
-    src += ' + (scale1 * apply_arf((100.0 * box1d.bmdl1))))'
+    src = 'apply_arf(100.0 * box1d.smdl)' + \
+        ' + scale1 * apply_arf(100.0 * box1d.bmdl1)'
 
     assert smdl.name == src
 
@@ -934,10 +924,10 @@ def test_pha1_eval_vector_show_two_separate(clean_astro_ui):
     assert ui.list_model_components() == ['bmdl1', 'bmdl2', 'smdl']
 
     bmdl = ui.get_bkg_model('foo')
-    assert bmdl.name == 'apply_arf((1000.0 * box1d.bmdl1))'
+    assert bmdl.name == 'apply_arf(1000.0 * box1d.bmdl1)'
 
     bmdl = ui.get_bkg_model('foo', bkg_id=2)
-    assert bmdl.name == 'apply_arf((750.0 * const1d.bmdl2))'
+    assert bmdl.name == 'apply_arf(750.0 * const1d.bmdl2)'
 
     assert ui.list_model_components() == ['bmdl1', 'bmdl2', 'smdl']
 
@@ -946,15 +936,15 @@ def test_pha1_eval_vector_show_two_separate(clean_astro_ui):
     # The ordering of this test can depend on the Python version
     # (before Python 3.7).
     #
-    src = '((apply_arf((100.0 * box1d.smdl))'
+    src = 'apply_arf(100.0 * box1d.smdl)'
 
     src1 = src
-    src1 += ' + (scalefoo_1 * apply_arf((100.0 * box1d.bmdl1))))'
-    src1 += ' + (scalefoo_2 * apply_arf((100.0 * const1d.bmdl2))))'
+    src1 += ' + scalefoo_1 * apply_arf(100.0 * box1d.bmdl1)'
+    src1 += ' + scalefoo_2 * apply_arf(100.0 * const1d.bmdl2)'
 
     src2 = src
-    src2 += ' + (scalefoo_1 * apply_arf((100.0 * const1d.bmdl2))))'
-    src2 += ' + (scalefoo_2 * apply_arf((100.0 * box1d.bmdl1))))'
+    src2 += ' + scalefoo_1 * apply_arf(100.0 * const1d.bmdl2)'
+    src2 += ' + scalefoo_2 * apply_arf(100.0 * box1d.bmdl1)'
 
     assert smdl.name in [src1, src2]
 

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1318,8 +1318,8 @@ def check_pha1_model_component_plot(mplot, mdl):
     # so do not use an equality check but something a bit-more forgiving
     # (could use a regexp but not worth it).
     #
-    assert mplot.title.startswith('Model component: apply_rmf(apply_arf((38564.60')
-    assert mplot.title.endswith(' * powlaw1d.pl)))')
+    assert mplot.title.startswith('Model component: apply_rmf(apply_arf(38564.60')
+    assert mplot.title.endswith(' * powlaw1d.pl))')
 
     # This may change if we change the filtering/grouping code
     # Note that the model is evaluated on the un-grouped data.

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1808,7 +1808,7 @@ m1.c0.units   = ""
 m1.c0.frozen  = False
 
 
-link(m2.c0, (m1.c0 + sep.c0))
+link(m2.c0, m1.c0 + sep.c0)
 
 """
 
@@ -3305,7 +3305,7 @@ def test_link_par():
     assert m2.c0.min == 10
     assert m2.c0.max == 500
     assert m2.c0.link is not None
-    assert m2.c0.link.name == "(m1.c0 + sep.c0)"
+    assert m2.c0.link.name == "m1.c0 + sep.c0"
 
     compare(_canonical_link_par)
 
@@ -3315,7 +3315,7 @@ def test_link_par():
     assert m2.c0.min == 10
     assert m2.c0.max == 500
     assert m2.c0.link is not None
-    assert m2.c0.link.name == "(m1.c0 + sep.c0)"
+    assert m2.c0.link.name == "m1.c0 + sep.c0"
 
 
 @pytest.mark.xfail

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -295,7 +295,7 @@ gal.nH.frozen  = False
 
 ######### Set Source, Pileup and Background Models
 
-set_source(1, (xsphabs.gal * (powlaw1d.pl + xsapec.src)))
+set_source(1, xsphabs.gal * (powlaw1d.pl + xsapec.src))
 
 """
 
@@ -415,7 +415,7 @@ ggal.nH.frozen  = True
 
 ######### Set Source, Pileup and Background Models
 
-set_source("grp", (xsphabs.ggal * powlaw1d.gpl))
+set_source("grp", xsphabs.ggal * powlaw1d.gpl)
 
 """
 
@@ -642,9 +642,9 @@ bpoly.offset.frozen  = True
 
 ######### Set Source, Pileup and Background Models
 
-set_source("bgrp", (xsphabs.ggal * powlaw1d.gpl))
+set_source("bgrp", xsphabs.ggal * powlaw1d.gpl)
 
-set_bkg_source("bgrp", (steplo1d.bstep + polynom1d.bpoly), bkg_id=1)
+set_bkg_source("bgrp", steplo1d.bstep + polynom1d.bpoly, bkg_id=1)
 
 
 ######### XSPEC Module Settings
@@ -981,7 +981,7 @@ mymodel.m.frozen  = True
 
 ######### Set Source, Pileup and Background Models
 
-set_source(3, (sin.sin_model + usermodel.mymodel))
+set_source(3, sin.sin_model + usermodel.mymodel)
 
 """
 
@@ -1131,7 +1131,7 @@ bmdl.c0.frozen  = False
 
 ######### Set Source, Pileup and Background Models
 
-set_source(1, (gauss2d.gmdl + scale2d.bmdl))
+set_source(1, gauss2d.gmdl + scale2d.bmdl)
 
 """
 
@@ -2322,7 +2322,7 @@ bpl.ampl.frozen  = False
 
 ######### Set Source, Pileup and Background Models
 
-set_source("csc", (xsphabs.gal * powlaw1d.spl))
+set_source("csc", xsphabs.gal * powlaw1d.spl)
 
 set_bkg_source("csc", powlaw1d.bpl, bkg_id=1)
 
@@ -2663,7 +2663,7 @@ def test_restore_pha_basic(make_data_path):
     assert ui.get_data().subtracted, 'Data should be subtracted'
 
     src_expr = ui.get_source()
-    assert src_expr.name == '(xsphabs.gal * (powlaw1d.pl + xsapec.src))'
+    assert src_expr.name == 'xsphabs.gal * (powlaw1d.pl + xsapec.src)'
     assert ui.xsphabs.gal.name == 'xsphabs.gal'
     assert ui.powlaw1d.pl.name == 'powlaw1d.pl'
     assert ui.xsapec.src.name == 'xsapec.src'
@@ -2706,7 +2706,7 @@ def test_restore_pha_grouped(make_data_path):
     assert_array_equal(qual, q, err_msg='grouping column')
 
     src_expr = ui.get_source('grp')
-    assert src_expr.name == '(xsphabs.ggal * powlaw1d.gpl)'
+    assert src_expr.name == 'xsphabs.ggal * powlaw1d.gpl'
     assert ui.xsphabs.ggal.nh.frozen, "is ggal.nh frozen?"
     assert ui.xsphabs.ggal.nh.val == 2.0
     assert ui.powlaw1d.gpl.gamma.max == 5.0
@@ -2771,10 +2771,10 @@ def test_restore_pha_back(make_data_path):
     assert ui.get_bkg("bgrp").get_filter(format="%.2f") == "1.61:8.76"
 
     src_expr = ui.get_source('bgrp')
-    assert src_expr.name == '(xsphabs.ggal * powlaw1d.gpl)'
+    assert src_expr.name == 'xsphabs.ggal * powlaw1d.gpl'
 
     bg_expr = ui.get_bkg_source('bgrp')
-    assert bg_expr.name == '(steplo1d.bstep + polynom1d.bpoly)'
+    assert bg_expr.name == 'steplo1d.bstep + polynom1d.bpoly'
 
     assert ui.xsphabs.ggal.nh.frozen, "is ggal.nh frozen?"
     assert ui.polynom1d.bpoly.c0.frozen, "is bpoly.c0 frozen?"
@@ -2834,7 +2834,7 @@ def test_restore_usermodel():
     #
     # src_expr = ui.get_source(3)
     src_expr = ui.get_model(3)
-    assert src_expr.name == '(sin.sin_model + usermodel.mymodel)'
+    assert src_expr.name == 'sin.sin_model + usermodel.mymodel'
     mymodel = ui.get_model_component("mymodel")
     assert mymodel.m.frozen, "is mymodel.m frozen?"
     assert mymodel.c.val == 2.0
@@ -3353,7 +3353,7 @@ def test_pha_full_model(make_data_path):
                        match=". You should use get_model instead.$"):
         ui.get_source()
 
-    assert ui.get_model().name == "(apply_rmf(apply_arf((38564.6089269 * powlaw1d.pl))) + polynom1d.con)"
+    assert ui.get_model().name == "apply_rmf(apply_arf(38564.6089269 * powlaw1d.pl)) + polynom1d.con"
 
     compare(add_datadir_path(_canonical_pha_full_model))
 
@@ -3369,7 +3369,7 @@ def test_pha_full_model(make_data_path):
                        match=". You should use get_model instead.$"):
         ui.get_source()
 
-    assert ui.get_model().name == "(apply_rmf(apply_arf((38564.6089269 * powlaw1d.pl))) + polynom1d.con)"
+    assert ui.get_model().name == "apply_rmf(apply_arf(38564.6089269 * powlaw1d.pl)) + polynom1d.con"
 
 
 @requires_data

--- a/sherpa/astro/xspec/tests/test_xspec_con.py
+++ b/sherpa/astro/xspec/tests/test_xspec_con.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2023
+#  Copyright (C) 2020, 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -587,7 +587,7 @@ def test_xspec_con_ui_cflux(make_data_path, clean_astro_ui, restore_xspec_settin
     ui.set_source('random', 'xsphabs.gal * xscflux.sflux(powlaw1d.pl)')
     mdl = ui.get_source('random')
 
-    assert mdl.name == '(xsphabs.gal * xscflux.sflux(powlaw1d.pl))'
+    assert mdl.name == 'xsphabs.gal * xscflux.sflux(powlaw1d.pl)'
     assert len(mdl.pars) == 7
     assert mdl.pars[0].fullname == 'gal.nH'
     assert mdl.pars[1].fullname == 'sflux.Emin'
@@ -663,7 +663,7 @@ def test_xspec_con_ui_shift(make_data_path, clean_astro_ui, restore_xspec_settin
     ui.set_source(ui.xsphabs.gal * ui.xszashift.zsh(msource))
     mdl = ui.get_source()
 
-    assert mdl.name == '(xsphabs.gal * xszashift.zsh((box1d.box + const1d.bgnd)))'
+    assert mdl.name == 'xsphabs.gal * xszashift.zsh(box1d.box + const1d.bgnd)'
     assert len(mdl.pars) == 6
     assert mdl.pars[0].fullname == 'gal.nH'
     assert mdl.pars[1].fullname == 'zsh.Redshift'
@@ -760,7 +760,7 @@ def test_xspec_con_ui_shift_regrid(make_data_path, clean_astro_ui, restore_xspec
 
     # What should the string representation be?
     #
-    assert mdl.name == '(xsphabs.gal * regrid1d(xszashift.zsh((box1d.box + const1d.bgnd))))'
+    assert mdl.name == 'xsphabs.gal * regrid1d(xszashift.zsh(box1d.box + const1d.bgnd))'
 
     assert len(mdl.pars) == 6
     assert mdl.pars[0].fullname == 'gal.nH'

--- a/sherpa/astro/xspec/tests/test_xspec_regrid.py
+++ b/sherpa/astro/xspec/tests/test_xspec_regrid.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2023
+#  Copyright (C) 2020, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -75,8 +75,8 @@ def test_regrid_name_combined():
     mdl = c1 * c2
     regrid = mdl.regrid(ebase[:-1], ebase[1:])
 
-    assert mdl.name == '(wabs * powerlaw)'
-    assert regrid.name == 'regrid1d((wabs * powerlaw))'
+    assert mdl.name == 'wabs * powerlaw'
+    assert regrid.name == 'regrid1d(wabs * powerlaw)'
 
 
 @requires_xspec

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -32,7 +32,7 @@ from sherpa.utils import bool_cast, get_position, guess_amplitude, \
 from .parameter import Parameter, tinyval
 from .model import ArithmeticModel, modelCacher1d, CompositeModel, \
     ArithmeticFunctionModel, RegriddableModel2D, RegriddableModel1D
-from . import _modelfcts
+from . import _modelfcts  # type: ignore
 
 warning = logging.getLogger(__name__).warning
 

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -322,7 +322,7 @@ import logging
 from typing import Callable, Optional
 import warnings
 
-import numpy
+import numpy as np
 
 from sherpa.models.regrid import EvaluationSpace1D, ModelDomainRegridder1D, EvaluationSpace2D, ModelDomainRegridder2D
 from sherpa.utils import NoNewAttributesAfterInit, formatting
@@ -443,18 +443,18 @@ def modelCacher1d(func):
             #
             integrate = kwargs.get('integrate', False)
 
-        data = [numpy.array(pars).tobytes(),
+        data = [np.array(pars).tobytes(),
                 boolean_to_byte(integrate),
-                numpy.asarray(xlo).tobytes()]
+                np.asarray(xlo).tobytes()]
         if args:
-            data.append(numpy.asarray(args[0]).tobytes())
+            data.append(np.asarray(args[0]).tobytes())
 
         # Add any keyword arguments to the list. This will
         # include the xhi named argument if given. Can the
         # value field fail here?
         #
         for k, v in kwargs.items():
-            data.extend([k.encode(), numpy.asarray(v).tobytes()])
+            data.extend([k.encode(), np.asarray(v).tobytes()])
 
         # Is the value cached?
         #
@@ -1075,7 +1075,7 @@ class ArithmeticConstantModel(Model):
     def __init__(self, val, name=None):
         val = SherpaFloat(val)
         if name is None:
-            if numpy.isscalar(val):
+            if np.isscalar(val):
                 name = str(val)
             else:
                 nstr = ','.join([str(s) for s in val.shape])
@@ -1174,19 +1174,19 @@ class ArithmeticModel(Model):
              f"check: {c['check']:5d}")
 
     # Unary operations
-    __neg__ = _make_unop(numpy.negative, '-')
-    __pos__ = _make_unop(numpy.positive, '+')
-    __abs__ = _make_unop(numpy.absolute, 'abs')
+    __neg__ = _make_unop(np.negative, '-')
+    __pos__ = _make_unop(np.positive, '+')
+    __abs__ = _make_unop(np.absolute, 'abs')
 
     # Binary operations
-    __add__, __radd__ = _make_binop(numpy.add, '+')
-    __sub__, __rsub__ = _make_binop(numpy.subtract, '-')
-    __mul__, __rmul__ = _make_binop(numpy.multiply, '*')
-    __div__, __rdiv__ = _make_binop(numpy.divide, '/')
-    __floordiv__, __rfloordiv__ = _make_binop(numpy.floor_divide, '//')
-    __truediv__, __rtruediv__ = _make_binop(numpy.true_divide, '/')
-    __mod__, __rmod__ = _make_binop(numpy.remainder, '%')
-    __pow__, __rpow__ = _make_binop(numpy.power, '**')
+    __add__, __radd__ = _make_binop(np.add, '+')
+    __sub__, __rsub__ = _make_binop(np.subtract, '-')
+    __mul__, __rmul__ = _make_binop(np.multiply, '*')
+    __div__, __rdiv__ = _make_binop(np.divide, '/')
+    __floordiv__, __rfloordiv__ = _make_binop(np.floor_divide, '//')
+    __truediv__, __rtruediv__ = _make_binop(np.true_divide, '/')
+    __mod__, __rmod__ = _make_binop(np.remainder, '%')
+    __pow__, __rpow__ = _make_binop(np.power, '**')
 
     def __setstate__(self, state):
         self.__dict__.update(state)
@@ -1214,7 +1214,7 @@ class ArithmeticModel(Model):
             return
 
         self._queue = [''] * int(self.cache)
-        frozen = numpy.array([par.frozen for par in self.pars], dtype=bool)
+        frozen = np.array([par.frozen for par in self.pars], dtype=bool)
         if len(frozen) > 0 and frozen.all():
             self._use_caching = cache
 

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -319,6 +319,7 @@ non-integrated and integrated datasets of any dimensionality (see
 
 import functools
 import logging
+from typing import Optional
 import warnings
 
 import numpy
@@ -524,7 +525,7 @@ class Model(NoNewAttributesAfterInit):
 
     """
 
-    ndim = None
+    ndim: Optional[int] = None
     "The dimensionality of the model, if defined, or None."
 
     def __init__(self, name, pars=()):

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -325,12 +325,12 @@ import warnings
 import numpy
 
 from sherpa.models.regrid import EvaluationSpace1D, ModelDomainRegridder1D, EvaluationSpace2D, ModelDomainRegridder2D
-from sherpa.utils import NoNewAttributesAfterInit, formatting, \
-    get_precedences_op, get_precedence_expr, \
-    get_precedence_lhs, get_precedence_rhs
+from sherpa.utils import NoNewAttributesAfterInit, formatting
 from sherpa.utils.err import ModelErr, ParameterErr
 from sherpa.utils.numeric_types import SherpaFloat
 
+from .op import get_precedences_op, get_precedence_expr, \
+    get_precedence_lhs, get_precedence_rhs
 from .parameter import Parameter
 
 # What routine do we use for the hash in modelCacher1d?  As we do not

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1173,6 +1173,7 @@ class ArithmeticModel(Model):
 
     # Unary operations
     __neg__ = _make_unop(numpy.negative, '-')
+    __pos__ = _make_unop(numpy.positive, '+')
     __abs__ = _make_unop(numpy.absolute, 'abs')
 
     # Binary operations

--- a/sherpa/models/op.py
+++ b/sherpa/models/op.py
@@ -1,0 +1,248 @@
+#
+#  Copyright (C) 2024
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Operator-related routines for the model and parameter classes.
+"""
+
+from typing import Any, Callable
+
+import numpy as np
+
+
+__all__ = ('get_precedences_op', 'get_precedence_expr',
+           'get_precedence_lhs', 'get_precedence_rhs',
+           )
+
+
+# We make remainder and floor_divide have the same precedence
+# as power (aka **) just to make things clear.
+#
+lprec : dict[Callable, int]
+lprec = {np.power: 4,
+         np.remainder: 4,
+         np.floor_divide: 4,
+         np.multiply: 3,
+         np.divide: 3,
+         np.true_divide: 3,
+         np.add: 2,
+         np.subtract: 2
+         }
+"""Represent the precedence for the left-hand side of a binary operator.
+
+All values must be below the `sherpa.models.op.NO_PRECEDENCE` value.
+"""
+
+
+rprec : dict[Callable, bool]
+rprec = {np.power: True,
+         np.remainder: True,
+         np.floor_divide: True
+         }
+"""Should the left-hand side of a binary operator be wrapped by brackets?"""
+
+
+NO_PRECEDENCE : int
+NO_PRECEDENCE = 9
+"""Represent "no precedence"."""
+
+
+# Expression terms (used to remove excess brackets from model and
+# parameter expressions).
+#
+def get_precedences_op(op: Callable) -> tuple[int, bool]:
+    """Return precedences for the operation.
+
+    Unrecognized parameters are mapped to
+    (`sherpa.models.op.NO_PRECEDENCE`, False).
+
+    Parameters
+    ----------
+    op : callable
+       The operator (e.g. np.multiply or np.power).
+
+    Returns
+    -------
+    lprec, rprec : (int, bool)
+       The left and right "precedences" (the right case only cares
+       about being set or not hence we use a boolean).
+
+    See Also
+    --------
+    get_precedence_expr, get_precedence_lhs, get_precedence_rhs
+
+    Notes
+    -----
+    This uses the module-level symbols: `sherpa.models.op.lprec`
+    and `sherpa.models.op.rprec`.
+
+    """
+
+    return lprec.get(op, NO_PRECEDENCE), rprec.get(op, False)
+
+
+# Typing is hard to get right here given that we want to allow this
+# for both models and parameters.
+#
+def get_precedence_expr(expr: Any) -> int:
+    """Return precedence for the expression.
+
+    This is the precedence of the operator in the expression,
+    if one exists.
+
+    Parameters
+    ----------
+    expr : Model or Parameter
+       The expression. It may have a .opprec field.
+
+    Returns
+    -------
+    prec : int
+       The "precedence" value `sherpa.models.op.NO_PRECEDENCE` is
+       returned if expr has an unknown operator or it does not
+       contain an operator.
+
+    See Also
+    --------
+    get_precedences_op, get_precedence_lhs, get_precedence_rhs
+
+    """
+
+    try:
+        return expr.opprec
+    except AttributeError:
+        return NO_PRECEDENCE
+
+
+def get_precedence_lhs(lstr: str, lp: int, p: int, a: bool) -> str:
+    """Return the string to use for the left side of a binary operator.
+
+    This is only needed when the operator (represented by the p value)
+    is written in infix form - such as 'a + b'- rather than prefix
+    form like 'np.add(a, b)'.
+
+    Parameters
+    ----------
+    lstr : str
+       The term to the left of the operator.
+    lp : int
+       Precedences of any operator in lstr.
+    p : int
+       Precedences of the current operator.
+    a : bool
+       Do we care about power-like terms.
+
+    Returns
+    -------
+    term : str
+       Either lstr or (lstr).
+
+    See Also
+    --------
+    get_precedences_op, get_precedence_expr, get_precedence_rhs
+
+    Examples
+    --------
+
+    >>> get_precedence_lhs("a", NO_PRECEDENCE, lprec[np.divide], False)
+    'a'
+
+    >>> get_precedence_lhs("a + b", lprec[np.add], lprec[np.divide], False)
+    '(a + b)'
+
+    >>> get_precedence_lhs("a * b", lprec[np.multiply], lprec[np.add], False)
+    'a * b'
+
+    """
+
+    if lp < p:
+        return f"({lstr})"
+
+    if not a:
+        return lstr
+
+    # We could combine all these into one, but for now keep
+    # them separate.
+    #
+    if lp == p:
+        # For now ensure the left term is bracketed just to be
+        # clear.
+        #
+        return f"({lstr})"
+
+    if lstr[0] == "-":
+        # If the term is negative then ensure it is included
+        # in a bracket before passed through to the power
+        # term.  Python has "-a ** 2" actually mapping to "-(a
+        # ** 2)" so we need to say "(-a) ** 2" if we really
+        # want the unary operator before the power term.
+        #
+        return f"({lstr})"
+
+    return lstr
+
+
+def get_precedence_rhs(rstr: str, opstr: str, rp: int, p: int) -> str:
+    """Return the string to use for the right side of a binary operator.
+
+    This is only needed when the operator (represented by the p value)
+    is written in infix form - such as 'a + b'- rather than prefix
+    form like 'np.add(a, b)'.
+
+    Parameters
+    ----------
+    rstr : str
+       The term to the right of the operator.
+    opstr : str
+       The string representing the operator.
+    rp : int
+       Precedences of any operator in rstr.
+    p : int
+       Precedences of the current operator.
+
+    Returns
+    -------
+    term : str
+       Either rstr or (rstr).
+
+    See Also
+    --------
+    get_precedences_op, get_precedence_expr, get_precedence_lhs
+
+    Examples
+    --------
+
+    >>> get_precedence_rhs("a", "/", NO_PRECEDENCE, lprec[np.divide])
+    'a'
+
+    >>> get_precedence_rhs("a + b", "/", lprec[np.add], lprec[np.divide])
+    '(a + b)'
+
+    """
+
+    if opstr in ["+", "*"]:
+        condition = rp < p
+    else:
+        condition = rp <= p
+
+    if condition:
+        return f"({rstr})"
+
+    return rstr

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -204,11 +204,13 @@ fit.
 
 import logging
 import numpy
-from sherpa.utils import NoNewAttributesAfterInit, formatting, \
-    get_precedences_op, get_precedence_expr, \
-    get_precedence_lhs, get_precedence_rhs
+
+from sherpa.utils import NoNewAttributesAfterInit, formatting
 from sherpa.utils.err import ParameterErr
 from sherpa.utils.numeric_types import SherpaFloat
+
+from .op import get_precedences_op, get_precedence_expr, \
+    get_precedence_lhs, get_precedence_rhs
 
 warning = logging.getLogger(__name__).warning
 

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -203,7 +203,7 @@ fit.
 """
 
 import logging
-import numpy
+import numpy as np
 
 from sherpa.utils import NoNewAttributesAfterInit, formatting
 from sherpa.utils.err import ParameterErr
@@ -226,8 +226,8 @@ __all__ = ('Parameter', 'CompositeParameter', 'ConstantParameter',
 # hugeval = 1.0e+38
 #
 # Use FLT_TINY and FLT_MAX
-tinyval = float(numpy.finfo(numpy.float32).tiny)
-hugeval = float(numpy.finfo(numpy.float32).max)
+tinyval = float(np.finfo(np.float32).tiny)
+hugeval = float(np.finfo(np.float32).max)
 
 
 def _make_set_limit(name):
@@ -259,10 +259,12 @@ def _make_set_limit(name):
            self._NoNewAttributesAfterInit__initialized:
             if name == "_min" and (val > self.val):
                 self.val = val
-                warning(('parameter %s less than new minimum; %s reset to %g') % (self.fullname, self.fullname, self.val))
+                warning('parameter %s less than new minimum; %s reset to %g',
+                        self.fullname, self.fullname, self.val)
             if name == "_max" and (val < self.val):
                 self.val = val
-                warning(('parameter %s greater than new maximum; %s reset to %g') % (self.fullname, self.fullname, self.val))
+                warning('parameter %s greater than new maximum; %s reset to %g',
+                        self.fullname, self.fullname, self.val)
 
         setattr(self, name, val)
 
@@ -533,7 +535,7 @@ class Parameter(NoNewAttributesAfterInit):
                  frozen=False, alwaysfrozen=False, hidden=False, aliases=None):
         self.modelname = modelname
         self.name = name
-        self.fullname = '%s.%s' % (modelname, name)
+        self.fullname = f"{modelname}.{name}"
 
         self._hard_min = SherpaFloat(hard_min)
         self._hard_max = SherpaFloat(hard_max)
@@ -566,9 +568,9 @@ class Parameter(NoNewAttributesAfterInit):
         return iter([self])
 
     def __repr__(self):
-        r = "<%s '%s'" % (type(self).__name__, self.name)
+        r = f"<{type(self).__name__} '{self.name}'"
         if self.modelname:
-            r += " of model '%s'" % self.modelname
+            r += f" of model '{self.modelname}'"
         r += '>'
         return r
 
@@ -578,18 +580,16 @@ class Parameter(NoNewAttributesAfterInit):
         else:
             linkstr = str(None)
 
-        return (('val         = %s\n' +
-                 'min         = %s\n' +
-                 'max         = %s\n' +
-                 'units       = %s\n' +
-                 'frozen      = %s\n' +
-                 'link        = %s\n'
-                 'default_val = %s\n' +
-                 'default_min = %s\n' +
-                 'default_max = %s') %
-                (str(self.val), str(self.min), str(self.max), self.units,
-                 self.frozen, linkstr, str(self.default_val),
-                 str(self.default_min), str(self.default_max)))
+        out = [f'val         = {self.val}',
+               f'min         = {self.min}',
+               f'max         = {self.max}',
+               f'units       = {self.units}',
+               f'frozen      = {self.frozen}',
+               f'link        = {linkstr}',
+               f'default_val = {self.default_val}',
+               f'default_min = {self.default_min}',
+               f'default_max = {self.default_max}']
+        return "\n".join(out)
 
     # Support 'rich display' representations
     #
@@ -607,23 +607,23 @@ class Parameter(NoNewAttributesAfterInit):
         #
         if v == hugeval:
             return 'MAX'
-        elif v == -hugeval:
+        if v == -hugeval:
             return '-MAX'
-        elif v == tinyval:
+        if v == tinyval:
             return 'TINY'
-        elif v == -tinyval:
+        if v == -tinyval:
             return '-TINY'
 
         if self.units in ['radian', 'radians']:
-            tau = 2 * numpy.pi
+            tau = 2 * np.pi
 
             if v == tau:
                 return '2&#960;'
-            elif v == -tau:
+            if v == -tau:
                 return '-2&#960;'
-            elif v == numpy.pi:
+            if v == np.pi:
                 return '&#960;'
-            elif v == -numpy.pi:
+            if v == -np.pi:
                 return '-&#960;'
 
         return str(v)
@@ -644,23 +644,23 @@ class Parameter(NoNewAttributesAfterInit):
 
     # Unary operations
     # It is safest to always say -(..) even if arg is a single field
-    __neg__ = _make_unop(numpy.negative, '-', strformat='-({arg})')
-    __abs__ = _make_unop(numpy.absolute, 'abs')
+    __neg__ = _make_unop(np.negative, '-', strformat='-({arg})')
+    __abs__ = _make_unop(np.absolute, 'abs')
 
     # Binary operations
-    __add__, __radd__ = _make_binop(numpy.add, '+')
-    __sub__, __rsub__ = _make_binop(numpy.subtract, '-')
-    __mul__, __rmul__ = _make_binop(numpy.multiply, '*')
-    __div__, __rdiv__ = _make_binop(numpy.divide, '/')
-    __floordiv__, __rfloordiv__ = _make_binop(numpy.floor_divide, '//')
-    __truediv__, __rtruediv__ = _make_binop(numpy.true_divide, '/')
-    __mod__, __rmod__ = _make_binop(numpy.remainder, '%')
-    __pow__, __rpow__ = _make_binop(numpy.power, '**')
+    __add__, __radd__ = _make_binop(np.add, '+')
+    __sub__, __rsub__ = _make_binop(np.subtract, '-')
+    __mul__, __rmul__ = _make_binop(np.multiply, '*')
+    __div__, __rdiv__ = _make_binop(np.divide, '/')
+    __floordiv__, __rfloordiv__ = _make_binop(np.floor_divide, '//')
+    __truediv__, __rtruediv__ = _make_binop(np.true_divide, '/')
+    __mod__, __rmod__ = _make_binop(np.remainder, '%')
+    __pow__, __rpow__ = _make_binop(np.power, '**')
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         if not method == '__call__':
             return NotImplemented
-        if hasattr(numpy, ufunc.__name__):
+        if hasattr(np, ufunc.__name__):
             name = f"numpy.{ufunc.__name__}"
         else:
             # Unfortunately, there is no ufunc.__module__ we could use
@@ -934,19 +934,19 @@ def html_parameter(par):
     #
     def addtd(val):
         "Use the parameter to convert to HTML"
-        return '<td>{}</td>'.format(par._val_to_html(val))
+        return f'<td>{par._val_to_html(val)}</td>'
 
     out = '<table class="model">'
     out += '<thead><tr>'
     cols = ['Component', 'Parameter', 'Thawed', 'Value',
             'Min', 'Max', 'Units']
     for col in cols:
-        out += '<th>{}</th>'.format(col)
+        out += f'<th>{col}</th>'
 
     out += '</tr></thead><tbody><tr>'
 
-    out += '<th class="model-odd">{}</th>'.format(par.modelname)
-    out += '<td>{}</td>'.format(par.name)
+    out += f'<th class="model-odd">{par.modelname}</th>'
+    out += f'<td>{par.name}</td>'
 
     linked = par.link is not None
     if linked:
@@ -963,13 +963,13 @@ def html_parameter(par):
         # 8656 is double left arrow
         #
         val = formatting.clean_bracket(par.link.fullname)
-        out += '<td colspan="2">&#8656; {}</td>'.format(val)
+        out += f'<td colspan="2">&#8656; {val}</td>'
 
     else:
         out += addtd(par.min)
         out += addtd(par.max)
 
-    out += '<td>{}</td>'.format(par._units_to_html())
+    out += f'<td>{par._units_to_html()}</td>'
     out += '</tr>'
 
     out += '</tbody></table>'

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -904,7 +904,7 @@ class BinaryOpParameter(CompositeParameter):
         self.rhs = self.wrapobj(rhs)
         self.op = op
 
-        p, a =  get_precedences_op(op)
+        p, a = get_precedences_op(op)
         self.opprec = p
 
         # Simplify the expression if possible.

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -909,13 +909,28 @@ class BinaryOpParameter(CompositeParameter):
         p, a = get_precedences_op(op)
         self.opprec = p
 
-        # Simplify the expression if possible.
+        # Is this an infix or prefix operator? This could be specified
+        # explicitly (and, in fact, could replace the use of the
+        # strformat argument), but for now the behvaiour is inferred
+        # by assuming that a prefix operator has strformat beginning
+        # with '{opstr}(. This heuristic is not perfect, but should be
+        # sufficient for our needs.
         #
-        lp = get_precedence_expr(self.lhs)
-        rp = get_precedence_expr(self.rhs)
+        if strformat.startswith("{opstr}("):
+            # This is a prefix form so we do not need to worry about
+            # adding brackets around the lhs and rhs terms.
+            #
+            lstr = self.lhs.fullname
+            rstr = self.rhs.fullname
 
-        lstr = get_precedence_lhs(self.lhs.fullname, lp, p, a)
-        rstr = get_precedence_rhs(self.rhs.fullname, opstr, rp, p)
+        else:
+            # Simplify the expression if possible.
+            #
+            lp = get_precedence_expr(self.lhs)
+            rp = get_precedence_expr(self.rhs)
+
+            lstr = get_precedence_lhs(self.lhs.fullname, lp, p, a)
+            rstr = get_precedence_rhs(self.rhs.fullname, opstr, rp, p)
 
         name = strformat.format(lhs=lstr, rhs=rstr, opstr=opstr)
         CompositeParameter.__init__(self, name, (self.lhs, self.rhs))

--- a/sherpa/models/regrid.py
+++ b/sherpa/models/regrid.py
@@ -34,7 +34,7 @@ import logging
 import warnings
 
 import numpy as np
-from sherpa.utils._utils import rebin
+from sherpa.utils._utils import rebin  # type: ignore
 from sherpa.utils.akima import akima
 
 from sherpa.astro.utils import reshape_2d_arrays

--- a/sherpa/models/template.py
+++ b/sherpa/models/template.py
@@ -108,11 +108,13 @@ array([5.34, 6.12, 6.  ])
 
 """
 
+from typing import Callable
 import operator
 
 import numpy as np
 
 from sherpa.utils.err import ModelErr
+
 from .parameter import Parameter
 from .model import ArithmeticModel, modelCacher1d
 from .basic import TableModel
@@ -123,7 +125,7 @@ __all__ = ('TemplateModel', 'InterpolatingTemplateModel',
 
 
 # This is reset by reset_interpolators below.
-interpolators = {}
+interpolators: dict[str, tuple[Callable, dict]] = {}
 
 
 def create_template_model(modelname, names, parvals, templates,
@@ -456,7 +458,7 @@ class TemplateModel(ArithmeticModel):
         return table_model(x0, x1, *args, **kwargs)
 
 
-def reset_interpolators():
+def reset_interpolators() -> None:
     """Reset the list of interpolators to the default.
 
     If the list does not exist then recreate it.
@@ -473,7 +475,7 @@ def reset_interpolators():
     }
 
 
-def add_interpolator(name, interpolator, **kwargs):
+def add_interpolator(name: str, interpolator: Callable, **kwargs) -> None:
     """Add the interpolator to the list.
 
     Parameters

--- a/sherpa/models/template.py
+++ b/sherpa/models/template.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2016, 2019, 2020, 2021, 2023
+#  Copyright (C) 2011, 2016, 2019 -2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -110,7 +110,7 @@ array([5.34, 6.12, 6.  ])
 
 import operator
 
-import numpy
+import numpy as np
 
 from sherpa.utils.err import ModelErr
 from .parameter import Parameter
@@ -302,7 +302,7 @@ class KNNInterpolator(InterpolatingTemplateModel):
         """What are the distances for the given set of parameters?"""
         distances = []
         for i, t_point in enumerate(self.template_model.parvals):
-            dist = numpy.linalg.norm(point - t_point, self.order)
+            dist = np.linalg.norm(point - t_point, self.order)
             distances.append((i, dist))
 
         return sorted(distances, key=operator.itemgetter(1))
@@ -313,8 +313,8 @@ class KNNInterpolator(InterpolatingTemplateModel):
             return self.template_model.templates[distances[0][0]]
 
         k_distances = distances[:self.k]
-        weights = [(idx, 1/numpy.array(distance)) for idx, distance in k_distances]
-        y_out = numpy.zeros(len(x_out))
+        weights = [(idx, 1/np.array(distance)) for idx, distance in k_distances]
+        y_out = np.zeros(len(x_out))
         for idx, weight in weights:
             y_out += self.template_model.templates[idx].calc((weight,), x_out)
 

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -619,7 +619,7 @@ def test_show_model():
     assert toks[3].strip().split() == ['thetestmodel.P1', 'thawed', '1', '0', '10']
     assert toks[4].strip().split() == ['thetestmodel.accent', 'frozen', '2', '0', '10']
     assert toks[5].strip().split() == ['thetestmodel.norm', 'linked', '12',
-                                       'expr:', '(10', '+', 'const1d.c0)']
+                                       'expr:', '10', '+', 'const1d.c0']
 
     # Should hidden parameters be capable of being thawed?
     assert m.notseen.val == 10

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -512,6 +512,9 @@ class TestBrackets:
                               (abs(b * (c + d)) * (a + d), "abs(b * (c + d)) * (a + d)"),
                               (-a, "-(a)"),
                               (+a, "+(a)"),
+                              ((-a) + ((b)), "-(a) + b"),
+                              # the following is ugly but is valid Python
+                              ((-(a)) + ((+b)), "-(a) + +(b)"),
                               (-a + b, "-(a) + b"),
                               (-a + 2, "-(a) + 2.0"),
                               (+a + b, "+(a) + b"),

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -647,3 +647,48 @@ class TestBrackets:
         ygot = got(x)
 
         assert ygot == pytest.approx(ymdl)
+
+
+def test_explicit_numpy_combination():
+    """This was a question I wondered when developing test_brackets,
+    so add a check.
+    """
+
+    mdl1 = basic.Scale1D("mdl1")
+    mdl2 = basic.Box1D("mdl2")
+    mdl3 = basic.Gauss1D("mdl3")
+
+    mdl1.c0 = 4
+    mdl2.xlow = 5
+    mdl2.xhi = 15
+    mdl2.ampl = 2
+    mdl3.pos = 10
+    mdl3.fwhm = 5
+    mdl3.ampl = 10
+
+    # These should be the same but check they are.
+    #
+    implicit = mdl1 * (mdl2 + mdl3)
+    explicit = np.multiply(mdl1,
+                           np.add(mdl2, mdl3))
+
+    assert isinstance(implicit, BinaryOpModel)
+    assert isinstance(explicit, BinaryOpModel)
+
+    # Check the names are the same.
+    #
+    assert explicit.name == implicit.name
+
+    # Check they evaluate to the same values.
+    #
+    x = np.arange(4, 14, 2)
+    y2 = mdl2(x)
+    y3 = mdl3(x)
+    yexp = 4 * (y2 + y3)
+
+    assert implicit(x) == pytest.approx(yexp)
+    assert explicit(x) == pytest.approx(yexp)
+
+    # Have an actual test, just in case,
+    assert yexp == pytest.approx([0.73812041, 14.78302164,
+                                  33.66851795, 48, 33.66851795])

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -543,7 +543,23 @@ class TestBrackets:
                               (a * rsp(a * (b + c * d)) + d * arf(a + b),
                                '((a * apply_rmf(apply_arf((100.0 * (a * (b + (c * d))))))) + (d * apply_arf((100.0 * (a + b)))))'),
                               (arf(b * (c + d)),
-                               "apply_arf((100.0 * (b * (c + d))))")
+                               "apply_arf((100.0 * (b * (c + d))))"),
+                              # How about expressions with exponentation
+                              (a**2, "(a ** 2.0)"),
+                              (a**-2, "(a ** -2.0)"),
+                              (a + b**2, "(a + (b ** 2.0))"),
+                              (a + (b + c)**2, "(a + ((b + c) ** 2.0))"),
+                              (a - b**(c - 2) - a, "((a - (b ** (c - 2.0))) - a)"),
+                              ((a ** 2) ** b, "((a ** 2.0) ** b)"),
+                              (-a ** 2, "-((a ** 2.0))"),
+                              ((-a)**2, "(-(a) ** 2.0)"),  # Is this wrong?
+                              # remainder and integer division, for fun
+                              (a // 2, "(a // 2.0)"),
+                              ((a + b) // 2, "((a + b) // 2.0)"),
+                              ((a * b) // 2, "((a * b) // 2.0)"),
+                              (a % 2, "(a % 2.0)"),
+                              ((a + b) % 2, "((a + b) % 2.0)"),
+                              ((a * b) % 2, "((a * b) % 2.0)")
                              ])
     def test_brackets(self, model, expected):
         """Do we get the expected number of brackets?"""

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -60,6 +60,17 @@ def test_basic_unop_neg():
     assert mdl.ndim == 2
 
 
+def test_basic_unop_pos():
+
+    cpt = basic.Polynom2D()
+    mdl = +cpt
+
+    assert mdl.name == '+(polynom2d)'
+    assert mdl.op == np.positive
+    assert mdl.opstr == '+'
+    assert mdl.ndim == 2
+
+
 def test_basic_unop_abs_raw():
 
     cpt = basic.Polynom2D()
@@ -149,6 +160,33 @@ def test_eval_op():
 
     got = mdl(x)
     assert got == pytest.approx(expected)
+
+
+def test_eval_add_sub_op():
+    """Another version of test_eval_op focussed on + and - unary ops"""
+
+    x = np.asarray([2, 4, 5, 6, 7])
+
+    m1 = basic.Const1D("c")
+    m1.c0 = 10
+
+    m2 = basic.Polynom1D("p")
+    m2.c0 = 5
+    m2.c1 = 1
+
+    m3 = basic.Box1D("b")
+    m3.xlow = 5
+    m3.xhi = 6
+
+    mdl = m1 - (+m2 - m3)
+    assert mdl.ndim == 1
+
+    assert mdl.name == "(c - (+(p) - b))"
+
+    bins = np.arange(2, 10, 2)
+    yexp = m1(bins) + m3(bins) - m2(bins)
+    y = mdl(bins)
+    assert y == pytest.approx(yexp)
 
 
 def test_combine_models1d():
@@ -473,7 +511,9 @@ class TestBrackets:
                               (a * abs(b * (c + d)), "(a * abs((b * (c + d))))"),
                               (abs(b * (c + d)) * (a + d), "(abs((b * (c + d))) * (a + d))"),
                               (-a, "-(a)"),
+                              (+a, "+(a)"),
                               (-a + b, "(-(a) + b)"),
+                              (+a + b, "(+(a) + b)"),
                               (-(a + b), "-((a + b))"),
                               (-(a * b), "-((a * b))"),
                               (-(a - b), "-((a - b))"),

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -28,7 +28,9 @@ import numpy as np
 
 import pytest
 
+from sherpa.astro.instrument import ARF1D, RMF1D, RSPModelNoPHA, create_arf, create_delta_rmf
 from sherpa.astro.ui.utils import Session
+from sherpa.instrument import PSFModel
 from sherpa.models import basic
 from sherpa.models.model import ArithmeticConstantModel, \
     ArithmeticFunctionModel, BinaryOpModel, UnaryOpModel
@@ -412,6 +414,21 @@ def test_binop_arithmeticfunction_works(m1, m2):
     assert y == pytest.approx(expected)
 
 
+class FakeResponse1D:
+    """sherpa.astro.instrument.Response1D requires a PHA. This doesn't.
+
+    This has limited functionality.
+    """
+
+    def __init__(self, arf, rmf):
+        self.arf = arf
+        self.rmf = rmf
+
+    def __call__(self, model):
+        return RSPModelNoPHA(self.arf, self.rmf,
+                             self.arf.exposure * model)
+
+
 class TestBrackets:
     """Provide a set of model instances for the tests."""
 
@@ -419,6 +436,23 @@ class TestBrackets:
     b = basic.Const1D('b')
     c = basic.Const1D('c')
     d = basic.Const1D('d')
+
+    # We don't need to 'load' the model data to use it here
+    tm = basic.TableModel('tm')
+
+    # Convolution-style model (PSF)
+    cm = PSFModel('cm', basic.Const1D('cmflat'))
+
+    # Convolution-style model (PHA)
+    #
+    egrid = np.arange(0.1, 0.5, 0.1)
+    chans = np.arange(1, egrid.size)
+    fake_arf = create_arf(egrid[:-1], egrid[1:], exposure=100.0)
+    fake_rmf = create_delta_rmf(egrid[:-1], egrid[1:])
+
+    arf = ARF1D(fake_arf)
+    rmf = RMF1D(fake_rmf)
+    rsp = FakeResponse1D(fake_arf, fake_rmf)
 
     # It would be nice to instead use a principled set of states,
     # but let's just try a somewhat-random set of expressions.
@@ -486,7 +520,30 @@ class TestBrackets:
                               ((a + b + c) * (c * b + d * a), "(((a + b) + c) * ((c * b) + (d * a)))"),
                               (2 * a * 2, "((2.0 * a) * 2.0)"),
                               (a * 2 * 2, "((a * 2.0) * 2.0)"),
-                              (2 * a + 2 * (b + c - 4) * 3, "((2.0 * a) + ((2.0 * ((b + c) - 4.0)) * 3.0))")
+                              (2 * a + 2 * (b + c - 4) * 3, "((2.0 * a) + ((2.0 * ((b + c) - 4.0)) * 3.0))"),
+                              (tm * (a + b) + tm * (a * b),
+                               '((tm * (a + b)) + (tm * (a * b)))'),
+                              (tm * (a + b) + tm * (a * (b + 3)),
+                               '((tm * (a + b)) + (tm * (a * (b + 3.0))))'),
+                              (cm(a) + b, '(cm(a) + b)'),
+                              (a * cm(b + c), '(a * cm((b + c)))'),
+                              (a + cm(b + 2 * d + c),
+                               '(a + cm(((b + (2.0 * d)) + c)))'),
+                              (arf(b * (c * d)) + d,
+                               "(apply_arf((100.0 * (b * (c * d)))) + d)"),
+                              (a + 2 * arf(b * (c + d)),
+                               "(a + (2.0 * apply_arf((100.0 * (b * (c + d))))))"),
+                              (a + 2 * rmf(b * (c + d)),
+                               "(a + (2.0 * apply_rmf((b * (c + d)))))"),
+                              # Manually combining RMF1D and ARF1D is interesting as we would normally
+                              # use RSPModelNoPHA
+                              (a * rmf(arf(a * (b + c * d))) + d * arf(a + b),
+                               '((a * apply_rmf(apply_arf((100.0 * (a * (b + (c * d))))))) + (d * apply_arf((100.0 * (a + b)))))'),
+                              # Repeat but with rsp instead
+                              (a * rsp(a * (b + c * d)) + d * arf(a + b),
+                               '((a * apply_rmf(apply_arf((100.0 * (a * (b + (c * d))))))) + (d * apply_arf((100.0 * (a + b)))))'),
+                              (arf(b * (c + d)),
+                               "apply_arf((100.0 * (b * (c + d))))")
                              ])
     def test_brackets(self, model, expected):
         """Do we get the expected number of brackets?"""

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2023
+#  Copyright (C) 2020, 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -410,3 +410,85 @@ def test_binop_arithmeticfunction_works(m1, m2):
 
     expected = 2 * np.sin(grid)
     assert y == pytest.approx(expected)
+
+
+class TestBrackets:
+    """Provide a set of model instances for the tests."""
+
+    a = basic.Const1D('a')
+    b = basic.Const1D('b')
+    c = basic.Const1D('c')
+    d = basic.Const1D('d')
+
+    # It would be nice to instead use a principled set of states,
+    # but let's just try a somewhat-random set of expressions.
+    #
+    @pytest.mark.parametrize("model,expected",
+                             [(a, "a"),
+                              (abs(a), "abs(a)"),
+                              (abs(a) + b, "(abs(a) + b)"),
+                              (b + abs(a), "(b + abs(a))"),
+                              (abs(a + b), "abs((a + b))"),
+                              (abs(a + b * c), "abs((a + (b * c)))"),
+                              (abs(a - b * c), "abs((a - (b * c)))"),
+                              (abs((a + b) * c), "abs(((a + b) * c))"),
+                              (abs((a - b) * c), "abs(((a - b) * c))"),
+                              (abs((a - b) / c), "abs(((a - b) / c))"),
+                              (abs((a * b) - c), "abs(((a * b) - c))"),
+                              (abs((a / b) - c), "abs(((a / b) - c))"),
+                              (a * abs(b * (c + d)), "(a * abs((b * (c + d))))"),
+                              (abs(b * (c + d)) * (a + d), "(abs((b * (c + d))) * (a + d))"),
+                              (-a, "-(a)"),
+                              (-a + b, "(-(a) + b)"),
+                              (-(a + b), "-((a + b))"),
+                              (-(a * b), "-((a * b))"),
+                              (-(a - b), "-((a - b))"),
+                              (-(a * b - c), "-(((a * b) - c))"),
+                              (-(a - b * c), "-((a - (b * c)))"),
+                              (a - a - b, "((a - a) - b)"),
+                              (a - (a - b), "(a - (a - b))"),
+                              (a - (b - (c - d)), '(a - (b - (c - d)))'),
+                              (a - (b + (c - d)), '(a - (b + (c - d)))'),
+                              (b - (c + d), '(b - (c + d))'),
+                              ((a - b) - (c + d), '((a - b) - (c + d))'),
+                              (a - (b - (c + d)), '(a - (b - (c + d)))'),
+                              (a - (b + (c + d)), '(a - (b + (c + d)))'),
+                              (2 * (a + b) - c * 3, "((2.0 * (a + b)) - (c * 3.0))"),
+                              (abs(2 * (a + b) - c * 3), "abs(((2.0 * (a + b)) - (c * 3.0)))"),
+                              (a + a, "(a + a)"),
+                              (a * b, "(a * b)"),
+                              (a - a, "(a - a)"),
+                              (a / b, "(a / b)"),
+                              (a + b + c, "((a + b) + c)"),
+                              (a * b * c, "((a * b) * c)"),
+                              ((a * b) + c, "((a * b) + c)"),
+                              ((a + b) * c, "((a + b) * c)"),
+                              (a + (b * c), "(a + (b * c))"),
+                              (a * (b + c), "(a * (b + c))"),
+                              ((a + b) * (c + d), "((a + b) * (c + d))"),
+                              ((a * b) * (c + d), "((a * b) * (c + d))"),
+                              ((a + b) * (c * d), "((a + b) * (c * d))"),
+                              ((a + (b * c) + d), "((a + (b * c)) + d)"),
+                              (100 * a * (b + c), "((100.0 * a) * (b + c))"),
+                              (100 * (a * (b + c)), "(100.0 * (a * (b + c)))"),
+                              (a + b + 2 * c + d + a, "((((a + b) + (2.0 * c)) + d) + a)"),
+                              (a + b + c * 2 + d + a, "((((a + b) + (c * 2.0)) + d) + a)"),
+                              (a + b * (c - 2) + d + a, "(((a + (b * (c - 2.0))) + d) + a)"),
+                              (a + b * (2 - c) + d + a, "(((a + (b * (2.0 - c))) + d) + a)"),
+                              ((a + b + c) + (c + b + d + a), "(((a + b) + c) + (((c + b) + d) + a))"),
+                              ((a + b + c) + (c + b - d + a), "(((a + b) + c) + (((c + b) - d) + a))"),
+                              ((a + b + c) + (c + b - abs(d) + a), "(((a + b) + c) + (((c + b) - abs(d)) + a))"),
+                              ((a + b + c) * (c + b + d + a), "(((a + b) + c) * (((c + b) + d) + a))"),
+                              ((a + b + c) * (c + b - d + a), "(((a + b) + c) * (((c + b) - d) + a))"),
+                              ((a + b + c) * (c + b - abs(d) + a), "(((a + b) + c) * (((c + b) - abs(d)) + a))"),
+                              ((a * b * c) * (c + b + d + a), "(((a * b) * c) * (((c + b) + d) + a))"),
+                              ((a + b + c) * (c * b * d * a), "(((a + b) + c) * (((c * b) * d) * a))"),
+                              ((a + b + c) * (c * b + d * a), "(((a + b) + c) * ((c * b) + (d * a)))"),
+                              (2 * a * 2, "((2.0 * a) * 2.0)"),
+                              (a * 2 * 2, "((a * 2.0) * 2.0)"),
+                              (2 * a + 2 * (b + c - 4) * 3, "((2.0 * a) + ((2.0 * ((b + c) - 4.0)) * 3.0))")
+                             ])
+    def test_brackets(self, model, expected):
+        """Do we get the expected number of brackets?"""
+
+        assert model.name == expected

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -227,7 +227,7 @@ def test_binop_string():
     comp = 1 + p * 2.7**p2
     assert repr(comp) == "<BinaryOpParameter '1 + model.p * 2.7 ** model.p2'>"
     comp = np.logaddexp2(p, p2)
-    assert repr(comp) == "<BinaryOpParameter 'numpy.logaddexp2(model.p, (model.p2))'>"
+    assert repr(comp) == "<BinaryOpParameter 'numpy.logaddexp2(model.p, model.p2)'>"
 
 
 def test_binop_string_with_custom_ufunc():
@@ -238,7 +238,7 @@ def test_binop_string_with_custom_ufunc():
     uf = np.frompyfunc(func, nin=2, nout=1)
     p, p2 = setUp_composite()
     comp = uf(p, p2)
-    assert repr(comp) == "<BinaryOpParameter 'func(model.p, (model.p2))'>"
+    assert repr(comp) == "<BinaryOpParameter 'func(model.p, model.p2)'>"
 
 
 class TestBrackets:
@@ -347,11 +347,11 @@ class TestBrackets:
                               (np.cos(a)**2 + np.sin(a)**2,
                                "numpy.cos(m.a) ** 2 + numpy.sin(m.a) ** 2"),
                               (np.logaddexp(a, b),
-                               "numpy.logaddexp(m.a, (m.b))"),
+                               "numpy.logaddexp(m.a, m.b)"),
                               (2 + np.logaddexp(a, b * 2),
-                               "2 + numpy.logaddexp(m.a, (m.b * 2))"),
+                               "2 + numpy.logaddexp(m.a, m.b * 2)"),
                               (np.logaddexp(2 / a, b * 2) - (2 * c),
-                               "numpy.logaddexp((2 / m.a), (m.b * 2)) - 2 * m.c"),
+                               "numpy.logaddexp(2 / m.a, m.b * 2) - 2 * m.c"),
                              ])
     def test_brackets(self, expr, expected):
         """Do we get the expected number of brackets?"""
@@ -598,7 +598,7 @@ def test_explicit_numpy_combination():
     #
     # assert explicit.name == implicit.name
     assert implicit.name == "m1.a * (m2.b + m4.xx)"
-    assert explicit.name == "numpy.multiply(m1.a, (numpy.add(m2.b, m4.xx)))"
+    assert explicit.name == "numpy.multiply(m1.a, numpy.add(m2.b, m4.xx))"
 
     # Check they evaluate to the same values.
     #

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -274,7 +274,7 @@ class TestBrackets:
                               # (+a, "+(m.a)"),  currently not supported
                               (-a + b, "-(m.a) + m.b"),
                               (-a + 2, "-(m.a) + 2"),
-                              # (+a + b, "+(m.a) + m.b"),  currenly not supported
+                              # (+a + b, "+(m.a) + m.b"),  currently not supported
                               (-(a + b), "-(m.a + m.b)"),
                               (-(a * b), "-(m.a * m.b)"),
                               (-(a - b), "-(m.a - m.b)"),
@@ -337,7 +337,21 @@ class TestBrackets:
                               ((a * b) // 2, "(m.a * m.b) // 2"),
                               (a % 2, "m.a % 2"),
                               ((a + b) % 2, "(m.a + m.b) % 2"),
-                              ((a * b) % 2, "(m.a * m.b) % 2")
+                              ((a * b) % 2, "(m.a * m.b) % 2"),
+                              # abs is special, how about other functions
+                              (np.sin(a), "numpy.sin(m.a)"),
+                              (np.sin(a + b), "numpy.sin(m.a + m.b)"),
+                              (np.sin(((a) * (b))), "numpy.sin(m.a * m.b)"),
+                              (np.cos((np.sin(a) * ((2) + np.tan(b)))),
+                               "numpy.cos(numpy.sin(m.a) * (2 + numpy.tan(m.b)))"),
+                              (np.cos(a)**2 + np.sin(a)**2,
+                               "numpy.cos(m.a) ** 2 + numpy.sin(m.a) ** 2"),
+                              (np.logaddexp(a, b),
+                               "numpy.logaddexp(m.a, (m.b))"),
+                              (2 + np.logaddexp(a, b * 2),
+                               "2 + numpy.logaddexp(m.a, (m.b * 2))"),
+                              (np.logaddexp(2 / a, b * 2) - (2 * c),
+                               "numpy.logaddexp((2 / m.a), (m.b * 2)) - 2 * m.c"),
                              ])
     def test_brackets(self, expr, expected):
         """Do we get the expected number of brackets?"""

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -188,7 +188,7 @@ def test_unop_string():
     printing the model representation.
     '''
     porig = setUp_p()
-    assert repr(-porig) == "<UnaryOpParameter '-model.name'>"
+    assert repr(-porig) == "<UnaryOpParameter '-(model.name)'>"
     assert repr(np.cos(porig)) == "<UnaryOpParameter 'numpy.cos(model.name)'>"
 
 
@@ -223,11 +223,11 @@ def test_binop_string():
     '''
     p, p2 = setUp_composite()
     comp = p + p2
-    assert repr(comp) == "<BinaryOpParameter '(model.p + model.p2)'>"
+    assert repr(comp) == "<BinaryOpParameter 'model.p + model.p2'>"
     comp = 1 + p * 2.7**p2
-    assert repr(comp) == "<BinaryOpParameter '(1 + (model.p * (2.7 ** model.p2)))'>"
+    assert repr(comp) == "<BinaryOpParameter '1 + model.p * 2.7 ** model.p2'>"
     comp = np.logaddexp2(p, p2)
-    assert repr(comp) == "<BinaryOpParameter 'numpy.logaddexp2(model.p, model.p2)'>"
+    assert repr(comp) == "<BinaryOpParameter 'numpy.logaddexp2(model.p, (model.p2))'>"
 
 
 def test_binop_string_with_custom_ufunc():
@@ -238,7 +238,7 @@ def test_binop_string_with_custom_ufunc():
     uf = np.frompyfunc(func, nin=2, nout=1)
     p, p2 = setUp_composite()
     comp = uf(p, p2)
-    assert repr(comp) == "<BinaryOpParameter 'func(model.p, model.p2)'>"
+    assert repr(comp) == "<BinaryOpParameter 'func(model.p, (model.p2))'>"
 
 
 class TestBrackets:
@@ -258,86 +258,86 @@ class TestBrackets:
     @pytest.mark.parametrize("expr,expected",
                              [(a, "a"),  # TODO: should this be m.a?
                               (abs(a), "abs(m.a)"),
-                              (abs(a) + b, "(abs(m.a) + m.b)"),
-                              (b + abs(a), "(m.b + abs(m.a))"),
-                              (abs(a + b), "abs((m.a + m.b))"),
-                              (abs(a + b * c), "abs((m.a + (m.b * m.c)))"),
-                              (abs(a - b * c), "abs((m.a - (m.b * m.c)))"),
-                              (abs((a + b) * c), "abs(((m.a + m.b) * m.c))"),
-                              (abs((a - b) * c), "abs(((m.a - m.b) * m.c))"),
-                              (abs((a - b) / c), "abs(((m.a - m.b) / m.c))"),
-                              (abs((a * b) - c), "abs(((m.a * m.b) - m.c))"),
-                              (abs((a / b) - c), "abs(((m.a / m.b) - m.c))"),
-                              (a * abs(b * (c + d)), "(m.a * abs((m.b * (m.c + m.d))))"),
-                              (abs(b * (c + d)) * (a + d), "(abs((m.b * (m.c + m.d))) * (m.a + m.d))"),
-                              (-a, "-m.a"),
-                              # (+a, "+m.a"),  currently not supported
-                              (-a + b, "(-m.a + m.b)"),
-                              (-a + 2, "(-m.a + 2)"),
+                              (abs(a) + b, "abs(m.a) + m.b"),
+                              (b + abs(a), "m.b + abs(m.a)"),
+                              (abs(a + b), "abs(m.a + m.b)"),
+                              (abs(a + b * c), "abs(m.a + m.b * m.c)"),
+                              (abs(a - b * c), "abs(m.a - m.b * m.c)"),
+                              (abs((a + b) * c), "abs((m.a + m.b) * m.c)"),
+                              (abs((a - b) * c), "abs((m.a - m.b) * m.c)"),
+                              (abs((a - b) / c), "abs((m.a - m.b) / m.c)"),
+                              (abs((a * b) - c), "abs(m.a * m.b - m.c)"),
+                              (abs((a / b) - c), "abs(m.a / m.b - m.c)"),
+                              (a * abs(b * (c + d)), "m.a * abs(m.b * (m.c + m.d))"),
+                              (abs(b * (c + d)) * (a + d), "abs(m.b * (m.c + m.d)) * (m.a + m.d)"),
+                              (-a, "-(m.a)"),
+                              # (+a, "+(m.a)"),  currently not supported
+                              (-a + b, "-(m.a) + m.b"),
+                              (-a + 2, "-(m.a) + 2"),
                               # (+a + b, "+(m.a) + m.b"),  currenly not supported
                               (-(a + b), "-(m.a + m.b)"),
                               (-(a * b), "-(m.a * m.b)"),
                               (-(a - b), "-(m.a - m.b)"),
-                              (-(a * b - c), "-((m.a * m.b) - m.c)"),
-                              (-(a - b * c), "-(m.a - (m.b * m.c))"),
-                              (a - a - b, "((m.a - m.a) - m.b)"),
-                              (a - (a - b), "(m.a - (m.a - m.b))"),
-                              (a - (b - (c - d)), '(m.a - (m.b - (m.c - m.d)))'),
-                              (a - (b + (c - d)), '(m.a - (m.b + (m.c - m.d)))'),
-                              (b - (c + d), '(m.b - (m.c + m.d))'),
-                              ((a - b) - (c + d), '((m.a - m.b) - (m.c + m.d))'),
-                              (a - (b - (c + d)), '(m.a - (m.b - (m.c + m.d)))'),
-                              (a - (b + (c + d)), '(m.a - (m.b + (m.c + m.d)))'),
-                              (2 * (a + b) - c * 3, "((2 * (m.a + m.b)) - (m.c * 3))"),
-                              (abs(2 * (a + b) - c * 3), "abs(((2 * (m.a + m.b)) - (m.c * 3)))"),
-                              (a + a, "(m.a + m.a)"),
-                              (a * b, "(m.a * m.b)"),
-                              (a - a, "(m.a - m.a)"),
-                              (a / b, "(m.a / m.b)"),
-                              (a + b + c, "((m.a + m.b) + m.c)"),
-                              (a * b * c, "((m.a * m.b) * m.c)"),
-                              ((a * b) + c, "((m.a * m.b) + m.c)"),
-                              ((a + b) * c, "((m.a + m.b) * m.c)"),
-                              (a + (b * c), "(m.a + (m.b * m.c))"),
-                              (a * (b + c), "(m.a * (m.b + m.c))"),
-                              ((a + b) * (c + d), "((m.a + m.b) * (m.c + m.d))"),
-                              ((a * b) * (c + d), "((m.a * m.b) * (m.c + m.d))"),
-                              ((a + b) * (c * d), "((m.a + m.b) * (m.c * m.d))"),
-                              ((a + (b * c) + d), "((m.a + (m.b * m.c)) + m.d)"),
-                              (100 * a * (b + c), "((100 * m.a) * (m.b + m.c))"),
-                              (100 * (a * (b + c)), "(100 * (m.a * (m.b + m.c)))"),
-                              (a + b + 2 * c + d + a, "((((m.a + m.b) + (2 * m.c)) + m.d) + m.a)"),
-                              (a + b + c * 2 + d + a, "((((m.a + m.b) + (m.c * 2)) + m.d) + m.a)"),
-                              (a + b * (c - 2) + d + a, "(((m.a + (m.b * (m.c - 2))) + m.d) + m.a)"),
-                              (a + b * (2 - c) + d + a, "(((m.a + (m.b * (2 - m.c))) + m.d) + m.a)"),
-                              ((a + b + c) + (c + b + d + a), "(((m.a + m.b) + m.c) + (((m.c + m.b) + m.d) + m.a))"),
-                              ((a + b + c) + (c + b - d + a), "(((m.a + m.b) + m.c) + (((m.c + m.b) - m.d) + m.a))"),
-                              ((a + b + c) + (c + b - abs(d) + a), "(((m.a + m.b) + m.c) + (((m.c + m.b) - abs(m.d)) + m.a))"),
-                              ((a + b + c) * (c + b + d + a), "(((m.a + m.b) + m.c) * (((m.c + m.b) + m.d) + m.a))"),
-                              ((a + b + c) * (c + b - d + a), "(((m.a + m.b) + m.c) * (((m.c + m.b) - m.d) + m.a))"),
-                              ((a + b + c) * (c + b - abs(d) + a), "(((m.a + m.b) + m.c) * (((m.c + m.b) - abs(m.d)) + m.a))"),
-                              ((a * b * c) * (c + b + d + a), "(((m.a * m.b) * m.c) * (((m.c + m.b) + m.d) + m.a))"),
-                              ((a + b + c) * (c * b * d * a), "(((m.a + m.b) + m.c) * (((m.c * m.b) * m.d) * m.a))"),
-                              ((a + b + c) * (c * b + d * a), "(((m.a + m.b) + m.c) * ((m.c * m.b) + (m.d * m.a)))"),
-                              (2 * a * 2, "((2 * m.a) * 2)"),
-                              (a * 2 * 2, "((m.a * 2) * 2)"),
-                              (2 * a + 2 * (b + c - 4) * 3, "((2 * m.a) + ((2 * ((m.b + m.c) - 4)) * 3))"),
+                              (-(a * b - c), "-(m.a * m.b - m.c)"),
+                              (-(a - b * c), "-(m.a - m.b * m.c)"),
+                              (a - a - b, "m.a - m.a - m.b"),
+                              (a - (a - b), "m.a - (m.a - m.b)"),
+                              (a - (b - (c - d)), 'm.a - (m.b - (m.c - m.d))'),
+                              (a - (b + (c - d)), 'm.a - (m.b + m.c - m.d)'),
+                              (b - (c + d), 'm.b - (m.c + m.d)'),
+                              ((a - b) - (c + d), 'm.a - m.b - (m.c + m.d)'),
+                              (a - (b - (c + d)), 'm.a - (m.b - (m.c + m.d))'),
+                              (a - (b + (c + d)), 'm.a - (m.b + m.c + m.d)'),
+                              (2 * (a + b) - c * 3, "2 * (m.a + m.b) - m.c * 3"),
+                              (abs(2 * (a + b) - c * 3), "abs(2 * (m.a + m.b) - m.c * 3)"),
+                              (a + a, "m.a + m.a"),
+                              (a * b, "m.a * m.b"),
+                              (a - a, "m.a - m.a"),
+                              (a / b, "m.a / m.b"),
+                              (a + b + c, "m.a + m.b + m.c"),
+                              (a * b * c, "m.a * m.b * m.c"),
+                              ((a * b) + c, "m.a * m.b + m.c"),
+                              ((a + b) * c, "(m.a + m.b) * m.c"),
+                              (a + (b * c), "m.a + m.b * m.c"),
+                              (a * (b + c), "m.a * (m.b + m.c)"),
+                              ((a + b) * (c + d), "(m.a + m.b) * (m.c + m.d)"),
+                              ((a * b) * (c + d), "m.a * m.b * (m.c + m.d)"),
+                              ((a + b) * (c * d), "(m.a + m.b) * m.c * m.d"),
+                              ((a + (b * c) + d), "m.a + m.b * m.c + m.d"),
+                              (100 * a * (b + c), "100 * m.a * (m.b + m.c)"),
+                              (100 * (a * (b + c)), "100 * m.a * (m.b + m.c)"),
+                              (a + b + 2 * c + d + a, "m.a + m.b + 2 * m.c + m.d + m.a"),
+                              (a + b + c * 2 + d + a, "m.a + m.b + m.c * 2 + m.d + m.a"),
+                              (a + b * (c - 2) + d + a, "m.a + m.b * (m.c - 2) + m.d + m.a"),
+                              (a + b * (2 - c) + d + a, "m.a + m.b * (2 - m.c) + m.d + m.a"),
+                              ((a + b + c) + (c + b + d + a), "m.a + m.b + m.c + m.c + m.b + m.d + m.a"),
+                              ((a + b + c) + (c + b - d + a), "m.a + m.b + m.c + m.c + m.b - m.d + m.a"),
+                              ((a + b + c) + (c + b - abs(d) + a), "m.a + m.b + m.c + m.c + m.b - abs(m.d) + m.a"),
+                              ((a + b + c) * (c + b + d + a), "(m.a + m.b + m.c) * (m.c + m.b + m.d + m.a)"),
+                              ((a + b + c) * (c + b - d + a), "(m.a + m.b + m.c) * (m.c + m.b - m.d + m.a)"),
+                              ((a + b + c) * (c + b - abs(d) + a), "(m.a + m.b + m.c) * (m.c + m.b - abs(m.d) + m.a)"),
+                              ((a * b * c) * (c + b + d + a), "m.a * m.b * m.c * (m.c + m.b + m.d + m.a)"),
+                              ((a + b + c) * (c * b * d * a), "(m.a + m.b + m.c) * m.c * m.b * m.d * m.a"),
+                              ((a + b + c) * (c * b + d * a), "(m.a + m.b + m.c) * (m.c * m.b + m.d * m.a)"),
+                              (2 * a * 2, "2 * m.a * 2"),
+                              (a * 2 * 2, "m.a * 2 * 2"),
+                              (2 * a + 2 * (b + c - 4) * 3, "2 * m.a + 2 * (m.b + m.c - 4) * 3"),
                               # How about expressions with exponentation
-                              (a**2, "(m.a ** 2)"),
-                              (a**-2, "(m.a ** -2)"),
-                              (a + b**2, "(m.a + (m.b ** 2))"),
-                              (a + (b + c)**2, "(m.a + ((m.b + m.c) ** 2))"),
-                              (a - b**(c - 2) - a, "((m.a - (m.b ** (m.c - 2))) - m.a)"),
-                              ((a ** 2) ** b, "((m.a ** 2) ** m.b)"),
+                              (a**2, "m.a ** 2"),
+                              (a**-2, "m.a ** -2"),
+                              (a + b**2, "m.a + m.b ** 2"),
+                              (a + (b + c)**2, "m.a + (m.b + m.c) ** 2"),
+                              (a - b**(c - 2) - a, "m.a - m.b ** (m.c - 2) - m.a"),
+                              ((a ** 2) ** b, "(m.a ** 2) ** m.b"),
                               (-a ** 2, "-(m.a ** 2)"),
-                              ((-a)**2, "(-m.a ** 2)"),  # test_unary_op_precedence
+                              ((-a)**2, "(-(m.a)) ** 2"),
                               # remainder and integer division, for fun
-                              (a // 2, "(m.a // 2)"),
-                              ((a + b) // 2, "((m.a + m.b) // 2)"),
-                              ((a * b) // 2, "((m.a * m.b) // 2)"),
-                              (a % 2, "(m.a % 2)"),
-                              ((a + b) % 2, "((m.a + m.b) % 2)"),
-                              ((a * b) % 2, "((m.a * m.b) % 2)")
+                              (a // 2, "m.a // 2"),
+                              ((a + b) // 2, "(m.a + m.b) // 2"),
+                              ((a * b) // 2, "(m.a * m.b) // 2"),
+                              (a % 2, "m.a % 2"),
+                              ((a + b) % 2, "(m.a + m.b) % 2"),
+                              ((a * b) % 2, "(m.a * m.b) % 2")
                              ])
     def test_brackets(self, expr, expected):
         """Do we get the expected number of brackets?"""
@@ -353,16 +353,11 @@ def test_unary_op_precedence():
     p = Parameter("m", "x", 3)
 
     expr = p ** 2
-    assert expr.name == "(m.x ** 2)"
+    assert expr.name == "m.x ** 2"
     assert expr.val == pytest.approx(9)
 
     expr = (-p) ** 2
-    # TODO: the string expression is wrong, since as we show below
-    #       -p **2
-    #       actually evaluates to -9, but I treat this as a regression
-    #       test for now
-    #
-    assert expr.name == "(-m.x ** 2)"
+    assert expr.name == "(-(m.x)) ** 2"
     assert expr.val == pytest.approx(9)
 
     expr = -p ** 2
@@ -370,7 +365,7 @@ def test_unary_op_precedence():
     assert expr.val == pytest.approx(-9)
 
     expr = p ** -2
-    assert expr.name == "(m.x ** -2)"
+    assert expr.name == "m.x ** -2"
     assert expr.val == pytest.approx(1 / 9)
 
 

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -557,3 +557,37 @@ def test_link_manual(attr):
     assert p.link.parts[0].val == 2
     assert isinstance(p.link.parts[1], Parameter)
     assert p.link.parts[1] is q
+
+
+def test_explicit_numpy_combination():
+    """This was a question I wondered when developing test_brackets,
+    so add a check.
+    """
+
+    p1 = Parameter("m1", "a", 4)
+    p2 = Parameter("m2", "b", 2)
+    p3 = Parameter("m4", "xx", 10)
+
+    # These should be the same but check they are.
+    #
+    implicit = p1 * (p2 + p3)
+    explicit = np.multiply(p1,
+                           np.add(p2, p3))
+
+    assert isinstance(implicit, BinaryOpParameter)
+    assert isinstance(explicit, BinaryOpParameter)
+
+    # The model version of this
+    # test_model_op::test_explicit_numpy_combination()
+    # has the names being the same, but they are not here.
+    # Is this related to #1653
+    #
+    # assert explicit.name == implicit.name
+    assert implicit.name == "m1.a * (m2.b + m4.xx)"
+    assert explicit.name == "numpy.multiply(m1.a, (numpy.add(m2.b, m4.xx)))"
+
+    # Check they evaluate to the same values.
+    #
+    yexp = 48
+    assert implicit.val == pytest.approx(yexp)
+    assert explicit.val == pytest.approx(yexp)

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2020, 2021, 2022, 2023
+#  Copyright (C) 2016, 2018, 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1694,7 +1694,7 @@ def test_fit_str_single(stat):
     out = str(fit)
 
     expected = [("data", "test"),
-                ("model", "((poly * step) + bg)"),
+                ("model", "poly * step + bg"),
                 ("stat", stat.__name__),
                 ("method", "LevMar"),
                 ("estmethod", "Covariance")]

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2020, 2021, 2022, 2023
+#  Copyright (C) 2017, 2018, 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -201,7 +201,7 @@ def test_guess_warns_no_guess_no_argument(caplog, clean_ui):
     lname, lvl, msg = caplog.record_tuples[0]
     assert lname == "sherpa.ui.utils"
     assert lvl == logging.WARNING
-    assert msg == "No guess found for (dummy + dummy)"
+    assert msg == "No guess found for dummy + dummy"
 
 
 class Parameter2(Parameter):

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -77,7 +77,8 @@ __all__ = ('NoNewAttributesAfterInit',
            'sao_arange', 'sao_fcmp', 'send_to_pager',
            'set_origin', 'sum_intervals', 'zeroin',
            'multinormal_pdf', 'multit_pdf', 'get_error_estimates', 'quantile',
-           'get_precedences_op', 'get_precedence_expr'
+           'get_precedences_op', 'get_precedence_expr',
+           'get_precedence_lhs', 'get_precedence_rhs',
            )
 
 
@@ -4164,7 +4165,7 @@ def get_precedences_op(op: Callable) -> tuple[int, bool]:
 
     See Also
     --------
-    get_precedence_expr
+    get_precedence_expr, get_precedence_lhs, get_precedence_rhs
 
     """
 
@@ -4192,20 +4193,105 @@ def get_precedence_expr(expr: Any) -> int:
     Parameters
     ----------
     expr : Model or Parameter
-       The expression. It may have a .op field.
+       The expression. It may have a .opprec field.
 
     Returns
     -------
     prec : int
-       The "precedence".
+       The "precedence"; 9 is returned if expr has an unknown
+       operator or it does not contain an operator.
 
     See Also
     --------
-    get_precedences_op
+    get_precedences_op, get_precedence_lhs, get_precedence_rhs
 
     """
 
     try:
-        return get_precedences_op(expr.op)[0]
+        return expr.opprec
     except AttributeError:
         return 9
+
+
+def get_precedence_lhs(lstr: str, lp: int, p: int, a: bool) -> str:
+    """Return the string to use for the left side of a binary operator.
+
+    Parameters
+    ----------
+    lstr : str
+       The term to the left of the operator.
+    lp, p : int
+       Precedences of any operator in lstr and the current operator.
+    a : bool
+       Do we care about power-like terms.
+
+    Returns
+    -------
+    term : str
+       Either lstr or (lstr).
+
+    See Also
+    --------
+    get_precedences_op, get_precedence_expr, get_precedence_rhsx
+
+    """
+
+    if lp < p:
+        return f"({lstr})"
+
+    if not a:
+        return lstr
+
+    # We could combine all these into one, but for now keep
+    # them separate.
+    #
+    if lp == p:
+        # For now ensure the left term is bracketed just to be
+        # clear.
+        #
+        return f"({lstr})"
+
+    if lstr[0] == "-":
+        # If the term is negative then ensure it is included
+        # in a bracket before passed through to the power
+        # term.  Python has "-a ** 2" actually mapping to "-(a
+        # ** 2)" so we need to say "(-a) ** 2" if we really
+        # want the unary operator before the power term.
+        #
+        return f"({lstr})"
+
+    return lstr
+
+
+def get_precedence_rhs(rstr: str, opstr: str, rp: int, p: int) -> str:
+    """Return the string to use for the right side of a binary operator.
+
+    Parameters
+    ----------
+    rstr : str
+       The term to the right of the operator.
+    opstr : str
+       The string representing the operator.
+    rp, p : int
+       Precedences of any operator in rstr and the current operator.
+
+    Returns
+    -------
+    term : str
+       Either rstr or (rstr).
+
+    See Also
+    --------
+    get_precedences_op, get_precedence_expr, get_precedence_lhs
+
+    """
+
+    if opstr in ["+", "*"]:
+        condition = rp < p
+    else:
+        condition = rp <= p
+
+    if condition:
+        return f"({rstr})"
+
+    return rstr


### PR DESCRIPTION
# Summary

Remove excess brackets from model and parameter expressions. This is purely a cosmetic change, but hopefully makes complicated model expressions easier to read. Fix #780.

# Details

This is back on the #1060 bandwagon. But less significantly invasive.

Can we make model expressions like `xsphabs.gal * (powlaw1d.pl + gauss1d.gl + xsapec.foo)` display as `gal * (pl + gl + foo)` rather than `(gal * ((pl + gl) + foo))`?

Note that I explicitly am not trying to "simplify" expressions - e.g. change `gal + gal` to `2 * gal` of `gal - gal` to `0`, as I want the actual evaluation to match the original requested expression (since there may be reasons a user wants the model to evaluate in a certain manner, and it also makes things a lot easier).

All the various attempts rely on the fact that the arithmetic expressions (model, via `ArithmeticModel` or parameter via `Parameter`)

- use the dunder methods for addition, subtraction, multiplication, ... which create "combined" models containing the
- use specialized versions based on `CompositeModel` or `CompositeParameter` to handle unary and binary operators
  - for models these are `UnaryOpModel` and `BinaryOpModel` 
  - they wrap numeric constants in specialized model/parameter classes that just return the content, so in "2 * mdl"
    the "2" value is actually `ArithmeticConstantModel`
    
        >>> 2 * mdl
        <BinaryOpModel model instance '(2.0 * const1d.mdl)'>
        >>> (2 * mdl).lhs
        <ArithmeticConstantModel model instance '2.0'>

    (this isn't hugely relevant to the discussion, but I thought I'd mention it).

So, in [BNF](https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form) form we have something like the following (but this is meant to be "in-spirit" rather than a faithful conversion, in particular it doesn't handle functions rather than operators for both the unary and binary cases):

    expr :: term | unop op_single term | binop op_binary term term
    op_single :: + | - | abs
    op_binary :: + | - | * | / | ** | %
    term :: numeric-value | object

where `object` refers to `Model` or `Parameter`. In the following XXX means "Model or Parameter" for the class names, as the logic is replicated.

So, when a user enters `a * (b - 3)` then Python automatically creates expression

    BinaryOpXXX(lhs=a,
                    rhs=BinaryOpXXX(lhs=b, rhs=3, op="-"),
                    op="*")

for us. We can then control the "string" version by controlling how the `name` fields are created for the `BinaryOpXXX` and `UnaryOpXXX` terms, since these `.name` fields are used to define the string output (it's not always `__str__` that we care about, e.g. for `Parameter`).

It turns out that we really only care about the `BinaryOpXXX` classes, since although the `UnaryOpXXX` case seems sensible, I've decided it's not worth the complexity, so we "always" add a bracket around the interior term (the unary case handles both "-a" and "abs(a)", so it actually gets a bit complex about the rule - e.g. see

- #1653 

which I want to expand from parameters to models as well).

So, in this PR the logic for removing the excess brackets is moved into the constructor for `BinaryOpXXX`, since this has all the information we need (the operator and the lhs and rhs terms). There are plenty of examples about converting from infix to postfix form (e.g. RPN) and/or handling of the brackets - e.g. https://stackoverflow.com/questions/18400741/remove-redundant-parentheses-from-an-arithmetic-expression . My original attempts were too much, and I realized that 

- much of the discussion on these sites is about parsing the expression, but we have Python doing this for us, so all we care about is how we iterate through the expression tree
- we just want to simplify common expressions that users might create - e.g. we are not trying to simplify `(a + (b - a))` to `b`, or remove every excess pair of brackets, in particular when it comes to subtraction, which is not a common use case for model expressions
- we only need to put the logic into `BinaryOpXXX`, as this is the part of the model language that handles `a <op> b` terms
- you have to be careful because many of the examples do not treat all the things we care about, in particular negation (e.g. what happens with `(a - (b - c))`?)

So, when calculating the `name` field to pass to the parent constructor, we have `lhs`, `rhs`, and the operator term. We can process the two sides and then decide whether they need to add brackets around them. This is slightly tricky as we have to deal with precedences - e.g. to make sure that "(a - (b - c))" doesn't become `a - b - c`. As mentioned, I want to deal with common cases and I am not too bothered if there are one or two too many brackets left! I have extensive tests to try and check the cases we care about.

For the parameter case there's a slight subtly in the choice of `name` vs `fullname` fields, and it's not clear our existing code really handles this well, but it only really matters when the term is a `Parameter` instance (rather than a `CompositeParameter`) and this is only for display (and this behaviour/distinction has been in Sherpa essentially for ever, so nothing I've changed here).

# Notes

One concern I have is over hitting a RecursionError, since this process is recursive. However, the way it is implemented it's not obvious whether we really hit this case. I have been able to create a model expression with > 1000 terms and no recursion error is reported, so I think we are okay.

I was initially concerned that convolution-style models would need to be special cased to benefit from this (e.g. expressions involving a RMF) but fortunately that was wrong, since the convolution models pick this up automatically (via BinaryOpModel).

This simplification only happens when the expression uses the NumPy operators (e.g. `np.add`, `np.multiply`). It would be possible for users to use sub-classes of these routines (or entirely different operators) and we'd miss out on the simplification. To "fix" this we could use the operator symbol rather than operator function but I think we can wait until people start to do this (which I don't see happening).

# Examples

## With CIAO 4.16

```
sherpa In [1]: from sherpa.models import basic

sherpa In [2]: a = basic.Const1D("a")

sherpa In [3]: b = basic.Const1D("b")

sherpa In [4]: c = basic.Const1D("c")

sherpa In [5]: a * b + 2 * c
Out[5]: <BinaryOpModel model instance '((a * b) + (2.0 * c))'>

sherpa In [6]: a - b - c
Out[6]: <BinaryOpModel model instance '((a - b) - c)'>

sherpa In [7]: a - (b - c)
Out[7]: <BinaryOpModel model instance '(a - (b - c))'>

sherpa In [8]: a * 2 * c + 2 * (a + b / c)
Out[8]: <BinaryOpModel model instance '(((a * 2.0) * c) + (2.0 * (a + (b / c))))'>

sherpa In [9]: (a + 2) ** 2
Out[9]: <BinaryOpModel model instance '((a + 2.0) ** 2.0)'>

sherpa In [10]: a + a + a + a - a + a
Out[10]: <BinaryOpModel model instance '(((((a + a) + a) + a) - a) + a)'>

sherpa In [11]: a + a + (a + a) - a + a
Out[11]: <BinaryOpModel model instance '((((a + a) + (a + a)) - a) + a)'>

sherpa In [12]: a - (b + c)
Out[12]: <BinaryOpModel model instance '(a - (b + c))'>
```

## With this PR

```
>>> from sherpa.models import basic
>>> a = basic.Const1D("a")
>>> b = basic.Const1D("b")
>>> c = basic.Const1D("c")
>>> a * b + 2 * c
<BinaryOpModel model instance 'a * b + 2.0 * c'>
>>> a - b - c
<BinaryOpModel model instance 'a - b - c'>
>>> a - (b - c)
<BinaryOpModel model instance 'a - (b - c)'>
>>> a * 2 * c + 2 * (a + b / c)
<BinaryOpModel model instance 'a * 2.0 * c + 2.0 * (a + b / c)'>
>>> (a + 2) ** 2
<BinaryOpModel model instance '(a + 2.0) ** 2.0'>
>>> a + a + a + a - a + a
<BinaryOpModel model instance 'a + a + a + a - a + a'>
>>> a + a + (a + a) - a + a
<BinaryOpModel model instance 'a + a + a + a - a + a'>
>>> a - (b + c)
<BinaryOpModel model instance 'a - (b + c)'>
```

If you have convolution-style models - such as a model expression for a PHA dataset  - then the term inside the `apply_rmf(apply_arf(...))` tokens will have this simplification. You can see the changes to the various tests that show this.

We do not bother with removing brackets around `UnaryOpModel` cases since I didn't think it worth it. This means we simplify

```
sherpa-4.16.0> -a - b
<BinaryOpModel model instance '(-(a) - b)'>
```

to

```
>>> -a - b
<BinaryOpModel model instance '-(a) - b'>
```

rather than to `-a - b`. As most people don't use UnaryOpModel I think this is okay.

