### PR TITLE
Add a security reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+
+We only support the latest minor version of `sherpa` with security updates. 
+
+## Reporting a Vulnerability
+
+[GitHub private security vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+should be enabled for `sherpa`. But if that does not work for whatever reason, please report to 
+cxchelp@cfa.harvard.edu.
+
+The Sherpa team will send a response indicating the next steps in handling your report. We will assess your report and determine the impact and severity of the vulnerability. If the report is accepted, we will work on a hotfix; if we deem this vulnerability not to be relevant, we may decide not to address it in the code. Either way, we will communicate back to you and may ask for additional information or guidance.
+
+Thank you for your help!


### PR DESCRIPTION
This text assumes that someone with "admin" permission in the repro (probably Warren?) activates github private security reporting, which wont' hurt: https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository

If that form is activated, all repro admins will get an email and see the report in the "security" tab on the repro. They can then decide how to continue, e.g. share the report with other developers as needed.