### PR TITLE
stats: add typing rules

### DIFF
--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -825,55 +825,50 @@ class UserStat(Stat):
     """
 
     def __init__(self, statfunc=None, errfunc=None, name='userstat'):
+        # These two could be checked by comparing
         self._statfuncset = False
-        self.statfunc = (lambda x: None)
-
         self._staterrfuncset = False
-        self.errfunc = (lambda x: None)
+
+        # statfunc and _calc serve the same purpose but leave as is
+        # in case users use the statfunc field
+        self.statfunc = None
+        self.errfunc = None
 
         if statfunc is not None:
             self.statfunc = statfunc
             self._calc = statfunc
-            self._statfuncset = True
 
         if errfunc is not None:
             self.errfunc = errfunc
-            self._staterrfuncset = True
 
         super().__init__(name=name)
 
     def __getstate__(self):
+        # TODO: Do we still need to do this?
         state = self.__dict__.copy()
-        # Function pointers to methods of the class
-        # (of type 'instancemethod') are NOT picklable
-        # remove them and restore later with a coord init
         del state['statfunc']
         del state['errfunc']
-
         return state
 
     def __setstate__(self, state):
-        # Populate the function pointers we deleted at pickle time with
-        # no-ops.
-        self.__dict__['statfunc'] = (lambda x: None)
-        self.__dict__['errfunc'] = (lambda x: None)
+        # TODO: Do we still need to do this?
+        self.__dict__['statfunc'] = None
+        self.__dict__['errfunc'] = None
         self.__dict__.update(state)
 
     def set_statfunc(self, func):
         self.statfunc = func
-        self._statfuncset = True
 
     def set_errfunc(self, func):
         self.errfunc = func
-        self._staterrfuncset = True
 
     def calc_staterror(self, data):
-        if not self._staterrfuncset:
+        if self.errfunc is None:
             raise StatErr('nostat', self.name, 'calc_staterror()')
         return self.errfunc(data)
 
     def calc_stat(self, data, model):
-        if not self._statfuncset:
+        if self.statfunc is None:
             raise StatErr('nostat', self.name, 'calc_stat()')
 
         fitdata, modeldata = self._get_fit_model_data(data, model)

--- a/sherpa/utils/types.py
+++ b/sherpa/utils/types.py
@@ -41,9 +41,17 @@ import numpy as np
 #
 ArrayType = Union[Sequence[float], np.ndarray]
 
-# Represent statistic evaluation, per-bin.
+# Represent statistic evaluation.
+#
+# Ideally the callable routines would be labelled as accepting
+# [ArrayType] and return np.ndarray, but we do not enforce this yet
+# (and it is not entirely clear whether the stat functions may accept
+# multiple arguments).
 #
 StatErrFunc = Callable[..., ArrayType]
+StatResults = tuple[float, np.ndarray]
+StatFunc = Callable[..., StatResults]
+
 
 # Represent model evaluation. Using a Protocol may be better, but
 # for now keep with a Callable. Ideally the model would just


### PR DESCRIPTION
# Summary

Add typing rules to sherpa.stats and minor internal clean up to the module.

# Details

This is spun out of #2022 (similar to #2033). The idea being that we need all these separate parts to have typing rules to be able to catch any issues.

This improves the typing rules for the routines in `sherpa.stats`. As mentioned in #2022 these are somewhat aspirational, since the reality of how they could be used is "tricky", but they have pointed out some internal issues. The `sherpa.stats.Stat` hierarchy could see some changes but it isn't worth it at this time (i.e. only worth doing if it would add some functionality).

Three "interesting" things this has shown are

- the `calc_staterror` routine is now marked `staticmethod` in the base class since some user-facing classes have it set up - and in fact the xspec variance needs it related to issue #356 - *but* the `UserStat` class needs it to be a normal method (ie have access to the object). The options are
  1. live with this mismatch - this is the option I have picked
  2. make everything a `staticmethod` - which I don't think is possible
  3. fix the code to allow `staticmethod` to be removed, which I just don't want to do at this time
- the tests seem to make interesting use of the class hierarchy, using `UserStat` as their starting point, when they should probably just extend the class they are "extending"
- a lot of the tests require having xspec, the data, and an IO package installed when they really should have most tests run without needing them; there's also a lot of use of UI level code when we should be using the objects directly (with ui tests in the ui area)

So there's more work we could do, but I don't really see it being worth it at this time (other than perhaps fixing the `staticmethod` issue).