### PR TITLE
Minor improvements to the RMF plot capability

### DIFF
--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2010, 2015, 2016, 2019 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -25,16 +25,15 @@ Classes for plotting, analysis of astronomical data sets
 import logging
 
 import numpy as np
-from numpy import iterable, array2string, asarray
 
-from sherpa.models.basic import Delta1D
+from sherpa.astro import hc
 from sherpa.astro.data import DataPHA
-from sherpa import plot as shplot
 from sherpa.astro.utils import bounds_check
-from sherpa.utils.err import PlotErr, IOErr
+from sherpa.models.basic import Delta1D
+from sherpa import plot as shplot
 from sherpa.utils import parse_expr, dataspace1d, histogram1d, filter_bins, \
     sao_fcmp
-from sherpa.astro import hc
+from sherpa.utils.err import PlotErr, IOErr
 
 warning = logging.getLogger(__name__).warning
 
@@ -453,7 +452,7 @@ class ARFPlot(shplot.HistogramPlot):
 
         if data is not None:
             if not isinstance(data, DataPHA):
-                raise PlotErr('notpha', data.name)
+                raise IOErr('notpha', data.name)
             if data.units == "wavelength":
                 self.xlabel = 'Wavelength (Angstrom)'
                 self.xlo = hc / self.xlo
@@ -671,18 +670,19 @@ class OrderPlot(ModelHistogram):
         self.use_default_colors = True
         super().__init__()
 
+    # Note: this does not accept a stat parameter.
     def prepare(self, data, model, orders=None, colors=None):
         self.orders = data.response_ids
 
         if orders is not None:
-            if iterable(orders):
+            if np.iterable(orders):
                 self.orders = list(orders)
             else:
                 self.orders = [orders]
 
         if colors is not None:
             self.use_default_colors = False
-            if iterable(colors):
+            if np.iterable(colors):
                 self.colors = list(colors)
             else:
                 self.colors = [colors]
@@ -777,20 +777,20 @@ class FluxHistogram(ModelHistogram):
     def __str__(self):
         vals = self.modelvals
         if self.modelvals is not None:
-            vals = array2string(asarray(self.modelvals), separator=',',
-                                precision=4, suppress_small=False)
+            vals = np.array2string(np.asarray(self.modelvals), separator=',',
+                                   precision=4, suppress_small=False)
 
         clip = self.clipped
         if self.clipped is not None:
             # Could convert to boolean, but it is surprising for
             # anyone trying to access the clipped field
-            clip = array2string(asarray(self.clipped), separator=',',
-                                precision=4, suppress_small=False)
+            clip = np.array2string(np.asarray(self.clipped), separator=',',
+                                   precision=4, suppress_small=False)
 
         flux = self.flux
         if self.flux is not None:
-            flux = array2string(asarray(self.flux), separator=',',
-                                precision=4, suppress_small=False)
+            flux = np.array2string(np.asarray(self.flux), separator=',',
+                                   precision=4, suppress_small=False)
 
         return '\n'.join([f'modelvals = {vals}',
                           f'clipped = {clip}',
@@ -813,7 +813,7 @@ class FluxHistogram(ModelHistogram):
 
         """
 
-        fluxes = asarray(fluxes)
+        fluxes = np.asarray(fluxes)
         y = fluxes[:, 0]
         self.flux = y
         self.modelvals = fluxes[:, 1:-1]

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -128,8 +128,8 @@ class DataPHAPlot(shplot.DataHistogramPlot):
         # Maybe to_plot should return the lo/hi edges as a pair
         # here.
         #
-        (_, self.y, self.yerr, self.xerr, self.xlabel,
-         self.ylabel) = data.to_plot()
+        plot = data.to_plot()
+        (_, self.y, self.yerr, _, self.xlabel, self.ylabel) = plot
 
         if stat is not None:
             yerrorbars = self.histo_prefs.get('yerrorbars', True)
@@ -704,7 +704,7 @@ class OrderPlot(ModelHistogram):
             self.xlo = []
             self.xhi = []
             self.y = []
-            (xlo, y, yerr, xerr,
+            (xlo, y, yerr, _,
              self.xlabel, self.ylabel) = data.to_plot(model)
             y = y[1]
             if data.units != 'channel':

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -501,7 +501,7 @@ class RMFPlot(shplot.HistogramPlot):
     energies = None
     """The energies at which to draw the response (in keV).
 
-    If set  to None then `n_lines` energies will be selected to span
+    If set to None then `n_lines` energies will be selected to span
     the energy range of the response.
     """
 

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -346,7 +346,7 @@ class SourcePlot(shplot.HistogramPlot):
                 post += pterm
 
         scale = (self.xhi + self.xlo) / 2
-        for ii in range(data.plot_fac):
+        for _ in range(data.plot_fac):
             self.y *= scale
 
         sqr = shplot.backend.get_latex_for_string('^2')
@@ -381,7 +381,7 @@ class ComponentModelPlot(shplot.ComponentSourcePlot, ModelHistogram):
 
     def prepare(self, data, model, stat=None):
         ModelHistogram.prepare(self, data, model, stat)
-        self.title = 'Model component: %s' % model.name
+        self.title = f'Model component: {model.name}'
 
     def _merge_settings(self, kwargs):
         return {**self.histo_prefs, **kwargs}
@@ -403,7 +403,7 @@ class ComponentSourcePlot(shplot.ComponentSourcePlot, SourcePlot):
 
     def prepare(self, data, model, stat=None):
         SourcePlot.prepare(self, data, model)
-        self.title = 'Source model component: %s' % model.name
+        self.title = f'Source model component: {model.name}'
 
     def _merge_settings(self, kwargs):
         return {**self.histo_prefs, **kwargs}
@@ -637,7 +637,7 @@ class BkgResidPlot(shplot.ResidPlot):
 
     def prepare(self, data, model, stat):
         super().prepare(data, model, stat)
-        self.title = 'Residuals of %s - Bkg Model' % data.name
+        self.title = f'Residuals of {data.name} - Bkg Model'
 
 
 class BkgRatioPlot(shplot.RatioPlot):
@@ -645,7 +645,7 @@ class BkgRatioPlot(shplot.RatioPlot):
 
     def prepare(self, data, model, stat):
         super().prepare(data, model, stat)
-        self.title = 'Ratio of %s : Bkg Model' % data.name
+        self.title = f'Ratio of {data.name} : Bkg Model'
 
 
 class BkgChisqrPlot(shplot.ChisqrPlot):
@@ -738,7 +738,7 @@ class OrderPlot(ModelHistogram):
                 for interval in old_filter:
                     data.notice(*interval)
 
-        self.title = 'Model Orders %s' % str(self.orders)
+        self.title = f'Model Orders {self.orders}'
 
         if len(self.xlo) != len(self.y):
             raise PlotErr("orderarrfail")

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -1333,7 +1333,7 @@ def test_arf_checks_arf():
     plotobj = ARFPlot()
     d = Data1D("x", [1, 2], [2, 3])
 
-    with pytest.raises(AttributeError, match="'Data1D' object has no attribute 'energ_lo'"):
+    with pytest.raises(IOErr, match="data set 'x' does not contain an ARF"):
         plotobj.prepare(arf=d)
 
 
@@ -1354,7 +1354,7 @@ def test_rmf_checks_arf():
     plotobj = RMFPlot()
     d = Data1D("x", [1, 2], [2, 3])
 
-    with pytest.raises(AttributeError, match="'Data1D' object has no attribute 'e_min'"):
+    with pytest.raises(IOErr, match="data set 'x' does not contain a RMF"):
         plotobj.prepare(rmf=d)
 
 
@@ -1365,5 +1365,5 @@ def test_rmf_checks_data_is_pha():
     rmf = create_delta_rmf(np.asarray([1, 2]), np.asarray([2, 3]))
     d = Data1D("x", [1, 2, 3], [2, 3, 4])
 
-    # At the moment there is no error check.
-    plotobj.prepare(rmf=rmf, data=d)
+    with pytest.raises(IOErr, match="data set 'x' does not contain a PHA spectrum"):
+        plotobj.prepare(rmf=rmf, data=d)

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -39,6 +39,7 @@ import pytest
 from sherpa.astro import ui
 import sherpa.plot
 
+from sherpa.astro import hc
 from sherpa.astro.data import DataPHA
 from sherpa.astro.instrument import create_arf
 import sherpa.astro.plot
@@ -73,6 +74,9 @@ _energies_lo = _energies[:-1]
 _energies_hi = _energies[1:]
 _energies_mid = (_energies_lo + _energies_hi) / 2
 _energies_width = _energies_hi - _energies_lo
+
+_wavelength_lo = hc / _energies_hi
+_wavelength_hi = hc / _energies_lo
 
 # How much longer is the background exposure compared to the source
 # exposure; chose a non-integer value to make it more obvious when
@@ -326,8 +330,65 @@ def test_get_arf_plot(idval, clean_astro_ui):
 
     setup_example(idval)
     if idval is None:
+        ui.set_analysis("energy")
         ap = ui.get_arf_plot()
     else:
+        ui.set_analysis(idval, "energy")
+        ap = ui.get_arf_plot(idval)
+
+    assert isinstance(ap, sherpa.astro.plot.ARFPlot)
+
+    assert ap.xlo == pytest.approx(_energies_lo)
+    assert ap.xhi == pytest.approx(_energies_hi)
+
+    assert ap.y == pytest.approx(_arf)
+
+    assert ap.title == 'test-arf'
+    assert ap.xlabel == 'Energy (keV)'
+
+    # the y label depends on the backend (due to LaTeX)
+    # assert ap.ylabel == 'cm$^2$'
+
+
+@pytest.mark.parametrize("idval", [None, 1, "one", 23])
+def test_get_arf_plot_wavelength(idval, clean_astro_ui):
+    """Basic testing of get_arf_plot
+    """
+
+    setup_example(idval)
+    if idval is None:
+        ui.set_analysis("wavelength")
+        ap = ui.get_arf_plot()
+    else:
+        ui.set_analysis(idval, "wavelength")
+        ap = ui.get_arf_plot(idval)
+
+    assert isinstance(ap, sherpa.astro.plot.ARFPlot)
+
+    assert ap.xlo == pytest.approx(_wavelength_lo)
+    assert ap.xhi == pytest.approx(_wavelength_hi)
+
+    assert ap.y == pytest.approx(_arf)
+
+    assert ap.title == 'test-arf'
+    assert ap.xlabel == 'Wavelength (Angstrom)'
+
+    # the y label depends on the backend (due to LaTeX)
+    # assert ap.ylabel == 'cm$^2$'
+
+
+@pytest.mark.parametrize("idval", [None, 1, "one", 23])
+def test_get_arf_plot_channel(idval, clean_astro_ui):
+    """Basic testing of get_arf_plot
+    """
+
+    # Does this error out or display energies?
+    setup_example(idval)
+    if idval is None:
+        ui.set_analysis("channel")
+        ap = ui.get_arf_plot()
+    else:
+        ui.set_analysis(idval, "channel")
         ap = ui.get_arf_plot(idval)
 
     assert isinstance(ap, sherpa.astro.plot.ARFPlot)
@@ -382,13 +443,15 @@ def test_get_rmf_plot_no_rmf(idval, clean_astro_ui):
 
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
 def test_get_rmf_plot(idval, clean_astro_ui):
-    """Basic testing of get_arf_plot
+    """Basic testing of get_rmf_plot
     """
 
     setup_example(idval)
     if idval is None:
+        ui.set_analysis("energy")
         rp = ui.get_rmf_plot()
     else:
+        ui.set_analysis(idval, "energy")
         rp = ui.get_rmf_plot(idval)
 
     assert isinstance(rp, sherpa.astro.plot.RMFPlot)
@@ -407,6 +470,68 @@ def test_get_rmf_plot(idval, clean_astro_ui):
 
     assert rp.title == 'delta-rmf'
     assert rp.xlabel == 'Energy (keV)'
+
+
+@pytest.mark.parametrize("idval", [None, 1, "one", 23])
+def test_get_rmf_plot_wavelength(idval, clean_astro_ui):
+    """Basic testing of get_rmf_plot
+    """
+
+    setup_example(idval)
+    if idval is None:
+        ui.set_analysis("wave")
+        rp = ui.get_rmf_plot()
+    else:
+        ui.set_analysis(idval, "wave")
+        rp = ui.get_rmf_plot(idval)
+
+    assert isinstance(rp, sherpa.astro.plot.RMFPlot)
+
+    assert rp.xlo == pytest.approx(_wavelength_lo)
+    assert rp.xhi == pytest.approx(_wavelength_hi)
+
+    # With nlines=5 in the RMF plot we get 5 lines
+    plotted_rmf = np.array(
+        [[1., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
+         [0., 1., 0., 0., 0., 0., 0., 0., 0., 0.],
+         [0., 0., 0., 1., 0., 0., 0., 0., 0., 0.],
+         [0., 0., 0., 0., 0., 1., 0., 0., 0., 0.],
+         [0., 0., 0., 0., 0., 0., 0., 1., 0., 0.]])
+    assert rp.y == pytest.approx(plotted_rmf)
+
+    assert rp.title == 'delta-rmf'
+    assert rp.xlabel == 'Wavelength (Angstrom)'
+
+
+@pytest.mark.parametrize("idval", [None, 1, "one", 23])
+def test_get_rmf_plot_channel(idval, clean_astro_ui):
+    """Basic testing of get_rmf_plot
+    """
+
+    setup_example(idval)
+    if idval is None:
+        ui.set_analysis("channel")
+        rp = ui.get_rmf_plot()
+    else:
+        ui.set_analysis(idval, "channel")
+        rp = ui.get_rmf_plot(idval)
+
+    assert isinstance(rp, sherpa.astro.plot.RMFPlot)
+
+    assert rp.xlo == pytest.approx(np.arange(1, 11))
+    assert rp.xhi == pytest.approx(np.arange(2, 12))
+
+    # With nlines=5 in the RMF plot we get 5 lines
+    plotted_rmf = np.array(
+        [[1., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
+         [0., 1., 0., 0., 0., 0., 0., 0., 0., 0.],
+         [0., 0., 0., 1., 0., 0., 0., 0., 0., 0.],
+         [0., 0., 0., 0., 0., 1., 0., 0., 0., 0.],
+         [0., 0., 0., 0., 0., 0., 0., 1., 0., 0.]])
+    assert rp.y == pytest.approx(plotted_rmf)
+
+    assert rp.title == 'delta-rmf'
+    assert rp.xlabel == 'Channel'
 
 
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -348,6 +348,8 @@ def test_get_arf_plot(idval, clean_astro_ui):
 
     # the y label depends on the backend (due to LaTeX)
     # assert ap.ylabel == 'cm$^2$'
+    assert 'cm' in ap.ylabel
+    assert '2' in ap.ylabel
 
 
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
@@ -375,6 +377,8 @@ def test_get_arf_plot_wavelength(idval, clean_astro_ui):
 
     # the y label depends on the backend (due to LaTeX)
     # assert ap.ylabel == 'cm$^2$'
+    assert 'cm' in ap.ylabel
+    assert '2' in ap.ylabel
 
 
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -651,6 +651,7 @@ class Histogram(NoNewAttributesAfterInit):
 
 
 class HistogramPlot(Histogram):
+    """Base class for histogram-style plots with a prepare method."""
 
     def __init__(self):
         self.xlo = None
@@ -677,20 +678,13 @@ class HistogramPlot(Histogram):
             y = np.array2string(np.asarray(self.y), separator=',',
                                 precision=4, suppress_small=False)
 
-        return (('xlo    = %s\n' +
-                 'xhi    = %s\n' +
-                 'y      = %s\n' +
-                 'xlabel = %s\n' +
-                 'ylabel = %s\n' +
-                 'title  = %s\n' +
-                 'histo_prefs = %s') %
-                (xlo,
-                 xhi,
-                 y,
-                 self.xlabel,
-                 self.ylabel,
-                 self.title,
-                 self.histo_prefs))
+        return f"""xlo    = {xlo}
+xhi    = {xhi}
+y      = {y}
+xlabel = {self.xlabel}
+ylabel = {self.ylabel}
+title  = {self.title}
+histo_prefs = {self.histo_prefs}"""
 
     def _repr_html_(self):
         """Return a HTML (string) representation of the histogram plot."""
@@ -820,6 +814,15 @@ class DataHistogramPlot(HistogramPlot):
 
         self.title = data.name
 
+    # We have
+    #
+    # - the base class Histogram.plot can accept a yerr argument
+    # - the superclass (HistogramPlot.plot) does not know
+    #   anything about yerr
+    #
+    # so the superclass is over-ridden here to basically call
+    # the base class.
+    #
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the data.
 
@@ -902,7 +905,7 @@ class PDFPlot(HistogramPlot):
                                      separator=',', precision=4,
                                      suppress_small=False)
 
-        return ('points = %s\n' % (points) + HistogramPlot.__str__(self))
+        return (f'points = {points}\n' + HistogramPlot.__str__(self))
 
     def _repr_html_(self):
         """Return a HTML (string) representation of the PDF plot."""
@@ -936,7 +939,7 @@ class PDFPlot(HistogramPlot):
         self.xhi = xx[1:]
         self.ylabel = "probability density"
         self.xlabel = xlabel
-        self.title = "PDF: {}".format(name)
+        self.title = f"PDF: {name}"
 
 
 class CDFPlot(Plot):
@@ -1046,8 +1049,8 @@ plot_prefs = {self.plot_prefs}"""
         xsize = len(self.x)
         self.y = (np.arange(xsize) + 1.0) / xsize
         self.xlabel = xlabel
-        self.ylabel = "p(<={})".format(xlabel)
-        self.title = "CDF: {}".format(name)
+        self.ylabel = f"p(<={xlabel})"
+        self.title = f"CDF: {name}"
 
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the data.
@@ -1103,8 +1106,8 @@ class LRHistogram(HistogramPlot):
                                      separator=',', precision=4,
                                      suppress_small=False)
 
-        return '\n'.join(['ratios = %s' % ratios,
-                          'lr = %s' % str(self.lr),
+        return '\n'.join([f'ratios = {ratios}',
+                          f'lr = {self.lr}',
                           HistogramPlot.__str__(self)])
 
     def _repr_html_(self):
@@ -1503,7 +1506,7 @@ class TracePlot(DataPlot):
         self.y = points
         self.xlabel = "iteration"
         self.ylabel = name
-        self.title = "Trace: {}".format(name)
+        self.title = f"Trace: {name}"
 
 
 class ScatterPlot(DataPlot):
@@ -1529,7 +1532,7 @@ class ScatterPlot(DataPlot):
         self.y = np.asarray(y, dtype=SherpaFloat)
         self.xlabel = xlabel
         self.ylabel = ylabel
-        self.title = "Scatter: {}".format(name)
+        self.title = f"Scatter: {name}"
 
 
 class PSFKernelPlot(DataPlot):
@@ -1807,7 +1810,7 @@ class ComponentModelPlot(ModelPlot):
 
     def prepare(self, data, model, stat=None):
         ModelPlot.prepare(self, data, model, stat)
-        self.title = 'Model component: %s' % model.name
+        self.title = f'Model component: {model.name}'
 
 
 class ComponentModelHistogramPlot(ModelHistogramPlot):
@@ -1818,7 +1821,7 @@ class ComponentModelHistogramPlot(ModelHistogramPlot):
 
     def prepare(self, data, model, stat=None):
         super().prepare(data, model, stat)
-        self.title = 'Model component: {}'.format(model.name)
+        self.title = f'Model component: {model.name}'
 
 
 class ComponentTemplateModelPlot(ComponentModelPlot):
@@ -1828,7 +1831,7 @@ class ComponentTemplateModelPlot(ComponentModelPlot):
         self.y = model.get_y()
         self.xlabel = data.get_xlabel()
         self.ylabel = data.get_ylabel()
-        self.title = 'Model component: {}'.format(model.name)
+        self.title = f'Model component: {model.name}'
 
 
 class SourcePlot(ModelPlot):
@@ -1862,7 +1865,7 @@ class ComponentSourcePlot(SourcePlot):
         (self.x, self.y, self.yerr, self.xerr,
          self.xlabel, self.ylabel) = data.to_component_plot(yfunc=model)
         self.y = self.y[1]
-        self.title = 'Source model component: {}'.format(model.name)
+        self.title = f'Source model component: {model.name}'
 
 
 class ComponentSourceHistogramPlot(SourceHistogramPlot):
@@ -1883,7 +1886,7 @@ class ComponentSourceHistogramPlot(SourceHistogramPlot):
         self.y = y[1]
         assert self.y.size == self.xlo.size
 
-        self.title = 'Source model component: {}'.format(model.name)
+        self.title = f'Source model component: {model.name}'
 
 
 class ComponentTemplateSourcePlot(ComponentSourcePlot):
@@ -1900,7 +1903,7 @@ class ComponentTemplateSourcePlot(ComponentSourcePlot):
 
         self.xlabel = data.get_xlabel()
         self.ylabel = data.get_ylabel()
-        self.title = 'Source model component: {}'.format(model.name)
+        self.title = f'Source model component: {model.name}'
 
 
 class PSFPlot(DataPlot):

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -764,9 +764,29 @@ class DataHistogramPlot(HistogramPlot):
     "The preferences for the plot."
 
     def __init__(self):
-        self.xerr = None
         self.yerr = None
         super().__init__()
+
+    @property
+    def xerr(self):
+        """Return abs(xhi - xlow) / 2
+
+        The plotting backends actually calculate the xerr values
+        explicitly rather than use this field, so it is provided as a
+        property in case users need it.
+
+        .. versionchanged:: 4.16.1
+           This field is now a property.
+
+        """
+
+        if self.xlo is None or self.xhi is None:
+            return None
+
+        # As we do not (yet) require NumPy arrays, enforce it.
+        xlo = np.asarray(self.xlo)
+        xhi = np.asarray(self.xhi)
+        return np.abs(xhi - xlo) / 2
 
     def prepare(self, data, stat=None):
         """Create the data to plot
@@ -789,8 +809,8 @@ class DataHistogramPlot(HistogramPlot):
         # Maybe to_plot should return the lo/hi edges as a pair
         # here.
         #
-        (_, self.y, self.yerr, self.xerr, self.xlabel,
-         self.ylabel) = data.to_plot()
+        plot = data.to_plot()
+        (_, self.y, self.yerr, _, self.xlabel, self.ylabel) = plot
 
         self.xlo, self.xhi = data.get_indep(True)
 

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -702,7 +702,6 @@ def test_histogram_returns_xerr():
         assert toks[0] != 'xerr'
 
 
-@pytest.mark.xfail
 def test_histogram_can_not_set_xerr():
     """We cannot change the xerr accessor"""
 
@@ -714,7 +713,6 @@ def test_histogram_can_not_set_xerr():
     dp = sherpaplot.DataHistogramPlot()
     dp.prepare(d)
 
-    # XFAIL: at the moment we can change xerr
     with pytest.raises(AttributeError):
         dp.xerr = xlo
 


### PR DESCRIPTION
# Summary

Improve the RMF plot display so that it recognizes the current units setting and allows the choice of energies to be over-ridden by the user.

# Details

This is taken from #1988 and just focuses on the RMF changes, not the larger architectural changes in that PR. It depends on #2003.

With this we have

```
>>> from sherpa.astro.ui import *
>>> load_pha("sherpa-test-data/sherpatest/3c273.pi")
>>> plot_rmf()
```

![sherpa](https://github.com/sherpa/sherpa/assets/224638/ebe5eeca-159a-4c8d-8bfc-9916643339fe)

This matches the existing behaviour. 

However we can now switch to Wavelength space:

```
>>> set_analysis("wave")
dataset 1: 0.829303:8492.07 Wavelength (Angstrom)
>>> plot_rmf()
```

![sherpa](https://github.com/sherpa/sherpa/assets/224638/bdd5e29e-34f2-4fc7-9ac4-c2a922219a3b)

Or select the energies to use:

```
>>> get_rmf_plot().energies = [0.2, 0.4, 0.8, 2, 4, 5, 7]
>>> plot_rmf()
```

![sherpa](https://github.com/sherpa/sherpa/assets/224638/ebed74df-5195-4d56-aacc-0d199162320b)

Or the number of lines to use (need to clear the `energies` setting for this to work):

```
>>> get_rmf_plot().energies = None
>>> get_rmf_plot().n_lines = 8
>>> set_analysis("energy")
dataset 1: 0.00146:14.9504 Energy (keV)
>>> plot_rmf()
```

![sherpa](https://github.com/sherpa/sherpa/assets/224638/e261a1f2-8590-443c-89c9-443aef13bfd8)

## Things to note:

- you can only specify the energies to draw in keV (we could have it instead chose the units based on the current setting, if we renamed the field from `energies`), but is it worth it
- selecting the `energies` or `n_lines` field to set / change does not match the other plot "options", but that's because these are needed in the `prepare` stage and the preferences ar eonly used in the `plot` stage [see issue #889 for some ruminations on this]
