### PR TITLE
Swap oldest-supported-numpy with numpy in requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools >= 51.0.0, < 60",
             "wheel",
-            "oldest-supported-numpy",
+            "numpy",
             ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
# Summary

Pulls the oldest-supported-numpy -> numpy swap from #1608.

# Details

See the details in the comments on #1608 here: https://github.com/sherpa/sherpa/pull/1608#issuecomment-2100777375
