### PR TITLE
Update Conda Deployment Workflow Action Versions

### DIFF
--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -211,7 +211,7 @@ jobs:
     - uses: actions/download-artifact@v4
       id: download
       with:
-        name: ${{ matrix.os-dir }}-*
+        pattern: ${{ matrix.os-dir }}-*
         path: packages
         merge-multiple: true
 

--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -9,7 +9,6 @@ on:
     - main
     - ciaox
     - 'release/**'
-    - conda-up-down-action
 
 #Reduces GH Action duplication:
 # Cancels the previous pipeline for this ref it is still running
@@ -29,7 +28,7 @@ jobs:
   check-skip:
     name: Skip the Pipeline if tagged and NOT on the release branch
     runs-on: ubuntu-latest
-#    if: github.repository == 'sherpa/sherpa'
+    if: github.repository == 'sherpa/sherpa'
     outputs:
       skip_pipeline: ${{ steps.skip_check.outputs.skip_pipeline }}
 

--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -9,6 +9,7 @@ on:
     - main
     - ciaox
     - 'release/**'
+    - conda-up-down-action
 
 #Reduces GH Action duplication:
 # Cancels the previous pipeline for this ref it is still running

--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -114,7 +114,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.os-dir }}-${{ python-version }}
+        name: ${{ matrix.os-dir }}-${{ matrix.python-version }}
         path: ${{ github.workspace }}/packages/*/sherpa*bz2
         if-no-files-found: error
         retention-days: 3

--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     #Checkout the code with a depth of 0 to grab the tags/branches as well
     - name: Checkout Code
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v4.1.1
       with:
         fetch-depth: 0
 
@@ -87,7 +87,7 @@ jobs:
 
     #Checkout the code with a depth of 0 to grab the tags/branches as well
     - name: Checkout Code
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v4.1.1
       with:
         fetch-depth: 0
         path: sherpa
@@ -111,9 +111,9 @@ jobs:
         echo "conda build --python ${SHERPA_PYTHON_VERSION} --output-folder ${GITHUB_WORKSPACE}/packages recipes/conda"
         conda build --python ${SHERPA_PYTHON_VERSION} --output-folder ${GITHUB_WORKSPACE}/packages recipes/conda
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.os-dir }}
+        name: ${{ matrix.os-dir }}-${{ python-version }}
         path: ${{ github.workspace }}/packages/*/sherpa*bz2
         if-no-files-found: error
         retention-days: 3
@@ -154,7 +154,7 @@ jobs:
         sudo tar -C /opt -xf MacOSX10.14.sdk.tar.xz
 
     - name: Checkout Code
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v4.1.1
       with:
         fetch-depth: 0
         path: sherpa
@@ -178,9 +178,9 @@ jobs:
         echo "conda build --python ${SHERPA_PYTHON_VERSION} --output-folder ${GITHUB_WORKSPACE}/packages recipes/conda"
         conda build --python ${SHERPA_PYTHON_VERSION} --output-folder ${GITHUB_WORKSPACE}/packages recipes/conda
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.os-dir }}
+        name: ${{ matrix.os-dir }}-${{ python-version }}
         path: ${{ github.workspace }}/packages/*/sherpa*bz2
         if-no-files-found: error
         retention-days: 3
@@ -207,11 +207,12 @@ jobs:
 
     steps:
     #Download all artifacts
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       id: download
       with:
-        name: ${{ matrix.os-dir }}
+        name: ${{ matrix.os-dir }}-*
         path: packages
+        merge-multiple: true
 
     - name: Conda Setup & Index Artifacts
       env:

--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -29,7 +29,7 @@ jobs:
   check-skip:
     name: Skip the Pipeline if tagged and NOT on the release branch
     runs-on: ubuntu-latest
-    if: github.repository == 'sherpa/sherpa'
+#    if: github.repository == 'sherpa/sherpa'
     outputs:
       skip_pipeline: ${{ steps.skip_check.outputs.skip_pipeline }}
 

--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -181,7 +181,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.os-dir }}-${{ python-version }}
+        name: ${{ matrix.os-dir }}-${{ matrix.python-version }}
         path: ${{ github.workspace }}/packages/*/sherpa*bz2
         if-no-files-found: error
         retention-days: 3


### PR DESCRIPTION
Updates the following actions in the deployment workflows:
- actions/checkout@v4.1.1
- actions/upload-artifact@v4
- actions/download-artifact@v4

The download action has this warning, but this is an open bug (okay for now): https://github.com/actions/download-artifact/issues/327

The update to v4 of the upload/download actions required changes to the naming conventions of the artifacts as outlined [here](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md). We previously uploaded each python version to linux-64 and osx-64, but this splits them up (and then downloads all for each OS).