### PR TITLE
Specialize the residual-style plots for histogram data

### DIFF
--- a/docs/plots/astroplot.rst
+++ b/docs/plots/astroplot.rst
@@ -17,6 +17,10 @@ The sherpa.astro.plot module
       SourcePlot
       ComponentModelPlot
       ComponentSourcePlot
+      RatioPHAPlot
+      ResidPHAPlot
+      DelchiPHAPlot
+      ChisqrPHAPlot
       ARFPlot
       RMFPlot
       BkgDataPlot
@@ -37,5 +41,5 @@ The sherpa.astro.plot module
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram::  DataPHAPlot ModelPHAHistogram ModelHistogram SourcePlot ComponentModelPlot ComponentSourcePlot ARFPlot RMFPlot BkgDataPlot BkgModelPHAHistogram BkgModelHistogram BkgFitPlot BkgDelchiPlot BkgResidPlot BkgRatioPlot BkgChisqrPlot BkgSourcePlot OrderPlot FluxHistogram EnergyFluxHistogram PhotonFluxHistogram DataIMGPlot
+.. inheritance-diagram::  DataPHAPlot ModelPHAHistogram ModelHistogram SourcePlot ComponentModelPlot ComponentSourcePlot RatioPHAPlot ResidPHAPlot DelchiPHAPlot ChisqrPHAPlot ARFPlot RMFPlot BkgDataPlot BkgModelPHAHistogram BkgModelHistogram BkgFitPlot BkgDelchiPlot BkgResidPlot BkgRatioPlot BkgChisqrPlot BkgSourcePlot OrderPlot FluxHistogram EnergyFluxHistogram PhotonFluxHistogram DataIMGPlot
    :parts: 1

--- a/docs/plots/plot.rst
+++ b/docs/plots/plot.rst
@@ -25,6 +25,7 @@ The sherpa.plot module
       LRHistogram
       SplitPlot
       JointPlot
+      MultiPlot
       DataPlot
       TracePlot
       ScatterPlot
@@ -45,11 +46,18 @@ The sherpa.plot module
       SourceContour
       FitPlot
       FitContour
+      BaseResidualPlot
       DelchiPlot
       ChisqrPlot
-      ResidPlot
-      ResidContour
       RatioPlot
+      ResidPlot
+      BaseResidualHistogramPlot
+      DelchiHistogramPlot
+      ChisqrHistogramPlot
+      RatioHistogramPlot
+      ResidHistogramPlot
+      BaseResidualContour
+      ResidContour
       RatioContour
       Confidence1D
       Confidence2D
@@ -69,5 +77,5 @@ The sherpa.plot module
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram::   Plot Contour Point Histogram HistogramPlot DataHistogramPlot ModelHistogramPlot SourceHistogramPlot PDFPlot CDFPlot LRHistogram SplitPlot JointPlot DataPlot TracePlot ScatterPlot PSFKernelPlot DataContour PSFKernelContour ModelPlot ComponentModelPlot ComponentModelHistogramPlot ComponentTemplateModelPlot SourcePlot ComponentSourcePlot ComponentSourceHistogramPlot ComponentTemplateSourcePlot PSFPlot ModelContour PSFContour SourceContour FitPlot FitContour DelchiPlot ChisqrPlot ResidPlot ResidContour RatioPlot RatioContour Confidence1D Confidence2D IntervalProjectionWorker IntervalProjection IntervalUncertaintyWorker IntervalUncertainty RegionProjectionWorker RegionProjection RegionUncertaintyWorker RegionUncertainty
+.. inheritance-diagram::   Plot Contour Point Histogram HistogramPlot DataHistogramPlot ModelHistogramPlot SourceHistogramPlot PDFPlot CDFPlot LRHistogram SplitPlot JointPlot MultiPlot DataPlot TracePlot ScatterPlot PSFKernelPlot DataContour PSFKernelContour ModelPlot ComponentModelPlot ComponentModelHistogramPlot ComponentTemplateModelPlot SourcePlot ComponentSourcePlot ComponentSourceHistogramPlot ComponentTemplateSourcePlot PSFPlot ModelContour PSFContour SourceContour FitPlot FitContour BaseResidualPlot DelchiPlot ChisqrPlot RatioPlot ResidPlot BaseResidualHistogramPlot DelchiHistogramPlot ChisqrHistogramPlot RatioHistogramPlot ResidHistogramPlot BaseResidualContour ResidContour RatioContour Confidence1D Confidence2D IntervalProjectionWorker IntervalProjection IntervalUncertaintyWorker IntervalUncertainty RegionProjectionWorker RegionProjection RegionUncertaintyWorker RegionUncertainty
    :parts: 1

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -182,7 +182,11 @@ class DataPHAPlot(shplot.DataHistogramPlot):
 
 
 class RatioPHAPlot(shplot.RatioHistogramPlot):
-    """Plot ratio for a PHA dataset."""
+    """Plot ratio for a PHA dataset.
+
+    .. versionadded:: 4.16.1
+
+    """
 
     def _calc_x(self, data: Data1DInt, model: Model) -> None:
         """Define the xlo and xhi fields"""
@@ -194,12 +198,11 @@ class RatioPHAPlot(shplot.RatioHistogramPlot):
 
 
 class ResidPHAPlot(shplot.ResidHistogramPlot):
-    """Plot residuals for a PHA dataset."""
+    """Plot residuals for a PHA dataset.
 
-    # Turn on yerrorbars by default. What is the best way to do this?
-    #
-    histo_prefs = shplot.ResidHistogramPlot.histo_prefs | {"yerrorbars": True}
-    "The preferences for the plot."
+    .. versionadded:: 4.16.1
+
+    """
 
     def _calc_x(self, data: Data1DInt, model: Model) -> None:
         """Define the xlo and xhi fields"""
@@ -217,7 +220,11 @@ class ResidPHAPlot(shplot.ResidHistogramPlot):
 
 
 class DelchiPHAPlot(shplot.DelchiHistogramPlot):
-    """Plot delchi residuals for a PHA dataset."""
+    """Plot delchi residuals for a PHA dataset.
+
+    .. versionadded:: 4.16.1
+
+    """
 
     def _calc_x(self, data: Data1DInt, model: Model) -> None:
         """Define the xlo and xhi fields"""
@@ -229,7 +236,11 @@ class DelchiPHAPlot(shplot.DelchiHistogramPlot):
 
 
 class ChisqrPHAPlot(shplot.ChisqrHistogramPlot):
-    """Plot residuals for a PHA dataset."""
+    """Plot residuals for a PHA dataset.
+
+    .. versionadded:: 4.16.1
+
+    """
 
     def _calc_x(self, data: Data1DInt, model: Model) -> None:
         """Define the xlo and xhi fields"""
@@ -326,6 +337,10 @@ class ModelHistogram(ModelPHAHistogram):
 
 class SourcePlot(shplot.SourceHistogramPlot):
     """Create PHA plots of unconvolved model values.
+
+    .. versionchanged:: 4.16.1
+       The parent class is now SourceHistogramPlot rather than
+       HistogramPlot.
 
     Attributes
     ----------
@@ -784,7 +799,13 @@ class BkgFitPlot(shplot.FitPlot):
 
 
 class BkgDelchiPlot(DelchiPHAPlot):
-    "Derived class for creating background plots of PHA delchi chi ((data-model)/error)"
+    """Derived class for creating background plots of PHA delchi chi ((data-model)/error).
+
+    .. versionchanged:: 4.16.1
+       The parent class is now DelchiPHAPlot rather than
+       DelchiPlot.
+
+    """
 
     # leave the title as the parent, which is
     # 'Sigma Residuals for <name>'.
@@ -793,21 +814,40 @@ class BkgDelchiPlot(DelchiPHAPlot):
 
 
 class BkgResidPlot(ResidPHAPlot):
-    "Derived class for creating background plots of PHA residual (data-model)"
+    """Derived class for creating background plots of PHA residual (data-model).
+
+    .. versionchanged:: 4.16.1
+       The parent class is now ResidPHAPlot rather than
+       ResidPlot.
+
+    """
 
     def _title(self, data: Data1DInt) -> None:
         self.title = f'Residuals of {data.name} - Bkg Model'
 
 
 class BkgRatioPlot(RatioPHAPlot):
-    "Derived class for creating background plots of PHA ratio (data:model)"
+    """Derived class for creating background plots of PHA ratio (data:model).
+
+    .. versionchanged:: 4.16.1
+       The parent class is now RatioPHAPlot rather than
+       RatioPlot.
+
+    """
 
     def _title(self, data: Data1DInt) -> None:
         self.title = f'Ratio of {data.name} : Bkg Model'
 
 
 class BkgChisqrPlot(ChisqrPHAPlot):
-    "Derived class for creating background plots of chi**2 ((data-model)/error)**2"
+    """Derived class for creating background plots of chi**2 ((data-model)/error)**2.
+
+    .. versionchanged:: 4.16.1
+       The parent class is now ChisqrPHAPlot rather than
+       ChisqrPlot.
+
+    """
+
     pass
 
 

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -159,6 +159,9 @@ class DataPHAPlot(shplot.DataHistogramPlot):
 
     def prepare(self, data, stat=None):
 
+        if not isinstance(data, DataPHA):
+            raise IOErr('notpha', data.name)
+
         # Need a better way of accessing the binning of the data.
         # Maybe to_plot should return the lo/hi edges as a pair
         # here.
@@ -209,6 +212,9 @@ class ModelHistogram(ModelPHAHistogram):
     """
 
     def prepare(self, data, model, stat=None):
+
+        if not isinstance(data, DataPHA):
+            raise IOErr('notpha', data.name)
 
         # We could fit this into a single try/finally group but
         # it makes it harder to see what is going on so split
@@ -760,6 +766,10 @@ class OrderPlot(ModelHistogram):
 
     # Note: this does not accept a stat parameter.
     def prepare(self, data, model, orders=None, colors=None):
+
+        if not isinstance(data, DataPHA):
+            raise IOErr('notpha', data.name)
+
         self.orders = data.response_ids
 
         if orders is not None:

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -30,6 +30,7 @@ from sherpa.astro import hc
 from sherpa.astro.data import DataARF, DataPHA, DataRMF
 from sherpa.astro.instrument import ARF1D, RMF1D
 from sherpa.astro.utils import bounds_check
+from sherpa.data import Data1D
 from sherpa.models.basic import Delta1D
 from sherpa import plot as shplot
 from sherpa.utils import parse_expr, dataspace1d, histogram1d, filter_bins, \
@@ -723,22 +724,24 @@ class BkgFitPlot(shplot.FitPlot):
 
 class BkgDelchiPlot(shplot.DelchiPlot):
     "Derived class for creating background plots of 1D delchi chi ((data-model)/error)"
+
+    # leave the title as the parent, which is
+    # 'Sigma Residuals for <name>'.
+    #
     pass
 
 
 class BkgResidPlot(shplot.ResidPlot):
     "Derived class for creating background plots of 1D residual (data-model)"
 
-    def prepare(self, data, model, stat):
-        super().prepare(data, model, stat)
+    def _title(self, data: Data1D) -> None:
         self.title = f'Residuals of {data.name} - Bkg Model'
 
 
 class BkgRatioPlot(shplot.RatioPlot):
     "Derived class for creating background plots of 1D ratio (data:model)"
 
-    def prepare(self, data, model, stat):
-        super().prepare(data, model, stat)
+    def _title(self, data: Data1D) -> None:
         self.title = f'Ratio of {data.name} : Bkg Model'
 
 

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -246,7 +246,7 @@ class ModelHistogram(ModelPHAHistogram):
             data.mask = old_mask
 
 
-class SourcePlot(shplot.HistogramPlot):
+class SourcePlot(shplot.SourceHistogramPlot):
     """Create PHA plots of unconvolved model values.
 
     Attributes
@@ -266,7 +266,6 @@ class SourcePlot(shplot.HistogramPlot):
         self.units = None
         self.mask = None
         super().__init__()
-        self.title = 'Source'
 
     def prepare(self, data, src, lo=None, hi=None):
         # Note: src is source model before folding
@@ -370,48 +369,40 @@ class SourcePlot(shplot.HistogramPlot):
                               **kwargs)
 
 
-class ComponentModelPlot(shplot.ComponentSourcePlot, ModelHistogram):
+# We do not derive from shplot.ComponentModelHistogramPlot to avoid
+# confusion over what behavior is wanted.
+#
+class ComponentModelPlot(ModelHistogram):
+    """The component model plot for DataPHA data.
+
+    .. versionchanged:: 4.16.1
+
+       The class no-longer derives from `sherpa.plot.ComponentSourcePlot`.
+    """
 
     histo_prefs = shplot.basicbackend.get_component_histo_defaults()
 
-    def __init__(self):
-        ModelHistogram.__init__(self)
-
-    def __str__(self):
-        return ModelHistogram.__str__(self)
-
     def prepare(self, data, model, stat=None):
-        ModelHistogram.prepare(self, data, model, stat)
+        super().prepare(data=data, model=model, stat=stat)
         self.title = f'Model component: {model.name}'
 
-    def _merge_settings(self, kwargs):
-        return {**self.histo_prefs, **kwargs}
 
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
-        ModelHistogram.plot(self, overplot=overplot,
-                            clearwindow=clearwindow, **kwargs)
+# We do not derive from shplot.ComponentSourceHistogramPlot to avoid
+# confusion over what behavior is wanted.
+#
+class ComponentSourcePlot(SourcePlot):
+    """The component source plot for DataPHA data.
 
+    .. versionchanged:: 4.16.1
 
-class ComponentSourcePlot(shplot.ComponentSourcePlot, SourcePlot):
+       The class no-longer derives from `sherpa.plot.ComponentSourcePlot`.
+    """
 
     histo_prefs = shplot.basicbackend.get_component_histo_defaults()
 
-    def __init__(self):
-        SourcePlot.__init__(self)
-
-    def __str__(self):
-        return SourcePlot.__str__(self)
-
     def prepare(self, data, model, stat=None):
-        SourcePlot.prepare(self, data, model)
+        super().prepare(data=data, src=model)
         self.title = f'Source model component: {model.name}'
-
-    def _merge_settings(self, kwargs):
-        return {**self.histo_prefs, **kwargs}
-
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
-        SourcePlot.plot(self, overplot=overplot,
-                        clearwindow=clearwindow, **kwargs)
 
 
 class ARFPlot(shplot.HistogramPlot):

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -30,17 +30,19 @@ from sherpa.astro import hc
 from sherpa.astro.data import DataARF, DataPHA, DataRMF
 from sherpa.astro.instrument import ARF1D, RMF1D
 from sherpa.astro.utils import bounds_check
-from sherpa.data import Data1D
+from sherpa.data import Data1DInt
 from sherpa.models.basic import Delta1D
+from sherpa.models.model import Model
 from sherpa import plot as shplot
 from sherpa.utils import parse_expr, dataspace1d, histogram1d, filter_bins, \
     sao_fcmp
-from sherpa.utils.err import PlotErr, IOErr
+from sherpa.utils.err import IOErr, PlotErr, StatErr
 
 warning = logging.getLogger(__name__).warning
 
 __all__ = ('DataPHAPlot', 'ModelPHAHistogram', 'ModelHistogram',
            'SourcePlot', 'ComponentModelPlot', 'ComponentSourcePlot',
+           'RatioPHAPlot', 'ResidPHAPlot', 'DelchiPHAPlot', 'ChisqrPHAPlot',
            'ARFPlot', 'RMFPlot',
            'BkgDataPlot', 'BkgModelPHAHistogram', 'BkgModelHistogram',
            'BkgFitPlot', 'BkgDelchiPlot', 'BkgResidPlot', 'BkgRatioPlot',
@@ -175,6 +177,65 @@ class DataPHAPlot(shplot.DataHistogramPlot):
             self.yerr = shplot.calculate_errors(data, stat, yerrorbars)
 
         self.title = data.name
+
+        self.xlo, self.xhi = calc_x(data)
+
+
+class RatioPHAPlot(shplot.RatioHistogramPlot):
+    """Plot ratio for a PHA dataset."""
+
+    def _calc_x(self, data: Data1DInt, model: Model) -> None:
+        """Define the xlo and xhi fields"""
+
+        if not isinstance(data, DataPHA):
+            raise IOErr('notpha', data.name)
+
+        self.xlo, self.xhi = calc_x(data)
+
+
+class ResidPHAPlot(shplot.ResidHistogramPlot):
+    """Plot residuals for a PHA dataset."""
+
+    # Turn on yerrorbars by default. What is the best way to do this?
+    #
+    histo_prefs = shplot.ResidHistogramPlot.histo_prefs | {"yerrorbars": True}
+    "The preferences for the plot."
+
+    def _calc_x(self, data: Data1DInt, model: Model) -> None:
+        """Define the xlo and xhi fields"""
+
+        if not isinstance(data, DataPHA):
+            raise IOErr('notpha', data.name)
+
+        self.xlo, self.xhi = calc_x(data)
+
+    def _change_ylabel(self) -> None:
+        # The original code had the y label displaying units rather
+        # than 'Data - Model', which is what the super-class sets. So
+        # we override the parent behaviour.
+        pass
+
+
+class DelchiPHAPlot(shplot.DelchiHistogramPlot):
+    """Plot delchi residuals for a PHA dataset."""
+
+    def _calc_x(self, data: Data1DInt, model: Model) -> None:
+        """Define the xlo and xhi fields"""
+
+        if not isinstance(data, DataPHA):
+            raise IOErr('notpha', data.name)
+
+        self.xlo, self.xhi = calc_x(data)
+
+
+class ChisqrPHAPlot(shplot.ChisqrHistogramPlot):
+    """Plot residuals for a PHA dataset."""
+
+    def _calc_x(self, data: Data1DInt, model: Model) -> None:
+        """Define the xlo and xhi fields"""
+
+        if not isinstance(data, DataPHA):
+            raise IOErr('notpha', data.name)
 
         self.xlo, self.xhi = calc_x(data)
 
@@ -722,8 +783,8 @@ class BkgFitPlot(shplot.FitPlot):
     pass
 
 
-class BkgDelchiPlot(shplot.DelchiPlot):
-    "Derived class for creating background plots of 1D delchi chi ((data-model)/error)"
+class BkgDelchiPlot(DelchiPHAPlot):
+    "Derived class for creating background plots of PHA delchi chi ((data-model)/error)"
 
     # leave the title as the parent, which is
     # 'Sigma Residuals for <name>'.
@@ -731,22 +792,22 @@ class BkgDelchiPlot(shplot.DelchiPlot):
     pass
 
 
-class BkgResidPlot(shplot.ResidPlot):
-    "Derived class for creating background plots of 1D residual (data-model)"
+class BkgResidPlot(ResidPHAPlot):
+    "Derived class for creating background plots of PHA residual (data-model)"
 
-    def _title(self, data: Data1D) -> None:
+    def _title(self, data: Data1DInt) -> None:
         self.title = f'Residuals of {data.name} - Bkg Model'
 
 
-class BkgRatioPlot(shplot.RatioPlot):
-    "Derived class for creating background plots of 1D ratio (data:model)"
+class BkgRatioPlot(RatioPHAPlot):
+    "Derived class for creating background plots of PHA ratio (data:model)"
 
-    def _title(self, data: Data1D) -> None:
+    def _title(self, data: Data1DInt) -> None:
         self.title = f'Ratio of {data.name} : Bkg Model'
 
 
-class BkgChisqrPlot(shplot.ChisqrPlot):
-    "Derived class for creating background plots of 1D chi**2 ((data-model)/error)**2"
+class BkgChisqrPlot(ChisqrPHAPlot):
+    "Derived class for creating background plots of chi**2 ((data-model)/error)**2"
     pass
 
 

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -54,7 +54,9 @@ __all__ = ('DataPHAPlot', 'ModelPHAHistogram', 'ModelHistogram',
 _tol = np.finfo(np.float32).eps
 
 
-def _check_hist_bins(xlo, xhi):
+def _check_hist_bins(xlo: np.ndarray,
+                     xhi: np.ndarray
+                     ) -> tuple[np.ndarray, np.ndarray]:
     """Ensure lo/hi edges that are "close" are merged.
 
     Ensure that "close-enough" bin edges use the same value.  We do
@@ -117,6 +119,38 @@ def _check_hist_bins(xlo, xhi):
     return xlo, xhi
 
 
+def calc_x(data: DataPHA) -> tuple[np.ndarray, np.ndarray]:
+    """Calculate the X axis values
+
+    Parameters
+    ----------
+    data : DataPHA
+       The data object.
+
+    Returns
+    -------
+    xlo, xhi : tuple of ndarray
+       The low and high edges of each bin.
+
+    """
+
+    # Get the X axis data.
+    #
+    if data.units != 'channel':
+        elo, ehi = data._get_ebins(group=False)
+    else:
+        elo, ehi = (data.channel, data.channel + 1.)
+
+    xlo = data.apply_filter(elo, data._min)
+    xhi = data.apply_filter(ehi, data._max)
+    if data.units == 'wavelength':
+        # Should this swap xlo and xhi here?
+        xlo = hc / xlo
+        xhi = hc / xhi
+
+    return _check_hist_bins(xlo, xhi)
+
+
 class DataPHAPlot(shplot.DataHistogramPlot):
     """Plot a PHA dataset."""
 
@@ -138,20 +172,7 @@ class DataPHAPlot(shplot.DataHistogramPlot):
 
         self.title = data.name
 
-        # Get the X axis data.
-        #
-        if data.units != 'channel':
-            elo, ehi = data._get_ebins(group=False)
-        else:
-            elo, ehi = (data.channel, data.channel + 1.)
-
-        self.xlo = data.apply_filter(elo, data._min)
-        self.xhi = data.apply_filter(ehi, data._max)
-        if data.units == 'wavelength':
-            self.xlo = hc / self.xlo
-            self.xhi = hc / self.xhi
-
-        self.xlo, self.xhi = _check_hist_bins(self.xlo, self.xhi)
+        self.xlo, self.xhi = calc_x(data)
 
 
 class ModelPHAHistogram(shplot.HistogramPlot):
@@ -176,18 +197,7 @@ class ModelPHAHistogram(shplot.HistogramPlot):
          self.xlabel, self.ylabel) = data.to_plot(yfunc=model)
         self.y = self.y[1]
 
-        if data.units != 'channel':
-            elo, ehi = data._get_ebins(group=False)
-        else:
-            elo, ehi = (data.channel, data.channel + 1.)
-
-        self.xlo = data.apply_filter(elo, data._min)
-        self.xhi = data.apply_filter(ehi, data._max)
-        if data.units == 'wavelength':
-            self.xlo = hc / self.xlo
-            self.xhi = hc / self.xhi
-
-        self.xlo, self.xhi = _check_hist_bins(self.xlo, self.xhi)
+        self.xlo, self.xhi = calc_x(data)
 
 
 class ModelHistogram(ModelPHAHistogram):
@@ -785,6 +795,10 @@ class OrderPlot(ModelHistogram):
             (xlo, y, yerr, _,
              self.xlabel, self.ylabel) = data.to_plot(model)
             y = y[1]
+
+            # TODO: should this use calc_x? The logic isn't quite the
+            # same but that may be a logical error in the following.
+            #
             if data.units != 'channel':
                 elo, ehi = data._get_ebins(group=False)
                 xlo = data.apply_filter(elo, data._min)

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -1262,7 +1262,7 @@ def test_pha_data_fails_not_pha(cls):
     d = Data1D("not-a-pha", [1, 2], [0, 2])
     plotobj = cls()
 
-    with pytest.raises(AttributeError, match="'Data1D' object has no attribute 'units'"):
+    with pytest.raises(IOErr, match="data set 'not-a-pha' does not contain a PHA spectrum"):
         plotobj.prepare(d, stat=stats.LeastSq())
 
 
@@ -1293,7 +1293,7 @@ def test_pha_model_fails_not_pha(cls):
     m = Const1D("mdl")
     plotobj = cls()
 
-    with pytest.raises(AttributeError, match="'Data1D' object has no attribute 'grouped'"):
+    with pytest.raises(IOErr, match="data set 'not-a-pha' does not contain a PHA spectrum"):
         plotobj.prepare(d, m, stat=stats.LeastSq())
 
 
@@ -1323,7 +1323,7 @@ def test_pha_model_no_stat_fails_not_pha(cls):
     m = Const1D("mdl")
     plotobj = cls()
 
-    with pytest.raises(AttributeError, match="'Data1D' object has no attribute 'response_ids'"):
+    with pytest.raises(IOErr, match="data set 'not-a-pha' does not contain a PHA spectrum"):
         plotobj.prepare(d, m)
 
 

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -1211,10 +1211,10 @@ def test_pha_model_plot_xerr(units):
         mplot.xerr
 
 
-@pytest.mark.parametrize("cls", [splot.ResidPlot,
-                                 splot.RatioPlot,
-                                 splot.DelchiPlot,
-                                 splot.ChisqrPlot])
+@pytest.mark.parametrize("cls", [aplot.ResidPHAPlot,
+                                 aplot.RatioPHAPlot,
+                                 aplot.DelchiPHAPlot,
+                                 aplot.ChisqrPHAPlot])
 @pytest.mark.parametrize("units", ["channel", "energy", "wavelength"])
 def test_pha_resid_plot_xerr(cls, units):
     """What is the xerr field for DataPHA residual.
@@ -1237,21 +1237,9 @@ def test_pha_resid_plot_xerr(cls, units):
     rplot = cls()
     rplot.prepare(pha, full_model, stat=stats.Chi2Gehrels())
 
-    if units == "channel":
-        xerr_chan = np.asarray([1, 2, 1, 2, 2, 1, 1]) / 2
-        assert rplot.xerr == pytest.approx(xerr_chan)
-        return
-
-    en_lo = np.asarray([0.5, 0.65, 0.8, 0.9, 1.1, 1.3, 1.4])
-    en_hi = np.asarray([0.65, 0.8, 0.9, 1.1, 1.3, 1.4, 1.5])
-
-    if units == "energy":
-        xerr_kev = (en_hi - en_lo) / 2
-        assert rplot.xerr == pytest.approx(xerr_kev)
-        return
-
-    xerr_lam = (hc / en_lo - hc / en_hi) / 2
-    assert rplot.xerr == pytest.approx(xerr_lam)
+    # Should we have an xerr field (to match shplot.DataHistogramPlot)?
+    with pytest.raises(AttributeError):
+        rplot.xerr
 
 
 @pytest.mark.parametrize("cls", [DataPHAPlot, BkgDataPlot,
@@ -1267,27 +1255,17 @@ def test_pha_data_fails_not_pha(cls):
 
 
 @pytest.mark.parametrize("cls", [ModelPHAHistogram,
+                                 ModelHistogram,
                                  BkgModelPHAHistogram,
-                                 ComponentSourcePlot])
+                                 BkgModelHistogram,
+                                 ComponentSourcePlot,
+                                 ComponentModelPlot,
+                                 aplot.ResidPHAPlot, aplot.BkgResidPlot,
+                                 aplot.RatioPHAPlot, aplot.BkgRatioPlot,
+                                 aplot.DelchiPHAPlot, aplot.BkgDelchiPlot,
+                                 aplot.ChisqrPHAPlot, aplot.BkgChisqrPlot])
 def test_pha_model_checks_not_pha(cls):
     """Check if error out with an invalid data message for Model classes"""
-
-    d = Data1D("not-a-pha", [1, 2], [0, 2])
-    m = Const1D("mdl")
-    plotobj = cls()
-
-    with pytest.raises(IOErr, match="data set 'not-a-pha' does not contain a PHA spectrum"):
-        plotobj.prepare(d, m, stat=stats.LeastSq())
-
-
-@pytest.mark.parametrize("cls", [ModelHistogram,
-                                 BkgModelHistogram,
-                                 ComponentModelPlot])
-def test_pha_model_fails_not_pha(cls):
-    """Check if error out with an invalid data message for Model classes
-
-    These should get merged into test_pha_model_checks_pha
-    """
 
     d = Data1D("not-a-pha", [1, 2], [0, 2])
     m = Const1D("mdl")

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -893,7 +893,8 @@ def test_get_bkg_resid_plot(idval, clean_astro_ui):
     else:
         bp = ui.get_bkg_resid_plot(idval)
 
-    assert bp.x == pytest.approx(_data_chan)
+    assert bp.xlo == pytest.approx(_data_chan)
+    assert bp.xhi == pytest.approx(_data_chan + 1)
 
     # correct the counts by the bin width and exposure time
     #
@@ -1082,6 +1083,8 @@ def check_bkg_resid(plotfunc, idval, isfit=True):
             continue
         else:
             pd = get(idval, recalc=False)
+            assert pd.xlo is None
+            assert pd.xhi is None
             assert pd.x is None
             assert pd.y is None
 
@@ -1112,7 +1115,8 @@ def check_bkg_resid(plotfunc, idval, isfit=True):
     else:
         assert False  # check I've caught everything
 
-    assert plot.x == pytest.approx(_data_chan)
+    assert plot.xlo == pytest.approx(_data_chan)
+    assert plot.xhi == pytest.approx(_data_chan + 1)
     assert plot.y is not None
 
     # the way the data and model are constructed, all residual values
@@ -1132,10 +1136,14 @@ def check_bkg_chisqr(plotfunc, idval, isfit=True):
                 ui.get_bkg_ratio_plot,
                 ui.get_bkg_resid_plot]:
         pd = get(idval, recalc=False)
+        assert pd.xlo is None
+        assert pd.xhi is None
         assert pd.x is None
         assert pd.y is None
 
     plot = ui.get_bkg_chisqr_plot(idval, recalc=False)
+    assert plot.xlo is not None
+    assert plot.xhi is not None
     assert plot.x is not None
     assert plot.y is not None
 
@@ -1159,6 +1167,8 @@ def check_bkg_model(plotfunc, idval, isfit=True):
                 ui.get_bkg_resid_plot,
                 ui.get_bkg_chisqr_plot]:
         pd = get(idval, recalc=False)
+        assert pd.xlo is None
+        assert pd.xhi is None
         assert pd.x is None
         assert pd.y is None
 
@@ -1189,6 +1199,8 @@ def check_bkg_source(plotfunc, idval, isfit=True):
                 ui.get_bkg_resid_plot,
                 ui.get_bkg_chisqr_plot]:
         pd = get(idval, recalc=False)
+        assert pd.xlo is None
+        assert pd.xhi is None
         assert pd.x is None
         assert pd.y is None
 
@@ -3599,8 +3611,8 @@ def test_set_plot_opt_x(cls, datafunc, plotfunc, all_plot_backends):
     mdl.c1 = 1
     s.set_source(mdl)
 
-    plot = getattr(s, 'plot_{}'.format(plotfunc))
-    pdata = getattr(s, 'get_{}_plot'.format(plotfunc))
+    plot = getattr(s, f'plot_{plotfunc}')
+    pdata = getattr(s, f'get_{plotfunc}_plot')
 
     # Create the plot
     plot()
@@ -3612,8 +3624,6 @@ def test_set_plot_opt_x(cls, datafunc, plotfunc, all_plot_backends):
         else:
             assert p1.dataplot.plot_prefs['xlog']
             assert p1.modelplot.plot_prefs['xlog']
-    elif plotfunc in ['resid', 'ratio', 'delchi']:
-        assert p1.plot_prefs['xlog']
     elif is_int:
         assert p1.histo_prefs['xlog']
     else:
@@ -3631,8 +3641,6 @@ def test_set_plot_opt_x(cls, datafunc, plotfunc, all_plot_backends):
         else:
             assert not p2.dataplot.plot_prefs['xlog']
             assert not p2.modelplot.plot_prefs['xlog']
-    elif plotfunc in ['resid', 'ratio', 'delchi']:
-        assert not p2.plot_prefs['xlog']
     elif is_int:
         assert not p2.histo_prefs['xlog']
     else:
@@ -3676,8 +3684,8 @@ def test_set_plot_opt_y(cls, datafunc, plotfunc, answer):
     mdl.c1 = 1
     s.set_source(mdl)
 
-    plot = getattr(s, 'plot_{}'.format(plotfunc))
-    pdata = getattr(s, 'get_{}_plot'.format(plotfunc))
+    plot = getattr(s, f'plot_{plotfunc}')
+    pdata = getattr(s, f'get_{plotfunc}_plot')
 
     plot()
     p1 = pdata()
@@ -3688,12 +3696,6 @@ def test_set_plot_opt_y(cls, datafunc, plotfunc, answer):
         else:
             assert p1.dataplot.plot_prefs['ylog'] == answer
             assert p1.modelplot.plot_prefs['ylog'] == answer
-    elif plotfunc in ['resid', 'ratio', 'delchi']:
-        # We use plot_prefs even if is_int is True for
-        # the residual-style plots. That is, the ordering
-        # of the checks here is important.
-        #
-        assert p1.plot_prefs['ylog'] == answer
     elif is_int:
         assert p1.histo_prefs['ylog'] == answer
     else:
@@ -3711,8 +3713,6 @@ def test_set_plot_opt_y(cls, datafunc, plotfunc, answer):
         else:
             assert not p2.dataplot.plot_prefs['ylog']
             assert not p2.modelplot.plot_prefs['ylog']
-    elif plotfunc in ['resid', 'ratio', 'delchi']:
-        assert not p2.plot_prefs['ylog']
     elif is_int:
         assert not p2.histo_prefs['ylog']
     else:
@@ -3761,8 +3761,8 @@ def test_set_plot_opt_x_astro(cls, datafunc, plotfunc):
     s.set_source(mdl)
     s.set_bkg_source(mdl)
 
-    plot = getattr(s, 'plot_{}'.format(plotfunc))
-    pdata = getattr(s, 'get_{}_plot'.format(plotfunc))
+    plot = getattr(s, f'plot_{plotfunc}')
+    pdata = getattr(s, f'get_{plotfunc}_plot')
 
     # Create the plot
     plot()
@@ -3779,8 +3779,6 @@ def test_set_plot_opt_x_astro(cls, datafunc, plotfunc):
         # actually required for the plot to work.
         #
         assert not p1.modelplot.histo_prefs['xlog']
-    elif plotfunc in ['resid', 'ratio', 'delchi', 'bkg_resid', 'bkg_ratio', 'bkg_delchi']:
-        assert p1.plot_prefs['xlog']
     else:
         assert p1.histo_prefs['xlog']
 
@@ -3792,8 +3790,6 @@ def test_set_plot_opt_x_astro(cls, datafunc, plotfunc):
     if plotfunc in ['fit', 'bkg_fit']:
         assert not p2.dataplot.histo_prefs['xlog']
         assert not p2.modelplot.histo_prefs['xlog']
-    elif plotfunc in ['resid', 'ratio', 'delchi', 'bkg_resid', 'bkg_ratio', 'bkg_delchi']:
-        assert not p2.plot_prefs['xlog']
     else:
         assert not p2.histo_prefs['xlog']
 
@@ -3837,8 +3833,8 @@ def test_set_plot_opt_y_astro(cls, datafunc, plotfunc, answer):
     s.set_source(mdl)
     s.set_bkg_source(mdl)
 
-    plot = getattr(s, 'plot_{}'.format(plotfunc))
-    pdata = getattr(s, 'get_{}_plot'.format(plotfunc))
+    plot = getattr(s, f'plot_{plotfunc}')
+    pdata = getattr(s, f'get_{plotfunc}_plot')
 
     plot()
     p1 = pdata()
@@ -3846,8 +3842,6 @@ def test_set_plot_opt_y_astro(cls, datafunc, plotfunc, answer):
         assert p1.dataplot.histo_prefs['ylog'] == answer
         # Check the current behavior of the model plot in case it changes
         assert not p1.modelplot.histo_prefs['xlog']
-    elif plotfunc in ['resid', 'ratio', 'delchi', 'bkg_resid', 'bkg_ratio', 'bkg_delchi']:
-        assert p1.plot_prefs['ylog'] == answer
     else:
         assert p1.histo_prefs['ylog'] == answer
 
@@ -3859,8 +3853,6 @@ def test_set_plot_opt_y_astro(cls, datafunc, plotfunc, answer):
     if plotfunc in ['fit', 'bkg_fit']:
         assert not p2.dataplot.histo_prefs['ylog']
         assert not p2.modelplot.histo_prefs['xlog']
-    elif plotfunc in ['resid', 'ratio', 'delchi', 'bkg_resid', 'bkg_ratio', 'bkg_delchi']:
-        assert not p2.plot_prefs['ylog']
     else:
         assert not p2.histo_prefs['ylog']
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -361,6 +361,11 @@ class Session(sherpa.ui.utils.Session):
         self._plot_types['source'].append(sherpa.astro.plot.SourcePlot())
         self._plot_types["source_component"].append(sherpa.astro.plot.ComponentSourcePlot())
 
+        self._plot_types["ratio"].append(sherpa.astro.plot.RatioPHAPlot())
+        self._plot_types["resid"].append(sherpa.astro.plot.ResidPHAPlot())
+        self._plot_types["delchi"].append(sherpa.astro.plot.DelchiPHAPlot())
+        self._plot_types["chisqr"].append(sherpa.astro.plot.ChisqrPHAPlot())
+
         self._plot_types['arf'] = [sherpa.astro.plot.ARFPlot()]
         self._plot_types['rmf'] = [sherpa.astro.plot.RMFPlot()]
         self._plot_types['order'] = [sherpa.astro.plot.OrderPlot()]
@@ -11379,6 +11384,74 @@ class Session(sherpa.ui.utils.Session):
         return super().get_source_component_plot(id, model=model, recalc=recalc)
 
     get_source_component_plot.__doc__ = sherpa.ui.utils.Session.get_source_component_plot.__doc__
+
+    def get_ratio_plot(self, id=None, recalc=True):
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        if isinstance(data, DataPHA):
+            plotobj = self._plot_types["ratio"][2]
+            if recalc:
+                plotobj.prepare(data, self.get_model(id), self.get_stat())
+
+            return plotobj
+
+        return super().get_ratio_plot(id, recalc=recalc)
+
+    get_ratio_plot.__doc__ = sherpa.ui.utils.Session.get_ratio_plot.__doc__
+
+    def get_resid_plot(self, id=None, recalc=True):
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        if isinstance(data, DataPHA):
+            plotobj = self._plot_types["resid"][2]
+            if recalc:
+                plotobj.prepare(data, self.get_model(id), self.get_stat())
+
+            return plotobj
+
+        return super().get_resid_plot(id, recalc=recalc)
+
+    get_resid_plot.__doc__ = sherpa.ui.utils.Session.get_resid_plot.__doc__
+
+    def get_delchi_plot(self, id=None, recalc=True):
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        if isinstance(data, DataPHA):
+            plotobj = self._plot_types["delchi"][2]
+            if recalc:
+                plotobj.prepare(data, self.get_model(id), self.get_stat())
+
+            return plotobj
+
+        return super().get_delchi_plot(id, recalc=recalc)
+
+    get_delchi_plot.__doc__ = sherpa.ui.utils.Session.get_delchi_plot.__doc__
+
+    def get_chisqr_plot(self, id=None, recalc=True):
+        if recalc:
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        if isinstance(data, DataPHA):
+            plotobj = self._plot_types["chisqr"][2]
+            if recalc:
+                plotobj.prepare(data, self.get_model(id), self.get_stat())
+
+            return plotobj
+
+        return super().get_chisqr_plot(id, recalc=recalc)
+
+    get_chisqr_plot.__doc__ = sherpa.ui.utils.Session.get_chisqr_plot.__doc__
 
     def get_pvalue_plot(self, null_model=None, alt_model=None, conv_model=None,
                         id=1, otherids=(), num=500, bins=25, numcores=None,

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -856,6 +856,9 @@ class DataHistogramPlot(HistogramPlot):
 class ModelHistogramPlot(HistogramPlot):
     """Display a model as a histogram."""
 
+    # TODO: should this include
+    # histo_prefs = shplot.basicbackend.get_model_histo_defaults()
+
     def __init__(self):
         super().__init__()
         self.title = 'Model'
@@ -1804,23 +1807,36 @@ class ModelPlot(Plot):
 
 
 class ComponentModelPlot(ModelPlot):
+    """Component model plots."""
 
     plot_prefs = basicbackend.get_component_plot_defaults()
     "The preferences for the plot."
 
+    # TODO: ComponentSourcePlot calls data.to_component_plot but this
+    # just uses data.to_plot. Does it matter?
+    #
     def prepare(self, data, model, stat=None):
-        ModelPlot.prepare(self, data, model, stat)
+        super().prepare(data=data, model=model, stat=stat)
         self.title = f'Model component: {model.name}'
 
 
 class ComponentModelHistogramPlot(ModelHistogramPlot):
+    """Component model plots for histogram data.
 
-    # Is this the correct setting?
-    plot_prefs = basicbackend.get_component_plot_defaults()
+    ..versionchanged:: 4.16.1
+      The `histo_prefs` attribute is now properly set (plot_prefs is
+      also no-longer set).
+
+    """
+
+    histo_prefs = basicbackend.get_component_histo_defaults()
     "The preferences for the plot."
 
+    # TODO: ComponentSourceHistogramPlot calls data.to_component_plot
+    # but this just uses data.to_plot. Does it matter?
+    #
     def prepare(self, data, model, stat=None):
-        super().prepare(data, model, stat)
+        super().prepare(data=data, model=model, stat=stat)
         self.title = f'Model component: {model.name}'
 
 
@@ -1858,6 +1874,7 @@ class SourcePlot(ModelPlot):
 
 
 class ComponentSourcePlot(SourcePlot):
+    """Component source plots."""
 
     plot_prefs = basicbackend.get_component_plot_defaults()
 
@@ -1869,9 +1886,15 @@ class ComponentSourcePlot(SourcePlot):
 
 
 class ComponentSourceHistogramPlot(SourceHistogramPlot):
+    """Component source plots for histogram data.
 
-    # Is this the correct setting?
-    plot_prefs = basicbackend.get_component_plot_defaults()
+    ..versionchanged:: 4.16.1
+      The `histo_prefs` attribute is now properly set (plot_prefs is
+      also no-longer set).
+
+    """
+
+    histo_prefs = basicbackend.get_component_histo_defaults()
 
     def prepare(self, data, model, stat=None):
 

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -3928,7 +3928,7 @@ class RegionUncertainty(Confidence2D):
             fit.model.thawedpars = oldpars
 
 
-class MultiPlot(NoNewAttributesAfterInit):
+class MultiPlot:
     """Combine multiple line-style plots.
 
     Allow multiple line-style plots - so those plot classes
@@ -3936,6 +3936,8 @@ class MultiPlot(NoNewAttributesAfterInit):
     the same area. Each plot is added with the add method.
 
     """
+
+    __slots__ = ("plots", "title")
 
     def __init__(self) -> None:
         self.plots: list[Union[Plot, HistogramPlot]] = []

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -2242,7 +2242,7 @@ class FitContour(Contour):
 class BaseResidualPlot(ModelPlot):
     """Residuals of model + data.
 
-    Only subclasses, that implement _calc_y, should be created.
+    Subclasses need to implement `_calc_y` and `_title`.
 
     .. versionadded:: 4.16.1
 
@@ -2322,7 +2322,7 @@ class BaseResidualPlot(ModelPlot):
 class BaseResidualHistogramPlot(ModelHistogramPlot):
     """Residuals of model + data for histogram data.
 
-    Only subclasses, that implement _calc_y, should be created.
+    Subclasses need to implement `_calc_y` and `_title`.
 
     .. versionadded:: 4.16.1
 
@@ -2417,7 +2417,7 @@ class BaseResidualHistogramPlot(ModelHistogramPlot):
 class BaseResidualContour(ModelContour):
     """Residuals of model + data for contour data.
 
-    Only subclasses, that implement _calc_y, should be created.
+    Subclasses need to implement `_calc_y` and `_title`.
 
     .. versionadded:: 4.16.1
 

--- a/sherpa/plot/backends.py
+++ b/sherpa/plot/backends.py
@@ -706,6 +706,7 @@ class BaseBackend(metaclass=MetaBaseBackend):
 
     def get_resid_histo_defaults(self):
         d = self.get_histo_defaults()
+        d['yerrorbars'] = True
         d['capsize'] = 0
         # d['marker'] = '_'
         return d

--- a/sherpa/plot/backends.py
+++ b/sherpa/plot/backends.py
@@ -704,6 +704,12 @@ class BaseBackend(metaclass=MetaBaseBackend):
         # d['marker'] = '_'
         return d
 
+    def get_resid_histo_defaults(self):
+        d = self.get_histo_defaults()
+        d['capsize'] = 0
+        # d['marker'] = '_'
+        return d
+
     def get_ratio_plot_defaults(self):
         d = self.get_data_plot_defaults()
         d['xerrorbars'] = True

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1309,3 +1309,29 @@ def test_lrhist_str(check_str):
                ])
 
     assert last.startswith("histo_prefs = {")
+
+
+@pytest.mark.parametrize("cls", [sherpaplot.Histogram,
+                                 sherpaplot.HistogramPlot,
+                                 sherpaplot.DataHistogramPlot,
+                                 sherpaplot.ModelHistogramPlot,
+                                 sherpaplot.SourceHistogramPlot,
+                                 sherpaplot.PDFPlot,
+                                 sherpaplot.LRHistogram,
+                                 pytest.param(sherpaplot.ComponentModelHistogramPlot, marks=pytest.mark.xfail),
+                                 pytest.param(sherpaplot.ComponentSourceHistogramPlot, marks=pytest.mark.xfail)
+                                 ])
+def test_histo_plot_preferences(cls):
+    """Check we have histo_prefs and not plot_prefs.
+
+    We have had code that accidentally created a plot_prefs
+    field, so we want to check this does not happen.
+    """
+
+    p = cls()
+    assert p.histo_prefs is not None
+    try:
+        p.plot_prefs
+        assert False, f"cls {cls} has a plot_prefs field"
+    except AttributeError:
+        pass

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1318,8 +1318,8 @@ def test_lrhist_str(check_str):
                                  sherpaplot.SourceHistogramPlot,
                                  sherpaplot.PDFPlot,
                                  sherpaplot.LRHistogram,
-                                 pytest.param(sherpaplot.ComponentModelHistogramPlot, marks=pytest.mark.xfail),
-                                 pytest.param(sherpaplot.ComponentSourceHistogramPlot, marks=pytest.mark.xfail)
+                                 sherpaplot.ComponentModelHistogramPlot,
+                                 sherpaplot.ComponentSourceHistogramPlot,
                                  ])
 def test_histo_plot_preferences(cls):
     """Check we have histo_prefs and not plot_prefs.

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -955,10 +955,10 @@ class Session(NoNewAttributesAfterInit):
             'source_component': [sherpa.plot.ComponentSourcePlot(), sherpa.plot.ComponentSourceHistogramPlot()],
             'source_components': [sherpa.plot.MultiPlot()],
             'fit': [sherpa.plot.FitPlot()],
-            'resid': [sherpa.plot.ResidPlot()],
-            'ratio': [sherpa.plot.RatioPlot()],
-            'delchi': [sherpa.plot.DelchiPlot()],
-            'chisqr': [sherpa.plot.ChisqrPlot()],
+            'resid': [sherpa.plot.ResidPlot(), sherpa.plot.ResidHistogramPlot()],
+            'ratio': [sherpa.plot.RatioPlot(), sherpa.plot.RatioHistogramPlot()],
+            'delchi': [sherpa.plot.DelchiPlot(), sherpa.plot.DelchiHistogramPlot()],
+            'chisqr': [sherpa.plot.ChisqrPlot(), sherpa.plot.ChisqrHistogramPlot()],
             'psf': [sherpa.plot.PSFPlot()],
             'kernel': [sherpa.plot.PSFKernelPlot()]
         }
@@ -12396,9 +12396,22 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._plot_types["resid"][0]
+        # Allow an answer to be returned if recalc is False and no
+        # data has been loaded. However, it's not obvious what the
+        # answer should be if recalc=False and the dataset has
+        # changed type since get_delchi_plot was last called.
+        #
         if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        # This uses the implicit conversion of bool to 0 or 1.
+        #
+        idx = isinstance(data, sherpa.data.Data1DInt)
+        plotobj = self._plot_types["resid"][idx]
+        if recalc:
+            plotobj.prepare(data, self.get_model(id), self.get_stat())
 
         return plotobj
 
@@ -12458,9 +12471,22 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._plot_types["delchi"][0]
+        # Allow an answer to be returned if recalc is False and no
+        # data has been loaded. However, it's not obvious what the
+        # answer should be if recalc=False and the dataset has
+        # changed type since get_delchi_plot was last called.
+        #
         if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        # This uses the implicit conversion of bool to 0 or 1.
+        #
+        idx = isinstance(data, sherpa.data.Data1DInt)
+        plotobj = self._plot_types["delchi"][idx]
+        if recalc:
+            plotobj.prepare(data, self.get_model(id), self.get_stat())
 
         return plotobj
 
@@ -12520,9 +12546,22 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._plot_types["chisqr"][0]
+        # Allow an answer to be returned if recalc is False and no
+        # data has been loaded. However, it's not obvious what the
+        # answer should be if recalc=False and the dataset has
+        # changed type since get_delchi_plot was last called.
+        #
         if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        # This uses the implicit conversion of bool to 0 or 1.
+        #
+        idx = isinstance(data, sherpa.data.Data1DInt)
+        plotobj = self._plot_types["chisqr"][idx]
+        if recalc:
+            plotobj.prepare(data, self.get_model(id), self.get_stat())
 
         return plotobj
 
@@ -12582,9 +12621,22 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self._plot_types["ratio"][0]
+        # Allow an answer to be returned if recalc is False and no
+        # data has been loaded. However, it's not obvious what the
+        # answer should be if recalc=False and the dataset has
+        # changed type since get_delchi_plot was last called.
+        #
         if recalc:
-            plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
+            data = self.get_data(id)
+        else:
+            data = self._get_data(id)
+
+        # This uses the implicit conversion of bool to 0 or 1.
+        #
+        idx = isinstance(data, sherpa.data.Data1DInt)
+        plotobj = self._plot_types["ratio"][idx]
+        if recalc:
+            plotobj.prepare(data, self.get_model(id), self.get_stat())
 
         return plotobj
 


### PR DESCRIPTION
# Summary

Improve the display of residual-style plots for integrated datasets. Fix https://github.com/sherpa/sherpa/issues/1817.

# Details

This is a rework of #1989 without the changes in #1988 (which involve the class structure and not really the functionality of the code).

This introduces Data1DInt and DataPHA variants of the resid/delchi/ratio/chisqr plots. It follows the approach taken in

- https://github.com/sherpa/sherpa/pull/931

(and perhaps should have been included in that PR). The main changes are 

- adding the new classes for residual+histogram data
- adding in support for them to the UI layer

However, as part of this there are some other clean ups and tweaks, including

- 814764cc which cleans up the component hierarchy as it looks like that was either written before some classes were added or the original author never realized we had more-appropriate superclasses (this doesn't change functionality, but rather makes things a little-bit clearer about what being a "component" class is). in particular, we avoid having multiple superclasses which mixed up histogram/Data1DInt and point/Data1D behaviour as we didn't gain anything from this.
- bfe07232 just adds a minor refactoring of some `DataPHA` plot code to encapsulate the logic for creating the X axis values
  - this should re-appear below 
- 2ba5ca05 just adds a check to ensure we send a DataPHA object to the plot code that accepts it (which just makes the error message if you ever send in the wrong object nicer, and will be helpful if we add type rules to this module, which is not done here as that leads into #1988 which we don't need here)
- 01e3f992 takes the existing resid/ratio/delchi/chisqr plot code and creates a new class that the `ResidPlot`/... classes inherit from
  - the old code had some idea of separating out the common behaviour from the class-specific, but it was done in such a way that we had to repeat the common code for each class. This approach now makes the common code actually be common and moves the class-specific logic into the classes
  - this approach is about to be repeated
-  8c6502eb is the actual main part of this PR as it adds in histogram-specific residual plots
  - this follows the approach I just added for the Data1D class 
  - it's a bit-more complex than the Data1D case as we allow the X values to be overloaded (as well as the y / yerr / labels values) since we want to take advantage of the DataPHA specialization I added earlier in bfe07232
  - it adds in code for the UI layer (so that `plot_resid` will use the correct class)
  - it cleans up a little bit of the test code as the behaviour is a bit-more self consistent (but this is mainly only visible to me as the person who originally wrote the tests in question)
- 7ba47bc2 repeats the process for the existing contour residual classes, although it's easier as we only have resid and ratio to care about here (ie no delchi or chisqr versions)
- ba2a60f4 pylint pointed out to me that the new `MultiPlot` class inherited from `NoNewAttributesAfterInit` but never actually called it, so I decided to "fix" this by moving this class over to using slots instead (a la #2008)
- 06ffa195 is just an attempt to improve the test coverage of this PR (thanks to the way the code is written there are some lines that are just not worth testing - e.g. the methods in the new `BaseResidualXXX` classes that have to be over-ridden, and some lines that got changed here but don't have existing tests) but may as well try to catch some simple cases
- 024820c8 just makes sure that the histogram residual plots display Y errorbars by default

There's definitely some bike-shedding (e.g. the names of these "intermediary" residual classes I add) and should they be included in the RTD documentation.

# Example

## Data1DInt

With the script

```python
import matplotlib.pyplot as plt
from sherpa import ui

ui.load_arrays(1, [1, 2, 4, 8], [2, 3, 7, 9], [2, 4, 22, 9], ui.Data1DInt)
ui.set_source(ui.polynom1d.poly)
poly.c0 = 1
poly.c1 = 1

ui.plot_resid()
plt.savefig("resid.png")

ui.plot_ratio()
plt.savefig("ratio.png")

ui.plot_delchi()
plt.savefig("delchi.png")

ui.plot_chisqr()
plt.savefig("chisqr.png")
```

we get

### CIAO 4.16

![resid](https://github.com/sherpa/sherpa/assets/224638/fc161e90-5ad3-41dc-848f-5041ab102477)

![ratio](https://github.com/sherpa/sherpa/assets/224638/023a3e9f-58f1-41d7-8d05-e71ab6df711c)

![delchi](https://github.com/sherpa/sherpa/assets/224638/5bce7d37-c273-4150-b169-90ee3b9016ee)

![chisqr](https://github.com/sherpa/sherpa/assets/224638/54a4696d-bb87-4524-853c-38b31fd2cefe)

### This PR

![resid](https://github.com/sherpa/sherpa/assets/224638/b00b10b8-ab2c-4224-94c6-3d07b2ee733f)

![ratio](https://github.com/sherpa/sherpa/assets/224638/71725ca0-045f-4b1e-9d01-29e80c7618a5)

![delchi](https://github.com/sherpa/sherpa/assets/224638/00b3b512-acc9-4091-9c0f-f360f5554158)

![chisqr](https://github.com/sherpa/sherpa/assets/224638/1df2bc8b-c061-461f-af18-c98a2dd6662b)

## DataPHA

With the script

```python
import matplotlib.pyplot as plt
from sherpa.astro import ui

ui.load_pha(1, "/home/dburke/sherpa/sherpa-1/sherpa-test-data/sherpatest/3c273.pi")
ui.ignore(hi=0.5)
ui.ignore(lo=7)

ui.set_source(ui.xsphabs.gal * ui.powlaw1d.pl)

ui.fit()

ui.plot_fit_resid(xlog=True, ylog=True)

plt.savefig("fit_resid.png")
```

which gets the fit (in both cases)

```
Dataset               = 1
Method                = levmar
Statistic             = chi2gehrels
Initial fit statistic = 5.43144e+10
Final fit statistic   = 20.7521 at function evaluation 259
Data points           = 40
Degrees of freedom    = 37
Probability [Q-value] = 0.985667
Reduced statistic     = 0.560868
Change in statistic   = 5.43144e+10
   gal.nH         0.00639106   +/- 0.135014    
   pl.gamma       1.9472       +/- 0.197551    
   pl.ampl        0.000184542  +/- 1.86246e-05 
```

### CIAO 4.16

![fit_resid](https://github.com/sherpa/sherpa/assets/224638/f16ae6dc-8862-4af0-ac60-0b9a772bbf00)

### this PR

![fit_resid](https://github.com/sherpa/sherpa/assets/224638/2407ec92-d285-4af5-a94f-16b9c862ad25)
