### PR TITLE
CM-481: update codecov action to v4, add upload token

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,7 +2,7 @@ codecov:
   require_ci_to_pass: yes
   #this handles notifications for bots (slack, gitter, etc)
   notify:    
-    after_n_builds: 8 #wait for 8 of the builds to finish and send their reports to send a notice, default is 2
+    after_n_builds: 13 #wait for 13 of the builds to finish and send their reports to send a notice, default is 2
     wait_for_ci: yes
   
 coverage:
@@ -31,7 +31,7 @@ comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default
   require_changes: no
-  after_n_builds: 8 # wait for 8 builds to finish and send their reports to make a comment, default 2
+  after_n_builds: 13 # wait for 13 builds to finish and send their reports to make a comment, default 2
   
 # Fix issue with 'work/sherpa/sherpa' being considered a seperate directory 
 fixes:

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -204,7 +204,7 @@ jobs:
         source ${CONDA}/etc/profile.d/conda.sh
         conda activate build
         conda install -yq pytest-cov
-        python setup.py -q test -a "--cov sherpa --cov-report xml"
+        python setup.py -q test -a "--cov sherpa --cov-report xml:${{ github.workspace }}/coverage.xml"
 
     - name: sherpa_test Tests
       if: matrix.test-data == 'package' || matrix.test-data == 'none'
@@ -213,11 +213,12 @@ jobs:
         conda activate build
         conda install -yq pytest-cov
         cd $HOME
-        sherpa_test --cov sherpa --cov-report xml
+        sherpa_test --cov sherpa --cov-report xml:${{ github.workspace }}/coverage.xml
 
     - name: upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
-        # only select the reports that we know are coverage reports, from linux conda, mac conda, and pip
-        files: /home/runner/work/sherpa/sherpa/coverage.xml,/Users/runner/work/sherpa/sherpa/coverage.xml,/home/runner/coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ${{ github.workspace }}/coverage.xml
         verbose: true
+      

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -109,21 +109,22 @@ jobs:
       run: |
         git submodule deinit -f .
         pip install pytest-cov
-        sherpa_test --cov=sherpa --cov-report=xml
+        cd $HOME
+        sherpa_test --cov=sherpa --cov-report=xml:${{ github.workspace }}/coverage.xml
 
     - name: Submodule test with pytest
       if: matrix.test-data == 'submodule'
       run: |
         pip install -r test_requirements.txt
         pip install pytest-cov
-
-        pytest --cov=sherpa --cov-report=xml
+        cd $HOME
+        pytest --cov=sherpa --cov-report=xml:${{ github.workspace }}/coverage.xml
 
     - name: upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
-        # only select the reports that we know are coverage reports, from linux conda, mac conda, and pip
-        files: /home/runner/work/sherpa/sherpa/coverage.xml,/Users/runner/work/sherpa/sherpa/coverage.xml,/home/runner/coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ${{ github.workspace }}/coverage.xml
         verbose: true
 
     - name: Smoke Test


### PR DESCRIPTION
Codecov seem to want us to start using v4, and that requires the codecov upload token. 

I added the upload token to the CI action secrets.

