### PR TITLE
Rework x errorbar support to better-match community expectations

### DIFF
--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -604,7 +604,7 @@ class BkgModelPHAHistogram(ModelPHAHistogram):
     """
 
     def __init__(self):
-        ModelPHAHistogram.__init__(self)
+        super().__init__()
         self.title = 'Background Model Contribution'
 
 
@@ -619,7 +619,7 @@ class BkgModelHistogram(ModelHistogram):
     """
 
     def __init__(self):
-        ModelPHAHistogram.__init__(self)
+        super().__init__()
         self.title = 'Background Model Contribution'
 
 

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -237,11 +237,11 @@ def test_pha_get_xerr_all_bad_channel_no_group():
     pha = DataPHA('name', [1, 2, 3], [1, 1, 1],
                   quality=[2, 2, 2])
 
-    assert pha.get_xerr() == pytest.approx([1, 1, 1])
+    assert pha.get_xerr() == pytest.approx([0.5, 0.5, 0.5])
 
     pha.ignore_bad()
     assert pha.get_filter() == ''
-    assert pha.get_xerr() == pytest.approx([1, 1, 1])
+    assert pha.get_xerr() == pytest.approx([0.5, 0.5, 0.5])
 
 
 def test_pha_get_xerr_all_bad_channel_group():
@@ -255,7 +255,7 @@ def test_pha_get_xerr_all_bad_channel_group():
                   grouping=[1, 1, 1],
                   quality=[2, 2, 2])
 
-    assert pha.get_xerr() == pytest.approx([1, 1, 1])
+    assert pha.get_xerr() == pytest.approx([0.5, 0.5, 0.5])
 
     assert pha.grouped
     pha.ignore_bad()
@@ -279,11 +279,11 @@ def test_pha_get_xerr_all_bad_energy_no_group():
     pha.set_rmf(rmf)
     pha.units = 'energy'
 
-    assert pha.get_xerr() == pytest.approx([2.0, 3.0, 4.0])
+    assert pha.get_xerr() == pytest.approx([1.0, 1.5, 2.0])
 
     pha.ignore_bad()
     assert pha.get_filter() == ''
-    assert pha.get_xerr() == pytest.approx([2.0, 3.0, 4.0])
+    assert pha.get_xerr() == pytest.approx([1.0, 1.5, 2.0])
 
 
 def test_pha_get_xerr_all_bad_energy_group():
@@ -304,7 +304,7 @@ def test_pha_get_xerr_all_bad_energy_group():
     pha.set_rmf(rmf)
     pha.units = 'energy'
 
-    assert pha.get_xerr() == pytest.approx([2.0, 3.0, 4.0])
+    assert pha.get_xerr() == pytest.approx([1.0, 1.5, 2.0])
 
     assert pha.grouped
     pha.ignore_bad()

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2007, 2015, 2018 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -205,7 +205,7 @@ def test_sourceplot(caplog, make_basic_datapha):
 
 def test_sourceplot_filtered(caplog, make_basic_datapha):
     """Filtering only changes the mask attribute"""
-    
+
     data = make_basic_datapha
     data.units = "energy"
 
@@ -343,7 +343,7 @@ def test_sourceplot_wavelength(caplog, make_basic_datapha):
 
 def test_sourceplot_wavelength_filtered(caplog, make_basic_datapha):
     """Filtering only changes the mask attribute"""
-    
+
     data = make_basic_datapha
     data.units = "wave"
 
@@ -576,6 +576,7 @@ def test_dataphahistogram_prepare_wavelength(make_data_path):
 
     # data is inverted
     assert plot.xlo[0] > plot.xlo[-1]
+    assert np.all(plot.xlo > plot.xhi)  # see issue #1986
 
     # can we access the "pseudo" x attribute?
     assert plot.x[0] > plot.x[-1]
@@ -618,6 +619,7 @@ def test_modelphahistogram_prepare_wavelength(make_data_path):
     # data is inverted
     assert plot.xlo[0] > plot.xlo[-1]
     assert plot.xlo[0] > plot.xhi[0]
+    assert np.all(plot.xlo > plot.xhi)  # see issue #1986
     assert np.all(plot.y > 0)
     assert plot.y.size == 9
 
@@ -653,6 +655,7 @@ def test_sourceplot_prepare_wavelength(make_data_path):
     # data is inverted
     assert plot.xlo[0] > plot.xlo[-1]
     assert plot.xlo[0] > plot.xhi[0]
+    assert np.all(plot.xlo > plot.xhi)  # see issue #1986
     assert np.all(plot.y > 0)
     assert plot.y.size == 1090
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2010, 2015 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -25,7 +25,7 @@ import sys
 from typing import Optional, Union
 import warnings
 
-import numpy
+import numpy as np
 
 import sherpa.ui.utils
 from sherpa.astro.instrument import create_arf, create_delta_rmf, \
@@ -134,7 +134,7 @@ def _pha_report_filter_change(session, idval, bkg_id, changefunc):
 
 
 def _check_pha_tabstops(data: DataPHA,
-                        tabStops: Optional[Union[str, list, numpy.ndarray]]) -> Union[None, numpy.ndarray]:
+                        tabStops: Optional[Union[str, list, np.ndarray]]) -> Union[None, np.ndarray]:
     """Validate the tabStops argument for the group_xxx calls.
 
     This converts from "nofilter" to numpy.zeros(nchan), where
@@ -161,7 +161,7 @@ def _check_pha_tabstops(data: DataPHA,
         # This might error out, but if so let it as it indicates a
         # user error.
         #
-        return numpy.asarray(tabStops)
+        return np.asarray(tabStops)
 
     if tabStops != "nofilter":
         raise ArgumentErr("bad", "tabStops", tabStops)
@@ -169,7 +169,7 @@ def _check_pha_tabstops(data: DataPHA,
     if data.size is None or data.size == 0:
         raise DataErr("The DataPHA object has no data")
 
-    return numpy.zeros(data.size)
+    return np.zeros(data.size)
 
 
 def _save_errorcol(session, idval, filename, bkg_id,
@@ -525,7 +525,7 @@ class Session(sherpa.ui.utils.Session):
                         data_str += f' {bkg_id}'
 
                     data_str += ': '
-                    if numpy.isscalar(scale):
+                    if np.isscalar(scale):
                         data_str += f'{float(scale):g}'
                     else:
                         # would like to use sherpa.utils/print_fields style output
@@ -1038,7 +1038,7 @@ class Session(sherpa.ui.utils.Session):
 
         is_pha = issubclass(dstype, DataPHA)
         if is_pha:
-            channel = numpy.arange(1, len(xlo) + 1, dtype=float)
+            channel = np.arange(1, len(xlo) + 1, dtype=float)
             args = [channel, y]
             # kwargs['bin_lo'] = xlo
             # kwargs['bin_hi'] = xhi
@@ -1723,7 +1723,7 @@ class Session(sherpa.ui.utils.Session):
                     return self.unpack_ascii(filename, *args, **kwargs)
 
     def load_ascii_with_errors(self, id, filename=None, colkeys=None, sep=' ',
-                               comment='#', func=numpy.average, delta=False):
+                               comment='#', func=np.average, delta=False):
         """Load an ASCII file with asymmetric errors as a data set.
 
         Parameters
@@ -1822,7 +1822,7 @@ class Session(sherpa.ui.utils.Session):
             data.elo = data.y - data.elo
             data.ehi = data.ehi - data.y
 
-        if func is numpy.average:
+        if func is np.average:
             staterror = func([data.elo, data.ehi], axis=0)
         else:
             staterror = func(data.elo, data.ehi)
@@ -1849,7 +1849,7 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        if not numpy.iterable(datasets):
+        if not np.iterable(datasets):
             self.set_data(id, datasets)
             return
 
@@ -3170,8 +3170,8 @@ class Session(sherpa.ui.utils.Session):
         if backscale is None:
             backscale, id = id, backscale
 
-        if numpy.iterable(backscale):
-            backscale = numpy.asarray(backscale)
+        if np.iterable(backscale):
+            backscale = np.asarray(backscale)
         elif backscale is not None:
             backscale = SherpaFloat(backscale)
 
@@ -4706,7 +4706,7 @@ class Session(sherpa.ui.utils.Session):
         #
         if d.mask is False:
             raise DataErr('notmask')
-        if not numpy.iterable(d.mask):
+        if not np.iterable(d.mask):
             raise DataErr('nomask', idval)
 
         if isinstance(d, DataPHA):
@@ -4714,7 +4714,7 @@ class Session(sherpa.ui.utils.Session):
         else:
             x = d.get_indep(filter=False)[0]
 
-        mask = numpy.asarray(d.mask, int)
+        mask = np.asarray(d.mask, int)
 
         self.save_arrays(filename, [x, mask], fields=['X', 'FILTER'],
                          ascii=ascii, clobber=clobber)
@@ -7919,7 +7919,7 @@ class Session(sherpa.ui.utils.Session):
 
         bkgsets = self.unpack_bkg(arg, use_errors)
 
-        if numpy.iterable(bkgsets):
+        if np.iterable(bkgsets):
             for bkgid, bkg in enumerate(bkgsets):
                 self.set_bkg(id, bkg, bkgid + 1)
         else:
@@ -9516,14 +9516,14 @@ class Session(sherpa.ui.utils.Session):
             raise DataErr('normffake', id)
 
         # TODO: do we still expect to get bytes here?
-        if isinstance(rmf, (str, numpy.bytes_)):
+        if isinstance(rmf, (str, np.bytes_)):
             if not os.path.isfile(rmf):
                 raise IOErr("filenotfound", rmf)
 
             rmf = self.unpack_rmf(rmf)
 
         # TODO: do we still expect to get bytes here?
-        if isinstance(arf, (str, numpy.bytes_)):
+        if isinstance(arf, (str, np.bytes_)):
             if not os.path.isfile(arf):
                 raise IOErr("filenotfound", arf)
 
@@ -9539,7 +9539,7 @@ class Session(sherpa.ui.utils.Session):
         # is not in the error messaage).
         if rmf is None:
             rmf0 = d.get_rmf()
-        elif numpy.iterable(rmf):
+        elif np.iterable(rmf):
             rmf0 = self.unpack_rmf(rmf[0])
         else:
             rmf0 = rmf
@@ -9554,7 +9554,7 @@ class Session(sherpa.ui.utils.Session):
         # at this point, we can be sure that arf is not a string, because
         # if it was, it would have gone through load_arf already above.
         if not (rmf is None and arf is None):
-            if numpy.iterable(arf):
+            if np.iterable(arf):
                 resp_ids = range(1, len(arf) + 1)
                 self.load_multi_arfs(id, arf, resp_ids=resp_ids)
             elif arf is None:
@@ -9565,7 +9565,7 @@ class Session(sherpa.ui.utils.Session):
             else:
                 self.set_arf(id, arf)
 
-            if numpy.iterable(rmf):
+            if np.iterable(rmf):
                 resp_ids = range(1, len(rmf) + 1)
                 self.load_multi_rmfs(id, rmf, resp_ids=resp_ids)
             else:
@@ -11064,7 +11064,7 @@ class Session(sherpa.ui.utils.Session):
         if 'filter_nan' in kwargs and kwargs.pop('filter_nan'):
             for idval in ids:
                 data = self.get_data(idval)
-                data.mask &= numpy.isfinite(data.get_x())
+                data.mask &= np.isfinite(data.get_x())
 
         res = f.fit(**kwargs)
         res.datasets = ids
@@ -14693,7 +14693,7 @@ class Session(sherpa.ui.utils.Session):
         if error:
 
             def is_numpy_ndarray(arg, name, npars, dim1=None):
-                if not isinstance(arg, numpy.ndarray):
+                if not isinstance(arg, np.ndarray):
                     msg = name + ' must be of type numpy.ndarray'
                     raise IOErr(msg)
                 shape = arg.shape
@@ -14712,7 +14712,7 @@ class Session(sherpa.ui.utils.Session):
             fit_results = self.get_fit_results()
             parnames = fit_results.parnames
             npar = len(parnames)
-            orig_par_vals = numpy.array(fit_results.parvals)
+            orig_par_vals = np.array(fit_results.parvals)
 
             if params is None:
                 # run get_draws or normal distribution depending on fit stat
@@ -14742,7 +14742,7 @@ class Session(sherpa.ui.utils.Session):
 
             mins = fit.model._get_thawed_par_mins()
             maxs = fit.model._get_thawed_par_maxes()
-            eqw = numpy.zeros_like(params[0, :])
+            eqw = np.zeros_like(params[0, :])
             for params_index in range(len(params[0, :])):
                 for parnames_index, parname in enumerate(parnames):
                     val = params[parnames_index, params_index]

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -30,7 +30,8 @@ import numpy as np
 import sherpa.ui.utils
 from sherpa.astro.instrument import create_arf, create_delta_rmf, \
     create_non_delta_rmf, has_pha_response
-from sherpa.ui.utils import _check_type, _check_str_type, _is_str
+from sherpa.ui.utils import _check_type, _check_str_type, _is_str, \
+    get_plot_prefs
 from sherpa.utils import sao_arange, send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
     IdentifierErr, ImportErr, IOErr, ModelErr
@@ -13523,25 +13524,28 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
+        # See sherpa.ui.utils.Session._jointplot2
+        #
         self._jointplot.reset()
 
         with sherpa.plot.backend:
             self._jointplot.plottop(plot1, overplot=overplot,
                                     clearwindow=clearwindow, **kwargs)
 
-            # Unlike the plot version we can assume we are dealing
-            # with histogram plots here.
+            # We know the plot types here but still use get_plot_prefs
+            # to keep the encapsulation.
             #
-            oldval = plot2.plot_prefs['xlog']
-            dprefs = plot1.dataplot.histo_prefs
-            mprefs = plot1.modelplot.histo_prefs
+            p2prefs = get_plot_prefs(plot2)
+            oldval = p2prefs['xlog']
+            dprefs = get_plot_prefs(plot1.dataplot)
+            mprefs = get_plot_prefs(plot1.modelplot)
 
             if dprefs['xlog'] or mprefs['xlog']:
-                plot2.plot_prefs['xlog'] = True
+                p2prefs['xlog'] = True
 
             self._jointplot.plotbot(plot2, overplot=overplot, **kwargs)
 
-            plot2.plot_prefs['xlog'] = oldval
+            p2prefs['xlog'] = oldval
 
     def plot_bkg_fit_ratio(self, id=None, bkg_id=None, replot=False,
                            overplot=False, clearwindow=True, **kwargs):

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2015, 2016, 2017, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2008, 2015 - 2017, 2019 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1302,8 +1302,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
                                 self.get_syserror(filter))
 
     def get_yerr(self, filter=False, staterrfunc=None):
-        """
-        Return errors in dependent axis in N-D view of dependent variable
+        """Return errors in dependent axis in N-D view of dependent variable.
 
         Parameters
         ----------
@@ -1317,8 +1316,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
         return self.get_error(filter, staterrfunc)
 
     def get_ylabel(self, yfunc=None):
-        """
-        Return label for dependent axis in N-D view of dependent variable"
+        """Return label for dependent axis in N-D view of dependent variable.
 
         Parameters
         ----------
@@ -1558,8 +1556,7 @@ class Data1D(Data):
         return self.get_evaluation_indep(filter, model, use_evaluation_space)[0]
 
     def get_xerr(self, filter=False, yfunc=None):
-        """
-        Return linear view of bin size in independent axis/axes"
+        """Return linear view of bin size in independent axis/axes.
 
         Parameters
         ----------
@@ -1568,15 +1565,17 @@ class Data1D(Data):
 
         Returns
         -------
+        xerr : array or None
 
         """
         return None
 
     def get_xlabel(self):
-        """
-        Return label for linear view of independent axis/axes
+        """Return label for linear view of independent axis/axes
+
         Returns
         -------
+        label : str
 
         """
         return 'x'
@@ -1585,8 +1584,7 @@ class Data1D(Data):
         return len(self.get_x(filter)),
 
     def get_y(self, filter=False, yfunc=None, use_evaluation_space=False):
-        """
-        Return dependent axis in N-D view of dependent variable"
+        """Return dependent axis in N-D view of dependent variable.
 
         Parameters
         ----------
@@ -1596,6 +1594,7 @@ class Data1D(Data):
 
         Returns
         -------
+        y : array or None
 
         """
         y = self.get_dep(filter)
@@ -1620,8 +1619,7 @@ class Data1D(Data):
         return mask, size
 
     def get_img(self, yfunc=None):
-        """
-        Return 1D dependent variable as a 1 x N image
+        """Return 1D dependent variable as a 1 x N image.
 
         Parameters
         ----------
@@ -1874,13 +1872,35 @@ class Data1DInt(Data1D):
         return (indep[0] + indep[1]) / 2.0
 
     def get_xerr(self, filter=False, model=None):
+        """Returns an X "error".
+
+        The error value for the independent axis is not well defined
+        in Sherpa.
+
+        .. versionchanged:: 4.16.1
+           The return value is now half the bin width instead of the
+           full bin width.
+
+        Parameters
+        ----------
+        filter : bool, optional
+           Should the values be filtered to the current notice range?
+        model : Model or None, optional
+
+        Returns
+        -------
+        xerr : ndarray
+           The half-width of each bin.
+
+        """
         indep = self.get_evaluation_indep(filter, model)
         if len(indep) == 1:
             # assume all data has been filtered out
             return numpy.asarray([])
 
+        # Return the half-width: see #748 #1817
         xlo, xhi = indep
-        return xhi - xlo
+        return (xhi - xlo) / 2
 
     def get_filter(self, format='%.4f', delim=':'):
         """Return the data filter as a string.
@@ -2116,8 +2136,7 @@ class Data2D(Data):
         return self._data_space.get(filter).x1
 
     def get_x0label(self):
-        """
-        Return label for first dimension in 2-D view of independent axis/axes
+        """Return label for first dimension in 2-D view of independent axis/axes.
 
         Returns
         -------
@@ -2126,8 +2145,7 @@ class Data2D(Data):
         return 'x0'
 
     def get_x1label(self):
-        """
-        Return label for second dimension in 2-D view of independent axis/axes
+        """Return label for second dimension in 2-D view of independent axis/axes.
         """
         return 'x1'
 

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -37,16 +37,17 @@ from typing import Any, Literal, Optional, Sequence, Union
 
 import numpy as np
 
-from sherpa.utils import NoNewAttributesAfterInit, erf, \
-    bool_cast, parallel_map, dataspace1d, histogram1d, get_error_estimates
-from sherpa.utils.err import PlotErr, StatErr, ConfidenceErr
-from sherpa.utils.numeric_types import SherpaFloat
+from sherpa import get_config
 from sherpa.estmethods import Covariance
 from sherpa.optmethods import LevMar, NelderMead
-from sherpa.stats import Likelihood, LeastSq, Chi2XspecVar
-from sherpa import get_config
-from sherpa.utils.err import ArgumentTypeErr, IdentifierErr
 from sherpa.plot.backends import BaseBackend, BasicBackend, PLOT_BACKENDS
+from sherpa.stats import Likelihood, LeastSq, Chi2XspecVar
+from sherpa.utils import NoNewAttributesAfterInit, erf, \
+    bool_cast, parallel_map, dataspace1d, histogram1d, get_error_estimates
+from sherpa.utils.err import ArgumentTypeErr, ConfidenceErr, \
+    IdentifierErr, PlotErr, StatErr
+from sherpa.utils.numeric_types import SherpaFloat
+
 # PLOT_BACKENDS only contains backends in modules that are imported successfully
 # but modules are not discovered by itself. Entrypoints would solve this problem
 # but the current implementation does not have this capability.

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -367,7 +367,7 @@ class Plot(NoNewAttributesAfterInit):
         the accidental creation of erroneous attributes)
         """
         self.plot_prefs = self.plot_prefs.copy()
-        NoNewAttributesAfterInit.__init__(self)
+        super().__init__()
 
     @staticmethod
     def vline(x, ymin=0, ymax=1,
@@ -462,7 +462,7 @@ class Contour(NoNewAttributesAfterInit):
         the accidental creation of erroneous attributes)
         """
         self.contour_prefs = self.contour_prefs.copy()
-        NoNewAttributesAfterInit.__init__(self)
+        super().__init__()
 
     def _merge_settings(self, kwargs):
         """Return the plot preferences merged with user settings."""
@@ -499,7 +499,7 @@ class Point(NoNewAttributesAfterInit):
         the accidental creation of erroneous attributes)
         """
         self.point_prefs = self.point_prefs.copy()
-        NoNewAttributesAfterInit.__init__(self)
+        super().__init__()
 
     def _merge_settings(self, kwargs):
         """Return the plot preferences merged with user settings."""
@@ -550,7 +550,7 @@ class Image(NoNewAttributesAfterInit):
         the accidental creation of erroneous attributes.)
         """
         self.image_prefs = self.image_prefs.copy()
-        NoNewAttributesAfterInit.__init__(self)
+        super().__init__()
 
     def _merge_settings(self, kwargs):
         """Return the plot preferences merged with user settings."""
@@ -599,7 +599,7 @@ class Histogram(NoNewAttributesAfterInit):
         the accidental creation of erroneous attributes)
         """
         self.histo_prefs = self.histo_prefs.copy()
-        NoNewAttributesAfterInit.__init__(self)
+        super().__init__()
 
     def _merge_settings(self, kwargs):
         """Return the plot preferences merged with user settings."""
@@ -657,7 +657,7 @@ class HistogramPlot(Histogram):
         self.xlabel = None
         self.ylabel = None
         self.title = None
-        Histogram.__init__(self)
+        super().__init__()
 
     def __str__(self):
         xlo = self.xlo
@@ -871,7 +871,7 @@ class PDFPlot(HistogramPlot):
 
     def __init__(self):
         self.points = None
-        HistogramPlot.__init__(self)
+        super().__init__()
 
     def __str__(self):
         points = self.points
@@ -968,7 +968,7 @@ class CDFPlot(Plot):
         self.xlabel = None
         self.ylabel = None
         self.title = None
-        Plot.__init__(self)
+        super().__init__()
 
     def __str__(self):
         x = self.x
@@ -1072,7 +1072,7 @@ class LRHistogram(HistogramPlot):
         self.ratios = None
         self.lr = None
         self.ppp = None
-        HistogramPlot.__init__(self)
+        super().__init__()
 
     def __str__(self):
         ratios = self.ratios
@@ -1157,8 +1157,7 @@ class SplitPlot(Plot, Contour):
 
     def __init__(self, rows=2, cols=1):
         self.reset(rows, cols)
-        Plot.__init__(self)
-        Contour.__init__(self)
+        super().__init__()
 
     def __str__(self):
         return (('rows   = %s\n' +
@@ -1266,7 +1265,7 @@ class JointPlot(SplitPlot):
     """
 
     def __init__(self):
-        SplitPlot.__init__(self)
+        super().__init__()
 
     def plottop(self, plot, *args, overplot=False, clearwindow=True,
                 **kwargs):
@@ -1359,7 +1358,7 @@ class DataPlot(Plot):
         self.xlabel = None
         self.ylabel = None
         self.title = None
-        Plot.__init__(self)
+        super().__init__()
 
     def __str__(self):
         x = self.x
@@ -1567,7 +1566,7 @@ class DataContour(Contour):
         self.ylabel = None
         self.title = None
         self.levels = None
-        Contour.__init__(self)
+        super().__init__()
 
     def __str__(self):
         x0 = self.x0
@@ -1685,7 +1684,7 @@ class ModelPlot(Plot):
         self.xlabel = None
         self.ylabel = None
         self.title = 'Model'
-        Plot.__init__(self)
+        super().__init__()
 
     def __str__(self):
         x = self.x
@@ -1829,7 +1828,7 @@ class SourcePlot(ModelPlot):
     """
 
     def __init__(self):
-        ModelPlot.__init__(self)
+        super().__init__()
         self.title = 'Source'
 
 
@@ -1921,7 +1920,7 @@ class ModelContour(Contour):
         self.ylabel = None
         self.title = 'Model'
         self.levels = None
-        Contour.__init__(self)
+        super().__init__()
 
     def __str__(self):
         x0 = self.x0
@@ -1985,7 +1984,7 @@ class SourceContour(ModelContour):
     "Derived class for creating 2D model contours"
 
     def __init__(self):
-        ModelContour.__init__(self)
+        super().__init__()
         self.title = 'Source'
 
 
@@ -2039,7 +2038,7 @@ class FitPlot(Plot):
     def __init__(self):
         self.dataplot = None
         self.modelplot = None
-        Plot.__init__(self)
+        super().__init__()
 
     def __str__(self):
         data_title = None
@@ -2123,7 +2122,7 @@ class FitContour(Contour):
     def __init__(self):
         self.datacontour = None
         self.modelcontour = None
-        Contour.__init__(self)
+        super().__init__()
 
     def __str__(self):
         data_title = None
@@ -2538,7 +2537,7 @@ class Confidence1D(DataPlot):
         self.parval = None
         self.stat = None
         self.numcores = None
-        DataPlot.__init__(self)
+        super().__init__()
 
     def __setstate__(self, state):
         self.__dict__.update(state)
@@ -2788,7 +2787,7 @@ class Confidence2D(DataContour, Point):
         self.parval1 = None
         self.stat = None
         self.numcores = None
-        DataContour.__init__(self)
+        super().__init__()
 
     def __setstate__(self, state):
         self.__dict__.update(state)
@@ -3181,7 +3180,7 @@ class IntervalProjection(Confidence1D):
 
     def __init__(self):
         self.fast = True
-        Confidence1D.__init__(self)
+        super().__init__()
 
     def prepare(self, fast=True, min=None, max=None, nloop=20,
                 delv=None, fac=1, log=False, numcores=None):
@@ -3377,7 +3376,7 @@ class RegionProjection(Confidence2D):
 
     def __init__(self):
         self.fast = True
-        Confidence2D.__init__(self)
+        super().__init__()
 
     def prepare(self, fast=True, min=None, max=None, nloop=(10, 10),
                 delv=None, fac=4, log=(False, False),

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2015, 2016, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2009, 2015, 2016, 2018 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -33,7 +33,7 @@ import logging
 import importlib
 from typing import Optional
 
-import numpy
+import numpy as np
 
 from sherpa.utils import NoNewAttributesAfterInit, erf, \
     bool_cast, parallel_map, dataspace1d, histogram1d, get_error_estimates
@@ -62,7 +62,7 @@ config.read(get_config())
 warning = logging.getLogger(__name__).warning
 
 # TODO: why is this module globally changing the invalid mode of NumPy?
-_ = numpy.seterr(invalid='ignore')
+_ = np.seterr(invalid='ignore')
 
 backend = None
 '''Currently active backend module for plotting.'''
@@ -645,18 +645,18 @@ class HistogramPlot(Histogram):
     def __str__(self):
         xlo = self.xlo
         if self.xlo is not None:
-            xlo = numpy.array2string(numpy.asarray(self.xlo), separator=',',
-                                     precision=4, suppress_small=False)
+            xlo = np.array2string(np.asarray(self.xlo), separator=',',
+                                  precision=4, suppress_small=False)
 
         xhi = self.xhi
         if self.xhi is not None:
-            xhi = numpy.array2string(numpy.asarray(self.xhi), separator=',',
-                                     precision=4, suppress_small=False)
+            xhi = np.array2string(np.asarray(self.xhi), separator=',',
+                                  precision=4, suppress_small=False)
 
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(numpy.asarray(self.y), separator=',',
-                                   precision=4, suppress_small=False)
+            y = np.array2string(np.asarray(self.y), separator=',',
+                                precision=4, suppress_small=False)
 
         return (('xlo    = %s\n' +
                  'xhi    = %s\n' +
@@ -690,8 +690,8 @@ class HistogramPlot(Histogram):
             return None
 
         # As we do not (yet) require NumPy arrays, enforce it.
-        xlo = numpy.asarray(self.xlo)
-        xhi = numpy.asarray(self.xhi)
+        xlo = np.asarray(self.xlo)
+        xhi = np.asarray(self.xhi)
         return (xlo + xhi) / 2
 
     def plot(self, overplot=False, clearwindow=True, **kwargs):
@@ -859,9 +859,9 @@ class PDFPlot(HistogramPlot):
     def __str__(self):
         points = self.points
         if self.points is not None:
-            points = numpy.array2string(numpy.asarray(self.points),
-                                        separator=',', precision=4,
-                                        suppress_small=False)
+            points = np.array2string(np.asarray(self.points),
+                                     separator=',', precision=4,
+                                     suppress_small=False)
 
         return ('points = %s\n' % (points) + HistogramPlot.__str__(self))
 
@@ -892,7 +892,7 @@ class PDFPlot(HistogramPlot):
         """
 
         self.points = points
-        self.y, xx = numpy.histogram(points, bins=bins, density=normed)
+        self.y, xx = np.histogram(points, bins=bins, density=normed)
         self.xlo = xx[:-1]
         self.xhi = xx[1:]
         self.ylabel = "probability density"
@@ -956,17 +956,17 @@ class CDFPlot(Plot):
     def __str__(self):
         x = self.x
         if self.x is not None:
-            x = numpy.array2string(self.x, separator=',', precision=4,
-                                   suppress_small=False)
+            x = np.array2string(self.x, separator=',', precision=4,
+                                suppress_small=False)
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4,
-                                   suppress_small=False)
+            y = np.array2string(self.y, separator=',', precision=4,
+                                suppress_small=False)
 
         points = self.points
         if self.points is not None:
-            points = numpy.array2string(self.points, separator=',',
-                                        precision=4, suppress_small=False)
+            points = np.array2string(self.points, separator=',',
+                                     precision=4, suppress_small=False)
 
         return f"""points = {points}
 x      = {x}
@@ -1000,12 +1000,12 @@ plot_prefs = {self.plot_prefs}"""
         plot
         """
 
-        self.points = numpy.asarray(points)
-        self.x = numpy.sort(points)
+        self.points = np.asarray(points)
+        self.x = np.sort(points)
         (self.median, self.lower,
          self.upper) = get_error_estimates(self.x, True)
         xsize = len(self.x)
-        self.y = (numpy.arange(xsize) + 1.0) / xsize
+        self.y = (np.arange(xsize) + 1.0) / xsize
         self.xlabel = xlabel
         self.ylabel = "p(<={})".format(xlabel)
         self.title = "CDF: {}".format(name)
@@ -1060,9 +1060,9 @@ class LRHistogram(HistogramPlot):
     def __str__(self):
         ratios = self.ratios
         if self.ratios is not None:
-            ratios = numpy.array2string(numpy.asarray(self.ratios),
-                                        separator=',', precision=4,
-                                        suppress_small=False)
+            ratios = np.array2string(np.asarray(self.ratios),
+                                     separator=',', precision=4,
+                                     suppress_small=False)
 
         return '\n'.join(['ratios = %s' % ratios,
                           'lr = %s' % str(self.lr),
@@ -1077,7 +1077,7 @@ class LRHistogram(HistogramPlot):
 
         self.ppp = float(ppp)
         self.lr = float(lr)
-        y = numpy.asarray(ratios)
+        y = np.asarray(ratios)
         self.ratios = y
         self.xlo, self.xhi = dataspace1d(y.min(), y.max(),
                                          numbins=bins + 1)[:2]
@@ -1165,10 +1165,10 @@ class SplitPlot(Plot, Contour):
             self._cleared_window = True
 
     def _reset_used(self):
-        self._used = numpy.zeros((self.rows, self.cols), numpy.bool_)
+        self._used = np.zeros((self.rows, self.cols), np.bool_)
 
     def _next_subplot(self):
-        row, col = numpy.where(~self._used)
+        row, col = np.where(~self._used)
         if row.size != 0:
             row, col = row[0], col[0]
         else:
@@ -1347,23 +1347,23 @@ class DataPlot(Plot):
     def __str__(self):
         x = self.x
         if self.x is not None:
-            x = numpy.array2string(self.x, separator=',', precision=4,
-                                   suppress_small=False)
+            x = np.array2string(self.x, separator=',', precision=4,
+                                suppress_small=False)
 
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4,
-                                   suppress_small=False)
+            y = np.array2string(self.y, separator=',', precision=4,
+                                suppress_small=False)
 
         yerr = self.yerr
         if self.yerr is not None:
-            yerr = numpy.array2string(self.yerr, separator=',', precision=4,
-                                      suppress_small=False)
+            yerr = np.array2string(self.yerr, separator=',', precision=4,
+                                   suppress_small=False)
 
         xerr = self.xerr
         if self.xerr is not None:
-            xerr = numpy.array2string(self.xerr, separator=',', precision=4,
-                                      suppress_small=False)
+            xerr = np.array2string(self.xerr, separator=',', precision=4,
+                                   suppress_small=False)
 
         return (('x      = %s\n' +
                  'y      = %s\n' +
@@ -1461,7 +1461,7 @@ class TracePlot(DataPlot):
         --------
         plot
         """
-        self.x = numpy.arange(len(points), dtype=SherpaFloat)
+        self.x = np.arange(len(points), dtype=SherpaFloat)
         self.y = points
         self.xlabel = "iteration"
         self.ylabel = name
@@ -1487,8 +1487,8 @@ class ScatterPlot(DataPlot):
         --------
         plot
         """
-        self.x = numpy.asarray(x, dtype=SherpaFloat)
-        self.y = numpy.asarray(y, dtype=SherpaFloat)
+        self.x = np.asarray(x, dtype=SherpaFloat)
+        self.y = np.asarray(y, dtype=SherpaFloat)
         self.xlabel = xlabel
         self.ylabel = ylabel
         self.title = "Scatter: {}".format(name)
@@ -1555,18 +1555,18 @@ class DataContour(Contour):
     def __str__(self):
         x0 = self.x0
         if self.x0 is not None:
-            x0 = numpy.array2string(self.x0, separator=',', precision=4,
-                                    suppress_small=False)
+            x0 = np.array2string(self.x0, separator=',', precision=4,
+                                 suppress_small=False)
 
         x1 = self.x1
         if self.x1 is not None:
-            x1 = numpy.array2string(self.x1, separator=',', precision=4,
-                                    suppress_small=False)
+            x1 = np.array2string(self.x1, separator=',', precision=4,
+                                 suppress_small=False)
 
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4,
-                                   suppress_small=False)
+            y = np.array2string(self.y, separator=',', precision=4,
+                                suppress_small=False)
 
         return (('x0     = %s\n' +
                  'x1     = %s\n' +
@@ -1673,23 +1673,23 @@ class ModelPlot(Plot):
     def __str__(self):
         x = self.x
         if self.x is not None:
-            x = numpy.array2string(self.x, separator=',', precision=4,
-                                   suppress_small=False)
+            x = np.array2string(self.x, separator=',', precision=4,
+                                suppress_small=False)
 
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4,
-                                   suppress_small=False)
+            y = np.array2string(self.y, separator=',', precision=4,
+                                suppress_small=False)
 
         yerr = self.yerr
         if self.yerr is not None:
-            yerr = numpy.array2string(self.yerr, separator=',', precision=4,
-                                      suppress_small=False)
+            yerr = np.array2string(self.yerr, separator=',', precision=4,
+                                   suppress_small=False)
 
         xerr = self.xerr
         if self.xerr is not None:
-            xerr = numpy.array2string(self.xerr, separator=',', precision=4,
-                                      suppress_small=False)
+            xerr = np.array2string(self.xerr, separator=',', precision=4,
+                                   suppress_small=False)
 
         return (('x      = %s\n' +
                  'y      = %s\n' +
@@ -1854,7 +1854,7 @@ class ComponentTemplateSourcePlot(ComponentSourcePlot):
         self.x = model.get_x()
         self.y = model.get_y()
 
-        if numpy.iterable(data.mask):
+        if np.iterable(data.mask):
             x = data.to_plot()[0]
             mask = (self.x > x.min()) & (self.x <= x.max())
             self.x = self.x[mask]
@@ -1909,18 +1909,18 @@ class ModelContour(Contour):
     def __str__(self):
         x0 = self.x0
         if self.x0 is not None:
-            x0 = numpy.array2string(self.x0, separator=',', precision=4,
-                                    suppress_small=False)
+            x0 = np.array2string(self.x0, separator=',', precision=4,
+                                 suppress_small=False)
 
         x1 = self.x1
         if self.x1 is not None:
-            x1 = numpy.array2string(self.x1, separator=',', precision=4,
-                                    suppress_small=False)
+            x1 = np.array2string(self.x1, separator=',', precision=4,
+                                 suppress_small=False)
 
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4,
-                                   suppress_small=False)
+            y = np.array2string(self.y, separator=',', precision=4,
+                                suppress_small=False)
 
         return (('x0     = %s\n' +
                  'x1     = %s\n' +
@@ -2361,9 +2361,9 @@ class RatioPlot(ModelPlot):
     "The preferences for the plot."
 
     def _calc_ratio(self, ylist):
-        data = numpy.array(ylist[0])
-        model = numpy.asarray(ylist[1])
-        bad = numpy.where(model == 0.0)
+        data = np.array(ylist[0])
+        model = np.asarray(ylist[1])
+        bad = np.where(model == 0.0)
         data[bad] = 0.0
         model[bad] = 1.0
         return data / model
@@ -2409,9 +2409,9 @@ class RatioContour(ModelContour):
     "The preferences for the plot."
 
     def _calc_ratio(self, ylist):
-        data = numpy.array(ylist[0])
-        model = numpy.asarray(ylist[1])
-        bad = numpy.where(model == 0.0)
+        data = np.array(ylist[0])
+        model = np.asarray(ylist[1])
+        bad = np.where(model == 0.0)
         data[bad] = 0.0
         model[bad] = 1.0
         return data / model
@@ -2435,7 +2435,7 @@ def calc_par_range(minval: float,
                    maxval: float,
                    nloop: int,
                    delv: Optional[float] = None,
-                   log: Optional[bool] = False) -> numpy.ndarray:
+                   log: Optional[bool] = False) -> np.ndarray:
     """Calculate the parameter range to use.
 
     This assumes that the arguments have already been checked for
@@ -2471,7 +2471,7 @@ def calc_par_range(minval: float,
     if delv is not None:
         # This assumes that delv > eps, but this should be safe.
         #
-        eps = numpy.finfo(numpy.float32).eps
+        eps = np.finfo(np.float32).eps
         maxval = maxval + eps
 
     if log:
@@ -2479,13 +2479,13 @@ def calc_par_range(minval: float,
             raise ConfidenceErr('badarg', 'Log scale',
                                 'on positive boundaries')
 
-        minval = numpy.log10(minval)
-        maxval = numpy.log10(maxval)
+        minval = np.log10(minval)
+        maxval = np.log10(maxval)
 
     if delv is None:
-        x = numpy.linspace(minval, maxval, nloop)
+        x = np.linspace(minval, maxval, nloop)
     else:
-        x = numpy.arange(minval, maxval, delv)
+        x = np.arange(minval, maxval, delv)
 
     if log:
         x = 10**x
@@ -2537,13 +2537,13 @@ class Confidence1D(DataPlot):
     def __str__(self):
         x = self.x
         if self.x is not None:
-            x = numpy.array2string(self.x, separator=',', precision=4,
-                                   suppress_small=False)
+            x = np.array2string(self.x, separator=',', precision=4,
+                                suppress_small=False)
 
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4,
-                                   suppress_small=False)
+            y = np.array2string(self.y, separator=',', precision=4,
+                                suppress_small=False)
 
         return (f'x      = {x}\n' +
                 f'y      = {y}\n' +
@@ -2625,10 +2625,10 @@ class Confidence1D(DataPlot):
 
         # Validate the values first (as much as we can).
         #
-        if self.min is not None and not numpy.isscalar(self.min):
+        if self.min is not None and not np.isscalar(self.min):
             raise ConfidenceErr('badarg', 'Parameter limits', 'scalars')
 
-        if self.max is not None and not numpy.isscalar(self.max):
+        if self.max is not None and not np.isscalar(self.max):
             raise ConfidenceErr('badarg', 'Parameter limits', 'scalars')
 
         if self.nloop <= 1:
@@ -2652,17 +2652,17 @@ class Confidence1D(DataPlot):
             if self.min is None:
                 self.min = par.min
                 minval = r.parmins[index]
-                if minval is not None and not numpy.isnan(minval):
+                if minval is not None and not np.isnan(minval):
                     self.min = par.val + minval
 
             if self.max is None:
                 self.max = par.max
                 maxval = r.parmaxes[index]
-                if maxval is not None and not numpy.isnan(maxval):
+                if maxval is not None and not np.isnan(maxval):
                     self.max = par.val + maxval
 
             v = (self.max + self.min) / 2.
-            dv = numpy.fabs(v - self.min)
+            dv = np.fabs(v - self.min)
             self.min = v - self.fac * dv
             self.max = v + self.fac * dv
 
@@ -2784,18 +2784,18 @@ class Confidence2D(DataContour, Point):
     def __str__(self):
         x0 = self.x0
         if self.x0 is not None:
-            x0 = numpy.array2string(self.x0, separator=',', precision=4,
-                                    suppress_small=False)
+            x0 = np.array2string(self.x0, separator=',', precision=4,
+                                 suppress_small=False)
 
         x1 = self.x1
         if self.x1 is not None:
-            x1 = numpy.array2string(self.x1, separator=',', precision=4,
-                                    suppress_small=False)
+            x1 = np.array2string(self.x1, separator=',', precision=4,
+                                 suppress_small=False)
 
         y = self.y
         if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4,
-                                   suppress_small=False)
+            y = np.array2string(self.y, separator=',', precision=4,
+                                suppress_small=False)
 
         return (f'x0      = {x0}\n' +
                 f'x1      = {x1}\n' +
@@ -2900,14 +2900,14 @@ class Confidence2D(DataContour, Point):
             if opt and value is None:
                 return None
 
-            if numpy.isscalar(value):
+            if np.isscalar(value):
                 raise ConfidenceErr('badarg', pname, 'a list')
 
             if len(value) != 2:
                 raise ConfidenceErr('badarg', pname, 'a list of size 2')
 
             # Ensure we return an ndarray
-            return numpy.asarray(value)
+            return np.asarray(value)
 
         # Issue #1093 points out that if min or max is a tuple we can
         # have a problem, as below the code can assign to an element
@@ -2938,11 +2938,11 @@ class Confidence2D(DataContour, Point):
         nloop = check2(self.nloop, "Nloop parameter", opt=False)
         delv = check2(self.delv, "delv parameter")
 
-        if numpy.any(nloop <= 1):
+        if np.any(nloop <= 1):
             raise ConfidenceErr('badarg', 'Nloop parameter',
                                 'a list with elements > 1')
 
-        if delv is not None and numpy.any(delv <= 0):
+        if delv is not None and np.any(delv <= 0):
             raise ConfidenceErr('badarg', 'delv parameter',
                                 'a list with elements > 0')
 
@@ -2954,12 +2954,12 @@ class Confidence2D(DataContour, Point):
 
         if self.levels is None:
             stat = self.stat
-            if self.sigma is None or numpy.isscalar(self.sigma):
+            if self.sigma is None or np.isscalar(self.sigma):
                 raise ConfidenceErr('needlist', 'sigma bounds')
 
-            sigma = numpy.asarray(self.sigma)
-            lvls = stat - (2. * numpy.log(1. - erf(sigma / numpy.sqrt(2.))))
-            self.levels = numpy.asarray(lvls, dtype=SherpaFloat)
+            sigma = np.asarray(self.sigma)
+            lvls = stat - (2. * np.log(1. - erf(sigma / np.sqrt(2.))))
+            self.levels = np.asarray(lvls, dtype=SherpaFloat)
 
         if self.min is None or self.max is None:
             oldestmethod = fit.estmethod
@@ -2972,35 +2972,35 @@ class Confidence2D(DataContour, Point):
             index1 = list(r.parnames).index(par1.fullname)
 
             if self.min is None:
-                self.min = numpy.array([par0.min, par1.min])
+                self.min = np.array([par0.min, par1.min])
                 min0 = r.parmins[index0]
                 min1 = r.parmins[index1]
 
-                if min0 is not None and not numpy.isnan(min0):
+                if min0 is not None and not np.isnan(min0):
                     self.min[0] = par0.val + min0
 
-                if min1 is not None and not numpy.isnan(min1):
+                if min1 is not None and not np.isnan(min1):
                     self.min[1] = par1.val + min1
 
             if self.max is None:
-                self.max = numpy.array([par0.max, par1.max])
+                self.max = np.array([par0.max, par1.max])
                 max0 = r.parmaxes[index0]
                 max1 = r.parmaxes[index1]
 
-                if max0 is not None and not numpy.isnan(max0):
+                if max0 is not None and not np.isnan(max0):
                     self.max[0] = par0.val + max0
 
-                if max1 is not None and not numpy.isnan(max1):
+                if max1 is not None and not np.isnan(max1):
                     self.max[1] = par1.val + max1
 
             # This assumes that self.min/max are ndarray
             v = (self.max + self.min) / 2.
-            dv = numpy.fabs(v - self.min)
+            dv = np.fabs(v - self.min)
             self.min = v - self.fac * dv
             self.max = v + self.fac * dv
 
-        hmin = numpy.array([par0.min, par1.min])
-        hmax = numpy.array([par0.max, par1.max])
+        hmin = np.array([par0.min, par1.min])
+        hmax = np.array([par0.max, par1.max])
 
         for i in [0, 1]:
             # check user limits for errors
@@ -3028,11 +3028,11 @@ class Confidence2D(DataContour, Point):
         # plotting may care (but at least self.x0 and self.x1 should
         # match the ordering of self.y).
         #
-        x0g, x1g = numpy.meshgrid(x0, x1)
+        x0g, x1g = np.meshgrid(x0, x1)
         self.x0 = x0g.flatten()
         self.x1 = x1g.flatten()
 
-        return numpy.array([self.x0, self.x1]).T
+        return np.array([self.x0, self.x1]).T
 
     def calc(self, fit, par0, par1):
         """Evaluate the statistic for the parameter range.
@@ -3222,7 +3222,7 @@ class IntervalProjection(Confidence1D):
 
             worker = IntervalProjectionWorker(par, fit, otherpars)
             res = parallel_map(worker, xvals, self.numcores)
-            self.y = numpy.asarray(res)
+            self.y = np.asarray(res)
 
         finally:
             # Set back data that we changed
@@ -3290,7 +3290,7 @@ class IntervalUncertainty(Confidence1D):
 
             worker = IntervalUncertaintyWorker(par, fit)
             res = parallel_map(worker, xvals, self.numcores)
-            self.y = numpy.asarray(res)
+            self.y = np.asarray(res)
 
         finally:
             # Set back data that we changed
@@ -3419,7 +3419,7 @@ class RegionProjection(Confidence2D):
 
             worker = RegionProjectionWorker(par0, par1, fit, otherpars)
             results = parallel_map(worker, grid, self.numcores)
-            self.y = numpy.asarray(results)
+            self.y = np.asarray(results)
 
         finally:
             # Set back data after we changed it
@@ -3491,7 +3491,7 @@ class RegionUncertainty(Confidence2D):
 
             worker = RegionUncertaintyWorker(par0, par1, fit)
             result = parallel_map(worker, grid, self.numcores)
-            self.y = numpy.asarray(result)
+            self.y = np.asarray(result)
 
         finally:
             # Set back data after we changed it

--- a/sherpa/plot/backends.py
+++ b/sherpa/plot/backends.py
@@ -53,6 +53,8 @@ backend_indep_kwargs = {
 '''List of keyword argument and possible values allowed in all backends'''
 
 
+# DOC-NOTE: can xerr be asymmetric (i.e. be 2D)?
+#
 kwargs_doc = {'xerr': ['float or array-like, shape(N,) or shape(2, N)',
                        '''The errorbar sizes can be:
   - scalar: Symmetric +/- values for all data points.
@@ -417,6 +419,11 @@ class BaseBackend(metaclass=MetaBaseBackend):
            This backend is a non-functional dummy. The documentation is provided
            as a template only.
 
+        .. versionchanged:: 4.16.1
+           The `xerr` setting now matches the `yerr` setting and
+           represents the distance from the center to the edge,
+           rather than twice this value.
+
         Parameters
         ----------
         x : array-like or scalar number
@@ -424,6 +431,7 @@ class BaseBackend(metaclass=MetaBaseBackend):
         y : array-like or scalar number
             y values, same dimension as `x`.
         {kwargs}
+
         """
         pass
 

--- a/sherpa/plot/bokeh_backend.py
+++ b/sherpa/plot/bokeh_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2023
+#  Copyright (C) 2023, 2024
 #  MIT
 #
 #
@@ -300,6 +300,8 @@ class BokehBackend(BasicBackend):
         # Use the color used for the data plot: should it
         # also be used for marker[face]color and ecolor?
         #
+        # NOTE: this ignores any xerr parameter.
+        #
         xmid = 0.5 * (xlo + xhi)
         xerr = (xhi - xlo) / 2 if xerrorbars else None
         yerr = yerr if yerrorbars else None
@@ -506,7 +508,6 @@ class BokehBackend(BasicBackend):
             objs.append(glyph)
 
         if xerrorbars and xerr is not None:
-            xerr = xerr / 2.
             source = ColumnDataSource({'x': np.atleast_1d(x),
                                        'y': np.atleast_1d(y),
                                        'lower': np.atleast_1d(x - xerr),

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2017, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2010, 2015, 2017, 2019 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -300,6 +300,8 @@ class PylabBackend(BasicBackend):
         # Use the color used for the data plot: should it
         # also be used for marker[face]color and ecolor?
         #
+        # NOTE: this ignores any xerr parameter.
+        #
         xmid = 0.5 * (xlo + xhi)
         xerr = (xhi - xlo) / 2 if xerrorbars else None
         yerr = yerr if yerrorbars else None
@@ -491,8 +493,6 @@ class PylabBackend(BasicBackend):
         if xerrorbars or yerrorbars:
             if markerfacecolor is None:
                 markerfacecolor = color
-            if xerr is not None:
-                xerr = xerr / 2.
             xerr = xerr if xerrorbars else None
             yerr = yerr if yerrorbars else None
             obj = axes.errorbar(x, y, yerr, xerr,

--- a/sherpa/plot/testing.py
+++ b/sherpa/plot/testing.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2023
+#  Copyright (C) 2023, 2024
 #  MIT
 #
 #
@@ -94,13 +94,13 @@ def check_full(r, summary, label='', title='', nsummary=0, test_other=None):
 
     assert r is not None
 
-    if HAS_PYLAB and isinstance(plot.backend, PylabBackend) or \
+    if (HAS_PYLAB and isinstance(plot.backend, PylabBackend)) or \
         (HAS_BOKEH and isinstance(plot.backend, BokehBackend)):
         assert f"<summary>{summary}</summary>" in r
 
-        if isinstance(plot.backend, PylabBackend):
+        if (HAS_PYLAB and isinstance(plot.backend, PylabBackend)):
             assert "<svg " in r
-        elif isinstance(plot.backend, BokehBackend):
+        elif (HAS_BOKEH and isinstance(plot.backend, BokehBackend)):
             assert "BokehJS library" in r
         return
 

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -608,6 +608,23 @@ def test_errors_with_no_stat():
     assert dp.yerr is None
 
 
+def test_data1d_xerr_is_none_by_default():
+    """Do we have an xerr field for Data1D.
+
+    It's not clear what the xerr field from the Data1DInt class
+    is meant to "be", so just check the Data1D classs.
+    """
+
+    x = [10, 20, 40, 80]
+    y = [1, 2, 3, 4]
+    d = Data1D('xx', x, y)
+
+    dp = sherpaplot.DataPlot()
+    dp.prepare(d)
+
+    assert dp.xerr is None
+
+
 def test_histogram_returns_x():
     """We support x accessor for histogram plots."""
 
@@ -654,6 +671,59 @@ def test_histogram_empty_x():
 
     dp = sherpaplot.DataHistogramPlot()
     assert dp.x is None
+
+
+def test_histogram_returns_xerr():
+    """What is xerr for histograms? Related to issue #1817.
+
+    It is not clear what we mean by xerr here, but let's just check
+    what is returned.
+
+    """
+
+    xlo = [10, 20, 40, 80]
+    xhi = [20, 40, 60, 90]
+    y = [1, 2, 3, 4]
+    d = Data1DInt('xx', xlo, xhi, y)
+
+    dp = sherpaplot.DataHistogramPlot()
+    dp.prepare(d)
+
+    xlo = numpy.asarray(xlo)
+    xhi = numpy.asarray(xhi)
+
+    assert dp.xerr == pytest.approx(xhi - xlo)
+
+    # check xerr is not in the str output
+    #
+    for line in str(dp).split('\n'):
+        toks = line.split()
+        assert len(toks) > 2
+        assert toks[0] != 'xerr'
+
+
+@pytest.mark.xfail
+def test_histogram_can_not_set_xerr():
+    """We cannot change the xerr accessor"""
+
+    xlo = [10, 20, 40, 80]
+    xhi = [20, 40, 60, 90]
+    y = [1, 2, 3, 4]
+    d = Data1DInt('xx', xlo, xhi, y)
+
+    dp = sherpaplot.DataHistogramPlot()
+    dp.prepare(d)
+
+    # XFAIL: at the moment we can change xerr
+    with pytest.raises(AttributeError):
+        dp.xerr = xlo
+
+
+def test_histogram_empty_xerr():
+    """xerr accessor is None if there's no data"""
+
+    dp = sherpaplot.DataHistogramPlot()
+    assert dp.xerr is None
 
 
 @pytest.mark.parametrize("cls", [sherpaplot.RegionUncertainty,

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -692,7 +692,7 @@ def test_histogram_returns_xerr():
     xlo = numpy.asarray(xlo)
     xhi = numpy.asarray(xhi)
 
-    assert dp.xerr == pytest.approx(xhi - xlo)
+    assert dp.xerr == pytest.approx((xhi - xlo) / 2)
 
     # check xerr is not in the str output
     #

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019, 2020, 2021, 2022
+#  Copyright (C) 2019 - 2022, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -758,7 +758,7 @@ def test_data1d_get_xerr(data):
 
 @pytest.mark.parametrize("data", (Data1DInt, ), indirect=True)
 def test_data_1d_int_get_xerr(data):
-    numpy.testing.assert_array_equal(data.get_xerr(), [1] * X_ARRAY.size)
+    assert data.get_xerr() == pytest.approx([0.5] * X_ARRAY.size)
 
 
 @pytest.mark.parametrize("data", (Data1D, Data1DInt), indirect=True)
@@ -1455,7 +1455,7 @@ def test_data1dint_get_x_xerr():
     d = Data1DInt('data', xlos, xhis, ys)
 
     x = [3.5, 6.5, 11, 13.5, 15.5, 18.5, 22.5]
-    xerr = xhis - xlos
+    xerr = (xhis - xlos) / 2
     assert d.get_x() == pytest.approx(x)
     assert d.get_xerr() == pytest.approx(xerr)
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -30,7 +30,7 @@ import pickle
 import sys
 from typing import Union
 
-import numpy
+import numpy as np
 
 from sherpa import get_config
 import sherpa.all
@@ -54,9 +54,9 @@ warning = logging.getLogger(__name__).warning
 config = ConfigParser()
 config.read(get_config())
 
-numpy.set_printoptions(threshold=int(config.get('verbosity',
-                                                'arraylength',
-                                                fallback=1000000)))
+np.set_printoptions(threshold=int(config.get('verbosity',
+                                             'arraylength',
+                                             fallback=1000000)))
 
 __all__ = ('ModelWrapper', 'Session')
 
@@ -87,7 +87,7 @@ def _check_str_type(arg: str, argname: str) -> None:
 
 
 def _is_integer(val):
-    return isinstance(val, (int, numpy.integer))
+    return isinstance(val, (int, np.integer))
 
 
 def _is_str(val):
@@ -331,7 +331,7 @@ def reduce_ufunc(func):
 
 
 copy_reg.constructor(construct_ufunc)
-copy_reg.pickle(numpy.ufunc, reduce_ufunc)
+copy_reg.pickle(np.ufunc, reduce_ufunc)
 
 
 ###############################################################################
@@ -408,9 +408,9 @@ def read_template_model(modelname, templatefile,
             parnames.remove(name)
             continue
 
-        parvals.append(numpy.array(col, dtype=SherpaFloat))
+        parvals.append(np.array(col, dtype=SherpaFloat))
 
-    parvals = numpy.asarray(parvals).T
+    parvals = np.asarray(parvals).T
 
     if len(parvals) == 0:
         raise IOErr("noparamcols", templatefile)
@@ -613,11 +613,11 @@ def set_dep(data, val):
 
     """
 
-    if numpy.iterable(val):
-        dep = numpy.asarray(val, SherpaFloat)
+    if np.iterable(val):
+        dep = np.asarray(val, SherpaFloat)
     else:
         val = SherpaFloat(val)
-        dep = numpy.array([val] * data.size)
+        dep = np.array([val] * data.size)
 
     data.dep = dep
 
@@ -645,15 +645,15 @@ def set_error(data, field, val, fractional=False):
     if val is None:
         err = None
 
-    elif numpy.iterable(val):
-        err = numpy.asarray(val, SherpaFloat)
+    elif np.iterable(val):
+        err = np.asarray(val, SherpaFloat)
 
     else:
         val = SherpaFloat(val)
         if sherpa.utils.bool_cast(fractional):
             err = val * data.get_dep()
         else:
-            err = numpy.array([val] * data.size)
+            err = np.array([val] * data.size)
 
     setattr(data, field, err)
 
@@ -678,7 +678,7 @@ def set_filter(data, val, ignore=False):
 
     """
 
-    val = numpy.asarray(val, dtype=numpy.bool_)
+    val = np.asarray(val, dtype=np.bool_)
     nval = len(val)
 
     # Note that we do not use data.size as the check, as that fails
@@ -686,7 +686,7 @@ def set_filter(data, val, ignore=False):
     # size" value?
     #
     nexp = len(data.get_y(False))
-    if numpy.iterable(data.mask):
+    if np.iterable(data.mask):
         if nexp != nval:
             raise sherpa.utils.err.DataErr('mismatchn', 'data', 'filter',
                                            nexp, nval)
@@ -729,7 +729,7 @@ class Session(NoNewAttributesAfterInit):
     def __init__(self):
         self.clean()
         self._model_types = {}
-        self._model_globals = numpy.__dict__.copy()
+        self._model_globals = np.__dict__.copy()
         NoNewAttributesAfterInit.__init__(self)
         global _session
         _session = self
@@ -740,7 +740,7 @@ class Session(NoNewAttributesAfterInit):
         return state
 
     def __setstate__(self, state):
-        self._model_globals = numpy.__dict__.copy()
+        self._model_globals = np.__dict__.copy()
 
         self._model_globals.update(state['_model_types'])
 
@@ -1036,8 +1036,8 @@ class Session(NoNewAttributesAfterInit):
         """
 
         if rng is not None and not isinstance(rng,
-                                              (numpy.random.Generator,
-                                               numpy.random.RandomState)):
+                                              (np.random.Generator,
+                                               np.random.RandomState)):
             # Do not include RandomState in the error message as it is
             # really meant for testing/old code.
             raise ArgumentTypeErr("badarg", "rng", "a Generator or None")
@@ -5124,11 +5124,11 @@ class Session(NoNewAttributesAfterInit):
 
         if d.mask is False:
             raise sherpa.utils.err.DataErr('notmask')
-        if not numpy.iterable(d.mask):
+        if not np.iterable(d.mask):
             raise sherpa.utils.err.DataErr('nomask', id)
 
         x = d.get_indep(filter=False)[0]
-        mask = numpy.asarray(d.mask, int)
+        mask = np.asarray(d.mask, int)
         self.save_arrays(filename, [x, mask], fields=['X', 'FILTER'],
                          clobber=clobber, sep=sep, comment=comment,
                          linebreak=linebreak, format=format)
@@ -5511,7 +5511,7 @@ class Session(NoNewAttributesAfterInit):
             raise IdentifierErr("nodatasets")
 
         # TODO: do we still expect to get bytes here?
-        if lo is not None and isinstance(lo, (str, numpy.bytes_)):
+        if lo is not None and isinstance(lo, (str, np.bytes_)):
             return self._notice_expr(lo, **kwargs)
 
         # Jump through the data sets in "order".
@@ -5731,7 +5731,7 @@ class Session(NoNewAttributesAfterInit):
                                       'an identifier or list of identifiers') from None
 
         # TODO: do we still expect to get bytes here?
-        if lo is not None and isinstance(lo, (str, numpy.bytes_)):
+        if lo is not None and isinstance(lo, (str, np.bytes_)):
             return self._notice_expr_id(ids, lo, **kwargs)
 
         # Unlike notice() we do not sort the id list as this
@@ -8036,11 +8036,11 @@ class Session(NoNewAttributesAfterInit):
                 psf.model is not None and isinstance(psf.model, sherpa.instrument.PSFKernel)):
 
             psf_center = psf.center
-            if numpy.isscalar(psf_center):
+            if np.isscalar(psf_center):
                 psf_center = [psf_center]
             try:
                 center = psf.kernel.get_center()
-                if (numpy.asarray(center) == 0.0).all():
+                if (np.asarray(center) == 0.0).all():
                     psf.kernel.set_center(*psf_center, values=True)
             except NotImplementedError:
                 pass

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -14519,16 +14519,17 @@ class Session(NoNewAttributesAfterInit):
             # plot preferences of plot1, and then check for different
             # types of plot objects.
             #
-            oldval = plot2.plot_prefs['xlog']
+            p2prefs = get_plot_prefs(plot2)
+            oldval = p2prefs['xlog']
             dprefs = get_plot_prefs(plot1.dataplot)
             mprefs = get_plot_prefs(plot1.modelplot)
 
             if dprefs['xlog'] or mprefs['xlog']:
-                plot2.plot_prefs['xlog'] = True
+                p2prefs['xlog'] = True
 
             self._jointplot.plotbot(plot2, overplot=overplot, **kwargs)
 
-            plot2.plot_prefs['xlog'] = oldval
+            p2prefs['xlog'] = oldval
 
     def plot_fit_resid(self, id=None, replot=False, overplot=False,
                        clearwindow=True, **kwargs):


### PR DESCRIPTION
# Summary

Improve the "x errorbar" handling for histogram-style data (including PHA), including support for the wavelength setting (fix #1985), to better match community expectations (e.g. #1817).

# Details

I have hit the point where I have several PRs changing the same code and so re-doing the same "helper-code" cleanup. So I want to get this merged first to avoid doing it differently in different PRs. I did end up finding one issue to address (#1985) and technically this addresses #1817 but I have a follow-up PR planned to do this "better".

These changes are mainly clean ups to the plot code but the actual fix is in the data class (although the `xerr` setting is only really used by the plot class). I don't really want to spend much time on this PR (e.g. expanding the routines that get docstrings added) as other parts of the `sherpa.plot` module are going to change and additions are better placed in later PRs.

Per-commit changes are:

- adds some simple tests of the str output of some classes I found had not been covered (or not as well as could be)
- add tests of the `xerr` handling
  - it is not-a-all clear what semantics we intend for the `xerr` field. I'd go as far as to say it is there just to allow us to draw "error bars" on the independent axis for PHA data
  - so I don't have any compunction in changing it's value (e.g., as discussed below, now returning the half-width) since this is what the community assumes it to be 
- tweak how the tests run when bokeh is available but matplotlib isn't (it would fail)
- "import numpy as np" rather than "import numpy" as it annoys me and it also makes the lines shorter
  - this is not-so important just yet but is more an issue once we add typing rules
- tweak how the jointplot code access plot preferences
  - use the "helper" routine rather than assume we know the plot is a "plot" or "histogram" class
  - this is not needed in this PR but is a useful change, and will be needed in a follow-up PR
- add typing rules to the plot backend handling
  - this changes the ordering of when `backend` is created to make sure it never stores a `None`, which (if we didn't it), would cause all typing code using backend to have to note that it's not None. This way we never construct a None and so we are all safer.
  - as part of this I've tweaked the context-manager code to return the values it should (although obviously it wasn't an issue that it hadn't been returning them)
  - I also have a small tweak needed to enforce a "float" value; I thought I'd addressed this as part of #1959 but obviously not
- re-order the sherpa imports
- make more use of super, although not in all cases as some of our multi-parent classes are "interesting"
- added an explicit check of issue #1986 (these tests already implicity tested the current behaviour but I wanted a simple explicit test so if we wver change this we can easily see in the tests).
- try to make our `xerr` handling sensible
  - rather than `xhi - xlo` return `(xhi - xlo) / 2` which is what the community expects it to be (e.g. see #1817)
  - previously `DataPHA` data returned keV values when `units=wavelength`, which is just wrong (#1985) so fix this, which leads into wondering about how the plot classes handle "wavelength" setting (since in this case it appears `xhi < xlo`), but this is **out of scope** for this PR

Some of this code is taken from #1679.

# Areas not looked at

This is an incomplete list, but I just want to mention them in case review suggests working on them here. As mentioned, I have follow-on PRs where some of these can be addressed.

- the `__str__` methods contain a lot of repeated code; I will address this in a future PR
- because of this I've limited the amount of f-string changes in this PR ...
- adding typing statements to the plot classes
  - this would add a lot of "noise" to this particular PR, which is noisy enough as is
  - it actually shows some issues with our class hierarchy (see next point)
- the class hierarchy is "interesting", such as some classes inheriting from both "point" and "histogram" classes and the `plot` method changing drastically between parent and child classes
  - some of this is addressed in future PRs
  - we could remove the `xerr` field, for instance, but I think this is too large a change at this point in time (since it's in both data and plot classes)
  - the data classes have a `to_plot` method which could be looked into but that is also a large change which is separate from this work

# Example

## CIAO 4.16

This is a fit using `xsphabs.gal * xspowerlaw.xpl` to our standard `3c273.pi` dataset, and then `set_analysis("wavelength")`. Here's the output of

```python
plot_fit(xlog=True)
plot_resid(overplot=True)
plt.xlim(1.8, 30)
```

![err1](https://github.com/sherpa/sherpa/assets/224638/227eaecb-8d29-4366-a0d5-2c3803d77bd9)

Note that the x errorbars on the residuals (green) are

a) overlapping at low wavelengths
b) much too small at large wavelengths

This is because they are actually the error bars calculated using the energy setting.

## This PR

![err2](https://github.com/sherpa/sherpa/assets/224638/af484927-493f-4dad-ae2e-452ace98a69e)

We can see that the x errorbars now match the model bins (i.e. the widths agree).