### PR TITLE
CI: bump the checkout actions versions

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -91,7 +91,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v4.1.1
       with:
         submodules: 'True'
 

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -68,7 +68,7 @@ jobs:
         submodules: 'True'
 
     - name: Pip Testing Setup - Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v4.1.1
       with:
         submodules: 'True'
 


### PR DESCRIPTION
# Summary

Internal change to how the GitHub actions are run for CI.

# Details

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

says we need to update, so do so. [if you ever look at the actions output you fin d they are always complaining about node-16 and the need to change to node-20].

There is the question of whether we change to

 - actions/checkout@v4
 - actions/checkout@v4.1.1
 - actions/checkout@v4.1.4

(v 4.1.4 is the latest). I have gone with the middle version since v4.1.2 has been reported to be problematic - see
https://github.com/actions/checkout/releases/tag/v4.1.2 - so let's be safe. I went with a specific version just because

a) the old code used a specific version
b) the ability to pin the version could be useful (e.g. to avoid issues like 4.1.2)

I note that we do not use much from the checkout action so we should be okay just using a "stable" version.

We need to do something similar for the `setup-python` action in the `pip` workflow. In this case I change `@3` to `@5` rather than pick a particular version (primarily because the old version just used `@3` and did not pick a specific version). There are "new" features in this we could maybe take advantage of (e.g. caching dependencies) but that would be for a different PR.