### PR TITLE
utils: add typing rules to random and parallel

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -881,7 +881,7 @@ or either). The aim is to try and model the intention of the API
 without matching every single possible type that could be used. The
 typing rules are also currently **not** checked in the Continuous
 Integration runs, or required to be run as part of the review process
-of pul requests.
+of pull requests.
 
 .. _handling_nd:
 

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -863,6 +863,26 @@ Notes
 
 Notes on the design and changes to Sherpa.
 
+.. _typing_statements:
+
+Adding typing statements
+------------------------
+
+Typing rules, such as::
+
+  def random(rng: Optional[RandomType]) -> float:
+
+are being added to the Sherpa code base to see if they improve the
+maintenance and development of Sherpa. This is an incremental process
+and it is likely that existing typing statements will need to be
+updated when new rules are added (for instance, it is not always
+obvious when a routine accepts or returns a sequence, a NumPy array,
+or either). The aim is to try and model the intention of the API
+without matching every single possible type that could be used. The
+typing rules are also currently **not** checked in the Continuous
+Integration runs, or required to be run as part of the review process
+of pul requests.
+
 .. _handling_nd:
 
 N-dimensional data and models

--- a/sherpa/utils/parallel.py
+++ b/sherpa/utils/parallel.py
@@ -42,7 +42,7 @@ import numpy as np
 from sherpa import get_config
 from .random import RandomType
 
-# A number of symbols has been added to this module in release 4.17.0
+# A number of symbols have been added to this module in release 4.17.0
 # to allow typing statements to be made. This is partly because the
 # multiprocessing module, which provides a number of symbols that
 # would be used in such statements, is optional (and so is the

--- a/sherpa/utils/parallel.py
+++ b/sherpa/utils/parallel.py
@@ -76,7 +76,7 @@ class CallbackWithRNG(Protocol[I_contra, O_co]):
 # is hard to type things with a class defined in these modules.
 #
 class SupportsProcess(Protocol):
-    """Label those methods from mulltiprocessing.Process we need."""
+    """Label those methods from multiprocessing.Process we need."""
 
     exitcode: Optional[int]
 

--- a/sherpa/utils/parallel.py
+++ b/sherpa/utils/parallel.py
@@ -594,9 +594,10 @@ def parallel_map(function: Callback[I_contra, O_co],
     # group sequence into numcores-worth of chunks
     sequence = split_array(sequence, ncores)
 
+    assert context.Process is not None
     procs = [context.Process(target=worker,
-                             args=(function, ii, chunk, out_q, err_q))
-             for ii, chunk in enumerate(sequence)]
+                             args=(function, idx, chunk, out_q, err_q))
+             for idx, chunk in enumerate(sequence)]
 
     return run_tasks(procs, err_q, out_q)
 
@@ -686,6 +687,10 @@ def parallel_map_funcs(funcs, datasets, numcores=None):
         #
         return list(map(funcs[0], datasets))
 
+    # At this point we know context is not None but the typing code
+    # does not.
+    assert context is not None
+
     if numcores is None:
         numcores = _ncpus
 
@@ -701,9 +706,10 @@ def parallel_map_funcs(funcs, datasets, numcores=None):
     out_q = manager.Queue()
     err_q = manager.Queue()
 
+    assert context.Process is not None
     procs = [context.Process(target=worker,
-                             args=(funcs[ii], ii, chunk, out_q, err_q))
-             for ii, chunk in enumerate(datasets)]
+                             args=(funcs[idx], idx, chunk, out_q, err_q))
+             for idx, chunk in enumerate(datasets)]
 
     return run_tasks(procs, err_q, out_q)
 
@@ -848,9 +854,10 @@ def parallel_map_rng(function: CallbackWithRNG[I_contra, O_co],
     # particular generator) or to get it to use np.random.RandomState
     # if required.
     #
+    assert context.Process is not None
     procs = [context.Process(target=worker_rng,
-                             args=(function, ii, chunk, out_q, err_q,
+                             args=(function, idx, chunk, out_q, err_q,
                                    np.random.default_rng(seed)))
-             for ii, (chunk, seed) in enumerate(zip(sequence, seeds))]
+             for idx, (chunk, seed) in enumerate(zip(sequence, seeds))]
 
     return run_tasks(procs, err_q, out_q)

--- a/sherpa/utils/parallel.py
+++ b/sherpa/utils/parallel.py
@@ -42,7 +42,7 @@ import numpy as np
 from sherpa import get_config
 from .random import RandomType
 
-# A numer of symbols has been added to this module in release 4.17.0
+# A number of symbols has been added to this module in release 4.17.0
 # to allow typing statements to be made. This is partly because the
 # multiprocessing module, which provides a number of symbols that
 # would be used in such statements, is optional (and so is the

--- a/sherpa/utils/random.py
+++ b/sherpa/utils/random.py
@@ -147,6 +147,12 @@ def random(rng: Optional[RandomType]) -> float:
     return rng.random()
 
 
+# The following routines do not add a type for the size parameter
+# because it would have to be something like
+#     int | Sequence[int] | ndarray
+# and it does not seem worth the complexity.
+#
+
 def uniform(rng: Optional[RandomType],
             low: float,
             high: float,

--- a/sherpa/utils/random.py
+++ b/sherpa/utils/random.py
@@ -27,7 +27,7 @@ allows both the legacy (pre 1.17) NumPy random API to be used
 
 """
 
-from typing import Optional, Sequence, SupportsFloat, Union, \
+from typing import Literal, Optional, Sequence, SupportsFloat, Union, \
     overload
 
 import numpy as np
@@ -62,9 +62,7 @@ def poisson_noise(x: Sequence[SupportsFloat],
                   ) -> np.ndarray:
     ...
 
-def poisson_noise(x: Union[SupportsFloat, Sequence[SupportsFloat]],
-                  rng: Optional[RandomType] = None
-                  ) -> Union[SherpaFloat, np.ndarray]:
+def poisson_noise(x, rng=None):
     """Draw samples from a Poisson distribution.
 
 
@@ -147,17 +145,27 @@ def random(rng: Optional[RandomType]) -> float:
     return rng.random()
 
 
-# The following routines do not add a type for the size parameter
-# because it would have to be something like
-#     int | Sequence[int] | ndarray
-# and it does not seem worth the complexity.
-#
+# Try to come up with a sensible type for the size field.
+SizeType = Union[int, Sequence[int], np.ndarray]
 
+
+@overload
 def uniform(rng: Optional[RandomType],
             low: float,
             high: float,
-            size=None
+            size: Literal[None]
+            ) -> float:
+    ...
+
+@overload
+def uniform(rng: Optional[RandomType],
+            low: float,
+            high: float,
+            size: SizeType
             ) -> np.ndarray:
+    ...
+
+def uniform(rng, low, high, size=None):
     """Create a random value within a uniform range.
 
     Parameters
@@ -214,11 +222,23 @@ def integers(rng: Optional[RandomType],
         return rng.randint(high)  # type: ignore[union-attr]
 
 
+@overload
 def normal(rng: Optional[RandomType],
-           loc: float = 0,
-           scale: float = 1,
-           size=None
+           loc: float,
+           scale: float,
+           size: Literal[None]
+           ) -> float:
+    ...
+
+@overload
+def normal(rng: Optional[RandomType],
+           loc: float,
+           scale: float,
+           size: SizeType
            ) -> np.ndarray:
+    ...
+
+def normal(rng, loc=0.0, scale=1.0, size=None):
     """Create a random value from a normal distribution.
 
     Parameters
@@ -245,9 +265,19 @@ def normal(rng: Optional[RandomType],
     return rng.normal(loc=loc, scale=scale, size=size)
 
 
+@overload
 def standard_normal(rng: Optional[RandomType],
-                    size=None
+                    size: Optional[None]
+                    ) -> float:
+    ...
+
+@overload
+def standard_normal(rng: Optional[RandomType],
+                    size: SizeType
                     ) -> np.ndarray:
+    ...
+
+def standard_normal(rng, size=None):
     """Create a random value from a normal distribution (mean=0, stdev=1).
 
     Parameters

--- a/sherpa/utils/random.py
+++ b/sherpa/utils/random.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2023
+#  Copyright (C) 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -27,9 +27,22 @@ allows both the legacy (pre 1.17) NumPy random API to be used
 
 """
 
+from typing import Optional, Sequence, SupportsFloat, Union, \
+    overload
+
 import numpy as np
 
 from .numeric_types import SherpaFloat
+
+# This should probably be an explicit type alias but for now leave it
+# like this. Users are expected to use the Generator rather than
+# RandomState form, but both are kept in (e.g. for testing).
+#
+# Once Python 3.10 or 3.12 is the minimum we can make this an actual
+# alias that we can export. For now this "alias" can be used by other
+# modules but the documentation is not ideal and the name may change.
+#
+RandomType = Union[np.random.Generator, np.random.RandomState]
 
 
 __all__ = ("chisquare", "choice", "integers",
@@ -37,7 +50,21 @@ __all__ = ("chisquare", "choice", "integers",
            "random", "standard_normal", "uniform")
 
 
-def poisson_noise(x, rng=None):
+@overload
+def poisson_noise(x: SupportsFloat,
+                  rng: Optional[RandomType] = None
+                  ) -> SherpaFloat:
+    ...
+
+@overload
+def poisson_noise(x: Sequence[SupportsFloat],
+                  rng: Optional[RandomType] = None
+                  ) -> np.ndarray:
+    ...
+
+def poisson_noise(x: Union[SupportsFloat, Sequence[SupportsFloat]],
+                  rng: Optional[RandomType] = None
+                  ) -> Union[SherpaFloat, np.ndarray]:
     """Draw samples from a Poisson distribution.
 
 
@@ -99,7 +126,7 @@ def poisson_noise(x, rng=None):
     return x_out
 
 
-def random(rng):
+def random(rng: Optional[RandomType]) -> float:
     """Create a random value [0, 1.0)
 
     Parameters
@@ -120,7 +147,11 @@ def random(rng):
     return rng.random()
 
 
-def uniform(rng, low, high, size=None):
+def uniform(rng: Optional[RandomType],
+            low: float,
+            high: float,
+            size=None
+            ) -> np.ndarray:
     """Create a random value within a uniform range.
 
     Parameters
@@ -145,7 +176,9 @@ def uniform(rng, low, high, size=None):
     return rng.uniform(low, high, size=size)
 
 
-def integers(rng, high):
+def integers(rng: Optional[RandomType],
+             high: int
+             ) -> int:
     """Create a random integer from [0, high).
 
     Parameters
@@ -169,14 +202,17 @@ def integers(rng, high):
     # method for Generator and RandomState.
     #
     try:
-        # Try Generator first
-        return rng.integers(high)
+        return rng.integers(high)  # type: ignore[union-attr]
     except AttributeError:
-        # Assume RandmoState
-        return rng.randint(high)
+        # Fall back on RandomState
+        return rng.randint(high)  # type: ignore[union-attr]
 
 
-def normal(rng, loc=0, scale=1, size=None):
+def normal(rng: Optional[RandomType],
+           loc: float = 0,
+           scale: float = 1,
+           size=None
+           ) -> np.ndarray:
     """Create a random value from a normal distribution.
 
     Parameters
@@ -203,7 +239,9 @@ def normal(rng, loc=0, scale=1, size=None):
     return rng.normal(loc=loc, scale=scale, size=size)
 
 
-def standard_normal(rng, size=None):
+def standard_normal(rng: Optional[RandomType],
+                    size=None
+                    ) -> np.ndarray:
     """Create a random value from a normal distribution (mean=0, stdev=1).
 
     Parameters
@@ -226,7 +264,11 @@ def standard_normal(rng, size=None):
     return rng.standard_normal(size=size)
 
 
-def multivariate_normal(rng, mean, cov, size=None):
+def multivariate_normal(rng: Optional[RandomType],
+                        mean,
+                        cov,
+                        size=None
+                        ) -> np.ndarray:
     """Create a random value from a multivariate normal distribution.
 
     Parameters
@@ -251,7 +293,10 @@ def multivariate_normal(rng, mean, cov, size=None):
     return rng.multivariate_normal(mean, cov, size=size)
 
 
-def chisquare(rng, df, size=None):
+def chisquare(rng: Optional[RandomType],
+              df,
+              size=None
+              ) -> np.ndarray:
     """Create a random value from a multivariate normal distribution.
 
     Parameters
@@ -276,7 +321,10 @@ def chisquare(rng, df, size=None):
     return rng.chisquare(df, size=size)
 
 
-def choice(rng, xs, n):
+def choice(rng: Optional[RandomType],
+           xs: Sequence,
+           n
+           ) -> np.ndarray:
     """Create a subset of elements from xs with no duplication.
 
     Parameters


### PR DESCRIPTION
# Summary

Add typing statements to the sherpa.utils.parallel and sherpa.utils.random modules. There should be no changes to the functionality of these modules.

# Details

These were created for #2022 but can be considered separately.

These are low-level routines which most people are not expected to use. In adding these typing rules I have

- taken the decision that we want to try to get something that matches the "intent" of the API but it may not actually match the reality (there are fun discussions about `Sequence` vs `np.ndarray` and `float` vs `SupportsFloat` that can hide the actual code). It's also the case that until we have "all" areas typed (or, at least, modules that interact, such as fit/stats/optimizers) that we won't know the "best" type to use.

- created a number of protocols to represent types from the multiprocessing module, since we can not guarantee that this module (or the threading module, which multiprocessing tends to replicate) are present. It does, however, make it more obvious what features we need.

- the multiprocessing.BaseContext class, which would be the obvious class to "type" the sherpa.utils.parallel.context variable (modulo the need for using a protocol) is not useful since this class does no have a Process attribute, whereas all the actual "usable" contexts do. This leads to several "type: ignore[assignment]" statements

- the use of generic types to track the values created/used by the random routines, and to make sure we have the correct callable and queue, can be considered somewhat experimental: this seems to work but we need to see how it is handled long term to know if it's useful or not. It is interesting (to me) that our use of the queue type is technically more constrained than the general version (i.e. our use of the queue assumes that each queue only handles a specific type, rather than just sending around "anything", and the question becomes how do we take advantage of this)

- it would be nice to use type aliases, but we still need to support Python 3.9 (although this may be relaxed soon) and the behavior changes between Python 3.10 (TypeAlias) and Python 3.12 (type and TypeAliasType). This is most keenly felt for the RandomType alias - at the moment we have it but do not directly export it (although we allow other code to use it).
