### PR TITLE
Allow linked parameters to be fit without including them in the model expression

### DIFF
--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2023
+#  Copyright (C) 2010, 2015, 2023, 2024
 #  Smithsonian Astrophysical Observator
 #
 #
@@ -120,7 +120,7 @@ class RMFModel(CompositeModel, ArithmeticModel):
         self.model = model
 
         # Logic for ArithmeticModel.__init__
-        self.pars = ()
+        self._pars = ()
 
         # FIXME: group pairs of coordinates with one attribute
 
@@ -181,7 +181,7 @@ class ARFModel(CompositeModel, ArithmeticModel):
         self.arfargs = ()
 
         # Logic for ArithmeticModel.__init__
-        self.pars = ()
+        self._pars = ()
 
         CompositeModel.__init__(self, f'apply_arf({model.name})', (model,))
         self.filter()
@@ -232,7 +232,7 @@ class RSPModel(CompositeModel, ArithmeticModel):
         self.arfargs = ()
 
         # Logic for ArithmeticModel.__init__
-        self.pars = ()
+        self._pars = ()
 
         CompositeModel.__init__(self, f'apply_rmf(apply_arf({model.name}))',
                                 (model,))
@@ -1045,7 +1045,7 @@ class PileupRMFModel(CompositeModel, ArithmeticModel):
         self.model = model
         self.otherargs = None
         self.otherkwargs = None
-        self.pars = ()
+        self._pars = ()
         CompositeModel.__init__(self,
                                 f'apply_rmf({self.model.name})',
                                 (self.model,))

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2015, 2016, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2009, 2015, 2016, 2018 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -276,8 +276,7 @@ class FitResults(NoNewAttributesAfterInit):
         _rstat, _qval = fit.stat.goodness_of_fit(results[2], _dof)
 
         self.succeeded = results[0]
-        self.parnames = tuple(p.fullname for p in fit.model.pars
-                              if not p.frozen)
+        self.parnames = tuple(p.fullname for p in fit.model.get_thawed_pars())
         self.parvals = tuple(results[1])
         self.istatval = init_stat
         self.statval = results[2]
@@ -424,7 +423,7 @@ class ErrorEstResults(NoNewAttributesAfterInit):
 
     def __init__(self, fit, results, parlist=None):
         if parlist is None:
-            parlist = [p for p in fit.model.pars if not p.frozen]
+            parlist = [p for p in fit.model.get_thawed_pars()]
 
         # TODO: Can we not just import them at the top level?  It may
         # cause an import loop.
@@ -644,8 +643,8 @@ class IterFit(NoNewAttributesAfterInit):
                 raise FitErr('noclobererr', outfile)
 
             names = ['# nfev statistic']
-            names.extend(f'{par.fullname}' for par in self.model.pars
-                         if not par.frozen)
+            names.extend(par.fullname
+                         for par in self.model.get_thawed_pars())
             self._file = open(outfile, 'w', encoding="ascii")
             print(' '.join(names), file=self._file)
 
@@ -943,12 +942,6 @@ class Fit(NoNewAttributesAfterInit):
         self.stat = stat
         self.method = method
         self.estmethod = estmethod
-        # Confidence limit code freezes one parameter
-        # at a time.  Keep a record here of which one
-        # that is, in case an exception is raised and
-        # this parameter needs to be thawed in the
-        # exception handler.
-        self.calc_thaw_indices()
         self.current_frozen = -1
 
         # The number of times that reminimization has occurred
@@ -962,11 +955,6 @@ class Fit(NoNewAttributesAfterInit):
         self._iterfit = IterFit(self.data, self.model, self.stat, self.method,
                                 itermethod_opts)
         NoNewAttributesAfterInit.__init__(self)
-
-    def calc_thaw_indices(self):
-        self.thaw_indices = \
-            tuple(i for i, par in enumerate(self.model.pars)
-                  if not par.frozen)
 
     def __setstate__(self, state):
         self.__dict__.update(state)
@@ -1157,8 +1145,9 @@ class Fit(NoNewAttributesAfterInit):
         output = tuple(tmp)
         # end of the gymnastics 'cause one cannot write to a tuple
 
-        # check if any parameter values are at boundaries,
-        # and warn user.
+        # Check if any parameter values are at boundaries, and warn
+        # user. This does not include any linked parameters.
+        #
         tol = np.finfo(np.float32).eps
         param_warnings = ""
         for par in self.model.pars:
@@ -1174,11 +1163,6 @@ class Fit(NoNewAttributesAfterInit):
             print(' '.join(vals), file=self._iterfit._file)
             self._iterfit._file.close()
             self._iterfit._file = None
-
-        # if a re-fit was performed with more/less thawed pars then
-        # self.thaw_indices must be re-calculated otherwise Confidence
-        # will get IndexError, see issue #342 for details
-        self.calc_thaw_indices()
 
         return FitResults(self, output, init_stat, param_warnings.strip("\n"))
 
@@ -1267,35 +1251,41 @@ class Fit(NoNewAttributesAfterInit):
         errors.
         """
 
+        # Since the set of thawed parameters can change during this
+        # loop we need to keep the "original" version for use.
+        #
+        thawedpars = self.model.get_thawed_pars()
+
         # Define functions to freeze and thaw a parameter before
         # we call fit function -- projection can call fit several
         # times, for each parameter -- that parameter must be frozen
         # while the others freely vary.
-        def freeze_par(pars, parmins, parmaxes, i):
+        def freeze_par(pars, parmins, parmaxes, idx):
             # Freeze the indicated parameter; return
             # its place in the list of all parameters,
             # and the current values of the parameters,
             # and the hard mins amd maxs of the parameters
-            self.model.pars[self.thaw_indices[i]].val = pars[i]
-            self.model.pars[self.thaw_indices[i]].frozen = True
-            self.current_frozen = self.thaw_indices[i]
+            thawedpars[idx].val = pars[idx]
+            thawedpars[idx].frozen = True
+            self.current_frozen = idx
+
             keep_pars = ones_like(pars)
-            keep_pars[i] = 0
+            keep_pars[idx] = 0
             current_pars = pars[where(keep_pars)]
             current_parmins = parmins[where(keep_pars)]
             current_parmaxes = parmaxes[where(keep_pars)]
             return (current_pars, current_parmins, current_parmaxes)
 
-        def thaw_par(i):
-            if i < 0:
+        def thaw_par(idx):
+            if idx < 0:
                 return
 
-            self.model.pars[self.thaw_indices[i]].frozen = False
+            thawedpars[idx].frozen = False
             self.current_frozen = -1
 
         # confidence needs to know which parameter it is working on.
-        def get_par_name(ii):
-            return self.model.pars[self.thaw_indices[ii]].fullname
+        def get_par_name(idx):
+            return thawedpars[idx].fullname
 
         # Call from a parameter estimation method, to report that
         # limits for a given parameter have been found At present (mid
@@ -1304,11 +1294,11 @@ class Fit(NoNewAttributesAfterInit):
         # the first element (otherwise there's a deprecation warning
         # from NumPy 1.25).
         #
-        def report_progress(i, lower, upper):
-            if i < 0:
+        def report_progress(idx, lower, upper):
+            if idx < 0:
                 return
 
-            name = self.model.pars[self.thaw_indices[i]].fullname
+            name = thawedpars[idx].fullname
             if isnan(lower) or isinf(lower):
                 info("%s \tlower bound: -----", name)
             else:
@@ -1339,7 +1329,7 @@ class Fit(NoNewAttributesAfterInit):
 
             # Degress of freedom are number of data bins included
             # in fit, minus the number of thawed parameters.
-            dof = len(dep) - len(self.model.thawedpars)
+            dof = len(dep) - len(thawedpars)
             if dof < 1:
                 raise EstErr('nodegfreedom')
 
@@ -1406,7 +1396,7 @@ class Fit(NoNewAttributesAfterInit):
         # is numpars.)
         parnums = []
         if parlist is not None:
-            allpars = [p for p in self.model.pars if not p.frozen]
+            allpars = self.model.get_thawed_pars()
             for p in parlist:
                 count = 0
                 match = False
@@ -1415,11 +1405,13 @@ class Fit(NoNewAttributesAfterInit):
                         parnums.append(count)
                         match = True
                     count = count + 1
+
                 if not match:
                     raise EstErr('noparameter', p.fullname)
+
             parnums = array(parnums)
         else:
-            parlist = [p for p in self.model.pars if not p.frozen]
+            parlist = self.model.get_thawed_pars()
             parnums = arange(len(startpars))
 
         # If we are here, we are ready to try to derive confidence limits.
@@ -1497,6 +1489,7 @@ class Fit(NoNewAttributesAfterInit):
 
         for p in parlist:
             p.frozen = False
+
         self.current_frozen = -1
         self.model.thawedpars = startpars
         self.model.thawedparmins = startsoftmins

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -730,13 +730,16 @@ class Model(NoNewAttributesAfterInit):
                 p._val = v
 
     thawedpars = property(_get_thawed_pars, _set_thawed_pars,
-                          doc='The thawed parameters of the model.\n\n' +
-                          'Get or set the thawed parameters of the model as a list of\n' +
-                          'numbers. If there are no thawed parameters then [] is used.\n' +
-                          'The ordering matches that of the pars attribute.\n\n' +
-                          'See Also\n' +
-                          '--------\n' +
-                          'thawedparmaxes, thawedparmins\n')
+                          doc="""The thawed parameters of the model.
+
+Get or set the thawed parameters of the model as a list of
+numbers. If there are no thawed parameters then [] is used.
+The ordering matches that of the pars attribute.
+
+See Also
+--------
+thawedparmaxes, thawedparmins
+""")
 
     def _get_thawed_par_mins(self) -> list[SupportsFloat]:
         return [p.min for p in self.pars if not p.frozen]
@@ -765,14 +768,17 @@ class Model(NoNewAttributesAfterInit):
                 p._min = v
 
     thawedparmins = property(_get_thawed_par_mins, _set_thawed_pars_mins,
-                             doc='The minimum limits of the thawed parameters.\n\n' +
-                             'Get or set the minimum limits of the thawed parameters\n' +
-                             'of the model as a list of numbers. If there are no\n' +
-                             'thawed parameters then [] is used. The ordering matches\n' +
-                             'that of the pars attribute.\n\n' +
-                             'See Also\n' +
-                             '--------\n' +
-                             'thawedpars, thawedarhardmins, thawedparmaxes\n')
+                             doc="""The minimum limits of the thawed parameters.
+
+Get or set the minimum limits of the thawed parameters
+of the model as a list of numbers. If there are no
+thawed parameters then [] is used. The ordering matches
+that of the pars attribute.
+
+See Also
+--------
+thawedpars, thawedarhardmins, thawedparmaxes
+""")
 
     def _get_thawed_par_maxes(self) -> list[SupportsFloat]:
         return [p.max for p in self.pars if not p.frozen]
@@ -801,40 +807,49 @@ class Model(NoNewAttributesAfterInit):
                 p._max = v
 
     thawedparmaxes = property(_get_thawed_par_maxes, _set_thawed_pars_maxes,
-                              doc='The maximum limits of the thawed parameters.\n\n' +
-                              'Get or set the maximum limits of the thawed parameters\n' +
-                              'of the model as a list of numbers. If there are no\n' +
-                              'thawed parameters then [] is used. The ordering matches\n' +
-                              'that of the pars attribute.\n\n' +
-                              'See Also\n' +
-                              '--------\n' +
-                              'thawedpars, thawedarhardmaxes, thawedparmins\n')
+                              doc="""The maximum limits of the thawed parameters.
+
+Get or set the maximum limits of the thawed parameters
+of the model as a list of numbers. If there are no
+thawed parameters then [] is used. The ordering matches
+that of the pars attribute.
+
+See Also
+--------
+thawedpars, thawedarhardmaxes, thawedparmins
+""")
 
     def _get_thawed_par_hardmins(self) -> list[SherpaFloat]:
         return [p.hard_min for p in self.pars if not p.frozen]
 
     thawedparhardmins = property(_get_thawed_par_hardmins,
-                                 doc='The hard minimum values for the thawed parameters.\n\n' +
-                                 'The minimum and maximum range of the parameters can be\n' +
-                                 'changed with thawedparmins and thawedparmaxes but only\n' +
-                                 'within the range given by thawedparhardmins\n' +
-                                 'to thawparhardmaxes.\n\n' +
-                                 'See Also\n' +
-                                 '--------\n' +
-                                 'thawedparhardmaxes, thawedparmins\n')
+                                 doc="""The hard minimum values for the thawed parameters.
+
+The minimum and maximum range of the parameters can be
+changed with thawedparmins and thawedparmaxes but only
+within the range given by thawedparhardmins
+to thawparhardmaxes.
+
+See Also
+--------
+thawedparhardmaxes, thawedparmins
+""")
 
     def _get_thawed_par_hardmaxes(self) -> list[SherpaFloat]:
         return [p.hard_max for p in self.pars if not p.frozen]
 
     thawedparhardmaxes = property(_get_thawed_par_hardmaxes,
-                                  doc='The hard maximum values for the thawed parameters.\n\n' +
-                                 'The minimum and maximum range of the parameters can be\n' +
-                                 'changed with thawedparmins and thawedparmaxes but only\n' +
-                                 'within the range given by thawedparhardmins\n' +
-                                 'to thawparhardmaxes.\n\n' +
-                                  'See Also\n' +
-                                  '--------\n' +
-                                  'thawedparhardmins, thawedparmaxes\n')
+                                  doc="""The hard maximum values for the thawed parameters.
+
+The minimum and maximum range of the parameters can be
+changed with thawedparmins and thawedparmaxes but only
+within the range given by thawedparhardmins
+to thawparhardmaxes.
+
+See Also
+--------
+thawedparhardmins, thawedparmaxes
+""")
 
     def reset(self) -> None:
         """Reset the parameter values.

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -701,8 +701,9 @@ class Model(NoNewAttributesAfterInit):
         # A bit of trickery, to make model creation
         # in IPython happen without raising errors, when
         # model is made automatically callable
-        if (len(args) == 0 and len(kwargs) == 0):
+        if len(args) == 0 and len(kwargs) == 0:
             return self
+
         return self.calc([p.val for p in self.pars], *args, **kwargs)
 
     def _get_thawed_pars(self) -> list[SherpaFloat]:
@@ -1381,7 +1382,8 @@ class UnaryOpModel(CompositeModel, ArithmeticModel):
         name = f'{opstr}({self.arg.name})'
         CompositeModel.__init__(self, name, (self.arg,))
 
-    def calc(self, p: Sequence[SupportsFloat], *args, **kwargs) -> np.ndarray:
+    def calc(self, p: Sequence[SupportsFloat],
+             *args, **kwargs) -> np.ndarray:
         return self.op(self.arg.calc(p, *args, **kwargs))
 
 
@@ -1473,7 +1475,8 @@ class BinaryOpModel(CompositeModel, RegriddableModel):
         self.rhs.teardown()
         CompositeModel.teardown(self)
 
-    def calc(self, p: Sequence[SupportsFloat], *args, **kwargs) -> np.ndarray:
+    def calc(self, p: Sequence[SupportsFloat],
+             *args, **kwargs) -> np.ndarray:
         # Note that the kwargs are sent to both model components.
         #
         nlhs = len(self.lhs.pars)
@@ -1553,7 +1556,8 @@ class ArithmeticFunctionModel(Model):
         self.func = func
         Model.__init__(self, func.__name__)
 
-    def calc(self, p: Sequence[SupportsFloat], *args, **kwargs) -> np.ndarray:
+    def calc(self, p: Sequence[SupportsFloat],
+             *args, **kwargs) -> np.ndarray:
         return self.func(*args, **kwargs)
 
     def startup(self, cache: bool = False) -> None:
@@ -1612,7 +1616,8 @@ class NestedModel(CompositeModel, ArithmeticModel):
         self.outer.teardown()
         CompositeModel.teardown(self)
 
-    def calc(self, p: Sequence[SupportsFloat], *args, **kwargs) -> np.ndarray:
+    def calc(self, p: Sequence[SupportsFloat],
+             *args, **kwargs) -> np.ndarray:
         nouter = len(self.outer.pars)
         return self.outer.calc(p[:nouter],
                                self.inner.calc(p[nouter:], *args, **kwargs),
@@ -1653,7 +1658,8 @@ class RegridWrappedModel(CompositeModel, ArithmeticModel):
                                 f"{self.wrapper.name}({self.model.name})",
                                 (self.model, ))
 
-    def calc(self, p: Sequence[SupportsFloat], *args, **kwargs) -> np.ndarray:
+    def calc(self, p: Sequence[SupportsFloat],
+             *args, **kwargs) -> np.ndarray:
         return self.wrapper.calc(p, self.model.calc, *args, **kwargs)
 
     def get_center(self):

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -346,18 +346,22 @@ class Parameter(NoNewAttributesAfterInit):
     def _get_hard_min(self) -> SherpaFloat:
         return self._hard_min
     hard_min = property(_get_hard_min,
-                        doc='The hard minimum of the parameter.\n\n' +
-                        'See Also\n' +
-                        '--------\n' +
-                        'hard_max')
+                        doc="""The hard minimum of the parameter.
+
+See Also
+--------
+hard_max
+""")
 
     def _get_hard_max(self) -> SherpaFloat:
         return self._hard_max
     hard_max = property(_get_hard_max,
-                        doc='The hard maximum of the parameter.\n\n' +
-                        'See Also\n' +
-                        '--------\n' +
-                        'hard_min')
+                        doc="""The hard maximum of the parameter.
+
+See Also
+--------
+hard_min
+""")
 
     # 'val' property
     #
@@ -399,13 +403,16 @@ class Parameter(NoNewAttributesAfterInit):
             self._default_val = val
 
     val = property(_get_val, _set_val,
-                   doc='The current value of the parameter.\n\n' +
-                   'If the parameter is a link then it is possible that accessing\n' +
-                   'the value will raise a ParameterErr in cases where the link\n' +
-                   'expression falls outside the soft limits of the parameter.\n\n' +
-                   'See Also\n' +
-                   '--------\n' +
-                   'default_val, link, max, min')
+                   doc="""The current value of the parameter.
+
+If the parameter is a link then it is possible that accessing
+the value will raise a ParameterErr in cases where the link
+expression falls outside the soft limits of the parameter.
+
+See Also
+--------
+default_val, link, max, min
+""")
 
     #
     # '_default_val' property
@@ -437,10 +444,12 @@ class Parameter(NoNewAttributesAfterInit):
         self._default_val = default_val
 
     default_val = property(_get_default_val, _set_default_val,
-                           doc='The default value of the parameter.\n\n' +
-                           'See Also\n' +
-                           '--------\n' +
-                           'val')
+                           doc="""The default value of the parameter.
+
+See Also
+--------
+val
+""")
 
     #
     # 'min' and 'max' properties
@@ -449,20 +458,26 @@ class Parameter(NoNewAttributesAfterInit):
     def _get_min(self) -> SupportsFloat:
         return self._min
     min = property(_get_min, _make_set_limit('_min'),
-                   doc='The minimum value of the parameter.\n\n' +
-                   'The minimum must lie between the hard_min and hard_max limits.\n\n' +
-                   'See Also\n' +
-                   '--------\n' +
-                   'max, val')
+                   doc="""The minimum value of the parameter.
+
+The minimum must lie between the hard_min and hard_max limits.
+
+See Also
+--------
+max, val
+""")
 
     def _get_max(self) -> SupportsFloat:
         return self._max
     max = property(_get_max, _make_set_limit('_max'),
-                   doc='The maximum value of the parameter.\n\n' +
-                   'The maximum must lie between the hard_min and hard_max limits.\n\n' +
-                   'See Also\n' +
-                   '--------\n' +
-                   'min, val')
+                   doc="""The maximum value of the parameter.
+
+The maximum must lie between the hard_min and hard_max limits.
+
+See Also
+--------
+min, val
+""")
 
     #
     # 'default_min' and 'default_max' properties
@@ -496,12 +511,15 @@ class Parameter(NoNewAttributesAfterInit):
         self._frozen = val
 
     frozen = property(_get_frozen, _set_frozen,
-                      doc='Is the parameter currently frozen?\n\n' +
-                      'Those parameters created with `alwaysfrozen` set can not\n' +
-                      'be changed.\n\n' +
-                      'See Also\n' +
-                      '--------\n' +
-                      'alwaysfrozen\n')
+                      doc="""Is the parameter currently frozen?
+
+Those parameters created with `alwaysfrozen` set can not
+be changed.
+
+See Also
+--------
+alwaysfrozen
+""")
 
     #
     # 'link' property'
@@ -540,22 +558,27 @@ class Parameter(NoNewAttributesAfterInit):
 
         self._link = link
     link = property(_get_link, _set_link,
-                    doc='The link expression to other parameters, if set.\n\n' +
-                    'The link expression defines if the parameter is not\n' +
-                    'a free parameter but is actually defined in terms of\n'
-                    'other parameters.\n\n' +
-                    'See Also\n' +
-                    '--------\n' +
-                    'val\n\n' +
-                    'Examples\n' +
-                    '--------\n\n' +
-                    '>>> a = Parameter("mdl", "a", 2)\n' +
-                    '>>> b = Parameter("mdl", "b", 1)\n' +
-                    '>>> b.link = 10 - a\n' +
-                    '>>> a.val\n' +
-                    '2.0\n' +
-                    '>>> b.val\n' +
-                    '8.0\n')
+                    doc="""The link expression to other parameters, if set.
+
+The link expression defines if the parameter is not
+a free parameter but is actually defined in terms of
+other parameters.
+
+See Also
+--------
+val
+
+Examples
+--------
+
+>>> a = Parameter("mdl", "a", 2)
+>>> b = Parameter("mdl", "b", 1)
+>>> b.link = 10 - a
+>>> a.val
+2.0
+>>> b.val
+8.0
+""")
 
     #
     # Methods

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -918,6 +918,10 @@ class ConstantParameter(CompositeParameter):
         self.value = SherpaFloat(value)
         CompositeParameter.__init__(self, str(value), ())
 
+        # Ensure the constant is considered frozen
+        self._alwaysfrozen = True
+        self.frozen = True
+
     def eval(self) -> SherpaFloat:
         return self.value
 

--- a/sherpa/models/template.py
+++ b/sherpa/models/template.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2016, 2019 -2024
+#  Copyright (C) 2011, 2016, 2019 - 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1746,6 +1746,12 @@ def test_model_simple_pars():
     assert mdl.pars[1].fullname == "xx.xhi"
     assert mdl.pars[2].fullname == "xx.ampl"
 
+    tpars = mdl.get_thawed_pars()
+    assert len(tpars) == 3
+    assert tpars[0].fullname == "xx.xlow"
+    assert tpars[1].fullname == "xx.xhi"
+    assert tpars[2].fullname == "xx.ampl"
+
     tpars = mdl.thawedpars
     assert len(tpars) == 3
     assert tpars[0] == -5
@@ -1770,6 +1776,11 @@ def test_model_complex_pars():
     assert mdl.pars[1].fullname == "xx.xlow"
     assert mdl.pars[2].fullname == "xx.xhi"
     assert mdl.pars[3].fullname == "xx.ampl"
+
+    tpars = mdl.get_thawed_pars()
+    assert len(tpars) == 2
+    assert tpars[0].fullname == "sc.c0"
+    assert tpars[1].fullname == "xx.ampl"
 
     tpars = mdl.thawedpars
     assert len(tpars) == 2
@@ -1799,6 +1810,7 @@ def test_model_frozen_pars():
     assert mdl.pars[2].fullname == "xx.xhi"
     assert mdl.pars[3].fullname == "xx.ampl"
 
+    assert mdl.get_thawed_pars() == []
     assert mdl.thawedpars == []
 
 
@@ -1824,6 +1836,12 @@ def test_model_with_links_pars():
     assert mdl.pars[1].fullname == "xx.xlow"
     assert mdl.pars[2].fullname == "xx.xhi"
     assert mdl.pars[3].fullname == "xx.ampl"
+
+    tpars = mdl.get_thawed_pars()
+    assert len(tpars) == 3
+    assert tpars[0].fullname == "sc.c0"
+    assert tpars[1].fullname == "xx.xlow"
+    assert tpars[2].fullname == "xx.xhi"
 
     tpars = mdl.thawedpars
     assert len(tpars) == 3
@@ -1911,6 +1929,13 @@ def test_model_with_repeated_links1_pars():
     assert mdl.pars[7].val == mdl.pars[1].val
     assert mdl.pars[8].val == mdl.pars[2].val
     assert mdl.pars[9].val == mdl.pars[3].val
+
+    tpars = mdl.get_thawed_pars()
+    assert len(tpars) == 4
+    assert tpars[0].fullname == "sc.c0"
+    assert tpars[1].fullname == "xx.xlow"
+    assert tpars[2].fullname == "xx.xhi"
+    assert tpars[3].fullname == "yy.xhi"
 
     tpars = mdl.thawedpars
     assert len(tpars) == 4
@@ -2001,9 +2026,38 @@ def test_model_with_repeated_links2_pars():
     assert mdl.pars[8].val == mdl.pars[2].val
     assert mdl.pars[9].val == mdl.pars[3].val
 
+    tpars = mdl.get_thawed_pars()
+    assert len(tpars) == 4
+    assert tpars[0].fullname == "sc.c0"
+    assert tpars[1].fullname == "xx.xlow"
+    assert tpars[2].fullname == "xx.xhi"
+    assert tpars[3].fullname == "yy.xhi"
+
     tpars = mdl.thawedpars
     assert len(tpars) == 4
     assert tpars[0] == 100
     assert tpars[1] == 5
     assert tpars[2] == 20
     assert tpars[3] == 40
+
+
+def test_model_can_not_change_pars():
+    """This was changed in 4.16.1 to disallow this.
+
+    Very minimal checks as this is a basic Python feature.
+    """
+
+    # We want to check a Model and a CompositeModel.
+    #
+    mdl1 = Scale1D("a")
+    mdl2 = Box1D("b")
+    mdl = mdl2 + mdl1
+
+    # We do not check the actual error string as it could vary with
+    # Python version.
+    #
+    with pytest.raises(AttributeError):
+        mdl1.pars = ()
+
+    with pytest.raises(AttributeError):
+        mdl.pars = [Parameter("x", "y", 2)]

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1741,10 +1741,13 @@ def test_model_simple_pars():
     mdl.xlow = -5
     mdl.xhi = 10
     mdl.ampl = 3
+
     assert len(mdl.pars) == 3
     assert mdl.pars[0].fullname == "xx.xlow"
     assert mdl.pars[1].fullname == "xx.xhi"
     assert mdl.pars[2].fullname == "xx.ampl"
+
+    assert len(mdl.lpars) == 0
 
     tpars = mdl.get_thawed_pars()
     assert len(tpars) == 3
@@ -1776,6 +1779,8 @@ def test_model_complex_pars():
     assert mdl.pars[1].fullname == "xx.xlow"
     assert mdl.pars[2].fullname == "xx.xhi"
     assert mdl.pars[3].fullname == "xx.ampl"
+
+    assert len(mdl.lpars) == 0
 
     tpars = mdl.get_thawed_pars()
     assert len(tpars) == 2
@@ -1810,6 +1815,8 @@ def test_model_frozen_pars():
     assert mdl.pars[2].fullname == "xx.xhi"
     assert mdl.pars[3].fullname == "xx.ampl"
 
+    assert len(mdl.lpars) == 0
+
     assert mdl.get_thawed_pars() == []
     assert mdl.thawedpars == []
 
@@ -1836,6 +1843,9 @@ def test_model_with_links_pars():
     assert mdl.pars[1].fullname == "xx.xlow"
     assert mdl.pars[2].fullname == "xx.xhi"
     assert mdl.pars[3].fullname == "xx.ampl"
+
+    assert len(mdl.lpars) == 1
+    assert mdl.lpars[0].fullname == "other.c0"
 
     tpars = mdl.get_thawed_pars()
     assert len(tpars) == 3
@@ -1929,6 +1939,12 @@ def test_model_with_repeated_links1_pars():
     assert mdl.pars[7].val == mdl.pars[1].val
     assert mdl.pars[8].val == mdl.pars[2].val
     assert mdl.pars[9].val == mdl.pars[3].val
+
+    assert len(mdl.lpars) == 1
+    assert mdl.lpars[0].fullname == "other.c0"
+    assert mdl.lpars[0].frozen == False
+    assert mdl.lpars[0].link is None
+    assert mdl.lpars[0].val == 19
 
     tpars = mdl.get_thawed_pars()
     assert len(tpars) == 4
@@ -2025,6 +2041,16 @@ def test_model_with_repeated_links2_pars():
     assert mdl.pars[7].val == mdl.pars[1].val
     assert mdl.pars[8].val == mdl.pars[2].val
     assert mdl.pars[9].val == mdl.pars[3].val
+
+    assert len(mdl.lpars) == 2
+    assert mdl.lpars[0].fullname == "other1.c0"
+    assert mdl.lpars[0].frozen == False
+    assert mdl.lpars[0].link is None
+    assert mdl.lpars[0].val == 3.5
+    assert mdl.lpars[1].fullname == "other2.c0"
+    assert mdl.lpars[1].frozen == False
+    assert mdl.lpars[1].link is None
+    assert mdl.lpars[1].val == 19
 
     tpars = mdl.get_thawed_pars()
     assert len(tpars) == 4

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1886,6 +1886,32 @@ def test_model_with_repeated_links1_pars():
     assert mdl.pars[8].link == mdl.pars[2]
     assert mdl.pars[9].link == mdl.pars[3]
 
+    # Check the status (the links are frozen).
+    #
+    assert mdl.pars[0].frozen == False
+    assert mdl.pars[1].frozen == False
+    assert mdl.pars[2].frozen == False
+    assert mdl.pars[3].frozen == True
+    assert mdl.pars[4].frozen == True
+    assert mdl.pars[5].frozen == False
+    assert mdl.pars[6].frozen == True
+    assert mdl.pars[7].frozen == True  # unlike pars[1]
+    assert mdl.pars[8].frozen == True  # unlike pars[2]
+    assert mdl.pars[9].frozen == True
+
+    # Check the parameter values.
+    #
+    assert mdl.pars[0].val == 100
+    assert mdl.pars[1].val == 5
+    assert mdl.pars[2].val == 20
+    assert mdl.pars[3].val == 38
+    assert mdl.pars[4].val == 15
+    assert mdl.pars[5].val == 40
+    assert mdl.pars[6].val == 5
+    assert mdl.pars[7].val == mdl.pars[1].val
+    assert mdl.pars[8].val == mdl.pars[2].val
+    assert mdl.pars[9].val == mdl.pars[3].val
+
     tpars = mdl.thawedpars
     assert len(tpars) == 4
     assert tpars[0] == 100
@@ -1948,6 +1974,32 @@ def test_model_with_repeated_links2_pars():
     assert mdl.pars[7].link == mdl.pars[1]
     assert mdl.pars[8].link == mdl.pars[2]
     assert mdl.pars[9].link == mdl.pars[3]
+
+    # Check the status (the links are frozen).
+    #
+    assert mdl.pars[0].frozen == False
+    assert mdl.pars[1].frozen == False
+    assert mdl.pars[2].frozen == False
+    assert mdl.pars[3].frozen == True
+    assert mdl.pars[4].frozen == True
+    assert mdl.pars[5].frozen == False
+    assert mdl.pars[6].frozen == True
+    assert mdl.pars[7].frozen == True  # unlike pars[1]
+    assert mdl.pars[8].frozen == True  # unlike pars[2]
+    assert mdl.pars[9].frozen == True
+
+    # Check the parameter values.
+    #
+    assert mdl.pars[0].val == 100
+    assert mdl.pars[1].val == 5
+    assert mdl.pars[2].val == 20
+    assert mdl.pars[3].val == 7
+    assert mdl.pars[4].val == 16
+    assert mdl.pars[5].val == 40
+    assert mdl.pars[6].val == 5
+    assert mdl.pars[7].val == mdl.pars[1].val
+    assert mdl.pars[8].val == mdl.pars[2].val
+    assert mdl.pars[9].val == mdl.pars[3].val
 
     tpars = mdl.thawedpars
     assert len(tpars) == 4

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1065,8 +1065,8 @@ class DoNotUseModel(Model):
 
     # We need this for modelCacher1d
     _use_caching = True
-    _cache = {}
-    _cache_ctr = {'hits': 0, 'misses': 0, 'check': 0}
+    _cache: dict[bytes, numpy.ndarray] = {}
+    _cache_ctr: dict[str, int] = {'hits': 0, 'misses': 0, 'check': 0}
     _queue = ['']
 
     @modelCacher1d

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -984,8 +984,8 @@ def test_link_expression_add():
     assert isinstance(expr.lhs, BinaryOpParameter)
     assert isinstance(expr.rhs, ConstantParameter)
 
-    # The constant term (40) should be frozen, but is not
-    assert not expr.rhs.frozen
+    # The constant term (40) should be frozen
+    assert expr.rhs.frozen
     assert expr.rhs.val == pytest.approx(40)
 
     # Do not use instance on Parameter as the objects we expect here
@@ -1003,8 +1003,8 @@ def test_link_expression_add():
     assert isinstance(expr.lhs.lhs.lhs, ConstantParameter)
     assert type(expr.lhs.lhs.rhs) == Parameter
 
-    # The constant term (2) should be frozen, but is not
-    assert not expr.lhs.lhs.lhs.frozen
+    # The constant term (2) should be frozen
+    assert expr.lhs.lhs.lhs.frozen
     assert expr.lhs.lhs.lhs.val == pytest.approx(2)
 
     assert expr.lhs.lhs.rhs.name == "a"
@@ -1034,8 +1034,8 @@ def test_link_expression_sub():
     assert isinstance(expr.lhs, BinaryOpParameter)
     assert isinstance(expr.rhs, ConstantParameter)
 
-    # The constant term (40) should be frozen, but is not
-    assert not expr.rhs.frozen
+    # The constant term (40) should be frozen
+    assert expr.rhs.frozen
     assert expr.rhs.val == pytest.approx(40)
 
     # Do not use instance on Parameter as the objects we expect here
@@ -1053,8 +1053,8 @@ def test_link_expression_sub():
     assert isinstance(expr.lhs.lhs.lhs, ConstantParameter)
     assert type(expr.lhs.lhs.rhs) == Parameter
 
-    # The constant term (2) should be frozen, but is not
-    assert not expr.lhs.lhs.lhs.frozen
+    # The constant term (2) should be frozen
+    assert expr.lhs.lhs.lhs.frozen
     assert expr.lhs.lhs.lhs.val == pytest.approx(2)
 
     assert expr.lhs.lhs.rhs.name == "a"

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -960,3 +960,103 @@ def test_set_for_default_params():
     assert p.max == 10
     assert p.default_min == -5
     assert p.default_max == 20
+
+
+def test_link_expression_add():
+    """Check that the model expression behaves as expected.
+
+    This encodes a number of checks which should be split out.
+    """
+
+    p1 = Parameter("p", "a", 10)
+    p2 = Parameter("p", "b", -5)
+    p2.frozen = True
+
+    expr = 2 * p1 + p2 + 40
+
+    assert expr.name == "2 * p.a + p.b + 40"
+    assert expr.val == 55
+    assert not expr.frozen
+
+    # Deconstruct the tree
+    assert isinstance(expr, BinaryOpParameter)
+    assert expr.op == np.add
+    assert isinstance(expr.lhs, BinaryOpParameter)
+    assert isinstance(expr.rhs, ConstantParameter)
+
+    # The constant term (40) should be frozen, but is not
+    assert not expr.rhs.frozen
+    assert expr.rhs.val == pytest.approx(40)
+
+    # Do not use instance on Parameter as the objects we expect here
+    # are all sub-classes of it, so it adds no real power to the test.
+    #
+    assert expr.lhs.op == np.add
+    assert isinstance(expr.lhs.lhs, BinaryOpParameter)
+    assert type(expr.lhs.rhs) == Parameter
+
+    assert expr.lhs.rhs.name == "b"
+    assert expr.lhs.rhs.val == pytest.approx(-5)
+    assert expr.lhs.rhs.frozen
+
+    assert expr.lhs.lhs.op == np.multiply
+    assert isinstance(expr.lhs.lhs.lhs, ConstantParameter)
+    assert type(expr.lhs.lhs.rhs) == Parameter
+
+    # The constant term (2) should be frozen, but is not
+    assert not expr.lhs.lhs.lhs.frozen
+    assert expr.lhs.lhs.lhs.val == pytest.approx(2)
+
+    assert expr.lhs.lhs.rhs.name == "a"
+    assert expr.lhs.lhs.rhs.val == pytest.approx(10)
+    assert not expr.lhs.lhs.rhs.frozen
+
+
+def test_link_expression_sub():
+    """Check that the model expression behaves as expected.
+
+    This encodes a number of checks which should be split out.
+    """
+
+    p1 = Parameter("p", "a", 10)
+    p2 = Parameter("p", "b", -5)
+    p2.frozen = True
+
+    expr = 2 * p1 - p2 + 40
+
+    assert expr.name == "2 * p.a - p.b + 40"
+    assert expr.val == 65
+    assert not expr.frozen
+
+    # Deconstruct the tree
+    assert isinstance(expr, BinaryOpParameter)
+    assert expr.op == np.add
+    assert isinstance(expr.lhs, BinaryOpParameter)
+    assert isinstance(expr.rhs, ConstantParameter)
+
+    # The constant term (40) should be frozen, but is not
+    assert not expr.rhs.frozen
+    assert expr.rhs.val == pytest.approx(40)
+
+    # Do not use instance on Parameter as the objects we expect here
+    # are all sub-classes of it, so it adds no real power to the test.
+    #
+    assert expr.lhs.op == np.subtract
+    assert isinstance(expr.lhs.lhs, BinaryOpParameter)
+    assert type(expr.lhs.rhs) == Parameter
+
+    assert expr.lhs.rhs.name == "b"
+    assert expr.lhs.rhs.val == pytest.approx(-5)
+    assert expr.lhs.rhs.frozen
+
+    assert expr.lhs.lhs.op == np.multiply
+    assert isinstance(expr.lhs.lhs.lhs, ConstantParameter)
+    assert type(expr.lhs.lhs.rhs) == Parameter
+
+    # The constant term (2) should be frozen, but is not
+    assert not expr.lhs.lhs.lhs.frozen
+    assert expr.lhs.lhs.lhs.val == pytest.approx(2)
+
+    assert expr.lhs.lhs.rhs.name == "a"
+    assert expr.lhs.lhs.rhs.val == pytest.approx(10)
+    assert not expr.lhs.lhs.rhs.frozen

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -3229,29 +3229,18 @@ def test_linked_parameter_implicit(setup_ldata):
     # check the fit succeeded
     assert res.succeeded
 
-    # Unfortunately the fit does not know about sigma3 so it has only
-    # fit the amplitude term.
-    #
-    # assert res.statval == pytest.approx(LPAR_STAT)
-    assert res.statval == pytest.approx(-634.5941622240598)
+    assert res.statval == pytest.approx(LPAR_STAT)
     assert res.numpoints == 12
-    # assert res.dof == 10
-    assert res.dof == 11
-    # assert len(res.parvals) == 2
-    assert len(res.parvals) == 1
-    # assert res.parnames == ("fit3.ampl", "sigma3.c0")
-    assert res.parnames == ("fit3.ampl", )
+    assert res.dof == 10
+    assert len(res.parvals) == 2
+    assert res.parnames == ("fit3.ampl", "sigma3.c0")
 
-    # assert res.parvals[0] == pytest.approx(LPAR_AMPL)
-    # assert res.parvals[1] == pytest.approx(LPAR_SIGMA)
-    assert res.parvals[0] == pytest.approx(94.41261426565819)
+    assert res.parvals[0] == pytest.approx(LPAR_AMPL)
+    assert res.parvals[1] == pytest.approx(LPAR_SIGMA)
 
-    # assert m3.fwhm.val == pytest.approx(LPAR_FWHM)
-    # assert m3.ampl.val == pytest.approx(LPAR_AMPL)
-    # assert sigma3.c0.val == pytest.approx(LPAR_SIGMA)
-    assert m3.fwhm.val == pytest.approx(10)
-    assert m3.ampl.val == pytest.approx(94.41261426565819)
-    assert sigma3.c0.val == pytest.approx(10 / convert)
+    assert m3.fwhm.val == pytest.approx(LPAR_FWHM)
+    assert m3.ampl.val == pytest.approx(LPAR_AMPL)
+    assert sigma3.c0.val == pytest.approx(LPAR_SIGMA)
 
 
 def test_repeated_model_expression(setup_ldata):

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -99,8 +99,10 @@ from sherpa.data import Data1D, Data2D, DataSimulFit
 from sherpa.astro.data import DataPHA
 from sherpa.astro.instrument import create_delta_rmf
 from sherpa.models.model import SimulFitModel
-from sherpa.models.basic import Const1D, Const2D, Gauss1D, Polynom1D, StepLo1D
+from sherpa.models.basic import Const1D, Const2D, Gauss1D, Polynom1D,\
+    Scale1D, StepLo1D
 from sherpa.utils.err import DataErr, EstErr, FitErr, StatErr
+from sherpa.utils import poisson_noise
 
 from sherpa.stats import LeastSq, Chi2, Chi2Gehrels, Chi2DataVar, \
     Chi2ConstVar, Chi2ModVar, Chi2XspecVar, Likelihood, \
@@ -3063,3 +3065,190 @@ def test_fit_outfile_simple_check(tmp_path, check_str):
                "9.000000e+00 -4.079456e+00 3.333329e+00",
                "1.000000e+01 -4.079456e+00 3.333329e+00",
                ""])
+
+
+@pytest.fixture
+def setup_ldata():
+    """Create the data for the GAUSS1D linked-parameter test."""
+
+    # We don't care about randomness as much as repeatability here
+    rng = np.random.RandomState(123)
+
+    base = Gauss1D("base")
+    base.pos = 100
+    base.ampl = 50
+    base.fwhm = 20
+
+    x = np.arange(70, 130, 5)
+    y_base = base(x)
+    y = poisson_noise(y_base, rng=rng)
+
+    return Data1D("x", x, y)
+
+
+LPAR_STAT = -949.8639549430894
+LPAR_FWHM = 19.910836513919275
+LPAR_SIGMA = 19.910836513919275 / 2.3548200450309493
+LPAR_AMPL = 47.4433673308311
+
+
+def test_linked_parameter_base(setup_ldata):
+    """What happens if link parameter is not in the model?
+
+    e.g. fit a gaussian and want to fit with sigma and not fwhm?
+    (hopefuly we can add something to Gauss1D to support this
+    automatically, we can also do it manually).
+
+    This is the base case. See the other test_linked_parameter_xxx
+    calls.
+
+    """
+
+    d = setup_ldata
+
+    m1 = Gauss1D("fit1")
+    m1.pos = 100
+    m1.pos.freeze()
+
+    assert m1.fwhm.val == pytest.approx(10)
+    assert m1.ampl.val == pytest.approx(1)
+
+    f = Fit(d, m1, stat=Cash())
+    res = f.fit()
+
+    # check the fit succeeded
+    assert res.succeeded
+    assert res.statval == pytest.approx(LPAR_STAT)
+    assert res.numpoints == 12
+    assert res.dof == 10
+    assert len(res.parvals) == 2
+    assert res.parnames == ("fit1.fwhm", "fit1.ampl")
+    assert res.parvals[0] == pytest.approx(LPAR_FWHM)
+    assert res.parvals[1] == pytest.approx(LPAR_AMPL)
+
+    # I addd checks of the actual parameter values because I saw some
+    # strange behavior, but that turned out to be user error. However,
+    # it makes sense to leave the checks in.
+    #
+    assert m1.fwhm.val == pytest.approx(LPAR_FWHM)
+    assert m1.ampl.val == pytest.approx(LPAR_AMPL)
+
+
+def test_linked_parameter_explicit(setup_ldata):
+    """Include the parameter in the model expression.
+
+    See the other test_linked_parameter_xxx calls.
+
+    """
+
+    d = setup_ldata
+
+    # Now fit with a model expression that uses sigma not FWHM
+    # but that includes the extra component as part of the
+    # model expression
+    #
+    m2 = Gauss1D("fit2")
+    sigma2 = Scale1D("sigma2")
+    m2.pos = 100
+    m2.pos.freeze()
+
+    convert = 2 * np.sqrt(2 * np.log(2))
+    m2.fwhm = convert * sigma2.c0
+
+    # Adjust c0 to better match the FWHM=10 value (just so we can
+    # check we end up in the same location). It's important to use
+    # the .val field here so we are not accidentally setting up
+    # another link.
+    #
+    sigma2.c0.val = 4.2466090014400955
+
+    assert m2.fwhm.val == pytest.approx(10)
+    assert m2.ampl.val == pytest.approx(1)
+    assert sigma2.c0.val == pytest.approx(10 / convert)
+
+    # We add the sigma2 component as a model component (so the
+    # system knows the parameter is part of the fit) but we multiply
+    # by 0 so it doesn't actually directly change the model.
+    #
+    f = Fit(d, m2 + sigma2 * 0, stat=Cash())
+    res = f.fit()
+
+    # check the fit succeeded
+    assert res.succeeded
+    assert res.statval == pytest.approx(LPAR_STAT)
+    assert res.numpoints == 12
+    assert res.dof == 10
+    assert len(res.parvals) == 2
+    assert res.parnames == ("fit2.ampl", "sigma2.c0")
+
+    assert res.parvals[0] == pytest.approx(LPAR_AMPL)
+    assert res.parvals[1] == pytest.approx(LPAR_SIGMA)
+
+    assert m2.fwhm.val == pytest.approx(LPAR_FWHM)
+    assert m2.ampl.val == pytest.approx(LPAR_AMPL)
+    assert sigma2.c0.val == pytest.approx(LPAR_SIGMA)
+
+
+def test_linked_parameter_implicit(setup_ldata):
+    """Do not include the parameter in the model expression.
+
+    See the other test_linked_parameter_xxx calls.
+
+    """
+
+    d = setup_ldata
+
+    # Now fit with a model expression that uses sigma not FWHM
+    # but that includes the extra component as part of the
+    # model expression
+    #
+    m3 = Gauss1D("fit3")
+    sigma3 = Scale1D("sigma3")
+    m3.pos = 100
+    m3.pos.freeze()
+
+    convert = 2 * np.sqrt(2 * np.log(2))
+    m3.fwhm = convert * sigma3.c0
+
+    # Adjust c0 to better match the FWHM=10 value (just so we can
+    # check we end up in the same location). It's important to use
+    # the .val field here so we are not accidentally setting up
+    # another link.
+    #
+    sigma3.c0.val = 10 / convert
+
+    assert m3.fwhm.val == pytest.approx(10)
+    assert m3.ampl.val == pytest.approx(1)
+    assert sigma3.c0.val == pytest.approx(10 / convert)
+
+    # Does the system know about sigma3?
+    #
+    f = Fit(d, m3, stat=Cash())
+    res = f.fit()
+
+    # check the fit succeeded
+    assert res.succeeded
+
+    # Unfortunately the fit does not know about sigma3 so it has only
+    # fit the amplitude term.
+    #
+    # assert res.statval == pytest.approx(LPAR_STAT)
+    assert res.statval == pytest.approx(-634.5941622240598)
+    assert res.numpoints == 12
+    # assert res.dof == 10
+    assert res.dof == 11
+    # assert len(res.parvals) == 2
+    assert len(res.parvals) == 1
+    # assert res.parnames == ("fit3.ampl", "sigma3.c0")
+    assert res.parnames == ("fit3.ampl", )
+
+    # assert res.parvals[0] == pytest.approx(LPAR_AMPL)
+    # assert res.parvals[1] == pytest.approx(LPAR_SIGMA)
+    assert res.parvals[0] == pytest.approx(94.41261426565819)
+
+    # assert m3.fwhm.val == pytest.approx(LPAR_FWHM)
+    # assert m3.ampl.val == pytest.approx(LPAR_AMPL)
+    # assert sigma3.c0.val == pytest.approx(LPAR_SIGMA)
+    assert m3.fwhm.val == pytest.approx(10)
+    assert m3.ampl.val == pytest.approx(94.41261426565819)
+    assert sigma3.c0.val == pytest.approx(10 / convert)

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2017, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2016, 2017, 2019 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -28,6 +28,7 @@ import logging
 import pickle
 from unittest.mock import patch
 
+import numpy as np
 from numpy.testing import assert_array_equal
 
 import pytest
@@ -38,6 +39,7 @@ from sherpa import estmethods as est
 from sherpa import optmethods as opt
 from sherpa import stats
 from sherpa.ui.utils import Session, ModelWrapper
+from sherpa.utils import poisson_noise
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \
     IdentifierErr, IOErr, SessionErr
 from sherpa.utils.logging import SherpaVerbosity
@@ -1428,3 +1430,138 @@ def test_save_filter_simple(idval, tmp_path):
         s.save_filter(idval, str(outfile), comment="P ", linebreak="+")
 
     assert outfile.read_text() == "P X FILTER+1 1+2 0+3 1+"
+
+
+def setup_linked_data(s):
+    """A simple 'random' dataset."""
+
+    # We don't care about randomness as much as repeatability here
+    rng = np.random.RandomState(123)
+
+    base = s.create_model_component("gauss1d", "base")
+    base.pos = 100
+    base.ampl = 50
+    base.fwhm = 20
+
+    x = np.arange(70, 130, 5)
+    y_base = base(x)
+    y = poisson_noise(y_base, rng=rng)
+
+    s.load_arrays(1, x, y)
+
+
+LPAR_STAT = -949.8639549430894
+LPAR_FWHM = 19.910836513919275
+LPAR_SIGMA = 19.910836513919275 / 2.3548200450309493
+LPAR_AMPL = 47.4433673308311
+
+
+def test_linked_parameter_explicit():
+    """See sherpa/tests/test_fit_unit.py::test_linked_parameter_explicit
+
+    We do not include test_fit_unit.py::test_linked_parameter_base as
+    we expect this to work correctly thanks to the other tests.
+    """
+
+    s = Session()
+    s._add_model_types(sherpa.models.basic)
+
+    setup_linked_data(s)
+    s.set_stat("cash")
+
+    m2 = s.create_model_component("gauss1d", "fit2")
+    s2 = s.create_model_component("scale1d", "sigma2")
+
+    m2.pos = 100
+    m2.pos.freeze()
+
+    convert = 2 * np.sqrt(2 * np.log(2))
+    m2.fwhm = convert * sigma2.c0
+
+    # Adjust c0 to better match the FWHM=10 value (just so we can
+    # check we end up in the same location as the
+    # sherpa/tests/test_fit_unit.py tests). It's important to use the
+    # .val field here so we are not accidentally setting up another
+    # link.
+    #
+    sigma2.c0.val = 4.2466090014400955
+
+    s.set_model(m2 + 0 * s2)
+
+    assert s.get_num_par() == 4
+    assert s.get_num_par_thawed() == 2
+
+    s.fit()
+    res = s.get_fit_results()
+
+    assert s.calc_stat() == pytest.approx(LPAR_STAT)
+    assert m2.fwhm.val == pytest.approx(LPAR_FWHM)
+    assert s2.c0.val == pytest.approx(LPAR_SIGMA)
+    assert m2.ampl.val == pytest.approx(LPAR_AMPL)
+
+    assert res.statval == pytest.approx(LPAR_STAT)
+    assert res.numpoints == 12
+    assert res.dof == 10
+    assert res.parnames == ('fit2.ampl', 'sigma2.c0')
+    assert res.parvals[0] == pytest.approx(LPAR_AMPL)
+    assert res.parvals[1] == pytest.approx(LPAR_SIGMA)
+
+
+def test_linked_parameter_implicit():
+    """See test_linked_parameter_explicit
+
+    What happens if we do not link the parameter to the model expression.
+    """
+
+    s = Session()
+    s._add_model_types(sherpa.models.basic)
+
+    setup_linked_data(s)
+    s.set_stat("cash")
+
+    m3 = s.create_model_component("gauss1d", "fit3")
+    s3 = s.create_model_component("scale1d", "sigma3")
+
+    m3.pos = 100
+    m3.pos.freeze()
+
+    convert = 2 * np.sqrt(2 * np.log(2))
+    m3.fwhm = convert * sigma3.c0
+
+    # Adjust c0 to better match the FWHM=10 value (just so we can
+    # check we end up in the same location as the
+    # sherpa/tests/test_fit_unit.py tests). It's important to use the
+    # .val field here so we are not accidentally setting up another
+    # link.
+    #
+    sigma3.c0.val = 4.2466090014400955
+
+    s.set_model(m3)
+
+    # assert s.get_num_par() == 4
+    # assert s.get_num_par_thawed() == 2
+    assert s.get_num_par() == 3
+    assert s.get_num_par_thawed() == 1
+
+    s.fit()
+    res = s.get_fit_results()
+
+    # assert s.calc_stat() == pytest.approx(LPAR_STAT)
+    # assert m3.fwhm.val == pytest.approx(LPAR_FWHM)
+    # assert s3.c0.val == pytest.approx(LPAR_SIGMA)
+    # assert m3.ampl.val == pytest.approx(LPAR_AMPL)
+    assert s.calc_stat() == pytest.approx(-634.5941622240598)
+    assert m3.fwhm.val == pytest.approx(10)
+    assert s3.c0.val == pytest.approx(10 / convert)
+    assert m3.ampl.val == pytest.approx(94.41261426565819)
+
+    # assert res.statval == pytest.approx(LPAR_STAT)
+    assert res.statval == pytest.approx(-634.5941622240598)
+    assert res.numpoints == 12
+    # assert res.dof == 10
+    assert res.dof == 11
+    # assert res.parnames == ('fit3.ampl', 'sigma3.c0')
+    assert res.parnames == ('fit3.ampl', )
+    assert res.parvals[0] == pytest.approx(94.41261426565819)
+    # assert res.parvals[0] == pytest.approx(LPAR_AMPL)
+    # assert res.parvals[1] == pytest.approx(LPAR_SIGMA)

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -1538,30 +1538,20 @@ def test_linked_parameter_implicit():
 
     s.set_model(m3)
 
-    # assert s.get_num_par() == 4
-    # assert s.get_num_par_thawed() == 2
-    assert s.get_num_par() == 3
-    assert s.get_num_par_thawed() == 1
+    assert s.get_num_par() == 4
+    assert s.get_num_par_thawed() == 2
 
     s.fit()
     res = s.get_fit_results()
 
-    # assert s.calc_stat() == pytest.approx(LPAR_STAT)
-    # assert m3.fwhm.val == pytest.approx(LPAR_FWHM)
-    # assert s3.c0.val == pytest.approx(LPAR_SIGMA)
-    # assert m3.ampl.val == pytest.approx(LPAR_AMPL)
-    assert s.calc_stat() == pytest.approx(-634.5941622240598)
-    assert m3.fwhm.val == pytest.approx(10)
-    assert s3.c0.val == pytest.approx(10 / convert)
-    assert m3.ampl.val == pytest.approx(94.41261426565819)
+    assert s.calc_stat() == pytest.approx(LPAR_STAT)
+    assert m3.fwhm.val == pytest.approx(LPAR_FWHM)
+    assert s3.c0.val == pytest.approx(LPAR_SIGMA)
+    assert m3.ampl.val == pytest.approx(LPAR_AMPL)
 
-    # assert res.statval == pytest.approx(LPAR_STAT)
-    assert res.statval == pytest.approx(-634.5941622240598)
+    assert res.statval == pytest.approx(LPAR_STAT)
     assert res.numpoints == 12
-    # assert res.dof == 10
-    assert res.dof == 11
-    # assert res.parnames == ('fit3.ampl', 'sigma3.c0')
-    assert res.parnames == ('fit3.ampl', )
-    assert res.parvals[0] == pytest.approx(94.41261426565819)
-    # assert res.parvals[0] == pytest.approx(LPAR_AMPL)
-    # assert res.parvals[1] == pytest.approx(LPAR_SIGMA)
+    assert res.dof == 10
+    assert res.parnames == ('fit3.ampl', 'sigma3.c0')
+    assert res.parvals[0] == pytest.approx(LPAR_AMPL)
+    assert res.parvals[1] == pytest.approx(LPAR_SIGMA)

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -1376,7 +1376,7 @@ def test_num_pars_links(clean_ui):
     gmdl.fwhm = 2.4 * smdl.c0  # approximate the sigma/FWHM scaling here
     ui.set_source(gmdl + bmdl)
 
-    # The linked parameter is not included here.
-    assert ui.get_num_par() == 4
-    assert ui.get_num_par_thawed() == 2
+    # The linked parameter is included here.
+    assert ui.get_num_par() == 5
+    assert ui.get_num_par_thawed() == 3
     assert ui.get_num_par_frozen() == 2

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -1306,3 +1306,77 @@ def test_calc_stat_info_output_multi(clean_ui, caplog, check_str):
                "Fit statistic value   = -99.4885",
                "Data points           = 6",
                "Degrees of freedom    = 5"])
+
+
+def test_num_pars_single(clean_ui):
+    """Related to issue #777 and #1982.
+
+    Let's just check what we get
+    """
+
+    gmdl = ui.create_model_component("gauss1d", "gmdl")
+    gmdl.ampl.freeze()
+    ui.set_source(gmdl)
+
+    assert ui.get_num_par() == 3
+    assert ui.get_num_par_thawed() == 2
+    assert ui.get_num_par_frozen() == 1
+
+
+def test_num_pars_combined(clean_ui):
+    """Related to issue #777 and #1982.
+
+    Let's just check what we get
+    """
+
+    gmdl = ui.create_model_component("gauss1d", "gmdl")
+    gmdl.ampl.freeze()
+    bmdl = ui.create_model_component("scale1d", "bmdl")
+    ui.set_source(gmdl + bmdl)
+
+    assert ui.get_num_par() == 4
+    assert ui.get_num_par_thawed() == 3
+    assert ui.get_num_par_frozen() == 1
+
+
+def test_num_pars_duplicated(clean_ui):
+    """Related to issue #777 and #1982.
+
+    Let's just check what we get
+    """
+
+    # For fun we repeat the gmdl component in the model expression. As
+    # written it does not make much sense but it is a simplified form
+    # for more-complex cases where it might end up having the same
+    # component appear multiple times.
+    #
+    gmdl = ui.create_model_component("gauss1d", "gmdl")
+    gmdl.ampl.freeze()
+    bmdl = ui.create_model_component("scale1d", "bmdl")
+    ui.set_source(gmdl + bmdl + gmdl)
+
+    assert ui.get_num_par() == 7
+    assert ui.get_num_par_thawed() == 3
+    assert ui.get_num_par_frozen() == 4
+
+
+def test_num_pars_links(clean_ui):
+    """Related to issue #777 and #1982.
+
+    Let's just check what we get
+    """
+
+    # Have a linked parameter that is not part of the model
+    # expression.
+    #
+    gmdl = ui.create_model_component("gauss1d", "gmdl")
+    gmdl.ampl.freeze()
+    bmdl = ui.create_model_component("scale1d", "bmdl")
+    smdl = ui.create_model_component("scale1d", "sigma")
+    gmdl.fwhm = 2.4 * smdl.c0  # approximate the sigma/FWHM scaling here
+    ui.set_source(gmdl + bmdl)
+
+    # The linked parameter is not included here.
+    assert ui.get_num_par() == 4
+    assert ui.get_num_par_thawed() == 2
+    assert ui.get_num_par_frozen() == 2


### PR DESCRIPTION
# Summary

Treat linked parameters as part of the model expression (via the new `lpars` attribute and `get_thawed_pars` routine) so that they can be included in a fit without including the linked model as part of the model expression. Fix #777

# Details

We would like to be able to fit a model with linked parameters - for instance (using the ui layer here)

    set_source(gauss1d.gmdl + polynom1d.bgnd)
    create_model_component('scale1d', 'sigma')
    gmdl.fwhm = 2 * np.sqrt(2 * np.log(2)) * sigma.c0

where we actually want to fit the `sigma` value of the gaussian rather than the `fwhm`. If you try this you will see that the `fwhm` value never changes, because it has become a frozen parameter and Sherpa doesn't `know` about the `c0` term (when fitting).

For reference we have

```
>>> mdl = get_source()
>>> print(mdl)
(gauss1d.gmdl + polynom1d.bgnd)
(gauss1d.gmdl + polynom1d.bgnd)
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   gmdl.fwhm    linked      2.35482 expr: numpy.multiply(2.3548200450309493, sigma.c0)           
   gmdl.pos     thawed            0 -3.40282e+38  3.40282e+38           
   gmdl.ampl    thawed            1 -3.40282e+38  3.40282e+38           
   bgnd.c0      thawed            1 -3.40282e+38  3.40282e+38           
   bgnd.c1      frozen            0 -3.40282e+38  3.40282e+38           
   bgnd.c2      frozen            0 -3.40282e+38  3.40282e+38           
   bgnd.c3      frozen            0 -3.40282e+38  3.40282e+38           
   bgnd.c4      frozen            0 -3.40282e+38  3.40282e+38           
   bgnd.c5      frozen            0 -3.40282e+38  3.40282e+38           
   bgnd.c6      frozen            0 -3.40282e+38  3.40282e+38           
   bgnd.c7      frozen            0 -3.40282e+38  3.40282e+38           
   bgnd.c8      frozen            0 -3.40282e+38  3.40282e+38           
   bgnd.offset  frozen            0 -3.40282e+38  3.40282e+38           

>>> mdl.pars
(<Parameter 'fwhm' of model 'gmdl'>,
 <Parameter 'pos' of model 'gmdl'>,
 <Parameter 'ampl' of model 'gmdl'>,
 <Parameter 'c0' of model 'bgnd'>,
 <Parameter 'c1' of model 'bgnd'>,
 <Parameter 'c2' of model 'bgnd'>,
 <Parameter 'c3' of model 'bgnd'>,
 <Parameter 'c4' of model 'bgnd'>,
 <Parameter 'c5' of model 'bgnd'>,
 <Parameter 'c6' of model 'bgnd'>,
 <Parameter 'c7' of model 'bgnd'>,
 <Parameter 'c8' of model 'bgnd'>,
 <Parameter 'offset' of model 'bgnd'>)
>>> mdl.thawedpars
[0.0, 1.0, 1.0]
>>> [p.fullname for p in mdl.pars if not p.frozen]
['gmdl.pos', 'gmdl.ampl', 'bgnd.c0']
```

So we can see that Sherpa doesn't think of `gmdl.fwhm` as a parameter to be fit. This is issue #777

The current work around is to include the model containing the linking parameter into the model expression, but multiplied by 0 so it adds no signal. This works but

- is ugly
- is easy to forget
- requires that we use a model for the linking parameter with the same dimensionality as the model terms.

As an example of this workaround is

```
>>> mdl2 = mdl + 0 * sigma
>>> mdl2.thawedpars
[0.0, 1.0, 1.0, 1.0]
>>> sigma.c0 = 10
>>> mdl2.thawedpars
Out[13]: [0.0, 1.0, 1.0, 10.0]
>>> [p.fullname for p in mdl2.pars if not p.frozen]
['gmdl.pos', 'gmdl.ampl', 'bgnd.c0', 'sigma.c0']
```

I have tried several possible solutions, such as extending `pars` to include the linked parameters, or doing the deconstruction in the `sherpa.fit` module, but they are not ideal since

a) the `.pars` attribute of a models used to send the parameter values to the model calculation code, and this does not want (or need) the linking parameters sent in; adding in the linking parameters here just complicated the existing model code and would likely **break** existing user models

b) we need some of the logic in the model class to answer questions that are related to fits, but does not need creating a `Fit` instance

So, first we add a bunch of tests related to #777 and issues I came across when developing this approach, and being side-tracked by earlier attempts and finding issues like 
- #1978
- #1980 
- #1981 

There are minor code clean ups of `model.py` and `parameter.py` after a bunch of tests are added (some of these tests repeat existing tests, but it's useful to have them in one place so we can check how the parameter handling changes, or does not; these tests are also not expensive to run).

The first significant change is making sure `ConstantParameter` objects are marked as `Frozen`. These are used to create the wrappers around the numeric terms in expressions like 2.345 * sigma.c0 - where the 2.345 gets wrapped up in a `ConstantParameter` term. I had thought I would need to do this to make it easy to extract thawed parameters in parameter expressions, but it turns out that for some reason `ConstantParameter` extends `CompositeParameter`, so we can just use a check like `not isinstance(term, CompositeParameter)` to ignore constant terms. However, I have kept this change in as I think it makes sense.

We then add some typing rules to the files in `sherpa/models`. There's the usual balance of trying to describe the needed types without going overboard: for example, should we treat parameter lists as `Sequence[SupportsFloat]` or some other protocol? I have generally tried to go for a combination of: a) does mypy not complain, and b) does it not seem too outlandish.

There's another bunch of tests - these are added to just check #1982 since I discovered them whilst writing this PR and I have spent enough time rebasing things so the tests come first.

To fix #777 we

- add a `get_thawed_pars` method to the `Model` class which makes it obvious what we are doing, and then take advantage of this (in particular in `sherpa.fit`)
  - as part of this the `pars` field is now a property (so stopping users from seriously borking their models)
    - I have some tests of the pars field as the behaviour surprised me at first, particularly when it came to having repeated models and how the repeated parameters are handled 
  - using `get_thawed_pars` let me clean up some logic in the `sherpa.fit.Fit` class related to the error analysis, where we need to switch the parameters being frozen; the current logic could have created a list of thawed parameters and then used them but instead we created a set of "adapter" values (the `thaw_indices` fields) which were used to map between the number of thawed parameters and the number of all parameters, and had previously caused confusion -e.g. #342 

- provide access to the linked parameters via the `lpars` attribute: this is similar to `pars` but it doesn't duplicate attributes and only contains parameters that are not in the `pars` field (so if `m1.ypos` is linked to `m1.xpos` and `m1.ampl` is linked to `m2.c0` then `m1.lpars` will only contain `m2.c0`); this field also drops the non-parameter elements, such as ArithmeticConstant parameters
 
- we then switch `get_thawed_pars` to returning the thawed parameters in `pars` + `lpars` 
  - with all the preparatory work, this is actually a relatively small change to get #777 fixed

I note that I have not tried to address 

- #1981 

but this is an existing issue (i.e. users have this issue in essentially all versions of Sherpa) rather than one I've introduced here.