### PR TITLE
Fix the requires_pylab decorator

### DIFF
--- a/docs/overview/testing.rst
+++ b/docs/overview/testing.rst
@@ -16,6 +16,5 @@ The sherpa.utils.testing module
       requires_fits
       requires_group
       requires_package
-      requires_pylab
       requires_stk
       requires_xspec

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -48,7 +48,7 @@ from sherpa.models.template import create_template_model
 
 from sherpa.utils.err import ArgumentTypeErr, DataErr, IdentifierErr, ModelErr, PlotErr
 from sherpa.utils.testing import requires_data, requires_fits, \
-    requires_xspec, requires_pylab, requires_wcs
+    requires_xspec, requires_wcs
 
 import sherpa.ui.utils
 import sherpa.astro.ui.utils
@@ -1086,7 +1086,6 @@ def check_bkg_source(plotfunc, idval, isfit=True):
     assert np.all(plot.y >= 0)
 
 
-@requires_pylab
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
 @pytest.mark.parametrize("plotfunc,checkfuncs",
                          [(ui.plot_bkg_delchi, [check_bkg_resid]),
@@ -1100,7 +1099,7 @@ def check_bkg_source(plotfunc, idval, isfit=True):
                           (ui.plot_bkg_fit_ratio, [check_bkg_fit, check_bkg_resid]),
                           (ui.plot_bkg_fit_resid, [check_bkg_fit, check_bkg_resid])])
 def test_bkg_plot_xxx(idval, plotfunc, checkfuncs,
-                      clean_astro_ui):
+                      clean_astro_ui, requires_pylab):
     """Test background plotting - channel space"""
 
     setup_example_bkg_model(idval)
@@ -1192,7 +1191,6 @@ def test_pha1_plot(plotfunc, clean_astro_ui, basic_pha1):
     plotfunc()
 
 
-@requires_pylab
 @pytest.mark.parametrize("plotfunc",
                          [ui.plot_data,
                           ui.plot_model,
@@ -1205,7 +1203,8 @@ def test_pha1_plot(plotfunc, clean_astro_ui, basic_pha1):
                           ui.plot_fit_resid,
                           ui.plot_fit_ratio,
                           ui.plot_chisqr])
-def test_xxx_plot_clearwindow(hide_logging, clean_astro_ui, plotfunc):
+def test_xxx_plot_clearwindow(hide_logging, clean_astro_ui,
+                              requires_pylab, plotfunc):
     """If set clearwindow=False does it run sensibly for Data1D data?
 
     This does not have a great check for what "sensibly" means.
@@ -1230,12 +1229,11 @@ def test_xxx_plot_clearwindow(hide_logging, clean_astro_ui, plotfunc):
     assert nlines1 == [2 * n for n in nlines0]
 
 
-@requires_pylab
 @requires_fits
 @requires_data
 @pytest.mark.parametrize("plotfunc", _basic_plotfuncs)
-def test_pha1_plot_clearwindow(hide_logging, clean_astro_ui, basic_pha1,
-                               plotfunc):
+def test_pha1_plot_clearwindow(hide_logging, clean_astro_ui,
+                               requires_pylab, basic_pha1, plotfunc):
     """If set clearwindow=False does it run sensibly for PHA data?
 
     This does not have a great check for what "sensibly" means.
@@ -1430,7 +1428,7 @@ def check_pha1_plot_model_component_plot():
     variants, as all we do is check the y axis range makes sense
     (as it wouldn't have with #1020 unfixed).
 
-    Any test calling this requires @requires_pylab
+    Any test calling this requires the requires_pylab fixture.
     """
     from matplotlib import pyplot as plt
 
@@ -1444,20 +1442,20 @@ def check_pha1_plot_model_component_plot():
     assert ylim[1] < 2e-2
 
 
-@requires_pylab
 @requires_fits
 @requires_data
-def test_pha1_plot_model_component_add_response(clean_astro_ui, basic_pha1):
+def test_pha1_plot_model_component_add_response(clean_astro_ui, basic_pha1,
+                                                requires_pylab):
     """Do we automatically add in the response? See issue #1020.
     """
     ui.plot_model_component('pl', ylog=True)
     check_pha1_plot_model_component_plot()
 
 
-@requires_pylab
 @requires_fits
 @requires_data
 def test_pha1_plot_with_model_component_add_response(clean_astro_ui,
+                                                     requires_pylab,
                                                      basic_pha1):
     """Do we automatically add in the response? See issue #1020.
     """
@@ -1465,10 +1463,11 @@ def test_pha1_plot_with_model_component_add_response(clean_astro_ui,
     check_pha1_plot_model_component_plot()
 
 
-@requires_pylab
 @requires_fits
 @requires_data
-def test_pha1_plot_model_component_with_response(clean_astro_ui, basic_pha1):
+def test_pha1_plot_model_component_with_response(clean_astro_ui,
+                                                 requires_pylab,
+                                                 basic_pha1):
     """Plot is okay if we include the response
     """
     rsp = ui.get_response()
@@ -1476,10 +1475,10 @@ def test_pha1_plot_model_component_with_response(clean_astro_ui, basic_pha1):
     check_pha1_plot_model_component_plot()
 
 
-@requires_pylab
 @requires_fits
 @requires_data
 def test_pha1_plot_with_model_component_with_response(clean_astro_ui,
+                                                      requires_pylab,
                                                       basic_pha1):
     """Plot is okay if we include the response
     """
@@ -1488,10 +1487,10 @@ def test_pha1_plot_with_model_component_with_response(clean_astro_ui,
     check_pha1_plot_model_component_plot()
 
 
-@requires_pylab
 @requires_fits
 @requires_data
-def test_pha1_plot_model_component_no_response(clean_astro_ui, basic_pha1_bg):
+def test_pha1_plot_model_component_no_response(clean_astro_ui, basic_pha1_bg,
+                                               requires_pylab):
     """PHA file but no response
     """
     from matplotlib import pyplot as plt
@@ -1504,10 +1503,10 @@ def test_pha1_plot_model_component_no_response(clean_astro_ui, basic_pha1_bg):
     assert ylim[1] < 1e-11
 
 
-@requires_pylab
 @requires_fits
 @requires_data
 def test_pha1_plot_with_model_component_no_response(clean_astro_ui,
+                                                    requires_pylab,
                                                     basic_pha1_bg):
     """PHA file but no response
     """
@@ -1558,10 +1557,9 @@ def test_img_contour_function(clean_astro_ui, basic_img, all_plot_backends_astro
     ui.contour("data", "model", "source", "fit")
 
 
-@requires_pylab
 @requires_fits
 @requires_data
-def test_img_contour_function_kwarg(clean_astro_ui, basic_img):
+def test_img_contour_function_kwarg(clean_astro_ui, requires_pylab, basic_img):
     """Check we can change the alpha setting."""
 
     from matplotlib import pyplot as plt
@@ -1598,10 +1596,10 @@ def test_img_contour(clean_astro_ui, basic_img, plotfunc, all_plot_backends_astr
 
 # Add in some pylab-specific tests to change default values
 #
-@requires_pylab
 @requires_fits
 @requires_data
-def test_pha1_plot_data_options(caplog, clean_astro_ui, basic_pha1):
+def test_pha1_plot_data_options(caplog, clean_astro_ui, requires_pylab,
+                                basic_pha1):
     """Test that the options have changed things, where easy to do so"""
 
     from matplotlib import pyplot as plt
@@ -1714,10 +1712,10 @@ def test_pha1_plot_data_options(caplog, clean_astro_ui, basic_pha1):
     assert a == pytest.approx(1)
 
 
-@requires_pylab
 @requires_fits
 @requires_data
-def test_pha1_plot_model_options(caplog, clean_astro_ui, basic_pha1):
+def test_pha1_plot_model_options(caplog, clean_astro_ui, requires_pylab,
+                                 basic_pha1):
     """Test that the options have changed things, where easy to do so
 
     In matplotlib 3.1 the plot_model call causes a MatplotlibDeprecationWarning
@@ -1804,10 +1802,9 @@ def test_pha1_plot_model_options(caplog, clean_astro_ui, basic_pha1):
     assert len(ax.collections) == 0
 
 
-@requires_pylab
 @requires_fits
 @requires_data
-def test_pha1_plot_fit_options(clean_astro_ui, basic_pha1):
+def test_pha1_plot_fit_options(clean_astro_ui, requires_pylab, basic_pha1):
     """Test that the options have changed things, where easy to do so"""
 
     from matplotlib import pyplot as plt
@@ -1913,11 +1910,10 @@ def test_pha1_plot_fit_options(clean_astro_ui, basic_pha1):
     assert a == pytest.approx(0.7)
 
 
-@requires_pylab
 @requires_fits
 @requires_data
 @requires_xspec
-def test_pha1_reg_proj(clean_astro_ui, basic_pha1):
+def test_pha1_reg_proj(clean_astro_ui, requires_pylab, basic_pha1):
     """This is potentially a time-consuming test to run, so simplify
     as much as possible.
     """
@@ -1965,13 +1961,11 @@ def test_pha1_reg_proj(clean_astro_ui, basic_pha1):
     assert line.get_marker() == '+'
 
     # the number depends on the matplotlib version: 2 for 2.2.3 and
-    # 3 for 3.1.1; it's not clear what the "extra" one is in matplotlib 3
-    # (it isn't obviously visible). DJB guesses that this would be
-    # clearer if we ran with more bins along each axis, but this would
-    # take more time.
+    # 3 for 3.1.1, 1 for 3.8.3. So, let's just check that there's
+    # something there...
     #
     ncontours = len(ax.collections)
-    assert ncontours in [2, 3]
+    assert ncontours > 0
 
 
 DATA_PREFS = {'alpha': None,
@@ -2952,7 +2946,6 @@ def test_data1d_get_model_plot_template(cls, plottype, extraargs, title, plotcls
     assert not isinstance(plot, sherpa.plot.ComponentTemplateSourcePlot)
 
 
-@requires_pylab
 @pytest.mark.parametrize("cls",
                          [sherpa.ui.utils.Session,
                           sherpa.astro.ui.utils.Session])
@@ -2963,7 +2956,8 @@ def test_data1d_get_model_plot_template(cls, plottype, extraargs, title, plotcls
                           ("source", [], "Source"),
                           ("source_component", ['mdl'],
                            "Source model component: polynom1d.mdl")])
-def test_data1d_plot_model(cls, plottype, extraargs, title):
+def test_data1d_plot_model(cls, plottype, extraargs, title,
+                           requires_pylab):
     """Check we can plot a Data1D model/source.
 
     For the Data1D case source and model return the
@@ -3011,7 +3005,6 @@ def test_data1d_plot_model(cls, plottype, extraargs, title):
     assert yplot == pytest.approx(np.asarray([100, 102, 104, 106, 108]))
 
 
-@requires_pylab
 @pytest.mark.parametrize("cls",
                          [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("plottype,extraargs,title",
@@ -3021,7 +3014,8 @@ def test_data1d_plot_model(cls, plottype, extraargs, title):
                           ("source", [], "Source"),
                           ("source_component", ['tmdl'],
                            "Source model component: template.tmdl")])
-def test_data1d_plot_model_template(cls, plottype, extraargs, title):
+def test_data1d_plot_model_template(cls, plottype, extraargs, title,
+                                    requires_pylab):
     """Template models are handled slightly differently.
     """
 
@@ -3128,7 +3122,6 @@ def test_data1dint_get_model_plot(cls, plottype, extraargs, title, plotcls):
     assert plot.y == pytest.approx(yexp)
 
 
-@requires_pylab
 @pytest.mark.parametrize("cls",
                          [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("plottype,extraargs,title",
@@ -3138,7 +3131,7 @@ def test_data1dint_get_model_plot(cls, plottype, extraargs, title, plotcls):
                           ("source", [], "Source"),
                           ("source_component", ['mdl'],
                            "Source model component: polynom1d.mdl")])
-def test_data1dint_plot_model(cls, plottype, extraargs, title):
+def test_data1dint_plot_model(cls, plottype, extraargs, title, requires_pylab):
     """Check we can plot a Data1DInt model.
 
     This is plotted as a histogram, not as x/y values like Data1D
@@ -3743,8 +3736,7 @@ def test_set_plot_opt_y_astro(cls, datafunc, plotfunc, answer):
         assert not p2.histo_prefs['ylog']
 
 
-@requires_pylab
-def test_set_plot_opt_with_plot_x():
+def test_set_plot_opt_with_plot_x(requires_pylab):
     """Does set_xlog/xlinear work with plot()  Astro data objects only.
 
     We could repeat the other tests - i.e. query the
@@ -3792,8 +3784,7 @@ def test_set_plot_opt_with_plot_x():
         assert ax.get_yscale() == 'linear', idx
 
 
-@requires_pylab
-def test_set_plot_opt_with_plot_y():
+def test_set_plot_opt_with_plot_y(requires_pylab):
     """Does set_ylog/ylinear work with plot()  Astro data objects only.
     """
 
@@ -3924,10 +3915,9 @@ def test_set_opt_valid_astro(name):
     s.set_ylinear(name)
 
 
-@requires_pylab
 @pytest.mark.parametrize("cls",
                          [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
-def test_set_plot_opt_explicit(cls):
+def test_set_plot_opt_explicit(cls, requires_pylab):
     """Check we can call set_xlog('data').
 
     We don't check all options (unlike the set_xlog/ylog
@@ -4012,8 +4002,7 @@ def test_set_plot_opt_changes_fields(cls, name, extraargs):
     assert not p2.histo_prefs["ylog"]
 
 
-@requires_pylab
-def test_set_plot_opt_explicit_astro():
+def test_set_plot_opt_explicit_astro(requires_pylab):
     """Check we can call set_xlog('data') with astro data.
 
     We don't check all options (unlike the set_xlog/ylog
@@ -4140,7 +4129,7 @@ def test_set_plot_opt_alias(cls, caplog):
 def check_plot2_xscale(xscale):
     """Are there two plots, y-axis linear, x axis set?
 
-    Any test using this needs @requires_pylab
+    Any test using this needs the requires_pylab fixture.
     """
 
     from matplotlib import pyplot as plt
@@ -4157,14 +4146,13 @@ def check_plot2_xscale(xscale):
     assert axes[1].yaxis.get_scale() == 'linear'
 
 
-@requires_pylab
 @pytest.mark.parametrize("idval", [None, "bob"])
 @pytest.mark.parametrize("plottype,xscale", [('data', 'log'),
                                              ('resid', 'log'),
                                              ('bkg', 'linear'),
                                              ('bkg_resid', 'linear')])
 def test_plot_fit_resid_set_xlog(idval, plottype, xscale,
-                                 clean_astro_ui):
+                                 clean_astro_ui, requires_pylab):
     """Check that set_xlog handling for plot_fit_resid.
 
     What is the X-axis scaling when you call set_xlog(plottype)?
@@ -4178,14 +4166,13 @@ def test_plot_fit_resid_set_xlog(idval, plottype, xscale,
     check_plot2_xscale(xscale)
 
 
-@requires_pylab
 @pytest.mark.parametrize("idval", [None, "bob"])
 @pytest.mark.parametrize("plottype,xscale", [('data', 'linear'),
                                              ('resid', 'linear'),
                                              ('bkg', 'log'),
                                              ('bkg_resid', 'log')])
 def test_plot_bkg_fit_resid_set_xlog(idval, plottype, xscale,
-                                     clean_astro_ui):
+                                     clean_astro_ui, requires_pylab):
     """Check that set_xlog handling for plot_bkg_fit_resid.
 
     This logic could be added to test_plot_fit_resid_set_xlog but it
@@ -4199,14 +4186,13 @@ def test_plot_bkg_fit_resid_set_xlog(idval, plottype, xscale,
     check_plot2_xscale(xscale)
 
 
-@requires_pylab
 @pytest.mark.parametrize("plot,yscale", [('data', 'linear'),
                                          ('ratio', 'linear'),
                                          ('fit', 'linear'),
                                          ('bkg', 'log'),
                                          ('bkg_resid', 'linear'),
                                          ('bkg_fit', 'log')])
-def test_set_ylog_bkg(plot, yscale, clean_astro_ui):
+def test_set_ylog_bkg(plot, yscale, clean_astro_ui, requires_pylab):
     """Check y axis after_ylog('bkg').
 
     The idea is to check how separate the "background" from

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -869,3 +869,20 @@ def xsmodel():
         return cls(mname)
 
     return func
+
+
+# Fixtures that control access to the tests, based on the availability
+# of external "features" (normally this is the presence of optional
+# modules). These used to be decorators in sherpa.utils.testing.
+#
+@pytest.fixture
+def requires_pylab():
+    """Runs the test with the pylab plotting backend if available."""
+
+    pylab_backend = pytest.importorskip("sherpa.plot.pylab_backend")
+    plt = pytest.importorskip("matplotlib.pyplot")
+
+    with TemporaryPlottingBackend(pylab_backend.PylabBackend()):
+        yield
+
+    plt.close(fig="all")

--- a/sherpa/plot/tests/test_pylab.py
+++ b/sherpa/plot/tests/test_pylab.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2016, 2018, 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2016, 2018 - 2021, 2024
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -23,7 +24,6 @@ import numpy as np
 
 import pytest
 
-from sherpa.utils.testing import requires_pylab
 from sherpa.data import Data1D, Data1DInt
 from sherpa.models.basic import Const1D
 from sherpa.stats import Chi2DataVar
@@ -31,9 +31,8 @@ from sherpa.plot import DataPlot, ModelHistogramPlot, \
     DelchiPlot, RatioPlot, ResidPlot
 
 
-@requires_pylab
 @pytest.mark.parametrize("plottype", [DelchiPlot, RatioPlot, ResidPlot])
-def test_ignore_ylog_prefs(plottype):
+def test_ignore_ylog_prefs(plottype, requires_pylab):
     """Do the "residual" style plots ignore the ylog preference setting?"""
 
     from matplotlib import pyplot as plt
@@ -56,9 +55,8 @@ def test_ignore_ylog_prefs(plottype):
     assert ax.get_yscale() == 'linear'
 
 
-@requires_pylab
 @pytest.mark.parametrize("plottype", [DelchiPlot, RatioPlot, ResidPlot])
-def test_ignore_ylog_kwarg(plottype):
+def test_ignore_ylog_kwarg(plottype, requires_pylab):
     """Do the "residual" style plots ignore the ylog keyword argument?"""
 
     from matplotlib import pyplot as plt
@@ -79,8 +77,7 @@ def test_ignore_ylog_kwarg(plottype):
     assert ax.get_yscale() == 'linear'
 
 
-@requires_pylab
-def test_warning_dataplot_linecolor(caplog):
+def test_warning_dataplot_linecolor(caplog, requires_pylab):
     """We get a warning when using linecolor: DataPlot"""
 
     data = Data1D('tst', np.asarray([1, 2, 3]), np.asarray([10, 12, 10.5]))
@@ -93,11 +90,10 @@ def test_warning_dataplot_linecolor(caplog):
     lname, lvl, msg = caplog.record_tuples[0]
     assert lname == 'sherpa.plot.pylab_backend'
     assert lvl == logging.WARNING
-    assert msg == 'The linecolor attribute, set to mousey, is unused.'
+    assert msg == 'The linecolor attribute (mousey) is unused.'
 
 
-@requires_pylab
-def test_warning_plot_hist_linecolor(caplog):
+def test_warning_plot_hist_linecolor(caplog, requires_pylab):
     """We get a warning when using linecolor: ModelHistogramPlot"""
 
     data = Data1DInt('tst', np.asarray([1, 2, 3]),

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2019 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -41,7 +41,6 @@ from sherpa.models import basic
 import sherpa.plot
 from sherpa.stats import Chi2Gehrels
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, IdentifierErr, PlotErr
-from sherpa.utils.testing import requires_pylab
 
 
 _data_x = [10, 20, 40, 90]
@@ -1112,9 +1111,8 @@ def test_plot_contour_error_out_invalid(plottype, session):
         func("fooflan flim flam")
 
 
-@requires_pylab
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_plot_single(session):
+def test_plot_single(session, requires_pylab):
     """Can we call plot() with a single plot type?
 
     There's no real way to test this without a backend.
@@ -1159,9 +1157,8 @@ def test_plot_single(session):
     plt.close()
 
 
-@requires_pylab
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_plot_multiple(session):
+def test_plot_multiple(session, requires_pylab):
     """Can we call plot() with multiple plot types?
 
     Also tests out sending in a kwarg.
@@ -1215,9 +1212,8 @@ def test_plot_multiple(session):
     plt.close()
 
 
-@requires_pylab
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_contour_single(session):
+def test_contour_single(session, requires_pylab):
     """Can we call contour() with a single plot type?
 
     There's no real way to test this without a backend.
@@ -1273,9 +1269,8 @@ def test_contour_single(session):
     plt.close()
 
 
-@requires_pylab
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_contour_multiple(session):
+def test_contour_multiple(session, requires_pylab):
     """Can we call contour() with multiple plot types?
 
     There's no real way to test this without a backend.
@@ -1321,7 +1316,6 @@ def test_contour_multiple(session):
     plt.close()
 
 
-@requires_pylab
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 @pytest.mark.parametrize("plotfunc,title,pcls",
                          [("data", "", sherpa.plot.DataContour),
@@ -1331,7 +1325,7 @@ def test_contour_multiple(session):
                           ("ratio", "Ratio of Data to Model", sherpa.plot.RatioContour),
                           ("fit", "", sherpa.plot.FitContour),
                           ("fit_resid", None, None)])
-def test_contour_xxx(plotfunc, title, pcls, session):
+def test_contour_xxx(plotfunc, title, pcls, session, requires_pylab):
     """Check we can call contour_xxx()/get_xxx_contour().
 
     There's no real way to test this without a backend.
@@ -1396,16 +1390,16 @@ def test_contour_xxx(plotfunc, title, pcls, session):
     plt.close()
 
 
-@requires_pylab
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 @pytest.mark.parametrize("ctype", ["data", "model"])
-def test_get_xxx_contour_prefs_pylab(ctype, session):
+def test_get_xxx_contour_prefs_pylab(ctype, session, requires_pylab):
 
     s = session()
     p = getattr(s, f"get_{ctype}_contour_prefs")()
     assert isinstance(p, dict)
     assert p == {'xlog': False, 'ylog': False,
-                 'alpha': None, 'linewidths': None, 'colors': None}
+                 'alpha': None, 'linewidths': None, 'colors': None,
+                 'label': None, 'levels': None, 'linestyles': 'solid'}
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
@@ -1640,9 +1634,8 @@ def test_get_cdf_plot_empty(session):
         assert getattr(p, f) is None
 
 
-@requires_pylab
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_plot_cdf_replot_no_data(session):
+def test_plot_cdf_replot_no_data(session, requires_pylab):
     """what does replot=True do for plot_cdf?
 
     The code doesn't check for this evantuality,
@@ -1658,9 +1651,8 @@ def test_plot_cdf_replot_no_data(session):
         s.plot_cdf(x, replot=True)
 
 
-@requires_pylab
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_plot_cdf_replot(session):
+def test_plot_cdf_replot(session, requires_pylab):
     """what does replot=True do for plot_cdf?
 
     """
@@ -1842,9 +1834,8 @@ def test_plot_pdf(session):
     assert p.title == 'PDF: x'
 
 
-@requires_pylab
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_plot_pdf_replot_no_data(session):
+def test_plot_pdf_replot_no_data(session, requires_pylab):
     """what does replot=True do for plot_pdf?
 
     The code doesn't check for this evantuality,
@@ -1862,9 +1853,8 @@ def test_plot_pdf_replot_no_data(session):
     assert "'NoneType' has no len" in str(exc.value)
 
 
-@requires_pylab
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_plot_pdf_replot(session):
+def test_plot_pdf_replot(session, requires_pylab):
     """what does replot=True do for plot_pdf?
 
     """
@@ -2374,9 +2364,8 @@ def test_get_model_component_plot_model(session):
     assert plot.title == 'Model component: const1d.gmdl'
 
 
-@requires_pylab
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_pylab_plot_scatter_empty_replot(session):
+def test_pylab_plot_scatter_empty_replot(session, requires_pylab):
     """plot_scatter with replot=False and no data
 
     Just check the current behavior
@@ -2408,9 +2397,8 @@ def test_pylab_plot_scatter_empty_replot(session):
     plt.close()
 
 
-@requires_pylab
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_pylab_plot_scatter(session):
+def test_pylab_plot_scatter(session, requires_pylab):
     """Simple test of plot_scatter"""
 
     from matplotlib import pyplot as plt
@@ -2445,9 +2433,8 @@ def test_pylab_plot_scatter(session):
     plt.close()
 
 
-@requires_pylab
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_pylab_plot_trace_empty_replot(session):
+def test_pylab_plot_trace_empty_replot(session, requires_pylab):
     """plot_trace with replot=False and no data
 
     Just check the current behavior
@@ -2462,9 +2449,8 @@ def test_pylab_plot_trace_empty_replot(session):
         s.plot_trace(y, replot=True)
 
 
-@requires_pylab
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_pylab_plot_trace(session):
+def test_pylab_plot_trace(session, requires_pylab):
     """Simple test of plot_trace"""
 
     from matplotlib import pyplot as plt
@@ -2785,10 +2771,9 @@ def test_fit_contour_recalc(session):
     assert pm.y.min() == pm.y.max()
 
 
-@requires_pylab
 @pytest.mark.parametrize("ptype",
                          ["resid", "ratio", "delchi"])
-def test_plot_fit_xxx_pylab(ptype, clean_ui):
+def test_plot_fit_xxx_pylab(ptype, clean_ui, requires_pylab):
     """Just ensure we can create a plot_fit_xxx call."""
 
     from matplotlib import pyplot as plt
@@ -2832,10 +2817,9 @@ def test_plot_fit_xxx_pylab(ptype, clean_ui):
     assert len(axes[1].lines) == 2
 
 
-@requires_pylab
 @pytest.mark.parametrize("ptype",
                          ["resid", "ratio", "delchi"])
-def test_plot_fit_xxx_overplot_pylab(ptype, caplog, clean_ui):
+def test_plot_fit_xxx_overplot_pylab(ptype, caplog, clean_ui, requires_pylab):
     """Just ensure we can create a plot_fit_xxx(overplot=True) call."""
 
     from matplotlib import pyplot as plt
@@ -2872,9 +2856,8 @@ def test_plot_fit_xxx_overplot_pylab(ptype, caplog, clean_ui):
         assert l0[1].get_xydata() == pytest.approx(l0[3].get_xydata())
 
 
-@requires_pylab
 @pytest.mark.parametrize("idval", [None, "bob"])
-def test_plot_fit_resid_handles_data_log(idval, clean_ui):
+def test_plot_fit_resid_handles_data_log(idval, clean_ui, requires_pylab):
     """Check that log handling is correct: data=log
 
     See also test_plot_fit_resid_handles_resid_log.
@@ -2900,9 +2883,8 @@ def test_plot_fit_resid_handles_data_log(idval, clean_ui):
     assert axes[1].yaxis.get_scale() == 'linear'
 
 
-@requires_pylab
 @pytest.mark.parametrize("idval", [None, "bob"])
-def test_plot_fit_resid_handles_resid_log(idval, clean_ui):
+def test_plot_fit_resid_handles_resid_log(idval, clean_ui, requires_pylab):
     """Check that log handling is correct: resid=log
 
     We need to decide whether we want the residual setting to override

--- a/sherpa/utils/testing.py
+++ b/sherpa/utils/testing.py
@@ -143,19 +143,6 @@ if HAS_PYTEST:
 
         return decorator
 
-
-    def requires_pylab(test_function):
-        """Runs the test with the PylabBackend plotting backend if available,
-        otherwise skips the test.
-        """
-        pylab_backend = pytest.importorskip("sherpa.plot.pylab_backend")
-        plt = pytest.importorskip("matplotlib.pyplot")
-
-        with TemporaryPlottingBackend(pylab_backend.PylabBackend()):
-            yield
-
-        plt.close(fig="all")
-
     def requires_fits(test_function):
         """Returns True if a working backend for FITS I/O is importable.
 
@@ -215,8 +202,6 @@ else:
         return wrapper
 
     requires_data = make_fake()
-
-    requires_pylab = make_fake()
 
     requires_fits = make_fake()
 

--- a/sherpa/utils/tests/test_utils_error_unit.py
+++ b/sherpa/utils/tests/test_utils_error_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2019, 2023
+#  Copyright (C) 2017 - 2019, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -37,11 +37,6 @@ def test_decorator_exception_when_pytest_is_absent(monkeypatch):
     from sherpa.utils import testing
 
     @testing.requires_data
-    def foo():
-        raise RuntimeError(SKIP_MESSAGE)
-    assert_decorated_function(foo)
-
-    @testing.requires_pylab
     def foo():
         raise RuntimeError(SKIP_MESSAGE)
     assert_decorated_function(foo)


### PR DESCRIPTION
# Summary

Change the testing code to better-handle those tests that want to check plotting when using the pylab backend. Fix #1971.

# Details

As noted in #1971 the current requires_pylab decorator, which is meant to only run tests when matplotlib is available, and then run the test with the pylab plot backend selected, does not work.

This is because it's trying to be both a decorator and a generator.

The easiest way I have found to do this is to move from requires_pylab being a decorator defined in sherpa.utils.testing to being a pytest fixture defined in sherpa/conftest.py. Actually, I couldn't easily come up with a different solution. That's not to mean there isn't one, but mixing decorators, generators, and pytest is a recipe for disaster so I wanted to make it as simple as I could understand.

I think there's a strong argument to be had to make these tests fixtures rather than decorators, but I am only doing it for requires_pylab because

- it is the only one that needs this
- there are not many users of requires_pylab so it is an easy-to-make change
- requires_pylab is a fairly-new invention so there's less likely to be downstream problems with this change (since it is simpler to remove the sherpa.utils.testing.requires_pylab symbol to make it obvious what is going on)
- doing the other symbols
  - would take too long
  - although I think it would be better, there may be some cases where we would want to retain the decorator

This should technically improve test coverage as it likely runs more code now. Some tests have had been to be updated because they were not actually correct.

This will cause fun for some existing PRs, such as 
- #1679 
I think

# Example

The `main` branch has this many tests

```
=================== 8920 passed, 74 skipped, 99 xfailed, 4 xpassed, 2 warnings in 541.45s (0:09:01) ===================
```

This branch has

```
=================== 9106 passed, 74 skipped, 99 xfailed, 4 xpassed, 2 warnings in 554.39s (0:09:14) ===================
```

That is, we "gain" 186 tests.
