### PR TITLE
IO: separate pack and set commands

### DIFF
--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -1708,7 +1708,7 @@ def pack_table(dataset):
     """
     data = _pack_table(dataset)
     names = list(data.keys())
-    return backend.set_table_data('', data, names, packup=True)
+    return backend.pack_table_data(data, names)
 
 
 def pack_image(dataset):
@@ -1739,7 +1739,7 @@ def pack_image(dataset):
 
     """
     data, hdr = _pack_image(dataset)
-    return backend.set_image_data('', data, hdr, packup=True)
+    return backend.pack_image_data(data, hdr)
 
 
 def pack_pha(dataset):
@@ -1762,8 +1762,7 @@ def pack_pha(dataset):
     """
     data, hdr = _pack_pha(dataset)
     col_names = list(data.keys())
-    return backend.set_pha_data('', data, col_names, header=hdr,
-                                packup=True)
+    return backend.pack_pha_data(data, col_names, header=hdr)
 
 
 def read_table_blocks(arg, make_copy=False):

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -1584,7 +1584,7 @@ def _pack_rmf(dataset: DataRMF) -> list[tuple[DataType, HdrType]]:
     nchan = dataset.offset + dataset.detchans - 1
     dchan = np.int32 if nchan > 32767 else np.int16
 
-    # Technically e_min/max can be empty, but we not expect
+    # Technically e_min/max can be empty, but we do not expect
     # this, and this support should probably be removed. For
     # now error out if we are sent such data.
     #

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -35,7 +35,8 @@ from sherpa.utils.err import ArgumentTypeErr, IOErr
 from sherpa.utils.numeric_types import SherpaInt, SherpaUInt, \
     SherpaFloat
 
-from .types import HdrType, KeyType
+from .types import ColumnsType, DataType, HdrType, HdrTypeArg, \
+    KeyType, NamesType
 from .xstable import HeaderItem, TableHDU
 
 warning = logging.getLogger(__name__).warning
@@ -53,6 +54,8 @@ except ImportError:
 __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'get_column_data', 'get_ascii_data',
            'get_arf_data', 'get_rmf_data', 'get_pha_data',
+           'pack_table_data', 'pack_image_data', 'pack_pha_data',
+           'pack_arf_data', 'pack_rmf_data', 'pack_hdus',
            'set_table_data', 'set_image_data', 'set_pha_data',
            'set_arf_data', 'set_rmf_data', 'set_hdus')
 
@@ -474,7 +477,13 @@ def _get_crate_by_blockname(dataset: CrateDataset,
 
 # Read Functions #
 
-def read_table_blocks(arg, make_copy=False):
+def read_table_blocks(arg: Union[str, CrateDataset, TABLECrate],
+                      make_copy: bool = False
+                      ) -> tuple[str,
+                                 dict[int, ColumnsType],
+                                 dict[int, HdrType]
+                                 ]:
+    """Read in tabular data with no restrictions on the columns."""
 
     dataset = None
     if isinstance(arg, TABLECrate):
@@ -489,8 +498,8 @@ def read_table_blocks(arg, make_copy=False):
     else:
         raise IOErr('badfile', arg, "CrateDataset obj")
 
-    cols = {}
-    hdr = {}
+    cols: dict[int, ColumnsType] = {}
+    hdr: dict[int, HdrType] = {}
     for idx in range(1, dataset.get_ncrates() + 1):
         crate = dataset.get_crate(idx)
         hdr[idx] = {}
@@ -510,10 +519,11 @@ def read_table_blocks(arg, make_copy=False):
     return filename, cols, hdr
 
 
-def get_header_data(arg, blockname=None, hdrkeys=None):
-    """
-    checked for new crates
-    """
+def get_header_data(arg: Union[str, TABLECrate],
+                    blockname: Optional[str] = None,
+                    hdrkeys: Optional[NamesType] = None
+                    ) -> HdrType:
+    """Read the metadata."""
 
     if isinstance(arg, str):
         arg = get_filename_from_dmsyntax(arg)
@@ -542,16 +552,9 @@ def get_header_data(arg, blockname=None, hdrkeys=None):
     return hdr
 
 
-def get_column_data(*args):
-    """
-    checked for new crates
+def get_column_data(*args) -> list[np.ndarray]:
+    """Extract the column data."""
 
-    get_column_data( *NumPy_args )
-
-    get_column_data( *CrateData_args )
-
-    get_column_data( *NumPy_and_CrateData_args )
-    """
     # args is passed as type list
     if len(args) == 0:
         raise IOErr('noarrays')
@@ -575,13 +578,23 @@ def get_column_data(*args):
     return cols
 
 
-def get_ascii_data(filename, ncols=2, colkeys=None, **kwargs):
+def get_ascii_data(filename: str,
+                   ncols: int = 2,
+                   colkeys: Optional[NamesType] = None,
+                   **kwargs
+                   ) -> tuple[list[str], list[np.ndarray], str]:
     """Read columns from an ASCII file"""
     return get_table_data(filename, ncols, colkeys)[:3]
 
 
-def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
-                   blockname=None, hdrkeys=None):
+def get_table_data(arg: Union[str, TABLECrate],
+                   ncols: int = 1,
+                   colkeys: Optional[NamesType] = None,
+                   make_copy: bool = True,
+                   fix_type: bool = True,
+                   blockname: Optional[str] = None,
+                   hdrkeys: Optional[NamesType] = None
+                   ) -> tuple[list[str], list[np.ndarray], str, HdrType]:
     """Read columns from a file or crate."""
 
     if isinstance(arg, str):
@@ -644,7 +657,10 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
     return colkeys, cols, filename, hdr
 
 
-def get_image_data(arg, make_copy=True, fix_type=True):
+def get_image_data(arg: Union[str, IMAGECrate],
+                   make_copy: bool = True,
+                   fix_type: bool = True
+                   ) -> tuple[DataType, str]:
     """Read image data from a file or crate"""
 
     if isinstance(arg, str):
@@ -662,7 +678,7 @@ def get_image_data(arg, make_copy=True, fix_type=True):
     else:
         raise IOErr('badfile', arg, "IMAGECrate obj")
 
-    data = {}
+    data: DataType = {}
 
     data['y'] = _require_image(img, filename, make_copy=make_copy,
                                fix_type=fix_type)
@@ -709,7 +725,9 @@ def get_image_data(arg, make_copy=True, fix_type=True):
     return data, filename
 
 
-def get_arf_data(arg, make_copy=True):
+def get_arf_data(arg: Union[str, TABLECrate],
+                 make_copy: bool = True
+                 ) -> tuple[DataType, str]:
     """Read an ARF from a file or crate"""
 
     if isinstance(arg, str):
@@ -728,7 +746,7 @@ def get_arf_data(arg, make_copy=True):
     if arf is None or arf.get_colnames() is None:
         raise IOErr('filenotfound', arg)
 
-    data = {}
+    data: DataType = {}
 
     data['energ_lo'] = _require_col(arf, 'ENERG_LO',
                                     make_copy=make_copy,
@@ -804,7 +822,9 @@ def _find_matrix_blocks(filename: str,
     return blnames
 
 
-def get_rmf_data(arg, make_copy=True):
+def get_rmf_data(arg: Union[str, pycrates.RMFCrateDataset],
+                 make_copy: bool = True
+                 ) -> tuple[DataType, str]:
     """Read a RMF from a file or crate"""
 
     if isinstance(arg, str):
@@ -856,7 +876,7 @@ def get_rmf_data(arg, make_copy=True):
     if not rmf.column_exists('N_CHAN'):
         raise IOErr('reqcol', 'N_CHAN', filename)
 
-    data = {}
+    data: DataType = {}
     data['detchans'] = _require_key(rmf, 'DETCHANS', dtype=SherpaInt)
     data['energ_lo'] = _require_col(rmf, 'ENERG_LO',
                                     make_copy=make_copy, fix_type=True)
@@ -931,7 +951,10 @@ def get_rmf_data(arg, make_copy=True):
     return data, filename
 
 
-def get_pha_data(arg, make_copy=True, use_background=False):
+def get_pha_data(arg: Union[str, pycrates.PHACrateDataset],
+                 make_copy: bool = True,
+                 use_background: bool = False
+                 ) -> tuple[list[DataType], str]:
     """Read PHA data from a file or crate"""
 
     if isinstance(arg, str):
@@ -989,7 +1012,7 @@ def get_pha_data(arg, make_copy=True, use_background=False):
     # Here, I instead test for a column, SPEC_NUM, that can
     # *only* be present in Type II. SMD 05/15/13
     if _try_col(pha, 'SPEC_NUM') is None:
-        data = {}
+        data: DataType = {}
 
         # Keywords
         data['exposure'] = _try_key(pha, 'EXPOSURE', SherpaFloat)
@@ -1047,7 +1070,6 @@ def get_pha_data(arg, make_copy=True, use_background=False):
 
     else:
         # Type 2 PHA file support
-        data = {}
         num = pha.get_nrows()
 
         # Keywords
@@ -1132,39 +1154,39 @@ def get_pha_data(arg, make_copy=True, use_background=False):
                       background_down, bin_lo, bin_hi, grouping, quality,
                       orders, parts, specnums, srcids):
 
-            data = {}
+            idata: DataType = {}
 
-            data['exposure'] = exposure
+            idata['exposure'] = exposure
             # data['poisserr'] = poisserr
-            data['backfile'] = backfile
-            data['arffile'] = arffile
-            data['rmffile'] = rmffile
+            idata['backfile'] = backfile
+            idata['arffile'] = arffile
+            idata['rmffile'] = rmffile
 
-            data['backscal'] = bscal
-            data['backscup'] = bscup
-            data['backscdn'] = bscdn
-            data['areascal'] = arsc
+            idata['backscal'] = bscal
+            idata['backscup'] = bscup
+            idata['backscdn'] = bscdn
+            idata['areascal'] = arsc
 
-            data['channel'] = chan
-            data['counts'] = cnt
-            data['staterror'] = staterr
-            data['syserror'] = syserr
-            data['background_up'] = backup
-            data['background_down'] = backdown
-            data['bin_lo'] = binlo
-            data['bin_hi'] = binhi
-            data['grouping'] = grp
-            data['quality'] = qual
-            data['header'] = _get_meta_data(pha)
-            data['header']['TG_M'] = ordr
-            data['header']['TG_PART'] = prt
-            data['header']['SPEC_NUM'] = specnum
-            data['header']['TG_SRCID'] = srcid
+            idata['channel'] = chan
+            idata['counts'] = cnt
+            idata['staterror'] = staterr
+            idata['syserror'] = syserr
+            idata['background_up'] = backup
+            idata['background_down'] = backdown
+            idata['bin_lo'] = binlo
+            idata['bin_hi'] = binhi
+            idata['grouping'] = grp
+            idata['quality'] = qual
+            idata['header'] = _get_meta_data(pha)
+            idata['header']['TG_M'] = ordr
+            idata['header']['TG_PART'] = prt
+            idata['header']['SPEC_NUM'] = specnum
+            idata['header']['TG_SRCID'] = srcid
 
             for key in keys:
-                data['header'].pop(key, None)
+                idata['header'].pop(key, None)
 
-            datasets.append(data)
+            datasets.append(idata)
 
     return datasets, filename
 
@@ -1173,20 +1195,15 @@ def get_pha_data(arg, make_copy=True, use_background=False):
 # Write/Pack Functions #
 #
 
-def check_clobber(filename: str, clobber: bool) -> None:
-    """Error out if the file exists and clobber is not set."""
-
-    if clobber or not os.path.isfile(filename):
-        return
-
-    raise IOErr("filefound", filename)
-
-
 def write_dataset(dataset: Union[TABLECrate, IMAGECrate, CrateDataset],
                   filename: str,
                   *,
-                  ascii: bool) -> None:
+                  ascii: bool,
+                  clobber: bool) -> None:
     """Write out the data."""
+
+    if not clobber and os.path.isfile(filename):
+        raise IOErr("filefound", filename)
 
     if ascii and '[' not in filename and ']' not in filename:
         filename += "[opt kernel=text/simple]"
@@ -1207,11 +1224,8 @@ def write_dataset(dataset: Union[TABLECrate, IMAGECrate, CrateDataset],
     dataset.write(filename, clobber=True)
 
 
-def set_image_data(filename, data, header, ascii=False, clobber=False,
-                   packup=False) -> Optional[IMAGECrate]:
-
-    if not packup:
-        check_clobber(filename, clobber)
+def pack_image_data(data, header) -> IMAGECrate:
+    """Pack up the image data."""
 
     img = IMAGECrate()
 
@@ -1264,23 +1278,21 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
     pix_col = pycrates.CrateData()
     pix_col.values = data['pixels']
     img.add_image(pix_col)
+    return img
 
-    if packup:
-        return img
+
+def set_image_data(filename, data, header, ascii=False, clobber=False) -> None:
+    """Write out the image data."""
 
     if ascii and '[' not in filename and ']' not in filename:
-        # filename += "[opt kernel=text/simple]"
         raise IOErr('writenoimg')
 
-    img.write(filename, clobber=True)
-    return None
+    img = pack_image_data(data, header)
+    write_dataset(img, filename, ascii=ascii, clobber=clobber)
 
 
-def set_table_data(filename, data, col_names, header=None,
-                   ascii=False, clobber=False, packup=False) -> Optional[TABLECrate]:
-
-    if not packup:
-        check_clobber(filename, clobber)
+def pack_table_data(data, col_names, header=None) -> TABLECrate:
+    """Pack up the table data."""
 
     tbl = TABLECrate()
     hdr = {} if header is None else header
@@ -1288,36 +1300,39 @@ def set_table_data(filename, data, col_names, header=None,
         _set_column(tbl, name, data[name])
 
     _update_header(tbl, hdr, skip_if_known=False)
+    return tbl
 
-    if packup:
-        return tbl
 
-    write_dataset(tbl, filename, ascii=ascii)
-    return None
+def set_table_data(filename, data, col_names, header=None,
+                   ascii=False, clobber=False) -> None:
+    """Write out the table data."""
+
+    tbl = pack_table_data(data, col_names, header=header)
+    write_dataset(tbl, filename, ascii=ascii, clobber=clobber)
+
+
+def pack_arf_data(data, col_names, header=None) -> TABLECrate:
+    """Pack the ARF"""
+
+    if header is None:
+        raise ArgumentTypeErr("badarg", "header", "set")
+
+    return pack_table_data(data, col_names, header)
 
 
 def set_arf_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False, packup=False) -> Optional[TABLECrate]:
-    """Create an ARF"""
+                 ascii=False, clobber=False) -> None:
+    """Write out the ARF"""
+
+    arf = pack_arf_data(data, col_names, header)
+    write_dataset(arf, filename, ascii=ascii, clobber=clobber)
+
+
+def pack_pha_data(data, col_names, header=None) -> pycrates.PHACrateDataset:
+    """Pack the PHA data."""
 
     if header is None:
         raise ArgumentTypeErr("badarg", "header", "set")
-
-    # Currently we can use the same logic as set_table_data
-    return set_table_data(filename, data, col_names, header=header,
-                          ascii=ascii, clobber=clobber, packup=packup)
-
-
-def set_pha_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False, packup=False
-                 ) -> Optional[pycrates.PHACrateDataset]:
-    """Create a PHA dataset/file"""
-
-    if header is None:
-        raise ArgumentTypeErr("badarg", "header", "set")
-
-    if not packup:
-        check_clobber(filename, clobber)
 
     phadataset = pycrates.PHACrateDataset()
 
@@ -1336,16 +1351,19 @@ def set_pha_data(filename, data, col_names, header=None,
         _set_column(pha, name, data[name])
 
     phadataset.add_crate(pha)
+    return phadataset
 
-    if packup:
-        return phadataset
 
-    write_dataset(phadataset, filename, ascii=ascii)
-    return None
+def set_pha_data(filename, data, col_names, header=None,
+                 ascii=False, clobber=False) -> None:
+    """Create a PHA dataset/file"""
+
+    pha = pack_pha_data(data, col_names, header)
+    write_dataset(pha, filename, ascii=ascii, clobber=clobber)
 
 
 def _update_header(cr: CrateType,
-                   header: dict[str, Optional[KeyType]],
+                   header: HdrTypeArg,
                    skip_if_known: bool = True) -> None:
     """Update the header of the crate."""
 
@@ -1353,6 +1371,7 @@ def _update_header(cr: CrateType,
         if skip_if_known and cr.key_exists(key):
             continue
 
+        # value should not be None, but just in case
         if value is None:
             continue
 
@@ -1361,17 +1380,8 @@ def _update_header(cr: CrateType,
         _set_key(cr, key, value)
 
 
-def set_rmf_data(filename, blocks, clobber=False):
-    """Save the RMF data to disk.
-
-    Unlike the other save_*_data calls this does not support the ascii
-    or packup arguments. It also relies on the caller to have set up
-    the headers and columns correctly apart for variable-length fields,
-    which are limited to F_CHAN, N_CHAN, and MATRIX.
-
-    """
-
-    check_clobber(filename, clobber)
+def pack_rmf_data(blocks) -> pycrates.RMFCrateDataset:
+    """Pack up the RMF data."""
 
     # For now assume only two blocks:
     #    MATRIX
@@ -1437,15 +1447,37 @@ def set_rmf_data(filename, blocks, clobber=False):
     _update_header(matrix_cr, matrix_header)
     _update_header(ebounds_cr, ebounds_header)
 
-    ds.write(filename, clobber=True)
+    return ds
 
 
-def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
+def set_rmf_data(filename: str,
+                 blocks,
+                 clobber: bool = False) -> None:
+    """Save the RMF data to disk.
+
+    Unlike the other save_*_data calls this does not support the ascii
+    argument. It also relies on the caller to have set up the headers
+    and columns correctly apart for variable-length fields, which are
+    limited to F_CHAN, N_CHAN, and MATRIX.
+
+    """
+
+    rmf = pack_rmf_data(blocks)
+    write_dataset(rmf, filename, ascii=False, clobber=clobber)
+
+
+def set_arrays(filename: str,
+               args: Sequence[np.ndarray],
+               fields: Optional[NamesType] = None,
+               ascii: bool = True,
+               clobber: bool = False) -> None:
+    """Write out the columns."""
 
     # Historically the clobber command has been checked before
     # processing the data, so do so here.
     #
-    check_clobber(filename, clobber)
+    if not clobber and os.path.isfile(filename):
+        raise IOErr("filefound", filename)
 
     # Check args is a sequence of sequences (although not a complete
     # check).
@@ -1468,7 +1500,7 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
     if fields is None:
         fieldnames = [f'col{idx + 1}' for idx in range(nargs)]
     elif nargs == len(fields):
-        fieldnames = fields
+        fieldnames = list(fields)
     else:
         raise IOErr('wrongnumcols', nargs, len(fields))
 
@@ -1476,7 +1508,7 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
     for val, name in zip(args, fieldnames):
         _set_column(tbl, name, val)
 
-    write_dataset(tbl, filename, ascii=ascii)
+    write_dataset(tbl, filename, ascii=ascii, clobber=clobber)
 
 
 def _add_header(cr: CrateType,
@@ -1569,20 +1601,29 @@ def _validate_block_names(hdulist: Sequence[TableHDU]) -> list[TableHDU]:
     return out
 
 
-def set_hdus(filename: str,
-             hdulist: Sequence[TableHDU],
-             clobber: bool = False) -> None:
-    """Write out multiple HDUS to a single file.
+def pack_hdus(blocks: Sequence[TableHDU]) -> CrateDataset:
+    """Create a dataset.
 
     At present we are restricted to tables only.
     """
 
-    check_clobber(filename, clobber)
-    nlist = _validate_block_names(hdulist)
+    nblocks = _validate_block_names(blocks)
 
-    ds = CrateDataset()
-    ds.add_crate(_create_primary_crate(nlist[0]))
-    for hdu in nlist[1:]:
-        ds.add_crate(_create_table_crate(hdu))
+    dset = CrateDataset()
+    dset.add_crate(_create_primary_crate(nblocks[0]))
+    for hdu in nblocks[1:]:
+        dset.add_crate(_create_table_crate(hdu))
 
-    ds.write(filename, clobber=True)
+    return dset
+
+
+def set_hdus(filename: str,
+             blocks: Sequence[TableHDU],
+             clobber: bool = False) -> None:
+    """Write out a dataset.
+
+    At present we are restricted to tables only.
+    """
+
+    dset = pack_hdus(blocks)
+    write_dataset(dset, filename, ascii=False, clobber=clobber)

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -35,8 +35,8 @@ from sherpa.utils.err import ArgumentTypeErr, IOErr
 from sherpa.utils.numeric_types import SherpaInt, SherpaUInt, \
     SherpaFloat
 
-from .types import ColumnsType, DataType, HdrType, HdrTypeArg, \
-    KeyType, NamesType
+from .types import ColumnsType, DataType, DataTypeArg, \
+    HdrType, HdrTypeArg, KeyType, NamesType
 from .xstable import HeaderItem, TableHDU
 
 warning = logging.getLogger(__name__).warning
@@ -1224,7 +1224,8 @@ def write_dataset(dataset: Union[TABLECrate, IMAGECrate, CrateDataset],
     dataset.write(filename, clobber=True)
 
 
-def pack_image_data(data, header) -> IMAGECrate:
+def pack_image_data(data: DataTypeArg,
+                    header: HdrTypeArg) -> IMAGECrate:
     """Pack up the image data."""
 
     img = IMAGECrate()
@@ -1281,7 +1282,11 @@ def pack_image_data(data, header) -> IMAGECrate:
     return img
 
 
-def set_image_data(filename, data, header, ascii=False, clobber=False) -> None:
+def set_image_data(filename: str,
+                   data: DataTypeArg,
+                   header: HdrTypeArg,
+                   ascii: bool = False,
+                   clobber: bool = False) -> None:
     """Write out the image data."""
 
     if ascii and '[' not in filename and ']' not in filename:
@@ -1291,7 +1296,9 @@ def set_image_data(filename, data, header, ascii=False, clobber=False) -> None:
     write_dataset(img, filename, ascii=ascii, clobber=clobber)
 
 
-def pack_table_data(data, col_names, header=None) -> TABLECrate:
+def pack_table_data(data: ColumnsType,
+                    col_names: NamesType,
+                    header: Optional[HdrTypeArg] = None) -> TABLECrate:
     """Pack up the table data."""
 
     tbl = TABLECrate()
@@ -1303,15 +1310,21 @@ def pack_table_data(data, col_names, header=None) -> TABLECrate:
     return tbl
 
 
-def set_table_data(filename, data, col_names, header=None,
-                   ascii=False, clobber=False) -> None:
+def set_table_data(filename: str,
+                   data: ColumnsType,
+                   col_names: NamesType,
+                   header: Optional[HdrTypeArg] = None,
+                   ascii: bool = False,
+                   clobber: bool = False) -> None:
     """Write out the table data."""
 
     tbl = pack_table_data(data, col_names, header=header)
     write_dataset(tbl, filename, ascii=ascii, clobber=clobber)
 
 
-def pack_arf_data(data, col_names, header=None) -> TABLECrate:
+def pack_arf_data(data: ColumnsType,
+                  col_names: NamesType,
+                  header: Optional[HdrTypeArg] = None) -> TABLECrate:
     """Pack the ARF"""
 
     if header is None:
@@ -1320,15 +1333,22 @@ def pack_arf_data(data, col_names, header=None) -> TABLECrate:
     return pack_table_data(data, col_names, header)
 
 
-def set_arf_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False) -> None:
+def set_arf_data(filename: str,
+                 data: ColumnsType,
+                 col_names: NamesType,
+                 header: Optional[HdrTypeArg] = None,
+                 ascii: bool = False,
+                 clobber: bool = False) -> None:
     """Write out the ARF"""
 
     arf = pack_arf_data(data, col_names, header)
     write_dataset(arf, filename, ascii=ascii, clobber=clobber)
 
 
-def pack_pha_data(data, col_names, header=None) -> pycrates.PHACrateDataset:
+def pack_pha_data(data: ColumnsType,
+                  col_names: NamesType,
+                  header: Optional[HdrTypeArg] = None
+                  ) -> pycrates.PHACrateDataset:
     """Pack the PHA data."""
 
     if header is None:
@@ -1354,8 +1374,12 @@ def pack_pha_data(data, col_names, header=None) -> pycrates.PHACrateDataset:
     return phadataset
 
 
-def set_pha_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False) -> None:
+def set_pha_data(filename: str,
+                 data: ColumnsType,
+                 col_names: NamesType,
+                 header: Optional[HdrTypeArg] = None,
+                 ascii: bool = False,
+                 clobber: bool = False) -> None:
     """Create a PHA dataset/file"""
 
     pha = pack_pha_data(data, col_names, header)

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -35,6 +35,7 @@ from sherpa.utils.err import ArgumentTypeErr, IOErr
 from sherpa.utils.numeric_types import SherpaInt, SherpaUInt, \
     SherpaFloat
 
+from .types import HdrType, KeyType
 from .xstable import HeaderItem, TableHDU
 
 warning = logging.getLogger(__name__).warning
@@ -57,7 +58,6 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
 
 
 CrateType = Union[TABLECrate, IMAGECrate]
-KeyType = Union[bool, int, str, float]
 
 
 def open_crate(filename: str,
@@ -199,7 +199,7 @@ def _try_key(crate: CrateType,
     return dtype(value)
 
 
-def _get_meta_data(crate: CrateType) -> dict[str, KeyType]:
+def _get_meta_data(crate: CrateType) -> HdrType:
     """Retrieve the header information from the crate.
 
     This loses the "specialized" keywords like HISTORY and COMMENT.

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -83,7 +83,11 @@ def open_crate(filename: str,
     when crates can not read a file because of an unknown datatype.
 
     """
-    dataset = CrateDataset(filename, mode=mode)
+    try:
+        dataset = CrateDataset(filename, mode=mode)
+    except OSError as oe:
+        raise IOErr('openfailed', f"unable to open {filename}: {oe}") from oe
+
     current = dataset.get_current_crate()
     try:
         return dataset.get_crate(current)
@@ -494,7 +498,11 @@ def read_table_blocks(arg: Union[str, CrateDataset, TABLECrate],
         dataset = arg
     elif isinstance(arg, str):
         filename = arg
-        dataset = CrateDataset(arg)
+        try:
+            dataset = CrateDataset(arg)
+        except OSError as oe:
+            raise IOErr('openfailed', f"unable to open {arg}: {oe}") from oe
+
     else:
         raise IOErr('badfile', arg, "CrateDataset obj")
 
@@ -828,7 +836,11 @@ def get_rmf_data(arg: Union[str, pycrates.RMFCrateDataset],
     """Read a RMF from a file or crate"""
 
     if isinstance(arg, str):
-        rmfdataset = pycrates.RMFCrateDataset(arg, mode="r")
+        try:
+            rmfdataset = pycrates.RMFCrateDataset(arg, mode="r")
+        except OSError as oe:
+            raise IOErr('openfailed', f"unable to open {arg}: {oe}") from oe
+
         if pycrates.is_rmf(rmfdataset) != 1:
             raise IOErr('badfile', arg, "RMFCrateDataset obj")
 
@@ -958,7 +970,11 @@ def get_pha_data(arg: Union[str, pycrates.PHACrateDataset],
     """Read PHA data from a file or crate"""
 
     if isinstance(arg, str):
-        phadataset = pycrates.PHACrateDataset(arg, mode="r")
+        try:
+            phadataset = pycrates.PHACrateDataset(arg, mode="r")
+        except OSError as oe:
+            raise IOErr('openfailed', f"unable to open {arg}: {oe}") from oe
+
         if pycrates.is_pha(phadataset) != 1:
             raise IOErr('badfile', arg, "PHACrateDataset obj")
 

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -19,15 +19,16 @@
 #
 '''A dummy backend for I/O.
 
-This backend provides no functionality and raises an error if any of its
-functions are used. It is provided as a model for what is needed in a
-backend, even if it does nothing, and to allow `sherpa.astro.io` to be
-imported even if no usable backend is available.
+This backend provides no functionality and raises an error if any of
+its functions are used. It is provided as a model for what routines
+are needed in a backend, even if it does nothing, and to allow
+`sherpa.astro.io` to be imported even if no usable backend is
+available.
 
 '''
 
 import logging
-from typing import Optional, Sequence
+from typing import Any, Optional, Sequence
 
 import numpy as np
 
@@ -37,8 +38,12 @@ from .types import NamesType, HdrTypeArg, HdrType, \
 from .xstable import TableHDU
 
 __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
-           'get_column_data', 'get_ascii_data',
-           'get_arf_data', 'get_rmf_data', 'get_pha_data',
+           'get_column_data', 'get_ascii_data', 'get_arf_data',
+           'get_rmf_data', 'get_pha_data',
+           #
+           'pack_table_data', 'pack_image_data', 'pack_pha_data',
+           'pack_arf_data', 'pack_rmf_data', 'pack_hdus',
+           #
            'set_table_data', 'set_image_data', 'set_pha_data',
            'set_arf_data', 'set_rmf_data', 'set_hdus')
 
@@ -381,18 +386,159 @@ def get_pha_data(arg,
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-# Note that we do not describe the packup arguments as the plan is to
-# remove them. This will then make the return value easier to type (as
-# it will be None rather than Optional[Any]).
-#
+def pack_table_data(data: ColumnsTypeArg,
+                    col_names: NamesType,
+                    header: Optional[HdrTypeArg] = None) -> Any:
+    """Create the tabular data.
+
+    .. versionadded:: 4.17.0
+
+    Parameters
+    ----------
+    data : dict
+        The table data, where the key is the column name and the value
+        the data.
+    col_names : sequence of str
+        The column names from data to use (this also sets the order).
+    header : dict or None, optional
+        Any header information to include.
+
+    Returns
+    -------
+    table
+        A data structure used by the backend to represent tabular data.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def pack_image_data(data: DataTypeArg,
+                    header: HdrTypeArg) -> Any:
+    """Create the image data.
+
+    .. versionadded:: 4.17.0
+
+    Parameters
+    ----------
+    data : dict
+        The image data, where the keys are arguments used to create a
+        sherpa.astro.data.DataIMG object.
+    header : dict
+        The header information to include.
+
+    Returns
+    -------
+    image
+        A data structure used by the backend to represent image data.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def pack_pha_data(data: ColumnsTypeArg,
+                  col_names: NamesType,
+                  header: Optional[HdrTypeArg] = None) -> Any:
+    """Create the PHA.
+
+    .. versionadded:: 4.17.0
+
+    Parameters
+    ----------
+    data : dict
+        The table data, where the key is the column name and the value
+        the data.
+    col_names : sequence of str
+        The column names from data to use (this also sets the order).
+    header : dict or None, optional
+        Any header information to include.
+
+    Returns
+    -------
+    pha
+        A data structure used by the backend to represent PHA data.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def pack_arf_data(data: ColumnsTypeArg,
+                  col_names: NamesType,
+                  header: Optional[HdrTypeArg] = None) -> Any:
+    """Create the ARF.
+
+    .. versionadded:: 4.17.0
+
+    Parameters
+    ----------
+    data : dict
+        The table data, where the key is the column name and the value
+        the data.
+    col_names : sequence of str
+        The column names from data to use (this also sets the order).
+    header : dict or None, optional
+        Any header information to include.
+
+    Returns
+    -------
+    arf
+        A data structure used by the backend to represent ARF data.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def pack_rmf_data(blocks) -> Any:
+    """Create the RMF.
+
+    .. versionadded:: 4.17.0
+
+    Parameters
+    ----------
+    blocks : sequence of pairs
+        The RMF data, stored as pairs of (data, header), where data is
+        a dictionary of column name (keys) and values, and header is a
+        dictionary of key and values. The first element is the MATRIX
+        block and the second is for the EBOUNDS block.
+
+    Returns
+    -------
+    rmf
+        A data structure used by the backend to represent RMF data.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def pack_hdus(blocks: Sequence[TableHDU]) -> Any:
+    """Create a dataset.
+
+    .. versionadded:: 4.17.0
+
+    Parameters
+    ----------
+    blocks : sequence of TableHDU
+        The blocks (HDUs) to store.
+
+    Returns
+    -------
+    hdus
+        A data structure used by the backend to represent the data.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
 def set_table_data(filename: str,
                    data: ColumnsTypeArg,
                    col_names: NamesType,
                    header: Optional[HdrTypeArg] = None,
                    ascii: bool = False,
-                   clobber: bool = False,
-                   packup: bool = False):
+                   clobber: bool = False) -> None:
     """Write out the tabular data.
+
+    .. versionchanged:: 4.17.0
+       The packup argument has been removed as `pack_table_data`
+       should be used instead.
 
     Parameters
     ----------
@@ -421,9 +567,12 @@ def set_image_data(filename: str,
                    data: DataTypeArg,
                    header: HdrTypeArg,
                    ascii: bool = False,
-                   clobber: bool = False,
-                   packup: bool = False):
+                   clobber: bool = False) -> None:
     """Write out the image data.
+
+    .. versionchanged:: 4.17.0
+       The packup argument has been removed as `pack_image_data`
+       should be used instead.
 
     Parameters
     ----------
@@ -451,9 +600,12 @@ def set_pha_data(filename: str,
                  col_names: NamesType,
                  header: Optional[HdrTypeArg] = None,
                  ascii: bool = False,
-                 clobber: bool = False,
-                 packup: bool = False):
+                 clobber: bool = False) -> None:
     """Write out the PHA.
+
+    .. versionchanged:: 4.17.0
+       The packup argument has been removed as `pack_pha_data`
+       should be used instead.
 
     Parameters
     ----------
@@ -483,9 +635,12 @@ def set_arf_data(filename: str,
                  col_names: NamesType,
                  header: Optional[HdrTypeArg] = None,
                  ascii: bool = False,
-                 clobber: bool = False,
-                 packup: bool = False):
+                 clobber: bool = False) -> None:
     """Write out the ARF.
+
+    .. versionchanged:: 4.17.0
+       The packup argument has been removed as `pack_arf_data`
+       should be used instead.
 
     Parameters
     ----------
@@ -514,6 +669,10 @@ def set_rmf_data(filename: str,
                  blocks,
                  clobber: bool = False) -> None:
     """Write out the RMF.
+
+    .. versionchanged:: 4.17.0
+       The packup argument has been removed as `pack_rmf_data`
+       should be used instead.
 
     Parameters
     ----------

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2022, 2023
+#  Copyright (C) 2021 - 2024
 #  MIT
 #
 #
@@ -20,10 +20,21 @@
 '''A dummy backend for I/O.
 
 This backend provides no functionality and raises an error if any of its
-functions are used. It is just here to ensure that `sherpa.astro.io` can be
-imported, even if no FITS reader is installed.
+functions are used. It is provided as a model for what is needed in a
+backend, even if it does nothing, and to allow `sherpa.astro.io` to be
+imported even if no usable backend is available.
+
 '''
+
 import logging
+from typing import Optional, Sequence
+
+import numpy as np
+
+from ..data import Data1D
+from .types import NamesType, HdrTypeArg, HdrType, \
+    ColumnsType, DataTypeArg, DataType
+from .xstable import TableHDU
 
 __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'get_column_data', 'get_ascii_data',
@@ -32,29 +43,583 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'set_arf_data', 'set_rmf_data', 'set_hdus')
 
 
-lgr = logging.getLogger(__name__)
-
-warning = lgr.warning
+warning = logging.getLogger(__name__).warning
 warning("""Cannot import usable I/O backend.
     If you are using CIAO, this is most likely an error and you should contact the CIAO helpdesk.
     If you are using Standalone Sherpa, please install astropy.""")
 
 
-def get_table_data(*args, **kwargs):
-    """A do-nothing operation"""
+def get_table_data(arg,
+                   ncols: int = 1,
+                   colkeys: Optional[NamesType] = None,
+                   make_copy: bool = True,
+                   fix_type: bool = True,
+                   blockname: Optional[str] = None,
+                   hdrkeys: Optional[NamesType] = None
+                   ) -> tuple[list[str], list[np.ndarray], str, HdrType]:
+    """Read columns from a file or object.
+
+    The columns to select depend on the ncols and colkeys arguments,
+    as well as the backend.
+
+    Parameters
+    ----------
+    arg
+        The data to read the columns from. This depends on the
+        backend but is expected to be a file name or a tabular
+        data structure supported by the backend.
+    ncols: int, optional
+        The number of columns to read in when colkeys is not
+        set (the first ncols columns are chosen).
+    colkeys: sequence of str or None, optional
+        If given, what columns from the table should be selected,
+        otherwise the backend selects. The default is `None`.
+        Names are compared using a case insensitive match.
+    make_copy: bool, optional
+        If set then the returned NumPy arrays are explictly copied,
+        rather than using a reference from the data structure
+        created by the backend. Backends are not required to
+        honor this setting. The default is `True`.
+    fix_type: bool, optional
+        Should the returned arrays be converted to the
+        `sherpa.utils.numeric_types.SherpaFloat` type. The default
+        is `True`.
+    blockname: str or None, optional
+        The name of the "block" (HDU) to read the column data (useful
+        for data structures containing multiple blocks/HDUs) or None.
+        Names are compared using a case insensitive match.
+    hdrkeys: sequence of str or None, optional
+        If set, the table structure must contain these keys, and the
+        values are returned.  Names are compared using a case
+        insensitive match.
+
+    Returns
+    -------
+    names, data, filename, hdr
+        The column names, as a list of strings, and the data as
+        a list of NumPy arrays (matching the order and length of
+        the names array). The filename is the name of the file (a
+        string) and hdr is a dictionary with the requested keywords
+        (when hdrkeys is `None` this dictionary will be empty).
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        The arg argument is invalid, or a required column or keyword
+        is missing.
+
+    """
     raise NotImplementedError('No usable I/O backend was imported.')
 
 
-get_header_data = get_table_data
-get_image_data = get_table_data
-get_column_data = get_table_data
-get_ascii_data = get_table_data
-get_arf_data = get_table_data
-get_rmf_data = get_table_data
-get_pha_data = get_table_data
-set_table_data = get_table_data
-set_image_data = get_table_data
-set_pha_data = get_table_data
-set_arf_data = get_table_data
-set_rmf_data = get_table_data
-set_hdus = get_table_data
+def get_header_data(arg,
+                    blockname: Optional[str] = None,
+                    hdrkeys: Optional[NamesType] = None
+                    ) -> HdrType:
+    """Read the metadata.
+
+    Parameters
+    ----------
+    arg
+        The data to read the header values from. This depends on the
+        backend but is expected to be a file name or a data structure
+        supported by the backend.
+    blockname: str or None, optional
+        The name of the "block" (HDU) to read the data (useful
+        for data structures containing multiple blocks/HDUs) or None.
+        Names are compared using a case insensitive match.
+    hdrkeys: sequence of str or None, optional
+        If set, the table structure must contain these keys, and the
+        values are returned. Names are compared using a case
+        insensitive match.
+
+    Returns
+    -------
+    hdr: dict
+        A dictionary with the keyword data (only the name and values
+        are returned, any sort of metadata, such as comments or units,
+        are not returned).
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        The arg argument is invalid or a keyword is missing.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def get_image_data(arg,
+                   make_copy: bool = True,
+                   fix_type: bool = True
+                   ) -> tuple[DataType, str]:
+    """Read image data.
+
+    Parameters
+    ----------
+    arg
+        The data to read the header values from. This depends on the
+        backend but is expected to be a file name or a data structure
+        supported by the backend.
+    make_copy: bool, optional
+        If set then the returned NumPy arrays are explictly copied,
+        rather than using a reference from the data structure
+        created by the backend. Backends are not required to
+        honor this setting. The default is `True`.
+    fix_type: bool, optional
+        Should the returned arrays be converted to the
+        `sherpa.utils.numeric_types.SherpaFloat` type. The default
+        is `True`.
+
+    Returns
+    -------
+    data, filename
+        The data, as a dictionary, and the filename. The keys of the
+        dictionary match the arguments when creating a
+        sherpa.astro.data.DataIMG object.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        The arg argument is invalid or not an image.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def get_column_data(*args) -> list[np.ndarray]:
+    """Extract the column data.
+
+    Parameters
+    ----------
+    *args
+        Extract column information from each argument. It can be an
+        ndarray, list, or tuple, or a data structure from the backend,
+        with each argument representing a column. 2D arguments are
+        separated by column.
+
+    Returns
+    -------
+    data: list of ndarray
+        The column data.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        There are no arguments or an argument is not supported.
+
+    Notes
+    -----
+
+    An argument can be None, which is just passed back to the caller.
+    This means the typing rules for the function are not quite
+    correct.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+# Follow sherpa.io.get_ascii_data API except that ncols defaults to 2.
+#
+def get_ascii_data(filename: str,
+                   ncols: int = 2,
+                   colkeys: Optional[NamesType] = None,
+                   sep: str = ' ',
+                   dstype: type = Data1D,
+                   comment: str = '#',
+                   require_floats: bool = True
+                   ) -> tuple[list[str], list[np.ndarray], str]:
+    """Read columns from an ASCII file.
+
+    The `sep`, `dstype`, `comment`, and `require_floats` arguments
+    may be ignored by the backend.
+
+    Parameters
+    ----------
+    filename : str
+       The name of the ASCII file to read in.
+    ncols : int, optional
+       The number of columns to read in (the first ``ncols`` columns
+       in the file). This is ignored if ``colkeys`` is given.
+    colkeys : array of str, optional
+       An array of the column name to read in. The default is
+       `None`.
+    sep : str, optional
+       The separator character. The default is ``' '``.
+    dstype : data class to use, optional
+       Used to check that the data file contains enough columns.
+    comment : str, optional
+       The comment character. The default is ``'#'``.
+    require_floats : bool, optional
+       If `True` (the default), non-numeric data values will
+       raise a `ValueError`.
+
+    Returns
+    -------
+    colnames, coldata, filename
+       The column names read in, the data for the columns
+       as an array, with each element being the data for the column
+       (the order matches ``colnames``), and the name of the file.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+       Raised if a requested column is missing or the file appears
+       to be a binary file.
+    ValueError
+       If a column value can not be converted into a numeric value
+       and the `require_floats` parameter is `True`.
+
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def get_arf_data(arg,
+                 make_copy: bool = False
+                 ) -> tuple[DataType, str]:
+    """Read in the ARF.
+
+    Parameters
+    ----------
+    arg
+        The data to read the ARF from. This depends on the backend but
+        is expected to be a file name or a data structure supported by
+        the backend.
+    make_copy: bool, optional
+        If set then the returned NumPy arrays are explictly copied,
+        rather than using a reference from the data structure
+        created by the backend. Backends are not required to
+        honor this setting.
+
+    Returns
+    -------
+    data, filename
+        The data, as a dictionary, and the filename. The keys of the
+        dictionary match the arguments when creating a
+        sherpa.astro.data.DataARF object.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        The arg argument is invalid or not an ARF.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def get_rmf_data(arg,
+                 make_copy: bool = False
+                 ) -> tuple[DataType, str]:
+    """Read in the RMF.
+
+    Parameters
+    ----------
+    arg
+        The data to read the RMF from. This depends on the backend but
+        is expected to be a file name or a data structure supported by
+        the backend.
+    make_copy: bool, optional
+        If set then the returned NumPy arrays are explictly copied,
+        rather than using a reference from the data structure
+        created by the backend. Backends are not required to
+        honor this setting.
+
+    Returns
+    -------
+    data, filename
+        The data, as a dictionary, and the filename. The keys of the
+        dictionary match the arguments when creating a
+        sherpa.astro.data.DataRMF object.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        The arg argument is invalid or not a RMF.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def get_pha_data(arg,
+                 make_copy: bool = False,
+                 use_background: bool = False
+                 ) -> tuple[list[DataType], str]:
+    """Read in the PHA.
+
+    Parameters
+    ----------
+    arg
+        The data to read the PHA from. This depends on the backend but
+        is expected to be a file name or a data structure supported by
+        the backend.
+    make_copy: bool, optional
+        If set then the returned NumPy arrays are explictly copied,
+        rather than using a reference from the data structure
+        created by the backend. Backends are not required to
+        honor this setting.
+    use_background: bool, optional
+        Should the data be read in as a background file (only relevant
+        for files that contain the background data in a separate block
+        of the same file, such as Chandra Level 3 PHA files, as used
+        by the Chandra Source Catalog). The default is `False`.
+
+    Returns
+    -------
+    datas, filename
+        A list of dictionaries, containing the PHA data (since there
+        can be multiple datasets with a PHA-II file) and the filename.
+        The keys of the dictionary match the arguments when creating
+        a sherpa.astro.data.DataPHA object.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        The arg argument is invalid or not a PHA.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+# Note that we do not describe the packup arguments as the plan is to
+# remove them. This will then make the return value easier to type (as
+# it will be None rather than Optional[Any]).
+#
+def set_table_data(filename: str,
+                   data: ColumnsType,
+                   col_names: NamesType,
+                   header: Optional[HdrTypeArg] = None,
+                   ascii: bool = False,
+                   clobber: bool = False,
+                   packup: bool = False):
+    """Write out the tabular data.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to create.
+    data : dict
+        The table data, where the key is the column name and the value
+        the data.
+    col_names : sequence of str
+        The column names from data to use (this also sets the order).
+    header : dict or None, optional
+        Any header information to include.
+    ascii : bool, optional
+        Is the file to be written out as a text file (`True`) or a
+        binary file? The default is `False`.
+    clobber : bool, optional
+        If the file already exists can it be over-written (`True`) or
+        will a sherpa.utils.err.IOErr error be raised? The default is
+        `False`.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_image_data(filename: str,
+                   data: DataTypeArg,
+                   header: HdrTypeArg,
+                   ascii: bool = False,
+                   clobber: bool = False,
+                   packup: bool = False):
+    """Write out the image data.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to create.
+    data : dict
+        The image data, where the keys are arguments used to create a
+        sherpa.astro.data.DataIMG object.
+    header : dict
+        The header information to include.
+    ascii : bool, optional
+        Is the file to be written out as a text file (`True`) or a
+        binary file? The default is `False`.
+    clobber : bool, optional
+        If the file already exists can it be over-written (`True`) or
+        will a sherpa.utils.err.IOErr error be raised? The default is
+        `False`.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_pha_data(filename: str,
+                 data: ColumnsType,
+                 col_names: NamesType,
+                 header: Optional[HdrTypeArg] = None,
+                 ascii: bool = False,
+                 clobber: bool = False,
+                 packup: bool = False):
+    """Write out the PHA.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to create.
+    data : dict
+        The table data, where the key is the column name and the value
+        the data.
+    col_names : sequence of str
+        The column names from data to use (this also sets the order).
+    header : dict or None, optional
+        Any header information to include.
+    ascii : bool, optional
+        Is the file to be written out as a text file (`True`) or a
+        binary file? The default is `False`.
+    clobber : bool, optional
+        If the file already exists can it be over-written (`True`) or
+        will a sherpa.utils.err.IOErr error be raised? The default is
+        `False`.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_arf_data(filename: str,
+                 data: ColumnsType,
+                 col_names: NamesType,
+                 header: Optional[HdrTypeArg] = None,
+                 ascii: bool = False,
+                 clobber: bool = False,
+                 packup: bool = False):
+    """Write out the ARF.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to create.
+    data : dict
+        The table data, where the key is the column name and the value
+        the data.
+    col_names : sequence of str
+        The column names from data to use (this also sets the order).
+    header : dict or None, optional
+        Any header information to include.
+    ascii : bool, optional
+        Is the file to be written out as a text file (`True`) or a
+        binary file? The default is `False`.
+    clobber : bool, optional
+        If the file already exists can it be over-written (`True`) or
+        will a sherpa.utils.err.IOErr error be raised? The default is
+        `False`.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_rmf_data(filename: str,
+                 blocks,
+                 clobber: bool = False) -> None:
+    """Write out the RMF.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to create.
+    blocks : sequence of pairs
+        The RMF data, stored as pairs of (data, header), where data is
+        a dictionary of column name (keys) and values, and header is a
+        dictionary of key and values. The first element is the MATRIX
+        block and the second is for the EBOUNDS block.
+    clobber : bool, optional
+        If the file already exists can it be over-written (`True`) or
+        will a sherpa.utils.err.IOErr error be raised? The default is
+        `False`.
+
+    Notes
+    -----
+    There is currently no support for writing out a RMF as an ASCII
+    file.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_hdus(filename: str,
+             blocks: Sequence[TableHDU],
+             clobber: bool = False) -> None:
+    """Write out (possibly multiple) blocks.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to create.
+    blocks : sequence of TableHDU
+        The blocks (HDUs) to store.
+    clobber : bool, optional
+        If the file already exists can it be over-written (`True`) or
+        will a sherpa.utils.err.IOErr error be raised? The default is
+        `False`.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def read_table_blocks(arg,
+                      make_copy: bool = False
+                      ) -> tuple[str,
+                                 dict[int, dict[str, np.ndarray]],
+                                 dict[int, HdrType]]:
+    """Read in tabular data with no restrictions on the columns.
+
+    Parameters
+    ----------
+    arg
+        The data to read the columns from. This depends on the
+        backend but is expected to be a file name or a tabular
+        data structure supported by the backend.
+    make_copy: bool, optional
+        If set then the returned NumPy arrays are explictly copied,
+        rather than using a reference from the data structure
+        created by the backend. Backends are not required to
+        honor this setting.
+
+    Returns
+    -------
+    filename, blockdata, hdrdata
+        The filename as a string. The blockdata and hdrdata values are
+        dictionaries where the key is an integer representing the
+        block (or HDU) number (where the first block is numbered 1 and
+        represents the first tabular block, that is it does not
+        include the primary HDU) and the values are dictionaries
+        representing the column data or header data for each block.
+
+    Raises
+    ------
+    sherpa.utils.err.IOErr
+        The arg argument is invalid, or a required column or keyword
+        is missing.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')
+
+
+def set_arrays(filename: str,
+               args: Sequence[np.ndarray],
+               fields: Optional[NamesType] = None,
+               ascii: bool = True,
+               clobber: bool = False) -> None:
+    """Write out columns.
+
+    Parameters
+    ----------
+    filename : str
+        The file name.
+    args : sequence of ndarray
+        The column data.
+    fields : sequence of str or None, optional
+        The column names to use. If set to `None` then the columns are
+        named ``col1``, ``col2``, ...
+    ascii : bool, optional
+        Is the file to be written out as a text file (`True`) or a
+        binary file? The default is `True`.
+    clobber : bool, optional
+        If the file already exists can it be over-written (`True`) or
+        will a sherpa.utils.err.IOErr error be raised? The default is
+        `False`.
+
+    """
+    raise NotImplementedError('No usable I/O backend was imported.')

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -33,7 +33,7 @@ import numpy as np
 
 from ..data import Data1D
 from .types import NamesType, HdrTypeArg, HdrType, \
-    ColumnsType, DataTypeArg, DataType
+    ColumnsType, ColumnsTypeArg, DataTypeArg, DataType
 from .xstable import TableHDU
 
 __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
@@ -386,7 +386,7 @@ def get_pha_data(arg,
 # it will be None rather than Optional[Any]).
 #
 def set_table_data(filename: str,
-                   data: ColumnsType,
+                   data: ColumnsTypeArg,
                    col_names: NamesType,
                    header: Optional[HdrTypeArg] = None,
                    ascii: bool = False,
@@ -447,7 +447,7 @@ def set_image_data(filename: str,
 
 
 def set_pha_data(filename: str,
-                 data: ColumnsType,
+                 data: ColumnsTypeArg,
                  col_names: NamesType,
                  header: Optional[HdrTypeArg] = None,
                  ascii: bool = False,
@@ -479,7 +479,7 @@ def set_pha_data(filename: str,
 
 
 def set_arf_data(filename: str,
-                 data: ColumnsType,
+                 data: ColumnsTypeArg,
                  col_names: NamesType,
                  header: Optional[HdrTypeArg] = None,
                  ascii: bool = False,
@@ -561,7 +561,7 @@ def set_hdus(filename: str,
 def read_table_blocks(arg,
                       make_copy: bool = False
                       ) -> tuple[str,
-                                 dict[int, dict[str, np.ndarray]],
+                                 dict[int, ColumnsType],
                                  dict[int, HdrType]]:
     """Read in tabular data with no restrictions on the columns.
 

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -247,7 +247,7 @@ def get_ascii_data(filename: str,
        The number of columns to read in (the first ``ncols`` columns
        in the file). This is ignored if ``colkeys`` is given.
     colkeys : array of str, optional
-       An array of the column name to read in. The default is
+       An array of the column names to read in. The default is
        `None`.
     sep : str, optional
        The separator character. The default is ``' '``.

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1085,7 +1085,7 @@ def _read_multi_pha(hdu,
 
     # We want an empty list so we can iterate over it and get back
     # "None". As this can be used for multiple fields make sure it
-    # isnot writeable.
+    # is not writeable.
     #
     empty = np.full(num, None)
     empty.setflags(write=False)

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -39,7 +39,7 @@ References
 
 import logging
 import os
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence, Union
 import warnings
 
 import numpy as np
@@ -55,7 +55,8 @@ from sherpa.utils.numeric_types import SherpaInt, SherpaUInt, \
     SherpaFloat
 from sherpa.io import get_ascii_data, write_arrays
 
-from .types import HdrType, KeyType, NamesType
+from .types import ColumnsType, DataType, HdrType, HdrTypeArg, \
+    KeyType, NamesType
 from .xstable import HeaderItem, TableHDU
 
 warning = logging.getLogger(__name__).warning
@@ -72,6 +73,8 @@ except ImportError:
 __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'get_column_data', 'get_ascii_data',
            'get_arf_data', 'get_rmf_data', 'get_pha_data',
+           'pack_table_data', 'pack_arf_data', 'pack_rmf_data',
+           'pack_image_data', 'pack_hdus',
            'set_table_data', 'set_image_data', 'set_pha_data',
            'set_arf_data', 'set_rmf_data', 'set_hdus')
 
@@ -288,7 +291,12 @@ def open_fits(filename: str) -> fits.HDUList:
     return out
 
 
-def read_table_blocks(arg, make_copy=False):
+def read_table_blocks(arg: DatasetType,
+                      make_copy: bool = False
+                      ) -> tuple[str,
+                                 dict[int, ColumnsType],
+                                 dict[int, HdrType]]:
+    """Read in tabular data with no restrictions on the columns."""
 
     # This sets nobinary=True to match the original version of
     # the code, which did not use _get_file_contents.
@@ -297,8 +305,8 @@ def read_table_blocks(arg, make_copy=False):
                                                exptype="BinTableHDU",
                                                nobinary=True)
 
-    cols = {}
-    hdr = {}
+    cols: dict[int, ColumnsType] = {}
+    hdr: dict[int, HdrType] = {}
     try:
         for blockidx, hdu in enumerate(hdus, 1):
             hdr[blockidx] = {}
@@ -324,7 +332,8 @@ def read_table_blocks(arg, make_copy=False):
 
 def _get_file_contents(arg: DatasetType,
                        exptype: str = "PrimaryHDU",
-                       nobinary: bool = False) -> tuple[fits.HDUList, str, bool]:
+                       nobinary: bool = False
+                       ) -> tuple[fits.HDUList, str, bool]:
     """Read in the contents if needed.
 
     Set nobinary to True to avoid checking that the input
@@ -381,7 +390,10 @@ def _find_binary_table(tbl: fits.HDUList,
     raise IOErr('badext', filename)
 
 
-def get_header_data(arg, blockname=None, hdrkeys=None):
+def get_header_data(arg: DatasetType,
+                    blockname: Optional[str] = None,
+                    hdrkeys: Optional[NamesType] = None
+                    ) -> HdrType:
     """Read in the header data."""
 
     tbl, filename, close = _get_file_contents(arg, exptype="BinTableHDU")
@@ -405,10 +417,9 @@ def get_header_data(arg, blockname=None, hdrkeys=None):
     return hdr
 
 
-def get_column_data(*args):
-    """
-    get_column_data( *NumPy_args )
-    """
+def get_column_data(*args) -> list[np.ndarray]:
+    """Extract the column data."""
+
     # args is passed as type list
     if len(args) == 0:
         raise IOErr('noarrays')
@@ -427,11 +438,15 @@ def get_column_data(*args):
     return cols
 
 
-def get_table_data(arg, ncols=1, colkeys=None, make_copy=False, fix_type=False,
-                   blockname=None, hdrkeys=None):
-    """
-    arg is a filename or a HDUList object.
-    """
+def get_table_data(arg: DatasetType,
+                   ncols: int = 1,
+                   colkeys: Optional[NamesType] = None,
+                   make_copy: bool = False,
+                   fix_type: bool = False,
+                   blockname: Optional[str] = None,
+                   hdrkeys: Optional[NamesType] = None
+                   ) -> tuple[list[str], list[np.ndarray], str, HdrType]:
+    """Read columns."""
 
     tbl, filename, close = _get_file_contents(arg, exptype="BinTableHDU")
 
@@ -468,10 +483,11 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=False, fix_type=False,
     return colkeys, cols, filename, hdr
 
 
-def get_image_data(arg, make_copy=False):
-    """
-    arg is a filename or a HDUList object
-    """
+def get_image_data(arg: DatasetType,
+                   make_copy: bool = False
+                   ) -> tuple[DataType, str]:
+    """Read image data."""
+
     hdus, filename, close = _get_file_contents(arg)
 
     #   FITS uses logical-to-world where we use physical-to-world.
@@ -505,7 +521,7 @@ def get_image_data(arg, make_copy=False):
     #
 
     try:
-        data = {}
+        data: DataType = {}
 
         # Look for data in the primary or first block.
         #
@@ -610,10 +626,10 @@ def _has_ogip_type(hdus: fits.HDUList,
     return None
 
 
-def get_arf_data(arg, make_copy=False):
-    """
-    arg is a filename or a HDUList object
-    """
+def get_arf_data(arg: DatasetType,
+                 make_copy: bool = False
+                 ) -> tuple[DataType, str]:
+    """Read in the ARF."""
 
     arf, filename, close = _get_file_contents(arg,
                                               exptype="BinTableHDU",
@@ -653,7 +669,7 @@ def get_arf_data(arg, make_copy=False):
     return data, filename
 
 
-def _read_col(hdu, name):
+def _read_col(hdu: fits.BinTableHDU, name: str) -> np.ndarray:
     """A specialized form of _require_col
 
     There is no attempt to convert from a variable-length field
@@ -720,7 +736,8 @@ def _find_matrix_blocks(filename: str,
     return blocks
 
 
-def _read_rmf_data(arg):
+def _read_rmf_data(arg: DatasetType
+                   ) -> tuple[DataType, str]:
     """Read in the data from the RMF."""
 
     rmf, filename, close = _get_file_contents(arg,
@@ -746,7 +763,7 @@ def _read_rmf_data(arg):
         # this conversion needs to be done after cleaning up the
         # data.
         #
-        data = {}
+        data: DataType = {}
         data['detchans'] = SherpaUInt(_require_key(hdu, 'DETCHANS'))
         data['energ_lo'] = _read_col(hdu, 'ENERG_LO')  # SherpaFloat
         data['energ_hi'] = _read_col(hdu, 'ENERG_HI')  # SherpaFloat
@@ -797,8 +814,10 @@ def _read_rmf_data(arg):
     return data, filename
 
 
-def get_rmf_data(arg, make_copy=False):
-    """arg is a filename or a HDUList object.
+def get_rmf_data(arg: DatasetType,
+                 make_copy: bool = False
+                 ) -> tuple[DataType, str]:
+    """Read in the RMF.
 
     Notes
     -----
@@ -924,10 +943,11 @@ def get_rmf_data(arg, make_copy=False):
     return data, filename
 
 
-def get_pha_data(arg, make_copy=False, use_background=False):
-    """
-    arg is a filename or a HDUList object
-    """
+def get_pha_data(arg: DatasetType,
+                 make_copy: bool = False,
+                 use_background: bool = False
+                 ) -> tuple[list[DataType], str]:
+    """Read in the PHA."""
 
     pha, filename, close = _get_file_contents(arg,
                                               exptype="BinTableHDU")
@@ -950,7 +970,7 @@ def get_pha_data(arg, make_copy=False, use_background=False):
         datasets = []
 
         if _try_col(hdu, 'SPEC_NUM') is None:
-            data = {}
+            data: DataType = {}
 
             # Create local versions of the "try" routines.
             #
@@ -1081,9 +1101,6 @@ def get_pha_data(arg, make_copy=False, use_background=False):
                 if int(channel[idx][0]) == 0:
                     channel[idx] += 1
 
-            # if ((tlmin is not None) and tlmin == 0) or int(channel[0]) == 0:
-            #     channel += 1
-
             # Why does this convert to SherpaFloat?
             counts = try_sfloat("COUNTS")
             staterror = _try_vec(hdu, 'STAT_ERR', size=num)
@@ -1115,7 +1132,8 @@ def get_pha_data(arg, make_copy=False, use_background=False):
                           counts, staterror, syserror, background_up,
                           background_down, bin_lo, bin_hi, grouping, quality,
                           orders, parts, specnums, srcids):
-                idata = {}
+
+                idata: DataType = {}
 
                 idata['exposure'] = exposure
                 # idata['poisserr'] = poisserr
@@ -1163,7 +1181,7 @@ def get_pha_data(arg, make_copy=False, use_background=False):
 # Write Functions
 
 def _create_table(names: NamesType,
-                  data: dict[str, Optional[np.ndarray]]) -> Table:
+                  data: Mapping[str, Optional[np.ndarray]]) -> Table:
     """Create a Table.
 
     The idea is that by going via a Table we let the AstroPy
@@ -1205,18 +1223,10 @@ def check_clobber(filename: str, clobber: bool) -> None:
     raise IOErr("filefound", filename)
 
 
-def set_table_data(filename, data, col_names, header=None,
-                   ascii=False, clobber=False, packup=False) -> Optional[fits.BinTableHDU]:
-
-    if not packup:
-        check_clobber(filename, clobber)
+def pack_table_data(data, col_names, header=None) -> fits.BinTableHDU:
+    """Pack up the table data."""
 
     tbl = _create_table(col_names, data)
-    if ascii:
-        tbl.write(filename, format='ascii.commented_header',
-                  overwrite=clobber)
-        return None
-
     hdu = fits.table_to_hdu(tbl)
 
     # Add in the header. We should special case the HISTORY/COMMENT
@@ -1231,30 +1241,41 @@ def set_table_data(filename, data, col_names, header=None,
     if header is not None:
         _update_header(hdu, header)
 
-    if packup:
-        return hdu
+    return hdu
 
+
+def set_table_data(filename: str,
+                   data, col_names, header=None,
+                   ascii: bool = False,
+                   clobber: bool = False) -> None:
+    """Write out the table data."""
+
+    check_clobber(filename, clobber)
+
+    if ascii:
+        tbl = _create_table(col_names, data)
+        tbl.write(filename, format='ascii.commented_header',
+                  overwrite=clobber)
+        return
+
+    hdu = pack_table_data(data, col_names, header)
     hdu.writeto(filename, overwrite=True)
-    return None
 
 
-def _create_header(header: HdrType) -> fits.Header:
+def _create_header(header: HdrTypeArg) -> fits.Header:
     """Create a FITS header with the contents of header,
     the Sherpa representation of the key,value store.
     """
 
     hdrlist = fits.Header()
     for key, value in header.items():
-        if value is None:
-            continue
-
         _add_keyword(hdrlist, key, value)
 
     return hdrlist
 
 
 def _update_header(hdu: HDUType,
-                   header: dict[str, Optional[KeyType]]) -> None:
+                   header: Mapping[str, Optional[KeyType]]) -> None:
     """Update the header of the HDU.
 
     Unlike the dict update method, this is left biased, in that
@@ -1280,46 +1301,52 @@ def _update_header(hdu: HDUType,
         hdu.header[key] = value
 
 
-def set_arf_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False, packup=False) -> Optional[fits.BinTableHDU]:
-    """Create an ARF"""
+def pack_arf_data(data, col_names, header) -> fits.BinTableHDU:
+    """Pack the ARF"""
+
+    return pack_table_data(data, col_names, header)
+
+
+def set_arf_data(filename: str,
+                 data, col_names, header=None,
+                 ascii: bool = False,
+                 clobber: bool = False) -> None:
+    """Write out the ARF"""
 
     if header is None:
         raise ArgumentTypeErr("badarg", "header", "set")
 
-    # Currently we can use the same logic as set_table_data
-    return set_table_data(filename, data, col_names, header=header,
-                          ascii=ascii, clobber=clobber, packup=packup)
+    # This does not use pack_arf_data as we need to deal with ASCII
+    # support.
+    #
+    set_table_data(filename, data, col_names, header=header,
+                   ascii=ascii, clobber=clobber)
 
 
-def set_pha_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False, packup=False) -> Optional[fits.BinTableHDU]:
-    """Create a PHA dataset/file
+def pack_pha_data(data, col_names, header) -> fits.BinTableHDU:
+    """Pack the PHA data."""
 
-    The header argument must be set as this routine does no validation
-    of its contents.
+    return pack_table_data(data, col_names, header)
 
-    """
+
+def set_pha_data(filename: str,
+                 data, col_names, header=None,
+                 ascii: bool = False,
+                 clobber: bool = False) -> None:
+    """ Write out the PHA."""
 
     if header is None:
         raise ArgumentTypeErr("badarg", "header", "set")
 
-    # Currently we can use the same logic as set_table_data
-    return set_table_data(filename, data, col_names, header=header,
-                          ascii=ascii, clobber=clobber, packup=packup)
+    # This does not use pack_pha_data as we need to deal with ASCII
+    # support.
+    #
+    set_table_data(filename, data, col_names, header=header,
+                   ascii=ascii, clobber=clobber)
 
 
-def set_rmf_data(filename, blocks, clobber=False) -> None:
-    """Save the RMF data to disk.
-
-    Unlike the other save_*_data calls this does not support the ascii
-    or packup arguments. It also relies on the caller to have set up
-    the headers and columns correctly apart for variable-length fields,
-    which are limited to F_CHAN, N_CHAN, and MATRIX.
-
-    """
-
-    check_clobber(filename, clobber)
+def pack_rmf_data(blocks) -> fits.HDUList:
+    """Pack up the RMF data."""
 
     # For now assume only two blocks:
     #    MATRIX
@@ -1427,20 +1454,28 @@ def set_rmf_data(filename, blocks, clobber=False) -> None:
     _update_header(ebounds_hdu, ebounds_header)
 
     primary_hdu = fits.PrimaryHDU()
-    hdulist = fits.HDUList([primary_hdu, matrix_hdu, ebounds_hdu])
-    hdulist.writeto(filename, overwrite=True)
+    return fits.HDUList([primary_hdu, matrix_hdu, ebounds_hdu])
 
 
-def set_image_data(filename, data, header, ascii=False, clobber=False,
-                   packup=False) -> Optional[fits.PrimaryHDU]:
+def set_rmf_data(filename: str,
+                 blocks,
+                 clobber: bool = False) -> None:
+    """Save the RMF data to disk.
 
-    if not packup:
-        check_clobber(filename, clobber)
+    Unlike the other save_*_data calls this does not support the ascii
+    argument. It also relies on the caller to have set up the headers
+    and columns correctly apart for variable-length fields, which are
+    limited to F_CHAN, N_CHAN, and MATRIX.
 
-    if ascii:
-        set_arrays(filename, [data['pixels'].ravel()],
-                   ascii=True, clobber=clobber)
-        return None
+    """
+
+    check_clobber(filename, clobber)
+    hdus = pack_rmf_data(blocks)
+    hdus.writeto(filename, overwrite=True)
+
+
+def pack_image_data(data, header) -> fits.PrimaryHDU:
+    """Pack up the image data."""
 
     hdrlist = _create_header(header)
 
@@ -1488,15 +1523,32 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
         _add_keyword(hdrlist, 'CUNIT2', 'deg     ')
         _add_keyword(hdrlist, 'EQUINOX', equin)
 
-    img = fits.PrimaryHDU(data['pixels'], header=fits.Header(hdrlist))
-    if packup:
-        return img
+    return fits.PrimaryHDU(data['pixels'], header=fits.Header(hdrlist))
 
+
+def set_image_data(filename: str,
+                   data, header,
+                   ascii: bool = False,
+                   clobber: bool = False) -> None:
+    """Write out the image data."""
+
+    check_clobber(filename, clobber)
+
+    if ascii:
+        set_arrays(filename, [data['pixels'].ravel()],
+                   ascii=True, clobber=clobber)
+        return
+
+    img = pack_image_data(data, header)
     img.writeto(filename, overwrite=True)
-    return None
+    return
 
 
-def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
+def set_arrays(filename: str,
+               args: Sequence[np.ndarray],
+               fields: Optional[NamesType] = None,
+               ascii: bool = True,
+               clobber: bool = False) -> None:
 
     # Historically the clobber command has been checked before
     # processing the data, so do so here.
@@ -1524,7 +1576,7 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
     if fields is None:
         fieldnames = [f'COL{idx + 1}' for idx in range(nargs)]
     elif nargs == len(fields):
-        fieldnames = fields
+        fieldnames = list(fields)
     else:
         raise IOErr("wrongnumcols", nargs, len(fields))
 
@@ -1607,8 +1659,22 @@ def _create_table_hdu(hdu: TableHDU) -> fits.BinTableHDU:
     return out
 
 
+def pack_hdus(blocks: Sequence[TableHDU]) -> fits.HDUList:
+    """Create a dataset.
+
+    At present we are restricted to tables only.
+    """
+
+    out = fits.HDUList()
+    out.append(_create_primary_hdu(blocks[0]))
+    for hdu in blocks[1:]:
+        out.append(_create_table_hdu(hdu))
+
+    return out
+
+
 def set_hdus(filename: str,
-             hdulist: Sequence[TableHDU],
+             blocks: Sequence[TableHDU],
              clobber: bool = False) -> None:
     """Write out multiple HDUS to a single file.
 
@@ -1616,10 +1682,5 @@ def set_hdus(filename: str,
     """
 
     check_clobber(filename, clobber)
-
-    out = fits.HDUList()
-    out.append(_create_primary_hdu(hdulist[0]))
-    for hdu in hdulist[1:]:
-        out.append(_create_table_hdu(hdu))
-
-    out.writeto(filename, overwrite=True)
+    hdus = pack_hdus(blocks)
+    hdus.writeto(filename, overwrite=True)

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1620,7 +1620,7 @@ def set_arrays(filename: str,
         # The fields setting can be None here, which means that
         # write_arrays will not write out a header line.
         #
-        write_arrays(filename, args, fields,
+        write_arrays(filename, args, fields=fields,
                      comment="# ", clobber=clobber)
         return
 

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -55,6 +55,7 @@ from sherpa.utils.numeric_types import SherpaInt, SherpaUInt, \
     SherpaFloat
 from sherpa.io import get_ascii_data, write_arrays
 
+from .types import HdrType, KeyType, NamesType
 from .xstable import HeaderItem, TableHDU
 
 warning = logging.getLogger(__name__).warning
@@ -77,7 +78,6 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
 
 DatasetType = Union[str, fits.HDUList]
 HDUType = Union[fits.PrimaryHDU, fits.BinTableHDU]
-KeyType = Union[bool, int, str, float]
 
 
 def _try_key(hdu, name, *, fix_type=False, dtype=SherpaFloat):
@@ -107,7 +107,7 @@ def _require_key(hdu, name, *, fix_type=False, dtype=SherpaFloat):
     return value
 
 
-def _get_meta_data(hdu: HDUType) -> dict[str, KeyType]:
+def _get_meta_data(hdu: HDUType) -> HdrType:
     # If the header keywords are not specified correctly then
     # astropy will error out when we try to access it. Since
     # this is not an uncommon problem, there is a verify method
@@ -590,8 +590,8 @@ def _is_ogip_block(hdu: HDUType,
 
 
 def _has_ogip_type(hdus: fits.HDUList,
-                  bltype: str,
-                  bltype2: Optional[str] = None) -> Optional[HDUType]:
+                   bltype: str,
+                   bltype2: Optional[str] = None) -> Optional[HDUType]:
     """Return True if hdus[1] exists and has
     the given type (as determined by the HDUCLAS1 or HDUCLAS2
     keywords). If bltype2 is None then bltype is used for
@@ -1162,7 +1162,7 @@ def get_pha_data(arg, make_copy=False, use_background=False):
 
 # Write Functions
 
-def _create_table(names: Sequence[str],
+def _create_table(names: NamesType,
                   data: dict[str, Optional[np.ndarray]]) -> Table:
     """Create a Table.
 
@@ -1238,7 +1238,7 @@ def set_table_data(filename, data, col_names, header=None,
     return None
 
 
-def _create_header(header: dict[str, KeyType]) -> fits.Header:
+def _create_header(header: HdrType) -> fits.Header:
     """Create a FITS header with the contents of header,
     the Sherpa representation of the key,value store.
     """

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2022, 2023, 2024
+#  Copyright (C) 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -821,10 +821,9 @@ def test_write_pha_fits_with_extras_roundtrip(tmp_path, caplog):
     assert lname == "sherpa.astro.io"
     assert lvl == logging.WARNING
 
-    # message depends on the backend
+    # message depends on the backend.
     if backend_is("crates"):
-        assert msg.startswith("File ")
-        assert msg.endswith("/made-up-ancrfile.fits does not exist.")
+        assert msg.startswith("unable to open ")
     elif backend_is("pyfits"):
         assert msg.startswith("file '")
         assert msg.endswith("/made-up-ancrfile.fits' not found")
@@ -902,10 +901,9 @@ def test_pha_missing_backfile(tmp_path, caplog):
     assert lname == "sherpa.astro.io"
     assert lvl == logging.WARNING
 
-    # message depends on the backend
+    # message depends on the backend.
     if backend_is("crates"):
-        assert msg.startswith("File ")
-        assert msg.endswith("/made-up-backfile.fits does not exist.")
+        assert msg.startswith("unable to open ")
     elif backend_is("pyfits"):
         assert msg.startswith("file '")
         assert msg.endswith("/made-up-backfile.fits' not found")

--- a/sherpa/astro/io/types.py
+++ b/sherpa/astro/io/types.py
@@ -1,0 +1,47 @@
+#
+#  Copyright (C) 2024
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Useful types for Sherpa Astronomy I/O.
+
+This module should be considered an internal module as its contents is
+likely to change as types get added to Sherpa and the typing ecosystem
+in Python matures.
+
+"""
+
+from typing import Any, Mapping, Sequence, Union
+
+import numpy as np
+
+
+# Some variants are named xxx and xxxArg, where the former is the
+# return value (an invariant type, like dict) and the latter is
+# covariant (such as Mapping) as it's used as an argument to a
+# function.
+#
+KeyType = Union[str, bool, int, float]
+NamesType = Sequence[str]
+HdrTypeArg = Mapping[str, KeyType]
+HdrType = dict[str, KeyType]
+ColumnsType = Mapping[str, Union[np.ndarray, list, tuple]]
+
+# It's hard to type the arguments to the Data constructors
+DataTypeArg = Mapping[str, Any]
+DataType = dict[str, Any]

--- a/sherpa/astro/io/types.py
+++ b/sherpa/astro/io/types.py
@@ -40,7 +40,12 @@ KeyType = Union[str, bool, int, float]
 NamesType = Sequence[str]
 HdrTypeArg = Mapping[str, KeyType]
 HdrType = dict[str, KeyType]
-ColumnsType = Mapping[str, Union[np.ndarray, list, tuple]]
+
+# Note that ColumnsTypeArg allows more for the values than does
+# ColumnsType.
+#
+ColumnsTypeArg = Mapping[str, Union[np.ndarray, list, tuple]]
+ColumnsType = dict[str, np.ndarray]
 
 # It's hard to type the arguments to the Data constructors
 DataTypeArg = Mapping[str, Any]

--- a/sherpa/astro/io/wcs.py
+++ b/sherpa/astro/io/wcs.py
@@ -18,16 +18,22 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+"""Handle basic WCS support.
+
+This only supports a limited number of 2D transformations.
+
+"""
+
 import logging
 
-import numpy
+import numpy as np
 
 from sherpa.utils import NoNewAttributesAfterInit
 
 warning = logging.getLogger(__name__).warning
 
 try:
-    from sherpa.astro.utils._wcs import pix2world, world2pix
+    from sherpa.astro.utils._wcs import pix2world, world2pix  # type: ignore
 except ImportError:
     warning('WCS support is not available')
 
@@ -44,28 +50,31 @@ class WCS(NoNewAttributesAfterInit):
                  crota=0.0, epoch=2000.0, equinox=2000.0):
         self.name = name
         self.type = type
-        self.crval = numpy.asarray(crval, dtype=float)
-        self.crpix = numpy.asarray(crpix, dtype=float)
-        self.cdelt = numpy.asarray(cdelt, dtype=float)
+        self.crval = np.asarray(crval, dtype=float)
+        self.crpix = np.asarray(crpix, dtype=float)
+        self.cdelt = np.asarray(cdelt, dtype=float)
         self.crota = crota
         self.epoch = epoch
         self.equinox = equinox
-        NoNewAttributesAfterInit.__init__(self)
+        super().__init__()
 
     def __repr__(self):
-        return ("<%s Coordinate instance '%s'>" %
-                (type(self).__name__, self.name))
+        return f"<{type(self).__name__} Coordinate instance '{self.name}'>"
 
     def __str__(self):
+        def tostr(vals):
+            return np.array2string(vals, separator=',', precision=4,
+                                   suppress_small=False)
+
         val = [self.name,
-               ' crval    = %s' % numpy.array2string(self.crval, separator=',', precision=4, suppress_small=False),
-               ' crpix    = %s' % numpy.array2string(self.crpix, separator=',', precision=4, suppress_small=False),
-               ' cdelt    = %s' % numpy.array2string(self.cdelt, separator=',', precision=4, suppress_small=False)]
+               f' crval    = {tostr(self.crval)}',
+               f' crpix    = {tostr(self.crpix)}',
+               f' cdelt    = {tostr(self.cdelt)}']
 
         if self.type == 'WCS':
-            val.append(' crota    = %g' % self.crota)
-            val.append(' epoch    = %g' % self.epoch)
-            val.append(' equinox  = %g' % self.equinox)
+            val.append(f' crota    = {self.crota:g}')
+            val.append(f' epoch    = {self.epoch:g}')
+            val.append(f' equinox  = {self.equinox:g}')
 
         return '\n'.join(val)
 

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
@@ -65,25 +65,19 @@ def test_fake_pha_missing_rmf(idval, clean_astro_ui, tmp_path):
 
     rmf = tmp_path / 'rmf'
 
-    # Wrap this so we don't repeat the logic below in the
-    # backend-specific code.
-    #
-    def call_fake():
-        ui.fake_pha(idval, None, str(rmf), 1000.0)
-
     # The error message depends on the backend.
+    #
     if io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
-        with pytest.raises(IOErr,
-                           match=f"file '{rmf}' not found"):
-            call_fake()
+        emsg = f"file '{rmf}' not found"
 
     elif io.backend.__name__ == "sherpa.astro.io.crates_backend":
-        with pytest.raises(OSError,
-                           match=f"File {rmf} does not exist"):
-            call_fake()
+        emsg = f"File {rmf} does not exist"
 
     else:
         assert False, "unknown backend"
+
+    with pytest.raises(IOErr, match=emsg):
+        ui.fake_pha(idval, None, str(rmf), 1000.0)
 
 
 @requires_fits
@@ -105,25 +99,19 @@ def test_fake_pha_missing_arf(idval, clean_astro_ui, tmp_path):
 
     arf = tmp_path / 'arf'
 
-    # Wrap this so we don't repeat the logic below in the
-    # backend-specific code.
-    #
-    def call_fake():
-        ui.fake_pha(idval, str(arf), rmf, 1000.0)
-
     # The error message depends on the backend.
+    #
     if io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
-        with pytest.raises(IOErr,
-                           match=f"file '{arf}' not found"):
-            call_fake()
+        emsg = f"file '{arf}' not found"
 
     elif io.backend.__name__ == "sherpa.astro.io.crates_backend":
-        with pytest.raises(OSError,
-                           match=f"File {arf} does not exist"):
-            call_fake()
+        emsg = f"File {arf} does not exist"
 
     else:
         assert False, "unknown backend"
+
+    with pytest.raises(IOErr, match=emsg):
+        ui.fake_pha(idval, str(arf), rmf, 1000.0)
 
 
 @pytest.mark.parametrize("idval", [None, 1, "faked"])

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -31,6 +31,7 @@ import numpy as np
 
 import pytest
 
+from sherpa.astro import io
 from sherpa.astro import ui
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
     IOErr
@@ -62,7 +63,9 @@ def test_load_table_model_fails_with_dir(tmp_path):
 
     ui.clean()
     assert ui.list_model_components() == []
-    with pytest.raises(IOError):
+
+    with pytest.raises(IOErr,
+                       match="^unable to open "):
         ui.load_table_model('tmpdir', str(tmpdir))
 
     assert ui.list_model_components() == []
@@ -81,25 +84,27 @@ def test_load_xstable_model_fails_with_dir(tmp_path):
 
     ui.clean()
     assert ui.list_model_components() == []
-    with pytest.raises(IOError):
+    with pytest.raises(IOErr,
+                       match="^unable to open "):
         ui.load_xstable_model('tmpdir', str(tmpdir))
 
     assert ui.list_model_components() == []
 
 
 @requires_fits
-@pytest.mark.skipif(not(os.path.exists('/dev/null')),
-                    reason='/dev/null does not exist')
-def test_load_table_model_fails_with_dev_null():
-    """Check that load_table_model fails with invalid input: /dev/null
+def test_load_table_model_fails_with_empty_file(tmp_path):
+    """Check that load_table_model fails with invalid input: empty file
 
-    This simulates an empty file (and relies on the system
-    containing a /dev/null file that reads in 0 bytes).
+    This used to use /dev/null to simulate an empty file but
+    why not just use an empty file.
 
     It is a regression test as the actual error type and message may
     change over time.
 
     """
+
+    empty = tmp_path / 'empty.dat'
+    empty.write_text('')
 
     ui.clean()
     assert ui.list_model_components() == []
@@ -113,21 +118,22 @@ def test_load_table_model_fails_with_dev_null():
 
 @requires_fits
 @requires_xspec
-@pytest.mark.skipif(not(os.path.exists('/dev/null')),
-                    reason='/dev/null does not exist')
-def test_load_xstable_model_fails_with_dev_null():
-    """Check that load_table_model fails with invalid input: /dev/null
+def test_load_xstable_model_fails_with_empty_file(tmp_path):
+    """Check that load_table_model fails with invalid input: empty file
 
-    This simulates an empty file (and relies on the system
-    containing a /dev/null file that reads in 0 bytes).
+    This used to use /dev/null to simulate an empty file but
+    why not just use an empty file.
     """
+
+    empty = tmp_path / 'empty.dat'
+    empty.write_text('')
 
     ui.clean()
     assert ui.list_model_components() == []
 
-    # The error depends on the load function
-    with pytest.raises(IOError):
-        ui.load_xstable_model('devnull', '/dev/null')
+    with pytest.raises(IOErr,
+                       match="^unable to open "):
+        ui.load_xstable_model('devnull', str(empty))
 
     assert ui.list_model_components() == []
 

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -95,13 +95,17 @@ def test_load_table_model_fails_with_dev_null():
 
     This simulates an empty file (and relies on the system
     containing a /dev/null file that reads in 0 bytes).
+
+    It is a regression test as the actual error type and message may
+    change over time.
+
     """
 
     ui.clean()
     assert ui.list_model_components() == []
 
-    with pytest.raises(ValueError,
-                       match="^need at least one array to concatenate$"):
+    with pytest.raises(IOErr,
+                       match="^No column data found in /dev/null$"):
         ui.load_table_model('devnull', '/dev/null')
 
     assert ui.list_model_components() == []

--- a/sherpa/io.py
+++ b/sherpa/io.py
@@ -24,6 +24,7 @@ These routines are currently restricted to reading from ASCII files.
 """
 
 import os
+from typing import Optional, Sequence
 
 import numpy as np
 
@@ -31,22 +32,31 @@ from sherpa.data import Data, Data1D
 from sherpa.utils import is_subclass, get_num_args, is_binary_file
 from sherpa.utils.err import IOErr
 from sherpa.utils.numeric_types import SherpaFloat
+from sherpa.utils.types import ArrayType
 
 
 __all__ = ('read_data', 'write_data', 'get_ascii_data', 'read_arrays',
            'write_arrays')
 
 
-def _check_args(size, dstype):
+NamesType = Sequence[str]
+
+
+def _check_args(size: int, dstype) -> None:
     # Find the number of required args minus self, filename
     req_args = get_num_args(dstype.__init__)[1] - 2
+    if size >= req_args:
+        return
 
-    if size < req_args:
-        # raise IOErr('badargs', dstype.__name__, req_args)
-        raise TypeError(f"data set '{dstype.__name__}' takes at least {req_args} args")
+    raise TypeError(f"data set '{dstype.__name__}' takes at "
+                    f"least {req_args} args")
 
 
-def read_file_data(filename, sep=' ', comment='#', require_floats=True):
+def read_file_data(filename: str,
+                   sep: str = ' ',
+                   comment: str = '#',
+                   require_floats: bool = True
+                   ) -> tuple[list[str], list[np.ndarray]]:
     """Read in column data from a file."""
 
     bad_chars = '\t\n\r,;: |'
@@ -97,14 +107,13 @@ def read_file_data(filename, sep=' ', comment='#', require_floats=True):
 
     names = [name.strip(bad_chars)
              for name in raw_names if name != '']
-
     if len(names) == 0:
         names = [f'col{i}' for i, _ in enumerate(args, 1)]
 
     return names, args
 
 
-def get_column_data(*args):
+def get_column_data(*args) -> list[Optional[np.ndarray]]:
     """
     get_column_data( *NumPy_args )
     """
@@ -128,8 +137,14 @@ def get_column_data(*args):
     return cols
 
 
-def get_ascii_data(filename, ncols=1, colkeys=None, sep=' ', dstype=Data1D,
-                   comment='#', require_floats=True):
+def get_ascii_data(filename: str,
+                   ncols: int = 1,
+                   colkeys: Optional[NamesType] = None,
+                   sep: str = ' ',
+                   dstype: type = Data1D,
+                   comment: str = '#',
+                   require_floats: bool = True
+                   ) -> tuple[list[str], list[np.ndarray], str]:
     r"""Read in columns from an ASCII file.
 
     Parameters
@@ -253,8 +268,13 @@ def get_ascii_data(filename, ncols=1, colkeys=None, sep=' ', dstype=Data1D,
     return (colkeys, kwargs, filename)
 
 
-def read_data(filename, ncols=2, colkeys=None, sep=' ', dstype=Data1D,
-              comment='#', require_floats=True):
+def read_data(filename: str,
+              ncols: int = 2,
+              colkeys: Optional[NamesType] = None,
+              sep: str = ' ',
+              dstype=Data1D,
+              comment: str = '#',
+              require_floats: bool = True) -> Data:
     """Create a data object from an ASCII file.
 
     Parameters
@@ -333,7 +353,7 @@ def read_data(filename, ncols=2, colkeys=None, sep=' ', dstype=Data1D,
     return dstype(name, *args)
 
 
-def read_arrays(*args):
+def read_arrays(*args) -> Data:
     """Create a data object from arrays.
 
     Parameters
@@ -392,8 +412,14 @@ def read_arrays(*args):
     return dstype('', *dargs)
 
 
-def write_arrays(filename, args, fields=None, sep=' ', comment='#',
-                 clobber=False, linebreak='\n', format='%g'):
+def write_arrays(filename: str,
+                 args: Sequence[ArrayType],
+                 fields: Optional[NamesType] = None,
+                 sep: str = ' ',
+                 comment: str = '#',
+                 clobber: bool = False,
+                 linebreak: str = '\n',
+                 format: str = '%g') -> None:
     """Write a list of arrays to an ASCII file.
 
     Parameters
@@ -476,8 +502,15 @@ def write_arrays(filename, args, fields=None, sep=' ', comment='#',
         fh.write(linebreak)
 
 
-def write_data(filename, dataset, fields=None, sep=' ', comment='#',
-               clobber=False, linebreak='\n', format='%g'):
+def write_data(filename: str,
+               dataset: Data,
+               fields: Optional[NamesType] = None,
+               sep: str = ' ',
+               comment: str = '#',
+               clobber: bool = False,
+               linebreak: str = '\n',
+               format: str = '%g'
+               ) -> None:
     """Write out a dataset as an ASCII file.
 
     Parameters

--- a/sherpa/tests/test_sherpa_io.py
+++ b/sherpa/tests/test_sherpa_io.py
@@ -69,11 +69,8 @@ def test_get_ascii_data_irregular_data(tmp_path):
     tfile = tmp_path / "col.dat"
     tfile.write_text("23 1\n24 2\n25 3 4\n")
 
-    # The error message may well depend on the NumPy version so we do
-    # not include a match argument. NumPy 1.26 uses the message
-    #   all the input array dimensions except for the concatenation axis must match exactly, but along dimension 0, the array at index 0 has size 2 and the array at index 2 has size 3
-    #
-    with pytest.raises(ValueError):
+    with pytest.raises(IOErr,
+                       match="^not all arrays are of equal length$"):
         get_ascii_data(str(tfile))
 
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -2257,20 +2257,24 @@ def is_binary_file(filename):
     # string.printable is kept in, since this is more restrictive
     # than UnicodeDecodeError.
     #
-    with open(filename, 'r') as fd:
-        try:
-            lines = fd.readlines(1024)
-        except UnicodeDecodeError:
-            return True
-
-    if len(lines) == 0:
-        return False
-
-    # Are there any non-printable characters in the buffer?
-    for line in lines:
-        for char in line:
-            if char not in string.printable:
+    try:
+        with open(filename, 'r') as fd:
+            try:
+                lines = fd.readlines(1024)
+            except UnicodeDecodeError:
                 return True
+
+        if len(lines) == 0:
+            return False
+
+        # Are there any non-printable characters in the buffer?
+        for line in lines:
+            for char in line:
+                if char not in string.printable:
+                    return True
+
+    except OSError as oe:
+       raise IOErr('openfailed', f"unable to open {filename}: {oe}") from oe
 
     return False
 


### PR DESCRIPTION
# Summary

Replace the logic of the packup argument to the set I/O commands by adding new `pack_xxx_data` commands (which return an object, and so correspond to the old `packup=True` case) and make the existing `set_xxx_data` calls never return anything (the old `packup=False` behaviour). As part of this, ensure that the dummy backend provides arguments and - for most arguments - types, which means the dummy backend can be thought of as defining the backend interface. There should be little change to users who use the sherpa.astro.io module routines, although some error conditions now raise an IOErr rather than a TypeError or ValueError.

# Details

This is #1929 but without the change to "make the backend use a module" approach that I added during development of #1929. I thought it better to create a new PR so we don't lose the old version (for reference) and since I can rebase things to avoid conflicts. There have also been changes to the code - e.g. some of the code went into #2061 instead.

The PR starts by reworking the dummy backend so that it "defines" the expected API, in terms of what routines need to be provided and what the input and outputs are, along with documentation. I note that the two existing backends do not always agree on the default values for some of these arguments - generally the `make_copy` and `fix_type` arguments so this is a "best guess" and we can iterate in later PRs to address small differences (at present I'm tempted to say that "some arguments are not guaranteed to be used in a backend", but I think until we get a new backend I don't think it's worth spending much time on this).

There is then a commit to fix up some recent type changes - probably from #2061 - just to try and be consistent, and then a "change numpy to np" change for an internal-ish module.

The "selling point" for this PR actually occurs in the fourth commit: ` IO: separate pack and set commands `. This changes the backend code to add `pack_xxx_data` routines and to drop the `packup` argument from the `set_xxx_data` calls. The idea is that the `set_xxx_data` call can just call `pack_xxx_data` and then write out the response but it's not always done like this (since we can go via the `set_table_data` call, for example). However, the individual pack routines are more used in the follow-up PR #1921.

We then add types to the actual backends to try and match the dummy backend.

There is then the start of a bunch of 'cleanup' commits where I try to update the code to

a) add useful types
b) use more-modern python idioms
c) clean up the code a bit
  - there's a lot of code moved around here and with minor tweaks to work better with the python typing programs, but functionally not much actually changes
d) address some changes seen in numpy since this code was first written means that sometimes, to avoid having version-specific code, I have changed how the code creates things (normally associated with converting between a 2D array of numbers and a text file). In particular asarray changed behaviour in 1.24 and 1.26 when dealing with ragged arrays.

I note that I have follow-on code in #1921 which uses this updated code to move the logic from the backend into the frontend, but that really is better done as a follow-on PR (and I need to update that PR to bring it up to date with this version).

There are then two commits

- `try to standardize basic I/O error handling`

  I try to have the routines ail with an IOErr rather than something from the backend or a ValueError/TypeError when possible.

- `treat a HDUList as a context manager (pyfits)`

  This is to address a review comment from #1929 by @hamogu that never got addressed in #2061, because I did not know how to do it then. It looks like a `fits.HDUList` behaves like a `ContextManager` so I can use `contextlib.nullcontext` to wrap the return value so that it skips the close, which lets me change

```
    tbl, fname, close = _get_file_contents(arg, ....)
    try:
        ...
    finally:
        if close:
            tbl.close()
```

  with

```
    cm, fname = _get_file_contents(arg, ....)
    with cm as tbl:
        ...
```


When working on this version I stumbled upon a very-bizarre case where only the Python 3.11 full-build would fail the CI runs. I could never replicate this behaviour. I ended up breaking code up (which should make the individual commits a bit easier to review, but I know this annoys @hamogu when I end up waiting till a later commit to make the change he suggests earlier) and have eventually either squashed this issue or it was a transient bizarro error from bizarro land. The numpy.asarray changes were annoying too.

I will note that there are a number of "obvious" places in the backend I/O code where we need to better handle the PHA offset/TLMIN issue, but that is really for another PR (and we have issues about this already). For example, hopefully after #1921 we will only have to do it in the frontend rather than have to apply changes to both backends as is needed here...