### PR TITLE
model: improve examples in docstrings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -55,9 +55,6 @@ doctest_norecursedirs =
     sherpa/image
     sherpa/include
     sherpa/io.py
-    sherpa/models/model.py
-    sherpa/models/parameter.py
-    sherpa/models/regrid.py
     sherpa/optmethods
     sherpa/sim
     sherpa/static

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2010, 2016 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -140,32 +140,33 @@ ensuring the fwhm parameter of one model is the same as the other:
 It can be more complex, such as ensuring the position of one line
 is a fixed distance from another:
 
-    >>> l2.pos = l1.pos + 23.4
+    >>> m2.pos = m1.pos + 23.4
 
 It can even include multiple parameters:
 
-    >>> l3.ampl = (l1.ampl + l2.ampl) / 2
+    >>> m3 = Gauss1D("m3")
+    >>> m3.ampl = (m1.ampl + m2.ampl) / 2
 
 Requesting the parameter value will return the evaluated expression,
 and the expression is stored in the link attribute:
 
-    >>> l1.ampl = 10
-    >>> l2.ampl = 12
-    >>> l3.ampl.val
+    >>> m1.ampl = 10
+    >>> m2.ampl = 12
+    >>> m3.ampl.val
     11.0
-    >>> l3.ampl.link
-    <BinaryOpParameter '((l1.ampl + l2.ampl) / 2)'>
+    >>> m3.ampl.link
+    <BinaryOpParameter '((gauss1d.ampl + gmdl.ampl) / 2)'>
 
 The string representation of the model changes for linked parameters
 to indicate the expression:
 
-    >>> print(l3)
-    l3
+    >>> print(m3)
+    m3
        Param        Type          Value          Min          Max      Units
        -----        ----          -----          ---          ---      -----
-       l3.fwhm      thawed           10  1.17549e-38  3.40282e+38
-       l3.pos       thawed            0 -3.40282e+38  3.40282e+38
-       l3.ampl      linked           11 expr: ((l1.ampl + l2.ampl) / 2)
+       m3.fwhm      thawed           10  1.17549e-38  3.40282e+38
+       m3.pos       thawed            0 -3.40282e+38  3.40282e+38
+       m3.ampl      linked           11 expr: ((gauss1d.ampl + gmdl.ampl) / 2)
 
 Model evaluation
 ================
@@ -349,6 +350,15 @@ __all__ = ('Model', 'CompositeModel', 'SimulFitModel',
            'ArithmeticConstantModel', 'ArithmeticModel', 'RegriddableModel1D', 'RegriddableModel2D',
            'UnaryOpModel', 'BinaryOpModel', 'FilterModel', 'modelCacher1d',
            'ArithmeticFunctionModel', 'NestedModel', 'MultigridSumModel')
+
+
+# These tests refer to other variables which are just not worth
+# setting up (or would require too much work to create any useful
+# state, such as the cache statis lines).
+#
+__doctest_skip__ = ['ArithmeticModel.cache_status',
+                    'CompositeModel.cache_status',
+                    'SimulFitModel']
 
 
 def boolean_to_byte(boolean_value):
@@ -874,19 +884,20 @@ class CompositeModel(Model):
     Composite models can be iterated through to find their
     components:
 
+    >>> from sherpa.models.basic import Gauss1D, Polynom1D
     >>> l1 = Gauss1D('l1')
     >>> l2 = Gauss1D('l2')
     >>> b = Polynom1D('b')
     >>> mdl = l1 + (0.5 * l2) + b
     >>> mdl
-    <BinaryOpModel model instance '((l1 + (0.5 * l2)) + polynom1d)'>
+    <BinaryOpModel model instance '((l1 + (0.5 * l2)) + b)'>
     >>> for cpt in mdl:
-    ...     print(type(c))
+    ...     print(type(cpt))
     ...
-    <class 'BinaryOpModel'>
+    <class 'sherpa.models.model.BinaryOpModel'>
     <class 'sherpa.models.basic.Gauss1D'>
-    <class 'BinaryOpModel'>
-    <class 'ArithmeticConstantModel'>
+    <class 'sherpa.models.model.BinaryOpModel'>
+    <class 'sherpa.models.model.ArithmeticConstantModel'>
     <class 'sherpa.models.basic.Gauss1D'>
     <class 'sherpa.models.basic.Polynom1D'>
 
@@ -1015,6 +1026,7 @@ class SimulFitModel(CompositeModel):
     Examples
     --------
 
+    >>> from sherpa.models.basic import Gauss1D, Polynom1D
     >>> m1 = Polynom1D('m1')
     >>> m2 = Gauss1D('g1')
     >>> mall = SimulFitModel('comp', (m1, m1 + m2))
@@ -1242,6 +1254,7 @@ class RegriddableModel1D(RegriddableModel):
         --------
         >>> import numpy as np
         >>> from sherpa.models.basic import Box1D
+        >>> from sherpa.utils import linear_interp
         >>> mybox = Box1D()
         >>> request_space = np.arange(1, 10, 0.1)
         >>> regrid_model = mybox.regrid(request_space, interp=linear_interp)
@@ -1296,7 +1309,8 @@ class UnaryOpModel(CompositeModel, ArithmeticModel):
     Examples
     --------
 
-    >>> m1 = Gauss1d()
+    >>> from sherpa.models.basic import Gauss1D
+    >>> m1 = Gauss1D()
     >>> m2 = UnaryOpModel(m1, numpy.negative, '-')
 
     """
@@ -1348,7 +1362,8 @@ class BinaryOpModel(CompositeModel, RegriddableModel):
     Examples
     --------
 
-    >>> m1 = Gauss1d()
+    >>> from sherpa.models.basic import Gauss1D, Polynom1D
+    >>> m1 = Gauss1D()
     >>> m2 = Polynom1D()
     >>> m = BinaryOpModel(m1, m2, numpy.add, '+')
 

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -354,7 +354,7 @@ __all__ = ('Model', 'CompositeModel', 'SimulFitModel',
 
 # These tests refer to other variables which are just not worth
 # setting up (or would require too much work to create any useful
-# state, such as the cache statis lines).
+# state, such as the cache status lines).
 #
 __doctest_skip__ = ['ArithmeticModel.cache_status',
                     'CompositeModel.cache_status',

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2017, 2020, 2021, 2022, 2023
+#  Copyright (C) 2007, 2017, 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -77,10 +77,13 @@ negative:
     >>> p.min
     -3.4028234663852886e+38
 
-Setting a value outside this range will raise a sherpa.utils.err.ParameterErr
+Setting a value outside this range will raise a
+`sherpa.utils.err.ParameterErr` exception:
 
     >>> p.val = 1e40
-    ParameterErr: parameter model.eta has a maximum of 3.40282e+38
+    Traceback (most recent call last):
+      ...
+    sherpa.utils.err.ParameterErr: parameter model.eta has a maximum of 3.40282e+38
 
 These limits can be changed, as shown below, but they must lie
 within the `hard_min` to `hard_max` range of the parameter (the
@@ -132,7 +135,9 @@ changed at once, as it allows for changes to both the value and
 limits, such as changing the value to be 20 and the limits to 8 to 30:
 
     >>> p.val = 20
-    ParameterErr: parameter model.eta has a maximum of 10
+    Traceback (most recent call last):
+      ...
+    sherpa.utils.err.ParameterErr: parameter model.eta has a maximum of 10
     >>> p.set(val=20, min=8, max=30)
     >>> print(p)
     val         = 20.0
@@ -153,7 +158,7 @@ value of the parameter is calculated based on the link expression,
 such as being twice the other parameter:
 
     >>> q = Parameter('other', 'beta', 4)
-    >>> p.val = 2 * p
+    >>> p.val = 2 * q
     >>> print(p)
     val         = 8.0
     min         = 8.0
@@ -179,9 +184,13 @@ but only when parameter p is checked, not when the related parameter
 
     >>> q.val = 3
     >>> print(p)
-    ParameterErr: parameter model.eta has a minimum of 8
+    Traceback (most recent call last):
+      ...
+    sherpa.utils.err.ParameterErr: parameter model.eta has a minimum of 8
     >>> p.val
-    ParameterErr: parameter model.eta has a minimum of 8
+    Traceback (most recent call last):
+      ...
+    sherpa.utils.err.ParameterErr: parameter model.eta has a minimum of 8
 
 Resetting a parameter
 =====================
@@ -778,10 +787,10 @@ class CompositeParameter(Parameter):
        >>> for cpt in c:
        ...     print(type(cpt))
        ...
-       <class 'BinaryOpParameter'>
-       <class 'Parameter'>
-       <class 'Parameter'>
-       <class 'ConstantParameter'>
+       <class 'sherpa.models.parameter.BinaryOpParameter'>
+       <class 'sherpa.models.parameter.Parameter'>
+       <class 'sherpa.models.parameter.Parameter'>
+       <class 'sherpa.models.parameter.ConstantParameter'>
 
     """
 

--- a/sherpa/models/regrid.py
+++ b/sherpa/models/regrid.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#  Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2017 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -868,6 +868,10 @@ class ModelDomainRegridder2D():
     ``internal_mdl`` on the grid ``x, y`` - but it illustrates
     the approach.
 
+    It is not obvious why this example appears to fail,
+    but it is left in as documentation. See issue 840 at
+    https://github.com/sherpa/sherpa/issues/840
+
     >>> from sherpa.models import Gauss2D, Const2D
     >>> internal_mdl = Gauss2D() + Const2D()
     >>> eval_space = EvaluationSpace2D(np.arange(0, 10, 0.5), np.arange(0, 10, 0.5))
@@ -876,7 +880,8 @@ class ModelDomainRegridder2D():
     >>> x = np.arange(1, 8, 0.7)
     >>> y = np.arange(1, 8, 0.7)
     >>> x, y = reshape_2d_arrays(x, y)
-    >>> z = mdl(x, y)
+    >>> z = mdl(x, y)  # doctest: +SHOW_WARNINGS
+    UserWarning: requested space and evaluation space do not overlap, evaluating model to 0
 
     """
 


### PR DESCRIPTION
# Summary

Allow model.py, parameter.py, and regrid.py to be included in the docstring pytest run.

# Details

I have several PRs that work on the model code so it would be good to get this in first - e.g.

- #1679 
- #1972 
- #1974

This involved

- tweaking a couple of examples to actually pass (since the environment they run in is a bit different from how they were created)

- change the choice of variables just to avoid having to create new objects just for the test

- hide some tests where it's just not worth creating objects used in the test (e.g. too complex to create the necessary state and it would hide from the actual example).

Note that one test in regrid.py is technically not-useful but this has already been noted as issue #840 so the example is kept (but we now note the warning message that is created), as this PR is just about testing the existing code.