### PR TITLE
Tests: improve coverage of parameter module

### DIFF
--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -730,7 +730,7 @@ def test_set_default_to_parameter(check_str):
 def test_set_default_to_parameter_to_parameter(check_str):
     """We support this, so make sure it is tested.
 
-    Maybe I shouldn't have watched Inception. There is the question of
+   There is the question of
     whether it makes sense to support this, but that's a different
     issue.
 

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -241,6 +241,23 @@ def test_binop_string_with_custom_ufunc():
     assert repr(comp) == "<BinaryOpParameter 'func(model.p, model.p2)'>"
 
 
+def test_multiop_string_with_custom_ufunc():
+    '''Get an operator which we do not support.'''
+    def func(a, b, c):
+        return a + b + c
+
+    uf = np.frompyfunc(func, nin=3, nout=1)
+    p, p2 = setUp_composite()
+    p3 = Parameter("model", "c", 15)
+
+    # This errors out because we do not suport three parameters.  It
+    # does not seem worth checking the error message as this comes
+    # from upstream code that could change.
+    #
+    with pytest.raises(TypeError):
+        uf(p, p2, p3)
+
+
 class TestBrackets:
     """Provide a set of model instances for the tests."""
 
@@ -605,3 +622,341 @@ def test_explicit_numpy_combination():
     yexp = 48
     assert implicit.val == pytest.approx(yexp)
     assert explicit.val == pytest.approx(yexp)
+
+
+def test_basic_reset():
+    """Try to understand the default_val setting."""
+
+    p1 = Parameter("m1", "a", 4)
+    assert p1.val == 4
+    assert p1.default_val == 4
+    assert p1.link is None
+
+    p1.reset()
+    assert p1.val == 4
+    assert p1.default_val == 4
+    assert p1.link is None
+
+
+def test_set_default_to_val(check_str):
+    """Try to understand the default_val setting."""
+
+    p1 = Parameter("m1", "a", 4)
+    p1.default_val = 2
+
+    # Note that p1.val has not changed, unlike test_set_default_to_parameter
+    assert p1.val == 4
+    assert p1.default_val == 2
+    assert p1.link is None
+
+    check_str(str(p1),
+              [ "val         = 4.0",
+                "min         = -3.4028234663852886e+38",
+                "max         = 3.4028234663852886e+38",
+                "units       = ",
+                "frozen      = False",
+                "link        = None",
+                "default_val = 2.0",
+                "default_min = -3.4028234663852886e+38",
+                "default_max = 3.4028234663852886e+38"
+               ])
+
+    p1.reset()
+    assert p1.val == 2
+    assert p1.default_val == 2
+    assert p1.link is None
+
+    check_str(str(p1),
+              [ "val         = 2.0",
+                "min         = -3.4028234663852886e+38",
+                "max         = 3.4028234663852886e+38",
+                "units       = ",
+                "frozen      = False",
+                "link        = None",
+                "default_val = 2.0",
+                "default_min = -3.4028234663852886e+38",
+                "default_max = 3.4028234663852886e+38"
+               ])
+
+
+def test_set_default_to_parameter(check_str):
+    """We support this, so make sure it is tested.
+
+    There is the question of whether it makes sense to support this,
+    but that's a different issue.
+    """
+
+    p1 = Parameter("m1", "a", 4)
+    p2 = Parameter("m2", "b", 12)
+
+    p1.default_val = 2 + p2
+
+    # Note that p1.val has changed, unlike test_set_default_to_val
+    assert p1.val == 14
+    assert p1.default_val == 14
+    assert p1.link is not None
+
+    check_str(str(p1),
+              [ "val         = 14.0",
+                "min         = -3.4028234663852886e+38",
+                "max         = 3.4028234663852886e+38",
+                "units       = ",
+                "frozen      = True",
+                "link        = 2 + m2.b",
+                "default_val = 14.0",
+                "default_min = -3.4028234663852886e+38",
+                "default_max = 3.4028234663852886e+38"
+               ])
+
+    p1.reset()
+
+    assert p1.val == 14
+    assert p1.default_val == 14
+    assert p1.link is not None
+
+    check_str(str(p1),
+              [ "val         = 14.0",
+                "min         = -3.4028234663852886e+38",
+                "max         = 3.4028234663852886e+38",
+                "units       = ",
+                "frozen      = True",
+                "link        = 2 + m2.b",
+                "default_val = 14.0",
+                "default_min = -3.4028234663852886e+38",
+                "default_max = 3.4028234663852886e+38"
+               ])
+
+
+def test_set_default_to_parameter_to_parameter(check_str):
+    """We support this, so make sure it is tested.
+
+    Maybe I shouldn't have watched Inception. There is the question of
+    whether it makes sense to support this, but that's a different
+    issue.
+
+    """
+
+    p1 = Parameter("m1", "a", 4)
+    p2 = Parameter("m2", "b", 12)
+    p3 = Parameter("m2", "b", 200)
+
+    p2.default_val = p3 / 100
+    p1.default_val = p2 - 5
+
+    assert p1.link is not None
+    assert p1.val == -3
+    assert p1.default_val == -3
+
+
+def test_set_default_to_value_after_parameter(check_str):
+    """Check what happens here."""
+
+    p1 = Parameter("m1", "a", 4)
+    p2 = Parameter("m2", "b", 12)
+
+    p1.default_val = 2 + p2
+
+    p1.default_val = 3
+
+    # Note: this is now back to the original value
+    assert p1.val == 4
+    assert p1.default_val == 3
+    assert p1.link is None
+
+    check_str(str(p1),
+              [ "val         = 4.0",
+                "min         = -3.4028234663852886e+38",
+                "max         = 3.4028234663852886e+38",
+                "units       = ",
+                "frozen      = False",
+                "link        = None",
+                "default_val = 3.0",
+                "default_min = -3.4028234663852886e+38",
+                "default_max = 3.4028234663852886e+38"
+               ])
+
+    p1.reset()
+
+    assert p1.val == 3
+    assert p1.default_val == 3
+
+    check_str(str(p1),
+              [ "val         = 3.0",
+                "min         = -3.4028234663852886e+38",
+                "max         = 3.4028234663852886e+38",
+                "units       = ",
+                "frozen      = False",
+                "link        = None",
+                "default_val = 3.0",
+                "default_min = -3.4028234663852886e+38",
+                "default_max = 3.4028234663852886e+38"
+               ])
+
+
+def test_set_value_to_none(check_str):
+    """This really should not be allowed. See #1992
+
+    Treat as a regression test for now, but we could change the
+    behaviour.
+    """
+
+    p1 = Parameter("m1", "a", 4)
+    p1.val = None
+
+    assert np.isnan(p1.val)
+    assert np.isnan(p1.default_val)
+
+    check_str(str(p1),
+              [ "val         = nan",
+                "min         = -3.4028234663852886e+38",
+                "max         = 3.4028234663852886e+38",
+                "units       = ",
+                "frozen      = False",
+                "link        = None",
+                "default_val = nan",
+                "default_min = -3.4028234663852886e+38",
+                "default_max = 3.4028234663852886e+38"
+               ])
+
+    p1.reset()
+
+    assert np.isnan(p1.val)
+    assert np.isnan(p1.default_val)
+
+
+def test_set_default_to_none(check_str):
+    """This really should not be allowed. See #1992
+
+    Treat as a regression test for now, but we could change the
+    behaviour.
+    """
+
+    p1 = Parameter("m1", "a", 4)
+    p1.default_val = None
+
+    assert p1.val == 4
+    assert np.isnan(p1.default_val)
+
+    check_str(str(p1),
+              [ "val         = 4.0",
+                "min         = -3.4028234663852886e+38",
+                "max         = 3.4028234663852886e+38",
+                "units       = ",
+                "frozen      = False",
+                "link        = None",
+                "default_val = nan",
+                "default_min = -3.4028234663852886e+38",
+                "default_max = 3.4028234663852886e+38"
+               ])
+
+    p1.reset()
+
+    assert np.isnan(p1.val)
+    assert np.isnan(p1.default_val)
+
+
+@pytest.mark.parametrize("dval,expected",
+                         [(0, "minimum of 1"),
+                          (20, "maximum of 5")])
+def test_set_default_to_invalid(dval, expected):
+    """Pick a value outside the min/max range."""
+
+    p1 = Parameter("m1", "a", 4, min=1, max=5)
+
+    with pytest.raises(ParameterErr,
+                       match=f"parameter m1.a has a {expected}"):
+        p1.default_val = dval
+
+
+def test_link_check_very_simple():
+    """Check link cycles.
+
+    This is related to the old (pre GitHub) issue 12287 which was
+    related to cycles in links but for which no test was added
+    (at least for the check_simple / check_involved cases).
+
+    """
+
+    p1 = Parameter("m1", "a", 400)
+    p2 = Parameter("m2", "b", 12)
+
+    p2.val = p1
+
+    # Should this report some sort of linked cycle or just clean
+    # out the old setting?
+    #
+    p1.val = p2
+
+    assert p2.link is None
+    assert p1.link is not None
+
+    assert p1.val == 12
+    assert p2.val == 12
+
+
+def test_link_check_simple():
+    """Check link cycles. See issue #1993."""
+
+    p1 = Parameter("m1", "a", 400)
+    p2 = Parameter("m2", "b", 12)
+
+    p2.val = p1 / 100
+
+    # This should report some sort of linked cycle
+    p1.val = p2 - 5
+
+    with pytest.raises(RecursionError):
+        p1.val
+
+
+def test_link_check_involved():
+    """Check link cycles. See issue #1993."""
+
+    p1 = Parameter("m1", "a", 4)
+    p2 = Parameter("m2", "b", 12)
+    p3 = Parameter("m2", "b", 200)
+
+    p3.val = 1 + p1
+    p2.val = p3 / 100
+
+    # This should report some sort of linked cycle
+    p1.val = p2 - 5
+
+    with pytest.raises(RecursionError):
+        p1.val
+
+
+def test_set_for_default_params():
+    """Check some corner cases."""
+
+    p = Parameter("mdl", "a", 5, min=0, max=10)
+    assert p.val == 5
+    assert p.default_val == 5
+    assert p.min == 0
+    assert p.max == 10
+    assert p.default_min == 0
+    assert p.default_max == 10
+
+    p.set(default_min=-5)
+    assert p.val == 5
+    assert p.default_val == 5
+    assert p.min == 0
+    assert p.max == 10
+    assert p.default_min == -5
+    assert p.default_max == 10
+
+    p.set(default_max=20)
+    assert p.val == 5
+    assert p.default_val == 5
+    assert p.min == 0
+    assert p.max == 10
+    assert p.default_min == -5
+    assert p.default_max == 20
+
+    p.set(default_val=2)
+    assert p.val == 5
+    assert p.default_val == 2
+    assert p.min == 0
+    assert p.max == 10
+    assert p.default_min == -5
+    assert p.default_max == 20


### PR DESCRIPTION
# Summary

Improve the test coverage of the parameter module.


# Details

When working on some recent changes to the model and parameter code, such as #1972 and #1974, I noticed some code paths that were not being checked. So this attempts to add coverage for these lines (although it does not guarantee to do so since there's a cost-benefit trade off here).

Writing these tests lead to noting issues

- #1992
- #1993

but these are not addressed here (but any changes to these issues is likely to be caught by these tests, which was the point in writing them!).