### PR TITLE
CI: drop the macOS run (temporary)

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -23,14 +23,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: MacOS Full Build
-            os: macos-latest
-            python-version: "3.10"
-            install-type: develop
-            fits: astropy
-            test-data: submodule
-            matplotlib-version: 3
-            xspec-version: 12.13.1
+          #- name: MacOS Full Build
+          #  os: macos-latest
+          #  python-version: "3.10"
+          #  install-type: develop
+          #  fits: astropy
+          #  test-data: submodule
+          #  matplotlib-version: 3
+          #  xspec-version: 12.13.1
 
           - name: Linux Minimum Setup (Python 3.9)
             os: ubuntu-latest


### PR DESCRIPTION
# Summary

Temporarily drop the macOS GitHub action. There is no change to Sherpa.

# Details

The macOS CI runner on GitHub has switched to an ARM build when previously it was Intel. This requires updating our build instructions and working through issues, so the short-term fix is to drop the CI macOS run.