### PR TITLE
BUILD: switch from oldest-supported-numpy to numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools >= 51.0.0, < 60",
             "wheel",
-            "oldest-supported-numpy",
+            "numpy",
             ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
# Summary

Change how we define the numpy version when building Sherpa.

# Details

According to #1790 we no-longer need the oldest-supported-numpy "helper" so let's see if we can remove it. Fix #1790.

This was originally introduced in #1608 but has been split out of that PR.