### PR TITLE
Use a separate context when handling multiprocessing calls

### DIFF
--- a/docs/overview/parallel.rst
+++ b/docs/overview/parallel.rst
@@ -6,15 +6,12 @@ The sherpa.utils.parallel module
 
 .. automodule:: sherpa.utils.parallel
 
-.. versionadded:: 4.16.0
-   Prior to this, these symbols were provided by the
-   :py:mod:`sherpa.utils` module.
-
    .. rubric:: Constants
 
    .. autosummary::
       :toctree: api
 
+      context
       multi
       ncpus
 

--- a/sherpa/estmethods/__init__.py
+++ b/sherpa/estmethods/__init__.py
@@ -1184,7 +1184,7 @@ def parallel_est(estfunc, limit_parnums, pars, numcores=ncpus):
                 # catch the EstNewMin exception and include the exception
                 # class and the modified parameter values to the error queue.
                 # These modified parvals determine the new lower statistic.
-                # The exception class will be instaniated re-raised with the
+                # The exception class will be re-raised with the
                 # parameter values attached.  C++ Python exceptions are not
                 # picklable for use in the queue.
                 err_q.put(EstNewMin(pars))

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019, 2020, 2021, 2023
+#  Copyright (C) 2019 - 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -18,12 +18,10 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import multiprocessing
-
 import numpy as np
 
 from sherpa.utils import Knuth_close, func_counter
-from sherpa.utils.parallel import multi, run_tasks
+from sherpa.utils.parallel import multi, context, run_tasks
 from sherpa.utils.random import uniform
 
 
@@ -58,12 +56,11 @@ class MyNcores:
         #
 
         # See sherpa.utils.parallel for the logic used here.
-        manager = multiprocessing.Manager()
+        manager = context.Manager()
         out_q = manager.Queue()
         err_q = manager.Queue()
-        # lock = manager.Lock()  # unused
-        procs = [multiprocessing.Process(target=self.my_worker,
-                                         args=(func, ii, out_q, err_q) + args)
+        procs = [context.Process(target=self.my_worker,
+                                 args=(func, ii, out_q, err_q) + args)
                  for ii, func in enumerate(funcs)]
 
         return run_tasks(procs, err_q, out_q)


### PR DESCRIPTION
# Summary

Ensure that Sherpa does not change the global multiprocessing state but instead uses the (new) `sherpa.utils.parallel.context` attribute. Fix #1015.

# Details

The multiprocessing documentation states, within https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods

> A library which wants to use a particular start method should probably use [get_context()](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.get_context) to avoid interfering with the choice of the library user.

This PR does this, making the context available as `sherpa.utils.parallel.context`.

I also made a small change to a callback routine since we don't need to send in the queues and lock since they are already ambient pieces of information (I do note that this is not great if we use spawn/forkserver but there are so many other issues there that I am working on that it's not an issue here - we can follow #2007 for that).

The coverage checks are not great because we do not actually run the multiprocessing code in our CI runs as thy tend to be run using an environment that only provides a single core, hence has no multiprocessing support.