### PR TITLE
Allow both Intel and ARM macOS GitHub runners for the conda builds

### DIFF
--- a/.github/scripts/setup_ds9.sh
+++ b/.github/scripts/setup_ds9.sh
@@ -2,7 +2,6 @@
 
 ds9_base_url=https://ds9.si.edu/download/
 
-# variable $CONDA_PREFIX should be defined by conda by using conda activate (in setup_conda.sh)
 if [[ "x${CONDA_PREFIX}" == "x" ]];
 then
     echo "Error: CONDA_PREFIX not set. This should be set for active Conda environments."
@@ -40,7 +39,7 @@ xpa_tar=xpa.${ds9_os}.2.1.20.tar.gz
 download $ds9_base_url/$ds9_os/$ds9_tar
 download $ds9_base_url/$ds9_os/$xpa_tar
 
-# untar them
+# untar them; assume $CONDA_PREFIX/bin is in the path
 echo "* unpacking ds9/XPA"
 start_dir=$(pwd)
 cd ${CONDA_PREFIX}/bin

--- a/.github/scripts/setup_xspec.sh
+++ b/.github/scripts/setup_xspec.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash -e
 
-# variable $CONDA_PREFIX should be defined by conda by using conda activate (in setup_conda.sh)
 if [[ "x${CONDA_PREFIX}" == "x" ]];
 then
     echo "Error: CONDA_PREFIX not set. This should be set for active Conda environments."

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -130,16 +130,22 @@ jobs:
       run: |
         source .github/scripts/setup_conda.sh
 
-    - name: Conda Setup (Xspec and DS9)
+    # At the moment we use XSPEC as the control for whether to install
+    # DS9 or not. However, the DS9 tests have been shown to be
+    # problematic on macOS/GitHub so we also skip macOS.
+    #
+    - name: Conda Setup (DS9)
+      if: matrix.xspec-version != '' && runner.os != 'macOS'
+      run: |
+        source .github/scripts/setup_ds9.sh
+        # We need xvfb to run the tests so ensure it's installed
+        pip install pytest-xvfb
+
+    - name: Conda Setup (Xspec)
       if: matrix.xspec-version != ''
       env:
         XSPECVER: ${{ matrix.xspec-version }}
       run: |
-        if [ "$RUNNER_OS" != "macOS" ]; then
-          source .github/scripts/setup_ds9.sh
-          # We need xvfb to run the tests so ensure it's installed
-          pip install pytest-xvfb
-        fi
         source .github/scripts/setup_xspec.sh
 
     - name: Build Sherpa (install)

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -32,14 +32,25 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: MacOS Full Build
-            os: macos-12
-            python-version: "3.10"
+          - name: MacOS Intel Full Build (Python 3.11)
+            os: macos-13
+            python-version: "3.11"
             install-type: develop
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
+            bokeh-version: 3
             xspec-version: 12.14.0i
+
+          - name: MacOS ARM Full Build (Python 3.11)
+            os: macos-14
+            python-version: "3.11"
+            install-type: develop
+            fits: astropy
+            test-data: submodule
+            matplotlib-version: 3
+            bokeh-version: 3
+            xspec-version: 12.13.1e
 
           - name: Linux Minimum Setup (Python 3.10)
             os: ubuntu-latest

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -22,7 +22,10 @@ jobs:
   tests:
     defaults:
       run:
-        shell: bash
+        # See
+        # https://github.com/marketplace/actions/setup-miniconda#use-a-default-shell
+        # for why we pass the "-el {0}" option
+        shell: bash -el {0}
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -108,6 +111,14 @@ jobs:
       run: |
         brew install --cask xquartz
 
+    - name: Install Miniforge
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        activate-environment: build
+        miniforge-version: latest
+        python-version: ${{ matrix.python-version }}
+        auto-update-conda: true
+
     - name: Conda Setup
       env:
         PYTHONVER: ${{ matrix.python-version }}
@@ -124,8 +135,6 @@ jobs:
       env:
         XSPECVER: ${{ matrix.xspec-version }}
       run: |
-        source ${CONDA}/etc/profile.d/conda.sh
-        conda activate build
         if [ "$RUNNER_OS" != "macOS" ]; then
           source .github/scripts/setup_ds9.sh
           # We need xvfb to run the tests so ensure it's installed
@@ -138,8 +147,6 @@ jobs:
       env:
         PYTHON_LDFLAGS: " "
       run: |
-        source ${CONDA}/etc/profile.d/conda.sh
-        conda activate build
         pip install .[test] --verbose
 
     - name: Build Sherpa (develop)
@@ -147,15 +154,11 @@ jobs:
       env:
         PYTHON_LDFLAGS: " "
       run: |
-        source ${CONDA}/etc/profile.d/conda.sh
-        conda activate build
         pip install -e .[test] --verbose
 
     - name: Install the test data?
       if: matrix.test-data == 'package'
       run: |
-        source ${CONDA}/etc/profile.d/conda.sh
-        conda activate build
         pip install ./sherpa-test-data
 
     - name: Remove submodule
@@ -181,8 +184,6 @@ jobs:
         fi
 
         echo "** smoke test: ${smokevars}"
-        source ${CONDA}/etc/profile.d/conda.sh
-        conda activate build
         cd /home
         sherpa_smoke ${smokevars}
 
@@ -215,16 +216,12 @@ jobs:
           # moment, but leave this in
           export PATH="${PATH}:/opt/X11/bin"
         fi
-        source ${CONDA}/etc/profile.d/conda.sh
-        conda activate build
         conda install -yq pytest-cov
         pytest --pyargs sherpa --cov sherpa --cov-report xml:${{ github.workspace }}/coverage.xml
 
     - name: sherpa_test Tests
       if: matrix.test-data == 'package' || matrix.test-data == 'none'
       run: |
-        source ${CONDA}/etc/profile.d/conda.sh
-        conda activate build
         conda install -yq pytest-cov
         cd $HOME
         sherpa_test --cov sherpa --cov-report xml:${{ github.workspace }}/coverage.xml
@@ -235,4 +232,3 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ${{ github.workspace }}/coverage.xml
         verbose: true
-      


### PR DESCRIPTION
The changes in #2195 invalidate this. Rather than change it I've created #2198 just so that we can see the difference that the `setup-miniconda` action makes. I've marked this as a draft.

# Summary

Switch the GitHub conda workflow to always install miniconda, add a macOS ARM build, and update the macOS Intel build to use the macOS-13 runner since the macOS-12 runner is about to be removed.

# Details

This is a rework of #1958.

There's three parts

a) switching everything to use miniforge by using the `setup-miniconda` action
b) a minor clean up of the workflow actions by splitting up the DS9 and XSPEC installation steps as they are technically separate (even if we only ever have both)
c) add a macOS ARM build

As part of this we have

- select the CIAO `conda` channel for macOS ARM since there's no ARM build of `xspec-modelsonly` in the `xspec` channel
- use version `12.13.1` rather than `12.14.0` of XSPEC for macOS ARM to match the CIAO `conda` channel
- an oddity in that the `default` channel seems to get added when adding the XSPEC channel (for both Linux and macOS) and I have no idea why but I just ensure it gets removed when added
- tweaked the macOS conda install to use Python 3.11 and install bokeh

I have **not** checked to see how this interacts with 

- #2156