### PR TITLE
Specialize residual-style plots (including delchi, ratio, chisqr) for histogram data

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -145,7 +145,7 @@ warning = logging.getLogger(__name__).warning
 
 regstatus = False
 try:
-    from sherpa.astro.utils._region import Region
+    from sherpa.astro.utils._region import Region  # type: ignore
     regstatus = True
 except ImportError:
     warning('failed to import sherpa.astro.utils._region; Region routines ' +
@@ -153,7 +153,7 @@ except ImportError:
 
 groupstatus = False
 try:
-    import group as pygroup
+    import group as pygroup  # type: ignore
     groupstatus = True
 except ImportError:
     groupstatus = False
@@ -1767,7 +1767,7 @@ will be removed. The identifiers can be integers or strings.
     # Override the mask handling because the mask matches the grouped
     # data length, not the independent axis.
     #
-    @Data1D.mask.setter
+    @Data1D.mask.setter  # type: ignore
     def mask(self, val):
 
         # We only need to over-ride the behavior if the data is
@@ -5046,7 +5046,7 @@ class DataIMG(Data2D):
 
         super().__init__(name, x0, x1, y, shape, staterror, syserror)
 
-    def _clear_filter(self):
+    def _clear_filter(self) -> None:
         if self._region is None:
             return
 

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -372,6 +372,12 @@ class SourcePlot(shplot.HistogramPlot):
 
 class ComponentModelPlot(shplot.ComponentSourcePlot, ModelHistogram):
 
+    # Since this derives from both a "plot" and a "histogram", be
+    # expicit about the fields to display.
+    #
+    _fields = ["xlo", "xhi", "y", "xlabel!", "ylabel!", "title!",
+               "histo_prefs!"]
+
     histo_prefs = shplot.basicbackend.get_component_histo_defaults()
 
     def __init__(self):
@@ -393,6 +399,12 @@ class ComponentModelPlot(shplot.ComponentSourcePlot, ModelHistogram):
 
 
 class ComponentSourcePlot(shplot.ComponentSourcePlot, SourcePlot):
+
+    # Since this derives from both a "plot" and a "histogram", be
+    # expicit about the fields to display.
+    #
+    _fields = ["xlo", "xhi", "y", "xlabel!", "ylabel!", "title!",
+               "histo_prefs!"]
 
     histo_prefs = shplot.basicbackend.get_component_histo_defaults()
 
@@ -855,34 +867,14 @@ class OrderPlot(ModelHistogram):
 class FluxHistogram(ModelHistogram):
     "Derived class for creating 1D flux distribution plots"
 
+    _fields = ["modelvals", "clipped", "flux", "xlo", "xhi", "y",
+               "xlabel!", "ylabel!", "title!", "histo_prefs!"]
+
     def __init__(self):
         self.modelvals = None
         self.clipped = None
         self.flux = None
         super().__init__()
-
-    def __str__(self):
-        vals = self.modelvals
-        if self.modelvals is not None:
-            vals = np.array2string(np.asarray(self.modelvals), separator=',',
-                                   precision=4, suppress_small=False)
-
-        clip = self.clipped
-        if self.clipped is not None:
-            # Could convert to boolean, but it is surprising for
-            # anyone trying to access the clipped field
-            clip = np.array2string(np.asarray(self.clipped), separator=',',
-                                   precision=4, suppress_small=False)
-
-        flux = self.flux
-        if self.flux is not None:
-            flux = np.array2string(np.asarray(self.flux), separator=',',
-                                   precision=4, suppress_small=False)
-
-        return '\n'.join([f'modelvals = {vals}',
-                          f'clipped = {clip}',
-                          f'flux = {flux}',
-                          ModelHistogram.__str__(self)])
 
     def prepare(self, fluxes, bins):
         """Define the histogram plot.

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -1211,10 +1211,10 @@ def test_pha_model_plot_xerr(units):
         mplot.xerr
 
 
-@pytest.mark.parametrize("cls", [splot.ResidPlot,
-                                 splot.RatioPlot,
-                                 splot.DelchiPlot,
-                                 splot.ChisqrPlot])
+@pytest.mark.parametrize("cls", [aplot.ResidPHAPlot,
+                                 aplot.RatioPHAPlot,
+                                 aplot.DelchiPHAPlot,
+                                 aplot.ChisqrPHAPlot])
 @pytest.mark.parametrize("units", ["channel", "energy", "wavelength"])
 def test_pha_resid_plot_xerr(cls, units):
     """What is the xerr field for DataPHA residual.
@@ -1237,21 +1237,9 @@ def test_pha_resid_plot_xerr(cls, units):
     rplot = cls()
     rplot.prepare(pha, full_model, stat=stats.Chi2Gehrels())
 
-    if units == "channel":
-        xerr_chan = np.asarray([1, 2, 1, 2, 2, 1, 1]) / 2
-        assert rplot.xerr == pytest.approx(xerr_chan)
-        return
-
-    en_lo = np.asarray([0.5, 0.65, 0.8, 0.9, 1.1, 1.3, 1.4])
-    en_hi = np.asarray([0.65, 0.8, 0.9, 1.1, 1.3, 1.4, 1.5])
-
-    if units == "energy":
-        xerr_kev = (en_hi - en_lo) / 2
-        assert rplot.xerr == pytest.approx(xerr_kev)
-        return
-
-    xerr_lam = (hc / en_lo - hc / en_hi) / 2
-    assert rplot.xerr == pytest.approx(xerr_lam)
+    # Should we have an xerr field (to match shplot.DataHistogramPlot)?
+    with pytest.raises(AttributeError):
+        rplot.xerr
 
 
 @pytest.mark.parametrize("cls", [DataPHAPlot, BkgDataPlot,

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -753,21 +753,21 @@ def test_str_flux_histogram_empty(energy, cls):
     out = str(obj).split('\n')
 
     assert out[0] == 'modelvals = None'
-    assert out[1] == 'clipped = None'
-    assert out[2] == 'flux = None'
-    assert out[3] == 'xlo    = None'
-    assert out[4] == 'xhi    = None'
-    assert out[5] == 'y      = None'
+    assert out[1] == 'clipped   = None'
+    assert out[2] == 'flux      = None'
+    assert out[3] == 'xlo       = None'
+    assert out[4] == 'xhi       = None'
+    assert out[5] == 'y         = None'
 
     # the exact text depends on the plot backend
     if energy:
-        assert out[6].startswith('xlabel = Energy flux ')
-        assert out[8] == 'title  = Energy flux distribution'
+        assert out[6].startswith('xlabel    = Energy flux ')
+        assert out[8] == 'title     = Energy flux distribution'
     else:
-        assert out[6].startswith('xlabel = Photon flux ')
-        assert out[8] == 'title  = Photon flux distribution'
+        assert out[6].startswith('xlabel    = Photon flux ')
+        assert out[8] == 'title     = Photon flux distribution'
 
-    assert out[7] == 'ylabel = Frequency'
+    assert out[7] == 'ylabel    = Frequency'
     assert out[9].startswith('histo_prefs = ')
 
     assert len(out) == 10
@@ -796,21 +796,21 @@ def test_str_flux_histogram_full(energy, cls, old_numpy_printing):
     # lines 1-4 are the modelvals array;assume they are
     # displayed correctly
     assert out[0] == 'modelvals = [[ 0.1, 1.1],'
-    assert out[4] == 'clipped = [ 1., 1., 0., 1.]'
-    assert out[5] == 'flux = [ 1. , 1.5, 2. , 0.5]'
-    assert out[6] == 'xlo    = [ 0.5  , 0.875, 1.25 , 1.625]'
-    assert out[7] == 'xhi    = [ 0.875, 1.25 , 1.625, 2.   ]'
-    assert out[8] == 'y      = [ 1., 1., 1., 1.]'
+    assert out[4] == 'clipped   = [ 1., 1., 0., 1.]'
+    assert out[5] == 'flux      = [ 1. , 1.5, 2. , 0.5]'
+    assert out[6] == 'xlo       = [ 0.5  , 0.875, 1.25 , 1.625]'
+    assert out[7] == 'xhi       = [ 0.875, 1.25 , 1.625, 2.   ]'
+    assert out[8] == 'y         = [ 1., 1., 1., 1.]'
 
     # the exact text depends on the plot backend
     if energy:
-        assert out[9].startswith('xlabel = Energy flux ')
-        assert out[11] == 'title  = Energy flux distribution'
+        assert out[9].startswith('xlabel    = Energy flux ')
+        assert out[11] == 'title     = Energy flux distribution'
     else:
-        assert out[9].startswith('xlabel = Photon flux ')
-        assert out[11] == 'title  = Photon flux distribution'
+        assert out[9].startswith('xlabel    = Photon flux ')
+        assert out[11] == 'title     = Photon flux distribution'
 
-    assert out[10] == 'ylabel = Frequency'
+    assert out[10] == 'ylabel    = Frequency'
     assert out[12].startswith('histo_prefs = ')
 
     assert len(out) == 13

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -1262,13 +1262,13 @@ def test_pha_data_fails_not_pha(cls):
     d = Data1D("not-a-pha", [1, 2], [0, 2])
     plotobj = cls()
 
-    with pytest.raises(AttributeError, match="'Data1D' object has no attribute 'units'"):
+    with pytest.raises(IOErr, match="data set 'not-a-pha' does not contain a PHA spectrum"):
         plotobj.prepare(d, stat=stats.LeastSq())
 
 
-@pytest.mark.parametrize("cls", [ModelPHAHistogram,
-                                 BkgModelPHAHistogram,
-                                 ComponentSourcePlot])
+@pytest.mark.parametrize("cls", [ModelPHAHistogram, ModelHistogram,
+                                 BkgModelPHAHistogram, BkgModelHistogram,
+                                 ComponentSourcePlot, ComponentModelPlot])
 def test_pha_model_checks_not_pha(cls):
     """Check if error out with an invalid data message for Model classes"""
 
@@ -1280,24 +1280,7 @@ def test_pha_model_checks_not_pha(cls):
         plotobj.prepare(d, m, stat=stats.LeastSq())
 
 
-@pytest.mark.parametrize("cls", [ModelHistogram,
-                                 BkgModelHistogram,
-                                 ComponentModelPlot])
-def test_pha_model_fails_not_pha(cls):
-    """Check if error out with an invalid data message for Model classes
-
-    These should get merged into test_pha_model_checks_pha
-    """
-
-    d = Data1D("not-a-pha", [1, 2], [0, 2])
-    m = Const1D("mdl")
-    plotobj = cls()
-
-    with pytest.raises(AttributeError, match="'Data1D' object has no attribute 'grouped'"):
-        plotobj.prepare(d, m, stat=stats.LeastSq())
-
-
-@pytest.mark.parametrize("cls", [SourcePlot])
+@pytest.mark.parametrize("cls", [SourcePlot, OrderPlot])
 def test_pha_model_no_stat_checks_not_pha(cls):
     """Check if error out with an invalid data message for Model classes
 
@@ -1309,21 +1292,6 @@ def test_pha_model_no_stat_checks_not_pha(cls):
     plotobj = cls()
 
     with pytest.raises(IOErr, match="data set 'not-a-pha' does not contain a PHA spectrum"):
-        plotobj.prepare(d, m)
-
-
-@pytest.mark.parametrize("cls", [OrderPlot])
-def test_pha_model_no_stat_fails_not_pha(cls):
-    """Check if error out with an invalid data message for Model classes
-
-    These classes do not take a stat argument for the prepare method.
-    """
-
-    d = Data1D("not-a-pha", [1, 2], [0, 2])
-    m = Const1D("mdl")
-    plotobj = cls()
-
-    with pytest.raises(AttributeError, match="'Data1D' object has no attribute 'response_ids'"):
         plotobj.prepare(d, m)
 
 
@@ -1348,7 +1316,7 @@ def test_arf_checks_data_is_pha():
         plotobj.prepare(arf=arf, data=d)
 
 
-def test_rmf_checks_arf():
+def test_rmf_checks_rmf():
     """Do we ensure it's an RMF?"""
 
     plotobj = RMFPlot()

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1038,11 +1038,9 @@ def check_bkg_fit(plotfunc, idval, isfit=True):
     mplot = fplot.modelplot
     assert isinstance(mplot, sherpa.astro.plot.BkgModelPHAHistogram)
 
-    xlabel = 'Channel' if plotfunc == ui.plot_bkg_fit else ''
-
     # check plot basics
     for plot in [dplot, mplot]:
-        assert plot.xlabel == xlabel
+        assert plot.xlabel == 'Channel'
         assert plot.ylabel == 'Counts/sec/channel'
 
     assert dplot.xlo == pytest.approx(_data_chan)
@@ -4266,7 +4264,7 @@ def check_plot2_xscale(xscale):
     fig = plt.gcf()
     axes = fig.axes
     assert len(axes) == 2
-    assert axes[0].xaxis.get_label().get_text() == ''
+    assert axes[0].xaxis.get_label().get_text() == 'Channel'
 
     assert axes[0].xaxis.get_scale() == xscale
     assert axes[0].yaxis.get_scale() == 'linear'

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -893,7 +893,8 @@ def test_get_bkg_resid_plot(idval, clean_astro_ui):
     else:
         bp = ui.get_bkg_resid_plot(idval)
 
-    assert bp.x == pytest.approx(_data_chan)
+    assert bp.xlo == pytest.approx(_data_chan)
+    assert bp.xhi == pytest.approx(_data_chan + 1)
 
     # correct the counts by the bin width and exposure time
     #
@@ -1080,6 +1081,8 @@ def check_bkg_resid(plotfunc, idval, isfit=True):
             continue
         else:
             pd = get(idval, recalc=False)
+            assert pd.xlo is None
+            assert pd.xhi is None
             assert pd.x is None
             assert pd.y is None
 
@@ -1110,7 +1113,8 @@ def check_bkg_resid(plotfunc, idval, isfit=True):
     else:
         assert False  # check I've caught everything
 
-    assert plot.x == pytest.approx(_data_chan)
+    assert plot.xlo == pytest.approx(_data_chan)
+    assert plot.xhi == pytest.approx(_data_chan + 1)
     assert plot.y is not None
 
     # the way the data and model are constructed, all residual values
@@ -1130,10 +1134,14 @@ def check_bkg_chisqr(plotfunc, idval, isfit=True):
                 ui.get_bkg_ratio_plot,
                 ui.get_bkg_resid_plot]:
         pd = get(idval, recalc=False)
+        assert pd.xlo is None
+        assert pd.xhi is None
         assert pd.x is None
         assert pd.y is None
 
     plot = ui.get_bkg_chisqr_plot(idval, recalc=False)
+    assert plot.xlo is not None
+    assert plot.xhi is not None
     assert plot.x is not None
     assert plot.y is not None
 
@@ -1157,6 +1165,8 @@ def check_bkg_model(plotfunc, idval, isfit=True):
                 ui.get_bkg_resid_plot,
                 ui.get_bkg_chisqr_plot]:
         pd = get(idval, recalc=False)
+        assert pd.xlo is None
+        assert pd.xhi is None
         assert pd.x is None
         assert pd.y is None
 
@@ -1187,6 +1197,8 @@ def check_bkg_source(plotfunc, idval, isfit=True):
                 ui.get_bkg_resid_plot,
                 ui.get_bkg_chisqr_plot]:
         pd = get(idval, recalc=False)
+        assert pd.xlo is None
+        assert pd.xhi is None
         assert pd.x is None
         assert pd.y is None
 
@@ -3597,8 +3609,8 @@ def test_set_plot_opt_x(cls, datafunc, plotfunc, all_plot_backends):
     mdl.c1 = 1
     s.set_source(mdl)
 
-    plot = getattr(s, 'plot_{}'.format(plotfunc))
-    pdata = getattr(s, 'get_{}_plot'.format(plotfunc))
+    plot = getattr(s, f'plot_{plotfunc}')
+    pdata = getattr(s, f'get_{plotfunc}_plot')
 
     # Create the plot
     plot()
@@ -3610,8 +3622,6 @@ def test_set_plot_opt_x(cls, datafunc, plotfunc, all_plot_backends):
         else:
             assert p1.dataplot.plot_prefs['xlog']
             assert p1.modelplot.plot_prefs['xlog']
-    elif plotfunc in ['resid', 'ratio', 'delchi']:
-        assert p1.plot_prefs['xlog']
     elif is_int:
         assert p1.histo_prefs['xlog']
     else:
@@ -3629,8 +3639,6 @@ def test_set_plot_opt_x(cls, datafunc, plotfunc, all_plot_backends):
         else:
             assert not p2.dataplot.plot_prefs['xlog']
             assert not p2.modelplot.plot_prefs['xlog']
-    elif plotfunc in ['resid', 'ratio', 'delchi']:
-        assert not p2.plot_prefs['xlog']
     elif is_int:
         assert not p2.histo_prefs['xlog']
     else:
@@ -3674,8 +3682,8 @@ def test_set_plot_opt_y(cls, datafunc, plotfunc, answer):
     mdl.c1 = 1
     s.set_source(mdl)
 
-    plot = getattr(s, 'plot_{}'.format(plotfunc))
-    pdata = getattr(s, 'get_{}_plot'.format(plotfunc))
+    plot = getattr(s, f'plot_{plotfunc}')
+    pdata = getattr(s, f'get_{plotfunc}_plot')
 
     plot()
     p1 = pdata()
@@ -3686,12 +3694,6 @@ def test_set_plot_opt_y(cls, datafunc, plotfunc, answer):
         else:
             assert p1.dataplot.plot_prefs['ylog'] == answer
             assert p1.modelplot.plot_prefs['ylog'] == answer
-    elif plotfunc in ['resid', 'ratio', 'delchi']:
-        # We use plot_prefs even if is_int is True for
-        # the residual-style plots. That is, the ordering
-        # of the checks here is important.
-        #
-        assert p1.plot_prefs['ylog'] == answer
     elif is_int:
         assert p1.histo_prefs['ylog'] == answer
     else:
@@ -3709,8 +3711,6 @@ def test_set_plot_opt_y(cls, datafunc, plotfunc, answer):
         else:
             assert not p2.dataplot.plot_prefs['ylog']
             assert not p2.modelplot.plot_prefs['ylog']
-    elif plotfunc in ['resid', 'ratio', 'delchi']:
-        assert not p2.plot_prefs['ylog']
     elif is_int:
         assert not p2.histo_prefs['ylog']
     else:
@@ -3759,8 +3759,8 @@ def test_set_plot_opt_x_astro(cls, datafunc, plotfunc):
     s.set_source(mdl)
     s.set_bkg_source(mdl)
 
-    plot = getattr(s, 'plot_{}'.format(plotfunc))
-    pdata = getattr(s, 'get_{}_plot'.format(plotfunc))
+    plot = getattr(s, f'plot_{plotfunc}')
+    pdata = getattr(s, f'get_{plotfunc}_plot')
 
     # Create the plot
     plot()
@@ -3777,8 +3777,6 @@ def test_set_plot_opt_x_astro(cls, datafunc, plotfunc):
         # actually required for the plot to work.
         #
         assert not p1.modelplot.histo_prefs['xlog']
-    elif plotfunc in ['resid', 'ratio', 'delchi', 'bkg_resid', 'bkg_ratio', 'bkg_delchi']:
-        assert p1.plot_prefs['xlog']
     else:
         assert p1.histo_prefs['xlog']
 
@@ -3790,8 +3788,6 @@ def test_set_plot_opt_x_astro(cls, datafunc, plotfunc):
     if plotfunc in ['fit', 'bkg_fit']:
         assert not p2.dataplot.histo_prefs['xlog']
         assert not p2.modelplot.histo_prefs['xlog']
-    elif plotfunc in ['resid', 'ratio', 'delchi', 'bkg_resid', 'bkg_ratio', 'bkg_delchi']:
-        assert not p2.plot_prefs['xlog']
     else:
         assert not p2.histo_prefs['xlog']
 
@@ -3835,8 +3831,8 @@ def test_set_plot_opt_y_astro(cls, datafunc, plotfunc, answer):
     s.set_source(mdl)
     s.set_bkg_source(mdl)
 
-    plot = getattr(s, 'plot_{}'.format(plotfunc))
-    pdata = getattr(s, 'get_{}_plot'.format(plotfunc))
+    plot = getattr(s, f'plot_{plotfunc}')
+    pdata = getattr(s, f'get_{plotfunc}_plot')
 
     plot()
     p1 = pdata()
@@ -3844,8 +3840,6 @@ def test_set_plot_opt_y_astro(cls, datafunc, plotfunc, answer):
         assert p1.dataplot.histo_prefs['ylog'] == answer
         # Check the current behavior of the model plot in case it changes
         assert not p1.modelplot.histo_prefs['xlog']
-    elif plotfunc in ['resid', 'ratio', 'delchi', 'bkg_resid', 'bkg_ratio', 'bkg_delchi']:
-        assert p1.plot_prefs['ylog'] == answer
     else:
         assert p1.histo_prefs['ylog'] == answer
 
@@ -3857,8 +3851,6 @@ def test_set_plot_opt_y_astro(cls, datafunc, plotfunc, answer):
     if plotfunc in ['fit', 'bkg_fit']:
         assert not p2.dataplot.histo_prefs['ylog']
         assert not p2.modelplot.histo_prefs['xlog']
-    elif plotfunc in ['resid', 'ratio', 'delchi', 'bkg_resid', 'bkg_ratio', 'bkg_delchi']:
-        assert not p2.plot_prefs['ylog']
     else:
         assert not p2.histo_prefs['ylog']
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -361,6 +361,11 @@ class Session(sherpa.ui.utils.Session):
         self._plot_types['source'].append(sherpa.astro.plot.SourcePlot())
         self._plot_types["source_component"].append(sherpa.astro.plot.ComponentSourcePlot())
 
+        self._plot_types["ratio"].append(sherpa.astro.plot.RatioPHAPlot())
+        self._plot_types["resid"].append(sherpa.astro.plot.ResidPHAPlot())
+        self._plot_types["delchi"].append(sherpa.astro.plot.DelchiPHAPlot())
+        self._plot_types["chisqr"].append(sherpa.astro.plot.ChisqrPHAPlot())
+
         self._plot_types['arf'] = [sherpa.astro.plot.ARFPlot()]
         self._plot_types['rmf'] = [sherpa.astro.plot.RMFPlot()]
         self._plot_types['order'] = [sherpa.astro.plot.OrderPlot()]
@@ -11379,6 +11384,74 @@ class Session(sherpa.ui.utils.Session):
         return super().get_source_component_plot(id, model=model, recalc=recalc)
 
     get_source_component_plot.__doc__ = sherpa.ui.utils.Session.get_source_component_plot.__doc__
+
+    def get_ratio_plot(self, id=None, recalc=True):
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        if isinstance(data, DataPHA):
+            plotobj = self._plot_types["ratio"][2]
+            if recalc:
+                plotobj.prepare(data, self.get_model(id), self.get_stat())
+
+            return plotobj
+
+        return super().get_ratio_plot(id, recalc=recalc)
+
+    get_ratio_plot.__doc__ = sherpa.ui.utils.Session.get_ratio_plot.__doc__
+
+    def get_resid_plot(self, id=None, recalc=True):
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        if isinstance(data, DataPHA):
+            plotobj = self._plot_types["resid"][2]
+            if recalc:
+                plotobj.prepare(data, self.get_model(id), self.get_stat())
+
+            return plotobj
+
+        return super().get_resid_plot(id, recalc=recalc)
+
+    get_resid_plot.__doc__ = sherpa.ui.utils.Session.get_resid_plot.__doc__
+
+    def get_delchi_plot(self, id=None, recalc=True):
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        if isinstance(data, DataPHA):
+            plotobj = self._plot_types["delchi"][2]
+            if recalc:
+                plotobj.prepare(data, self.get_model(id), self.get_stat())
+
+            return plotobj
+
+        return super().get_delchi_plot(id, recalc=recalc)
+
+    get_delchi_plot.__doc__ = sherpa.ui.utils.Session.get_delchi_plot.__doc__
+
+    def get_chisqr_plot(self, id=None, recalc=True):
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        if isinstance(data, DataPHA):
+            plotobj = self._plot_types["chisqr"][2]
+            if recalc:
+                plotobj.prepare(data, self.get_model(id), self.get_stat())
+
+            return plotobj
+
+        return super().get_chisqr_plot(id, recalc=recalc)
+
+    get_chisqr_plot.__doc__ = sherpa.ui.utils.Session.get_chisqr_plot.__doc__
 
     def get_pvalue_plot(self, null_model=None, alt_model=None, conv_model=None,
                         id=1, otherids=(), num=500, bins=25, numcores=None,

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -115,9 +115,11 @@ dependent axis (``y``) then filter to select only those values between
 >>> d1.ignore(520, 530)
 
 """
-import logging
-import warnings
+
 from abc import ABCMeta
+import logging
+from typing import Optional
+import warnings
 
 import numpy
 
@@ -810,6 +812,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
 
     """
 
+    _fields: tuple[str, ...]
     _fields = ("name", "indep", "dep", "staterror", "syserror")
     """The main data values stored by the object (as a tuple).
 
@@ -818,9 +821,11 @@ class Data(NoNewAttributesAfterInit, BaseData):
     field. Other fields are listed in _extra_fields.
     """
 
+    _extra_fields: tuple[str, ...]
     _extra_fields = ()
     """Any extra fields that should be displayed by str(object)."""
 
+    _related_fields: tuple[str, ...]
     _related_fields = ("y", "staterror", "syserror")
     """What fields must match the size of the independent axis.
 
@@ -831,6 +836,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
     _y = None
     _size = None
 
+    ndim : Optional[int]
     ndim = None
     "The dimensionality of the dataset, if defined, or None."
 
@@ -1053,18 +1059,6 @@ class Data(NoNewAttributesAfterInit, BaseData):
         """
         return self._data_space.get().grid
 
-    def _clear_filter(self):
-        """Clear out the existing filter.
-
-        This is designed for use by @indep.setter.
-
-        """
-
-        # This is currently a no-op. It may beover-ridden by a
-        # subclass.
-        #
-        pass
-
     @indep.setter
     def indep(self, val):
 
@@ -1079,6 +1073,18 @@ class Data(NoNewAttributesAfterInit, BaseData):
 
         self._data_space = self._init_data_space(self._data_space.filter, *val)
         self._clear_filter()
+
+    def _clear_filter(self) -> None:
+        """Clear out the existing filter.
+
+        This is designed for use by @indep.setter.
+
+        """
+
+        # This is currently a no-op. It may be over-ridden by a
+        # subclass.
+        #
+        pass
 
     def get_indep(self, filter=False):
         """Return the independent axes of a data set.
@@ -1526,7 +1532,10 @@ class Data1D(Data):
     syserror : array-like
         the systematic error associated with the data
     '''
+
+    _fields: tuple[str, ...]
     _fields = ("name", "x", "y", "staterror", "syserror")
+
     ndim = 1
 
     def __init__(self, name, x, y, staterror=None, syserror=None):
@@ -1812,6 +1821,7 @@ class Data1DAsymmetricErrs(Data1D):
     Note: elo and ehi shall be stored as delta values from y
     """
 
+    _fields: tuple[str, ...]
     _fields = ("name", "x", "y", "staterror", "syserror", "elo", "ehi")
 
     def __init__(self, name, x, y, elo, ehi, staterror=None, syserror=None):
@@ -1844,6 +1854,8 @@ class Data1DInt(Data1D):
     syserror : array-like
         the systematic error associated with the data
     """
+
+    _fields: tuple[str, ...]
     _fields = ("name", "xlo", "xhi", "y", "staterror", "syserror")
 
     def __init__(self, name, xlo, xhi, y, staterror=None, syserror=None):
@@ -2100,7 +2112,10 @@ class Data2D(Data):
         Sherpa provides the `~sherpa.astro.data.DataIMG` class to handle
         regularly-gridded data more easily.
     '''
+
+    _fields: tuple[str, ...]
     _fields = ("name", "x0", "x1", "y", "shape", "staterror", "syserror")
+
     ndim = 2
 
     # Why should we add shape to extra-fields instead? See #1359 to
@@ -2341,7 +2356,11 @@ class Data2DInt(Data2D):
         Sherpa provides the `~sherpa.astro.data.DataIMGInt` class to make it easier
         to work with regularly-gridded data.
     '''
+
+    _fields: tuple[str, ...]
     _fields = ("name", "x0lo", "x1lo", "x0hi", "x1hi", "y", "staterror", "syserror")
+
+    _extra_fields: tuple[str, ...]
     _extra_fields = ("shape", )
 
     def __init__(self, name, x0lo, x1lo, x0hi, x1hi, y, shape=None, staterror=None, syserror=None):

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -34,13 +34,15 @@ import contextlib
 import copy
 import logging
 import importlib
-from typing import Any, Literal, Optional, Sequence, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, \
+    SupportsFloat, TypeVar, Union
 
 import numpy as np
 
 from sherpa import get_config
-from sherpa.data import Data
+from sherpa.data import Data, Data1DInt
 from sherpa.estmethods import Covariance
+from sherpa.models.model import Model
 from sherpa.optmethods import LevMar, NelderMead
 from sherpa.plot.backends import BaseBackend, BasicBackend, PLOT_BACKENDS
 from sherpa.stats import Stat, Likelihood, LeastSq, Chi2XspecVar
@@ -395,7 +397,7 @@ class Plot(NoNewAttributesAfterInit):
     plot_prefs = basicbackend.get_plot_defaults()
     "The preferences for the plot."
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initialize a Plot object.  All 1D line plot
         instances utilize Plot, which provides a generic
@@ -409,30 +411,48 @@ class Plot(NoNewAttributesAfterInit):
         super().__init__()
 
     @staticmethod
-    def vline(x, ymin=0, ymax=1,
-              linecolor=None, linestyle=None, linewidth=None,
-              overplot=False, clearwindow=True):
+    def vline(x: SupportsFloat,
+              ymin: SupportsFloat = 0,
+              ymax: SupportsFloat = 1,
+              linecolor: Optional[str] = None,
+              linestyle: Optional[str] = None,
+              linewidth: Optional[SupportsFloat] = None,
+              overplot: bool = False,
+              clearwindow: bool = True) -> None:
         "Draw a line at constant x, extending over the plot."
         backend.vline(x, ymin=ymin, ymax=ymax, linecolor=linecolor,
                       linestyle=linestyle, linewidth=linewidth,
                       overplot=overplot, clearwindow=clearwindow)
 
     @staticmethod
-    def hline(y, xmin=0, xmax=1,
-              linecolor=None, linestyle=None, linewidth=None,
-              overplot=False, clearwindow=True):
+    def hline(y: SupportsFloat,
+              xmin: SupportsFloat = 0,
+              xmax: SupportsFloat = 1,
+              linecolor: Optional[str] = None,
+              linestyle: Optional[str] = None,
+              linewidth: Optional[SupportsFloat] = None,
+              overplot: bool = False,
+              clearwindow: bool = True) -> None:
         "Draw a line at constant y, extending over the plot."
         backend.hline(y, xmin=xmin, xmax=xmax, linecolor=linecolor,
                       linestyle=linestyle, linewidth=linewidth,
                       overplot=overplot, clearwindow=clearwindow)
 
-    def _merge_settings(self, kwargs):
+    def _merge_settings(self, kwargs: dict) -> dict:
         """Return the plot preferences merged with user settings."""
         return {**self.plot_prefs, **kwargs}
 
-    def plot(self, x, y, yerr=None, xerr=None, title=None, xlabel=None,
-             ylabel=None, overplot=False, clearwindow=True,
-             **kwargs):
+    def plot(self,
+             x: np.ndarray,
+             y: np.ndarray,
+             yerr: Optional[np.ndarray] = None,
+             xerr: Optional[np.ndarray] = None,
+             title: Optional[str] = None,
+             xlabel: Optional[str] = None,
+             ylabel: Optional[str] = None,
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs) -> None:
         """Plot the data.
 
         Parameters
@@ -469,7 +489,7 @@ class Plot(NoNewAttributesAfterInit):
                      overplot=overplot, clearwindow=clearwindow,
                      **opts)
 
-    def overplot(self, *args, **kwargs):
+    def overplot(self, *args, **kwargs) -> None:
         """Add the data to an existing plot.
 
         This is the same as calling the plot method with
@@ -490,7 +510,7 @@ class Contour(NoNewAttributesAfterInit):
     contour_prefs = basicbackend.get_contour_defaults()
     "The preferences for the plot."
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initialize a Contour object.  All 2D contour plot
         instances utilize Contour, which provides a generic
@@ -503,13 +523,20 @@ class Contour(NoNewAttributesAfterInit):
         self.contour_prefs = self.contour_prefs.copy()
         super().__init__()
 
-    def _merge_settings(self, kwargs):
+    def _merge_settings(self, kwargs: dict) -> dict:
         """Return the plot preferences merged with user settings."""
         return {**self.contour_prefs, **kwargs}
 
-    def contour(self, x0, x1, y, title=None, xlabel=None,
-                ylabel=None, overcontour=False, clearwindow=True,
-                **kwargs):
+    def contour(self,
+                x0: np.ndarray,
+                x1: np.ndarray,
+                y: np.ndarray,
+                title: Optional[str] = None,
+                xlabel: Optional[str] = None,
+                ylabel: Optional[str] = None,
+                overcontour: bool = False,
+                clearwindow: bool = True,
+                **kwargs) -> None:
         """Display the contour data.
 
         Parameters
@@ -542,7 +569,7 @@ class Contour(NoNewAttributesAfterInit):
                         overcontour=overcontour,
                         clearwindow=clearwindow, **opts)
 
-    def overcontour(self, *args, **kwargs):
+    def overcontour(self, *args, **kwargs) -> None:
         kwargs['overcontour'] = True
         self.contour(*args, **kwargs)
 
@@ -553,7 +580,7 @@ class Point(NoNewAttributesAfterInit):
     point_prefs = basicbackend.get_point_defaults()
     "The preferences for the plot."
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initialize a Point object.  All 1D point plot
         instances utilize Point, which provides a generic
@@ -566,11 +593,16 @@ class Point(NoNewAttributesAfterInit):
         self.point_prefs = self.point_prefs.copy()
         super().__init__()
 
-    def _merge_settings(self, kwargs):
+    def _merge_settings(self, kwargs: dict) -> dict:
         """Return the plot preferences merged with user settings."""
         return {**self.point_prefs, **kwargs}
 
-    def point(self, x, y, overplot=True, clearwindow=False, **kwargs):
+    def point(self,
+              x: SupportsFloat,
+              y: SupportsFloat,
+              overplot: bool = True,
+              clearwindow: bool = False,
+              **kwargs) -> None:
         """Draw a point at the given location.
 
         Parameters
@@ -606,7 +638,7 @@ class Image(NoNewAttributesAfterInit):
     image_prefs = basicbackend.get_image_defaults()
     "The preferences for the plot."
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initialize a Image object.
 
@@ -617,11 +649,17 @@ class Image(NoNewAttributesAfterInit):
         self.image_prefs = self.image_prefs.copy()
         super().__init__()
 
-    def _merge_settings(self, kwargs):
+    def _merge_settings(self, kwargs: dict) -> dict:
         """Return the plot preferences merged with user settings."""
         return {**self.image_prefs, **kwargs}
 
-    def plot(self, x0, x1, y, overplot=True, clearwindow=False, **kwargs):
+    def plot(self,
+             x0: np.ndarray,
+             x1: np.ndarray,
+             y: np.ndarray,
+             overplot: bool = True,
+             clearwindow: bool = False,
+             **kwargs) -> None:
         """Draw a point at the given location.
 
         Parameters
@@ -654,7 +692,7 @@ class Histogram(NoNewAttributesAfterInit):
     histo_prefs = basicbackend.get_histo_defaults()
     "The preferences for the plot."
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initialize a Histogram object.  All 1D histogram plot
         instances utilize Histogram, which provides a generic
@@ -667,12 +705,21 @@ class Histogram(NoNewAttributesAfterInit):
         self.histo_prefs = self.histo_prefs.copy()
         super().__init__()
 
-    def _merge_settings(self, kwargs):
+    def _merge_settings(self, kwargs: dict) -> dict:
         """Return the plot preferences merged with user settings."""
         return {**self.histo_prefs, **kwargs}
 
-    def plot(self, xlo, xhi, y, yerr=None, title=None, xlabel=None,
-             ylabel=None, overplot=False, clearwindow=True, **kwargs):
+    def plot(self,
+             xlo: np.ndarray,
+             xhi: np.ndarray,
+             y: np.ndarray,
+             yerr: Optional[np.ndarray] = None,
+             title: Optional[str] = None,
+             xlabel: Optional[str] = None,
+             ylabel: Optional[str] = None,
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs) -> None:
         """Plot the data.
 
         Parameters
@@ -709,7 +756,7 @@ class Histogram(NoNewAttributesAfterInit):
                       xlabel=xlabel, ylabel=ylabel, overplot=overplot,
                       clearwindow=clearwindow, **opts)
 
-    def overplot(self, *args, **kwargs):
+    def overplot(self, *args, **kwargs) -> None:
         kwargs['overplot'] = True
         self.plot(*args, **kwargs)
 
@@ -880,24 +927,24 @@ class BaseHistogram(Histogram):
 
     """
 
-    def __init__(self):
-        self.xlo = None
-        self.xhi = None
-        self.y = None
-        self.xlabel = None
-        self.ylabel = None
-        self.title = None
+    def __init__(self) -> None:
+        self.xlo: Optional[np.ndarray] = None
+        self.xhi: Optional[np.ndarray] = None
+        self.y: Optional[np.ndarray] = None
+        self.xlabel: Optional[str] = None
+        self.ylabel: Optional[str] = None
+        self.title: Optional[str] = None
         super().__init__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return display_fields(self, self._fields)
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the histogram plot."""
         return backend.as_html_histogram(self)
 
     @property
-    def x(self):
+    def x(self) -> Optional[np.ndarray]:
         """Return (xlo + xhi) / 2
 
         This is intended to make it easier to swap between
@@ -913,7 +960,7 @@ class BaseHistogram(Histogram):
         xhi = np.asarray(self.xhi)
         return (xlo + xhi) / 2
 
-    def prepare(self, *args, **kwargs):
+    def prepare(self, *args, **kwargs) -> None:
         """Create the data to plot.
 
         This sets the xlo, xhi, y and related fields so that plot will
@@ -928,7 +975,10 @@ class BaseHistogram(Histogram):
         # require significant changes to the class setup.
         raise NotImplementedError()
 
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
+    def plot(self,  # type: ignore[override]
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs) -> None:
         """Plot the data.
 
         This will plot the data created by the prepare method.
@@ -972,7 +1022,7 @@ class HistogramPlot(BaseHistogram):
 # I think we want slightly different histogram preferences
 # than most (mark by point rather than line).
 #
-def get_data_hist_prefs():
+def get_data_hist_prefs() -> dict[str, Any]:
     """Copy the data preferences to the histogram class"""
 
     hprefs = basicbackend.get_model_histo_defaults()
@@ -990,12 +1040,12 @@ class DataHistogramPlot(HistogramPlot):
     histo_prefs = get_data_hist_prefs()
     "The preferences for the plot."
 
-    def __init__(self):
-        self.yerr = None
+    def __init__(self) -> None:
+        self.yerr: Optional[np.ndarray] = None
         super().__init__()
 
     @property
-    def xerr(self):
+    def xerr(self) -> Optional[np.ndarray]:
         """Return abs(xhi - xlow) / 2
 
         The plotting backends actually calculate the xerr values
@@ -1015,7 +1065,9 @@ class DataHistogramPlot(HistogramPlot):
         xhi = np.asarray(self.xhi)
         return np.abs(xhi - xlo) / 2
 
-    def prepare(self, data, stat=None):
+    def prepare(self,
+                data: Data1DInt,
+                stat: Optional[Stat] = None) -> None:
         """Create the data to plot
 
         Parameters
@@ -1056,7 +1108,10 @@ class DataHistogramPlot(HistogramPlot):
     # so the superclass is over-ridden here to basically call
     # the base class.
     #
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
+    def plot(self,  # type: ignore[override]
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs) -> None:
         """Plot the data.
 
         This will plot the data created by the prepare method.
@@ -1094,11 +1149,14 @@ class DataHistogramPlot(HistogramPlot):
 class ModelHistogramPlot(HistogramPlot):
     """Display a model as a histogram."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.title = 'Model'
 
-    def prepare(self, data, model, stat=None):
+    def prepare(self,
+                data: Data1DInt,
+                model: Model,
+                stat: Optional[Stat] = None) -> None:
         """Create the plot.
 
         The stat parameter is ignored.
@@ -1113,13 +1171,12 @@ class ModelHistogramPlot(HistogramPlot):
         self.xlo = indep[0]
         self.xhi = indep[1]
         self.y = y[1]
-        assert self.y.size == self.xlo.size
 
 
 class SourceHistogramPlot(ModelHistogramPlot):
     """Display a source model as a histogram."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.title = 'Source'
 
@@ -1135,15 +1192,20 @@ class PDFPlot(HistogramPlot):
     _fields = ["points", "xlo", "xhi", "y", "xlabel!", "ylabel!",
                "title!", "histo_prefs!"]
 
-    def __init__(self):
-        self.points = None
+    def __init__(self) -> None:
+        self.points: Optional[np.ndarray] = None
         super().__init__()
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the PDF plot."""
         return backend.as_html_pdf(self)
 
-    def prepare(self, points, bins=12, normed=True, xlabel="x", name="x"):
+    def prepare(self,
+                points: Sequence[SupportsFloat],
+                bins: int = 12,
+                normed: bool = True,
+                xlabel: str = "x",
+                name: str = "x") -> None:
         """Create the data to plot.
 
         Parameters
@@ -1165,8 +1227,9 @@ class PDFPlot(HistogramPlot):
         plot
         """
 
-        self.points = points
-        self.y, xx = np.histogram(points, bins=bins, density=normed)
+        self.points = np.asarray(points)
+        self.y, xx = np.histogram(self.points, bins=bins,
+                                  density=normed)
         self.xlo = xx[:-1]
         self.xhi = xx[1:]
         self.ylabel = "probability density"
@@ -1299,17 +1362,22 @@ class LRHistogram(HistogramPlot):
     _fields = ["ratios", "lr!", "xlo", "xhi", "y", "xlabel!",
                "ylabel!", "title!", "histo_prefs!"]
 
-    def __init__(self):
-        self.ratios = None
-        self.lr = None
-        self.ppp = None
+    def __init__(self) -> None:
+        self.ratios: Optional[np.ndarray] = None
+        self.lr: Optional[float] = None
+        self.ppp: Optional[float] = None
         super().__init__()
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the LRHistogram plot."""
         return backend.as_html_lr(self)
 
-    def prepare(self, ratios, bins, niter, lr, ppp):
+    def prepare(self,
+                ratios: Sequence[SupportsFloat],
+                bins: int,
+                niter: int,
+                lr: SupportsFloat,
+                ppp: SupportsFloat) -> None:
         "Create the data to plot"
 
         self.ppp = float(ppp)
@@ -1324,7 +1392,10 @@ class LRHistogram(HistogramPlot):
         self.xlabel = "Likelihood Ratio"
         self.ylabel = "Frequency"
 
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
+    def plot(self,  # type: ignore[override]
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs) -> None:
         """Plot the data.
 
         This will plot the data created by the prepare method.
@@ -1352,6 +1423,13 @@ class LRHistogram(HistogramPlot):
 
         if self.lr is None:
             return
+
+        if TYPE_CHECKING:
+            # The super().plot call has already checked this but the type
+            # checker may not recognize this.
+            #
+            assert self.xlo is not None
+            assert self.xhi is not None
 
         # Note: the user arguments are not applied to the vertical line
         #
@@ -1944,7 +2022,10 @@ class ComponentModelHistogramPlot(ModelHistogramPlot):
     plot_prefs = basicbackend.get_component_plot_defaults()
     "The preferences for the plot."
 
-    def prepare(self, data, model, stat=None):
+    def prepare(self,
+                data: Data1DInt,
+                model: Model,
+                stat: Optional[Stat] = None) -> None:
         super().prepare(data, model, stat)
         self.title = f'Model component: {model.name}'
 
@@ -1998,7 +2079,10 @@ class ComponentSourceHistogramPlot(SourceHistogramPlot):
     # Is this the correct setting?
     plot_prefs = basicbackend.get_component_plot_defaults()
 
-    def prepare(self, data, model, stat=None):
+    def prepare(self,
+                data: Data1DInt,
+                model: Model,
+                stat: Optional[Stat] = None) -> None:
 
         plot = data.to_component_plot(yfunc=model)
         (_, y, _, _, self.xlabel, self.ylabel) = plot
@@ -2009,7 +2093,6 @@ class ComponentSourceHistogramPlot(SourceHistogramPlot):
         self.xlo = indep[0]
         self.xhi = indep[1]
         self.y = y[1]
-        assert self.y.size == self.xlo.size
 
         self.title = f'Source model component: {model.name}'
 

--- a/sherpa/plot/backends.py
+++ b/sherpa/plot/backends.py
@@ -704,6 +704,12 @@ class BaseBackend(metaclass=MetaBaseBackend):
         # d['marker'] = '_'
         return d
 
+    def get_resid_histo_defaults(self):
+        d = self.get_histo_defaults()
+        d['capsize'] = 0
+        # d['marker'] = '_'
+        return d
+
     def get_ratio_plot_defaults(self):
         d = self.get_data_plot_defaults()
         d['xerrorbars'] = True

--- a/sherpa/plot/testing.py
+++ b/sherpa/plot/testing.py
@@ -102,6 +102,7 @@ def check_full(r, summary, label='', title='', nsummary=0, test_other=None):
             assert "<svg " in r
         elif (HAS_BOKEH and isinstance(plot.backend, BokehBackend)):
             assert "BokehJS library" in r
+
         return
 
     assert '<svg ' not in r

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1279,7 +1279,7 @@ def test_lrhist_str(check_str):
 
     check_str("\n".join(out),
               ["ratios = None",
-               "lr = None",
+               "lr     = None",
                "xlo    = None",
                "xhi    = None",
                "y      = None",
@@ -1299,7 +1299,7 @@ def test_lrhist_str(check_str):
 
     check_str("\n".join(out),
               ["ratios = [0. ,0.5,1. ,1.5,2. ,2.5,3. ,3.5,4. ,4.5]",
-               "lr = 0.1",
+               "lr     = 0.1",
                "xlo    = [0.  ,0.75,1.5 ,2.25,3.  ,3.75]",
                "xhi    = [0.75,1.5 ,2.25,3.  ,3.75,4.5 ]",
                "y      = [1. ,0.5,1. ,0.5,1. ,1. ]",

--- a/sherpa/plot/tests/test_plot_notebook.py
+++ b/sherpa/plot/tests/test_plot_notebook.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2022, 2023
+#  Copyright (C) 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -92,7 +92,7 @@ def test_lrhist(all_plot_backends):
 def test_data(all_plot_backends):
     p = plot.DataPlot()
     r = p._repr_html_()
-    check_full(r, 'DataPlot', 'None', 'None', nsummary=7)  # NOT empty
+    check_empty(r, 'DataPlot', nsummary=7)
 
     x = np.arange(5, 8, 0.5)
     y = np.ones(x.size)

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -217,12 +217,12 @@ def change_fit(idval):
     change_model(idval)
 
 
-def check_example(idval, xlabel='x'):
+def check_example(idval):
     """Check that the data plot has not changed"""
 
     dplot = ui.get_data_plot(id=idval, recalc=False)
 
-    assert dplot.xlabel == xlabel
+    assert dplot.xlabel == 'x'
     assert dplot.ylabel == 'y'
     assert dplot.title == 'example'
     assert dplot.x == pytest.approx(_data_x)
@@ -233,7 +233,7 @@ def check_example(idval, xlabel='x'):
     assert dplot.yerr == pytest.approx(calc_errors(_data_y))
 
 
-def check_example_changed(idval, xlabel='x'):
+def check_example_changed(idval):
     """Check that the data plot has changed
 
     Assumes change_example has been called
@@ -241,7 +241,7 @@ def check_example_changed(idval, xlabel='x'):
 
     dplot = ui.get_data_plot(id=idval, recalc=False)
 
-    assert dplot.xlabel == xlabel
+    assert dplot.xlabel == 'x'
     assert dplot.ylabel == 'y'
     assert dplot.title == 'example'
     assert dplot.x == pytest.approx(_data_x)
@@ -252,10 +252,10 @@ def check_example_changed(idval, xlabel='x'):
     assert dplot.yerr == pytest.approx(calc_errors(_data_y2))
 
 
-def check_model_plot(plot, title='Model', xlabel='x', modelval=35):
+def check_model_plot(plot, title='Model', modelval=35):
     """Helper for check_model/source"""
 
-    assert plot.xlabel == xlabel
+    assert plot.xlabel == 'x'
     assert plot.ylabel == 'y'
     assert plot.title == title
     assert plot.x == pytest.approx(_data_x)
@@ -264,21 +264,21 @@ def check_model_plot(plot, title='Model', xlabel='x', modelval=35):
     assert plot.yerr is None
 
 
-def check_model(idval, xlabel='x'):
+def check_model(idval):
     """Check that the model plot has not changed"""
 
     mplot = ui.get_model_plot(id=idval, recalc=False)
-    check_model_plot(mplot, title='Model', xlabel=xlabel)
+    check_model_plot(mplot, title='Model')
 
 
-def check_model_changed(idval, xlabel='x'):
+def check_model_changed(idval):
     """Check that the model plot has changed
 
     Assumes change_model has been called
     """
 
     mplot = ui.get_model_plot(id=idval, recalc=False)
-    check_model_plot(mplot, title='Model', xlabel=xlabel, modelval=41)
+    check_model_plot(mplot, title='Model', modelval=41)
 
 
 def check_source(idval):
@@ -500,8 +500,8 @@ def check_fit_changed(idval):
 def check_fit_resid(idval):
     """Check that the fit + resid plot has not changed"""
 
-    check_example(idval, xlabel='')
-    check_model(idval, xlabel='')
+    check_example(idval)
+    check_model(idval)
     check_resid(idval, title='')
 
 
@@ -511,16 +511,16 @@ def check_fit_resid_changed(idval):
     Assumes that change_fit has been called
     """
 
-    check_example_changed(idval, xlabel='')
-    check_model_changed(idval, xlabel='')
+    check_example_changed(idval)
+    check_model_changed(idval)
     check_resid_changed2(idval, title='')
 
 
 def check_fit_ratio(idval):
     """Check that the fit + ratio plot has not changed"""
 
-    check_example(idval, xlabel='')
-    check_model(idval, xlabel='')
+    check_example(idval)
+    check_model(idval)
     check_ratio(idval, title='')
 
 
@@ -530,16 +530,16 @@ def check_fit_ratio_changed(idval):
     Assumes that change_fit has been called
     """
 
-    check_example_changed(idval, xlabel='')
-    check_model_changed(idval, xlabel='')
+    check_example_changed(idval)
+    check_model_changed(idval)
     check_ratio_changed2(idval, title='')
 
 
 def check_fit_delchi(idval):
     """Check that the fit + delchi plot has not changed"""
 
-    check_example(idval, xlabel='')
-    check_model(idval, xlabel='')
+    check_example(idval)
+    check_model(idval)
     check_delchi(idval, title='')
 
 
@@ -549,8 +549,8 @@ def check_fit_delchi_changed(idval):
     Assumes that change_fit has been called
     """
 
-    check_example_changed(idval, xlabel='')
-    check_model_changed(idval, xlabel='')
+    check_example_changed(idval)
+    check_model_changed(idval)
     check_delchi_changed2(idval, title='')
 
 
@@ -2801,7 +2801,7 @@ def test_plot_fit_xxx_pylab(ptype, clean_ui, requires_pylab):
         print('---')
 
     assert len(axes) == 2
-    assert axes[0].xaxis.get_label().get_text() == ''
+    assert axes[0].xaxis.get_label().get_text() == 'x'
 
     assert axes[0].xaxis.get_scale() == 'log'
     assert axes[0].yaxis.get_scale() == 'log'
@@ -2834,7 +2834,7 @@ def test_plot_fit_xxx_overplot_pylab(ptype, caplog, clean_ui, requires_pylab):
     fig = plt.gcf()
     axes = fig.axes
     assert len(axes) == 2
-    assert axes[0].xaxis.get_label().get_text() == ''
+    assert axes[0].xaxis.get_label().get_text() == 'x'
 
     assert axes[0].xaxis.get_scale() == 'log'
     assert axes[0].yaxis.get_scale() == 'log'
@@ -2874,7 +2874,7 @@ def test_plot_fit_resid_handles_data_log(idval, clean_ui, requires_pylab):
     fig = plt.gcf()
     axes = fig.axes
     assert len(axes) == 2
-    assert axes[0].xaxis.get_label().get_text() == ''
+    assert axes[0].xaxis.get_label().get_text() == 'x'
 
     assert axes[0].xaxis.get_scale() == 'log'
     assert axes[0].yaxis.get_scale() == 'linear'
@@ -2904,7 +2904,7 @@ def test_plot_fit_resid_handles_resid_log(idval, clean_ui, requires_pylab):
     fig = plt.gcf()
     axes = fig.axes
     assert len(axes) == 2
-    assert axes[0].xaxis.get_label().get_text() == ''
+    assert axes[0].xaxis.get_label().get_text() == 'x'
 
     assert axes[0].xaxis.get_scale() == 'log'
     assert axes[0].yaxis.get_scale() == 'linear'

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -40,7 +40,8 @@ from sherpa.data import Data1D, Data1DInt, Data2D
 from sherpa.models import basic
 import sherpa.plot
 from sherpa.stats import Chi2Gehrels
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, IdentifierErr, PlotErr
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, IdentifierErr, \
+    PlotErr
 
 
 _data_x = [10, 20, 40, 90]
@@ -1635,7 +1636,7 @@ def test_get_cdf_plot_empty(session):
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_plot_cdf_replot_no_data(session, requires_pylab):
+def test_plot_cdf_replot_no_data(session):
     """what does replot=True do for plot_cdf?
 
     The code doesn't check for this evantuality,
@@ -1646,8 +1647,7 @@ def test_plot_cdf_replot_no_data(session, requires_pylab):
 
     x = np.asarray([2, 8, 4, 6])
 
-    # error can depend on matplotlib version
-    with pytest.raises(ValueError):
+    with pytest.raises(PlotErr, match="prepare has not been called"):
         s.plot_cdf(x, replot=True)
 
 
@@ -1835,7 +1835,7 @@ def test_plot_pdf(session):
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_plot_pdf_replot_no_data(session, requires_pylab):
+def test_plot_pdf_replot_no_data(session):
     """what does replot=True do for plot_pdf?
 
     The code doesn't check for this evantuality,
@@ -1847,10 +1847,8 @@ def test_plot_pdf_replot_no_data(session, requires_pylab):
     x = np.asarray([2, 8, 4, 6])
 
     # check on the error so we know when the code has changed
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(PlotErr, match="prepare has not been called"):
         s.plot_pdf(x, replot=True)
-
-    assert "'NoneType' has no len" in str(exc.value)
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
@@ -2365,36 +2363,18 @@ def test_get_model_component_plot_model(session):
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_pylab_plot_scatter_empty_replot(session, requires_pylab):
+def test_pylab_plot_scatter_empty_replot(session):
     """plot_scatter with replot=False and no data
 
     Just check the current behavior
     """
 
-    from matplotlib import pyplot as plt
-
     s = session()
 
     x = np.arange(3)
     y = x + 5
-    s.plot_scatter(x, y, replot=True)
-
-    fig = plt.gcf()
-
-    assert len(fig.axes) == 1
-
-    ax = fig.axes[0]
-
-    assert ax.xaxis.get_label().get_text() == ''
-    assert ax.yaxis.get_label().get_text() == ''
-
-    assert len(ax.lines) == 1
-    line = ax.lines[0]
-
-    assert line.get_xdata() == [None]
-    assert line.get_ydata() == [None]
-
-    plt.close()
+    with pytest.raises(PlotErr, match="prepare has not been called"):
+        s.plot_scatter(x, y, replot=True)
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
@@ -2444,8 +2424,7 @@ def test_pylab_plot_trace_empty_replot(session, requires_pylab):
 
     y = np.arange(100, 104)
 
-    # error can depend on matplotlib version
-    with pytest.raises(ValueError):
+    with pytest.raises(PlotErr, match="prepare has not been called"):
         s.plot_trace(y, replot=True)
 
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -955,10 +955,10 @@ class Session(NoNewAttributesAfterInit):
             'source_component': [sherpa.plot.ComponentSourcePlot(), sherpa.plot.ComponentSourceHistogramPlot()],
             'source_components': [sherpa.plot.MultiPlot()],
             'fit': [sherpa.plot.FitPlot()],
-            'resid': [sherpa.plot.ResidPlot()],
-            'ratio': [sherpa.plot.RatioPlot()],
-            'delchi': [sherpa.plot.DelchiPlot()],
-            'chisqr': [sherpa.plot.ChisqrPlot()],
+            'resid': [sherpa.plot.ResidPlot(), sherpa.plot.ResidHistogramPlot()],
+            'ratio': [sherpa.plot.RatioPlot(), sherpa.plot.RatioHistogramPlot()],
+            'delchi': [sherpa.plot.DelchiPlot(), sherpa.plot.DelchiHistogramPlot()],
+            'chisqr': [sherpa.plot.ChisqrPlot(), sherpa.plot.ChisqrHistogramPlot()],
             'psf': [sherpa.plot.PSFPlot()],
             'kernel': [sherpa.plot.PSFKernelPlot()]
         }
@@ -12396,9 +12396,22 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._plot_types["resid"][0]
+        # Allow an answer to be returned if recalc is False and no
+        # data has been loaded. However, it's not obvious what the
+        # answer should be if recalc=False and the dataset has
+        # changed type since get_delchi_plot was last called.
+        #
         if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        # This uses the implicit conversion of bool to 0 or 1.
+        #
+        idx = isinstance(data, sherpa.data.Data1DInt)
+        plotobj = self._plot_types["resid"][idx]
+        if recalc:
+            plotobj.prepare(data, self.get_model(id), self.get_stat())
 
         return plotobj
 
@@ -12458,9 +12471,22 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._plot_types["delchi"][0]
+        # Allow an answer to be returned if recalc is False and no
+        # data has been loaded. However, it's not obvious what the
+        # answer should be if recalc=False and the dataset has
+        # changed type since get_delchi_plot was last called.
+        #
         if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        # This uses the implicit conversion of bool to 0 or 1.
+        #
+        idx = isinstance(data, sherpa.data.Data1DInt)
+        plotobj = self._plot_types["delchi"][idx]
+        if recalc:
+            plotobj.prepare(data, self.get_model(id), self.get_stat())
 
         return plotobj
 
@@ -12520,9 +12546,22 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._plot_types["chisqr"][0]
+        # Allow an answer to be returned if recalc is False and no
+        # data has been loaded. However, it's not obvious what the
+        # answer should be if recalc=False and the dataset has
+        # changed type since get_delchi_plot was last called.
+        #
         if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        # This uses the implicit conversion of bool to 0 or 1.
+        #
+        idx = isinstance(data, sherpa.data.Data1DInt)
+        plotobj = self._plot_types["chisqr"][idx]
+        if recalc:
+            plotobj.prepare(data, self.get_model(id), self.get_stat())
 
         return plotobj
 
@@ -12582,9 +12621,22 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._plot_types["ratio"][0]
+        # Allow an answer to be returned if recalc is False and no
+        # data has been loaded. However, it's not obvious what the
+        # answer should be if recalc=False and the dataset has
+        # changed type since get_delchi_plot was last called.
+        #
         if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        # This uses the implicit conversion of bool to 0 or 1.
+        #
+        idx = isinstance(data, sherpa.data.Data1DInt)
+        plotobj = self._plot_types["ratio"][idx]
+        if recalc:
+            plotobj.prepare(data, self.get_model(id), self.get_stat())
 
         return plotobj
 


### PR DESCRIPTION
Leaving as a draft at the moment as I want to see the fallout from the review of #1988

# Summary

Improve the display of residual-style plots for integrated datasets. Fix #1817.

# Details

Requires
-  #1988 

This introduces `Data1DInt` and `DataPHA` variants of the `resid`/`delchi`/`ratio`/`chisqr` plots. It follows the approach taken in

- #931 

(and perhaps should have been included in that PR). There's three parts:

1. add typing rules to the classes
   
    This takes advantages of some of the earlier changes, but it does show how our classes are not set up as classes are expected to be in Python, for example, our `prepare` method (for the `Plot` case) starts off accepting `x` and `y` but quickly changes to requiring some form of a `Data` object (and possibly other items). There's also some fun multi-class behaviour as we inherit from both the `Plot` and `Histogram` hierarchies which makes working out what to do somewhat murky.
2. add the histogram-based plot classes to replicate the "point" style classes
3. add support for them in the UI layer.

The class names are not ideal, and there are thoughts that could be had over the current class hierarchy, but that can be done in a later PR as it would be very invasive.

# Example

We now have, for a PHA dataset, 

```python
plot_fit(xlog=True)
plot_resid(overplot=True)
```

looking like - for `set_analysis("energy")` 

![err3](https://github.com/sherpa/sherpa/assets/224638/636bc801-0ec7-4238-bc47-d3f589ba5b1b)

and for `set_analysis("wave")`

![wav3](https://github.com/sherpa/sherpa/assets/224638/773e7e59-b450-4feb-80f5-22b64ba9c8cf)

which can be compared to the version included in https://github.com/sherpa/sherpa/pull/1984 - which is, for the wavelength case [note, this fit is not exactly the same as the one above, so the points are not going to be in exactly the same place, nor are the limits the same, but the overall difference of using a histogram for the residuals rather than points holds):

![err2](https://github.com/sherpa/sherpa/assets/224638/af484927-493f-4dad-ae2e-452ace98a69e)
