### PR TITLE
Minor plot work

### DIFF
--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2010, 2015, 2016, 2019 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -25,16 +25,15 @@ Classes for plotting, analysis of astronomical data sets
 import logging
 
 import numpy as np
-from numpy import iterable, array2string, asarray
 
-from sherpa.models.basic import Delta1D
+from sherpa.astro import hc
 from sherpa.astro.data import DataPHA
-from sherpa import plot as shplot
 from sherpa.astro.utils import bounds_check
-from sherpa.utils.err import PlotErr, IOErr
+from sherpa.models.basic import Delta1D
+from sherpa import plot as shplot
 from sherpa.utils import parse_expr, dataspace1d, histogram1d, filter_bins, \
     sao_fcmp
-from sherpa.astro import hc
+from sherpa.utils.err import PlotErr, IOErr
 
 warning = logging.getLogger(__name__).warning
 
@@ -453,7 +452,7 @@ class ARFPlot(shplot.HistogramPlot):
 
         if data is not None:
             if not isinstance(data, DataPHA):
-                raise PlotErr('notpha', data.name)
+                raise IOErr('notpha', data.name)
             if data.units == "wavelength":
                 self.xlabel = 'Wavelength (Angstrom)'
                 self.xlo = hc / self.xlo
@@ -671,18 +670,19 @@ class OrderPlot(ModelHistogram):
         self.use_default_colors = True
         super().__init__()
 
+    # Note: this does not accept a stat parameter.
     def prepare(self, data, model, orders=None, colors=None):
         self.orders = data.response_ids
 
         if orders is not None:
-            if iterable(orders):
+            if np.iterable(orders):
                 self.orders = list(orders)
             else:
                 self.orders = [orders]
 
         if colors is not None:
             self.use_default_colors = False
-            if iterable(colors):
+            if np.iterable(colors):
                 self.colors = list(colors)
             else:
                 self.colors = [colors]
@@ -777,20 +777,20 @@ class FluxHistogram(ModelHistogram):
     def __str__(self):
         vals = self.modelvals
         if self.modelvals is not None:
-            vals = array2string(asarray(self.modelvals), separator=',',
-                                precision=4, suppress_small=False)
+            vals = np.array2string(np.asarray(self.modelvals), separator=',',
+                                   precision=4, suppress_small=False)
 
         clip = self.clipped
         if self.clipped is not None:
             # Could convert to boolean, but it is surprising for
             # anyone trying to access the clipped field
-            clip = array2string(asarray(self.clipped), separator=',',
-                                precision=4, suppress_small=False)
+            clip = np.array2string(np.asarray(self.clipped), separator=',',
+                                   precision=4, suppress_small=False)
 
         flux = self.flux
         if self.flux is not None:
-            flux = array2string(asarray(self.flux), separator=',',
-                                precision=4, suppress_small=False)
+            flux = np.array2string(np.asarray(self.flux), separator=',',
+                                   precision=4, suppress_small=False)
 
         return '\n'.join([f'modelvals = {vals}',
                           f'clipped = {clip}',
@@ -813,7 +813,7 @@ class FluxHistogram(ModelHistogram):
 
         """
 
-        fluxes = asarray(fluxes)
+        fluxes = np.asarray(fluxes)
         y = fluxes[:, 0]
         self.flux = y
         self.modelvals = fluxes[:, 1:-1]

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -128,8 +128,8 @@ class DataPHAPlot(shplot.DataHistogramPlot):
         # Maybe to_plot should return the lo/hi edges as a pair
         # here.
         #
-        (_, self.y, self.yerr, self.xerr, self.xlabel,
-         self.ylabel) = data.to_plot()
+        plot = data.to_plot()
+        (_, self.y, self.yerr, _, self.xlabel, self.ylabel) = plot
 
         if stat is not None:
             yerrorbars = self.histo_prefs.get('yerrorbars', True)
@@ -704,7 +704,7 @@ class OrderPlot(ModelHistogram):
             self.xlo = []
             self.xhi = []
             self.y = []
-            (xlo, y, yerr, xerr,
+            (xlo, y, yerr, _,
              self.xlabel, self.ylabel) = data.to_plot(model)
             y = y[1]
             if data.units != 'channel':

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -346,7 +346,7 @@ class SourcePlot(shplot.HistogramPlot):
                 post += pterm
 
         scale = (self.xhi + self.xlo) / 2
-        for ii in range(data.plot_fac):
+        for _ in range(data.plot_fac):
             self.y *= scale
 
         sqr = shplot.backend.get_latex_for_string('^2')
@@ -381,7 +381,7 @@ class ComponentModelPlot(shplot.ComponentSourcePlot, ModelHistogram):
 
     def prepare(self, data, model, stat=None):
         ModelHistogram.prepare(self, data, model, stat)
-        self.title = 'Model component: %s' % model.name
+        self.title = f'Model component: {model.name}'
 
     def _merge_settings(self, kwargs):
         return {**self.histo_prefs, **kwargs}
@@ -403,7 +403,7 @@ class ComponentSourcePlot(shplot.ComponentSourcePlot, SourcePlot):
 
     def prepare(self, data, model, stat=None):
         SourcePlot.prepare(self, data, model)
-        self.title = 'Source model component: %s' % model.name
+        self.title = f'Source model component: {model.name}'
 
     def _merge_settings(self, kwargs):
         return {**self.histo_prefs, **kwargs}
@@ -637,7 +637,7 @@ class BkgResidPlot(shplot.ResidPlot):
 
     def prepare(self, data, model, stat):
         super().prepare(data, model, stat)
-        self.title = 'Residuals of %s - Bkg Model' % data.name
+        self.title = f'Residuals of {data.name} - Bkg Model'
 
 
 class BkgRatioPlot(shplot.RatioPlot):
@@ -645,7 +645,7 @@ class BkgRatioPlot(shplot.RatioPlot):
 
     def prepare(self, data, model, stat):
         super().prepare(data, model, stat)
-        self.title = 'Ratio of %s : Bkg Model' % data.name
+        self.title = f'Ratio of {data.name} : Bkg Model'
 
 
 class BkgChisqrPlot(shplot.ChisqrPlot):
@@ -738,7 +738,7 @@ class OrderPlot(ModelHistogram):
                 for interval in old_filter:
                     data.notice(*interval)
 
-        self.title = 'Model Orders %s' % str(self.orders)
+        self.title = f'Model Orders {self.orders}'
 
         if len(self.xlo) != len(self.y):
             raise PlotErr("orderarrfail")

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -651,6 +651,7 @@ class Histogram(NoNewAttributesAfterInit):
 
 
 class HistogramPlot(Histogram):
+    """Base class for histogram-style plots with a prepare method."""
 
     def __init__(self):
         self.xlo = None
@@ -677,20 +678,13 @@ class HistogramPlot(Histogram):
             y = np.array2string(np.asarray(self.y), separator=',',
                                 precision=4, suppress_small=False)
 
-        return (('xlo    = %s\n' +
-                 'xhi    = %s\n' +
-                 'y      = %s\n' +
-                 'xlabel = %s\n' +
-                 'ylabel = %s\n' +
-                 'title  = %s\n' +
-                 'histo_prefs = %s') %
-                (xlo,
-                 xhi,
-                 y,
-                 self.xlabel,
-                 self.ylabel,
-                 self.title,
-                 self.histo_prefs))
+        return f"""xlo    = {xlo}
+xhi    = {xhi}
+y      = {y}
+xlabel = {self.xlabel}
+ylabel = {self.ylabel}
+title  = {self.title}
+histo_prefs = {self.histo_prefs}"""
 
     def _repr_html_(self):
         """Return a HTML (string) representation of the histogram plot."""
@@ -820,6 +814,15 @@ class DataHistogramPlot(HistogramPlot):
 
         self.title = data.name
 
+    # We have
+    #
+    # - the base class Histogram.plot can accept a yerr argument
+    # - the superclass (HistogramPlot.plot) does not know
+    #   anything about yerr
+    #
+    # so the superclass is over-ridden here to basically call
+    # the base class.
+    #
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the data.
 
@@ -902,7 +905,7 @@ class PDFPlot(HistogramPlot):
                                      separator=',', precision=4,
                                      suppress_small=False)
 
-        return ('points = %s\n' % (points) + HistogramPlot.__str__(self))
+        return (f'points = {points}\n' + HistogramPlot.__str__(self))
 
     def _repr_html_(self):
         """Return a HTML (string) representation of the PDF plot."""
@@ -936,7 +939,7 @@ class PDFPlot(HistogramPlot):
         self.xhi = xx[1:]
         self.ylabel = "probability density"
         self.xlabel = xlabel
-        self.title = "PDF: {}".format(name)
+        self.title = f"PDF: {name}"
 
 
 class CDFPlot(Plot):
@@ -1046,8 +1049,8 @@ plot_prefs = {self.plot_prefs}"""
         xsize = len(self.x)
         self.y = (np.arange(xsize) + 1.0) / xsize
         self.xlabel = xlabel
-        self.ylabel = "p(<={})".format(xlabel)
-        self.title = "CDF: {}".format(name)
+        self.ylabel = f"p(<={xlabel})"
+        self.title = f"CDF: {name}"
 
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the data.
@@ -1103,8 +1106,8 @@ class LRHistogram(HistogramPlot):
                                      separator=',', precision=4,
                                      suppress_small=False)
 
-        return '\n'.join(['ratios = %s' % ratios,
-                          'lr = %s' % str(self.lr),
+        return '\n'.join([f'ratios = {ratios}',
+                          f'lr = {self.lr}',
                           HistogramPlot.__str__(self)])
 
     def _repr_html_(self):
@@ -1503,7 +1506,7 @@ class TracePlot(DataPlot):
         self.y = points
         self.xlabel = "iteration"
         self.ylabel = name
-        self.title = "Trace: {}".format(name)
+        self.title = f"Trace: {name}"
 
 
 class ScatterPlot(DataPlot):
@@ -1529,7 +1532,7 @@ class ScatterPlot(DataPlot):
         self.y = np.asarray(y, dtype=SherpaFloat)
         self.xlabel = xlabel
         self.ylabel = ylabel
-        self.title = "Scatter: {}".format(name)
+        self.title = f"Scatter: {name}"
 
 
 class PSFKernelPlot(DataPlot):
@@ -1807,7 +1810,7 @@ class ComponentModelPlot(ModelPlot):
 
     def prepare(self, data, model, stat=None):
         ModelPlot.prepare(self, data, model, stat)
-        self.title = 'Model component: %s' % model.name
+        self.title = f'Model component: {model.name}'
 
 
 class ComponentModelHistogramPlot(ModelHistogramPlot):
@@ -1818,7 +1821,7 @@ class ComponentModelHistogramPlot(ModelHistogramPlot):
 
     def prepare(self, data, model, stat=None):
         super().prepare(data, model, stat)
-        self.title = 'Model component: {}'.format(model.name)
+        self.title = f'Model component: {model.name}'
 
 
 class ComponentTemplateModelPlot(ComponentModelPlot):
@@ -1828,7 +1831,7 @@ class ComponentTemplateModelPlot(ComponentModelPlot):
         self.y = model.get_y()
         self.xlabel = data.get_xlabel()
         self.ylabel = data.get_ylabel()
-        self.title = 'Model component: {}'.format(model.name)
+        self.title = f'Model component: {model.name}'
 
 
 class SourcePlot(ModelPlot):
@@ -1862,7 +1865,7 @@ class ComponentSourcePlot(SourcePlot):
         (self.x, self.y, self.yerr, self.xerr,
          self.xlabel, self.ylabel) = data.to_component_plot(yfunc=model)
         self.y = self.y[1]
-        self.title = 'Source model component: {}'.format(model.name)
+        self.title = f'Source model component: {model.name}'
 
 
 class ComponentSourceHistogramPlot(SourceHistogramPlot):
@@ -1883,7 +1886,7 @@ class ComponentSourceHistogramPlot(SourceHistogramPlot):
         self.y = y[1]
         assert self.y.size == self.xlo.size
 
-        self.title = 'Source model component: {}'.format(model.name)
+        self.title = f'Source model component: {model.name}'
 
 
 class ComponentTemplateSourcePlot(ComponentSourcePlot):
@@ -1900,7 +1903,7 @@ class ComponentTemplateSourcePlot(ComponentSourcePlot):
 
         self.xlabel = data.get_xlabel()
         self.ylabel = data.get_ylabel()
-        self.title = 'Source model component: {}'.format(model.name)
+        self.title = f'Source model component: {model.name}'
 
 
 class PSFPlot(DataPlot):

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -764,9 +764,29 @@ class DataHistogramPlot(HistogramPlot):
     "The preferences for the plot."
 
     def __init__(self):
-        self.xerr = None
         self.yerr = None
         super().__init__()
+
+    @property
+    def xerr(self):
+        """Return abs(xhi - xlow) / 2
+
+        The plotting backends actually calculate the xerr values
+        explicitly rather than use this field, so it is provided as a
+        property in case users need it.
+
+        .. versionchanged:: 4.16.1
+           This field is now a property.
+
+        """
+
+        if self.xlo is None or self.xhi is None:
+            return None
+
+        # As we do not (yet) require NumPy arrays, enforce it.
+        xlo = np.asarray(self.xlo)
+        xhi = np.asarray(self.xhi)
+        return np.abs(xhi - xlo) / 2
 
     def prepare(self, data, stat=None):
         """Create the data to plot
@@ -789,8 +809,8 @@ class DataHistogramPlot(HistogramPlot):
         # Maybe to_plot should return the lo/hi edges as a pair
         # here.
         #
-        (_, self.y, self.yerr, self.xerr, self.xlabel,
-         self.ylabel) = data.to_plot()
+        plot = data.to_plot()
+        (_, self.y, self.yerr, _, self.xlabel, self.ylabel) = plot
 
         self.xlo, self.xhi = data.get_indep(True)
 

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -702,7 +702,6 @@ def test_histogram_returns_xerr():
         assert toks[0] != 'xerr'
 
 
-@pytest.mark.xfail
 def test_histogram_can_not_set_xerr():
     """We cannot change the xerr accessor"""
 
@@ -714,7 +713,6 @@ def test_histogram_can_not_set_xerr():
     dp = sherpaplot.DataHistogramPlot()
     dp.prepare(d)
 
-    # XFAIL: at the moment we can change xerr
     with pytest.raises(AttributeError):
         dp.xerr = xlo
 


### PR DESCRIPTION
# Summary

Internal clean up of the plotting code in preparation for future changes. The ARFPlot class will now generate an IOErr rather than PlotErr if sent a non-PHA dataset (to better match other calls). The DataHistogramPlot class now treats xerr as a property that can not be changed, and is fixed to be the half-width of the X bins, although note that this field is not really used and may be removed at some point in the future.

# Details

This is taken from #1988 and is the (hopefully) simple changes before things got complex in that PR.