### PR TITLE
[CI] Update ci-conda-workflow.yml to pin back to macos-12

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - name: MacOS Full Build
-            os: macos-13
+            os: macos-12
             python-version: "3.10"
             install-type: develop
             fits: astropy

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - name: MacOS Full Build
-            os: macos-latest
+            os: macos-13
             python-version: "3.10"
             install-type: develop
             fits: astropy


### PR DESCRIPTION
pin back to macos-12. This version is specific to macOS-intel. 13 doesn't work as conda is removed from it.