### PR TITLE
Mark code as deprecated in sherpa.utils

### DIFF
--- a/sherpa/estmethods/__init__.py
+++ b/sherpa/estmethods/__init__.py
@@ -25,7 +25,7 @@ import numpy as np
 from numpy.linalg import LinAlgError
 
 from sherpa.utils import NoNewAttributesAfterInit, print_fields, Knuth_close, \
-    is_iterable, list_to_open_interval, mysgn, quad_coef, \
+    is_iterable, list_to_open_interval, quad_coef, \
     demuller, zeroin, OutOfBoundErr, func_counter
 from sherpa.utils.parallel import multi, ncpus, context, process_tasks
 
@@ -719,7 +719,7 @@ class ConfRootBracket(ConfRootNone):
         xxx = self.trial_points[0]
         fff = self.trial_points[1]
 
-        if mysgn(fff[-2]) == mysgn(fff[-1]):
+        if np.sign(fff[-2]) == np.sign(fff[-1]):
             self.root = None
             return None
 
@@ -733,7 +733,7 @@ class ConfRootBracket(ConfRootNone):
             xbfb = answer[1][1]
             xb = xbfb[0]
             fb = xbfb[1]
-            if mysgn(fa) != mysgn(fb):
+            if np.sign(fa) != np.sign(fb):
                 if not self.open_interval:
                     warn_user_about_open_interval([xa, xb])
                     return (xa + xb) / 2.0
@@ -793,7 +793,7 @@ class ConfStep:
 
     def is_same_dir(self, dir, current_pos, proposed_pos):
         delta = proposed_pos - current_pos
-        return mysgn(delta) == ConfBracket.neg_pos[dir]
+        return np.sign(delta) == ConfBracket.neg_pos[dir]
 
     def quad(self, dir, iter, step_size, base, bloginfo):
 

--- a/sherpa/estmethods/__init__.py
+++ b/sherpa/estmethods/__init__.py
@@ -26,7 +26,7 @@ from numpy.linalg import LinAlgError
 
 from sherpa.utils import NoNewAttributesAfterInit, print_fields, Knuth_close, \
     is_iterable, list_to_open_interval, quad_coef, \
-    demuller, zeroin, OutOfBoundErr, func_counter
+    demuller, zeroin, OutOfBoundErr, FuncCounter
 from sherpa.utils.parallel import multi, ncpus, context, process_tasks
 
 import sherpa.estmethods._est_funcs
@@ -1027,8 +1027,7 @@ def confidence(pars, parmins, parmaxes, parhardmins, parhardmaxes, sigma, eps,
 
     def func(counter, singleparnum, lock=None):
 
-        # nfev contains the number of times it was fitted
-        nfev, counter_cb = func_counter(fit_cb)
+        counter_cb = FuncCounter(fit_cb)
 
         #
         # These are the bounds to be returned by this method
@@ -1101,7 +1100,7 @@ def confidence(pars, parmins, parmaxes, parhardmins, parhardmaxes, sigma, eps,
         store[par_name] = trial_points
 
         return (conf_int[0][0], conf_int[1][0], error_flags[0],
-                nfev[0], None)
+                counter_cb.nfev, None)
 
     if len(limit_parnums) < 2 or not multi or numcores < 2:
         do_parallel = False

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -28,7 +28,7 @@ from numpy import arange, array, iterable, sqrt, where, \
     ones_like, isnan, isinf
 
 from sherpa.utils import NoNewAttributesAfterInit, print_fields, erf, \
-    bool_cast, is_in, is_iterable, list_to_open_interval, sao_fcmp
+    bool_cast, is_iterable, list_to_open_interval, sao_fcmp
 from sherpa.utils.err import DataErr, EstErr, FitErr, SherpaErr
 from sherpa.utils import formatting
 from sherpa.data import DataSimulFit
@@ -530,10 +530,8 @@ class ErrorEstResults(NoNewAttributesAfterInit):
 
             return out
 
-        low = map(is_iterable, self.parmins)
-        high = map(is_iterable, self.parmaxes)
-        in_low = is_in(True, low)
-        in_high = is_in(True, high)
+        in_low = True in map(is_iterable, self.parmins)
+        in_high = True in map(is_iterable, self.parmaxes)
         mymethod = self.methodname == 'confidence'
 
         lowstr = '%12s '

--- a/sherpa/optmethods/ncoresde.py
+++ b/sherpa/optmethods/ncoresde.py
@@ -279,7 +279,7 @@ class MyDifEvo(Opt):
 
         mypop = self.polytope
         npop_1 = self.npop - 1
-        while self.nfev[0] < maxnfev:
+        while self.nfev < maxnfev:
             for pop_index in range(self.npop):
                 key = self.calc_key([pop_index])
                 # trial = self.all_strategies(pop_index)
@@ -294,7 +294,7 @@ class MyDifEvo(Opt):
         best_vertex = mypop[0]
         best_par = best_vertex[:-1]
         best_val = best_vertex[-1]
-        return self.nfev[0], best_val, best_par
+        return self.nfev, best_val, best_par
 
     def all_strategies(self, key):
         rand, index = self.key2.parse(key)

--- a/sherpa/optmethods/ncoresnm.py
+++ b/sherpa/optmethods/ncoresnm.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019, 2020, 2021, 2023
+#  Copyright (C) 2019- 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -42,16 +42,13 @@ class MyNelderMead(Opt):
 
     def __call__(self, xpar, maxnfev, tol, step, finalsimplex, verbose):
 
-        # print('MyNelderMead::__call__ xpar =', xpar)
         npar = len(xpar)
         simplex = SimplexStep(func=self.func, npop=npar + 1,
                               xpar=xpar, xmin=self.xmin,
                               xmax=self.xmax, step=step, seed=None,
                               factor=None)
-        result = self.optimize(xpar, simplex, maxnfev, tol,
-                               finalsimplex, verbose)
-        # print('MyNelderMead::__call__ result =', result)
-        return result
+        return self.optimize(xpar, simplex, maxnfev, tol,
+                             finalsimplex, verbose)
 
     def contract_in_out(self, simplex, centroid, reflection_pt, rho_gamma,
                         contraction_coef, badindex, maxnfev, verbose):
@@ -95,7 +92,7 @@ class MyNelderMead(Opt):
         rho_gamma = self.reflection_coef * self.contraction_coef
         bad_index = len(xpar)
 
-        while self.nfev[0] < maxnfev:
+        while self.nfev < maxnfev:
 
             simplex.sort()
             if verbose > 2:
@@ -135,7 +132,7 @@ class MyNelderMead(Opt):
         best_vertex = simplex[0]
         best_par = best_vertex[:-1]
         best_val = best_vertex[-1]
-        return self.nfev[0], best_val, best_par
+        return self.nfev, best_val, best_par
 
 
 class NelderMeadBase:
@@ -167,10 +164,8 @@ class NelderMead0(NelderMeadBase):
 
     def __call__(self, fcn, x, xmin, xmax, tol=1.0e-6,  maxnfev=None, step=None,
                  finalsimplex=1, verbose=0):
-        nfev, fmin, par = \
-            self.neldermead0(fcn, x, xmin, xmax, step, finalsimplex, maxnfev,
-                             tol, verbose)
-        return nfev, fmin, par
+        return self.neldermead0(fcn, x, xmin, xmax, step, finalsimplex, maxnfev,
+                                tol, verbose)
 
     def calc_step(self, x):
         return 1.2 * x
@@ -183,10 +178,8 @@ class NelderMead0(NelderMeadBase):
         my_nm = MyNelderMead(fcn, xmin, xmax)
         if step is None:
             step = self.calc_step(x0)
-        nfev, fmin, par = my_nm(x0, maxnfev, tol, step, finalsimplex, verbose)
-        # print('f', par, '=', fmin, '@', nfev, 'nfevs')
-        # print('neldermead0 covar=\n', my_nm.calc_covar())
-        return nfev, fmin, par
+
+        return my_nm(x0, maxnfev, tol, step, finalsimplex, verbose)
 
 
 class NelderMead1(NelderMead0):
@@ -279,18 +272,15 @@ class NelderMead6(NelderMeadBase):
                                     xpar=x, xmin=self.xmin,
                                     xmax=self.xmax, step=None,
                                     seed=None, factor=None)
-            result = self.optimize(x, simplex, maxnfev, tol,
-                                   finalsimplex, verbose)
-            # print('MyNelderMead6::__call__ result =', result)
-            return result
+            return self.optimize(x, simplex, maxnfev, tol,
+                                 finalsimplex, verbose)
 
     def __call__(self, fcn, x, xmin, xmax, tol=1.0e-6,  maxnfev=None,
                  step=None, finalsimplex=1, verbose=0):
         my_nm_6 = NelderMead6.MyNelderMead6(fcn, xmin, xmax)
         if maxnfev is None:
             maxnfev = 512 * len(x)
-        result = my_nm_6(x, maxnfev, tol, step, finalsimplex, verbose)
-        return result
+        return my_nm_6(x, maxnfev, tol, step, finalsimplex, verbose)
 
 
 class NelderMead7(NelderMeadBase):
@@ -304,18 +294,15 @@ class NelderMead7(NelderMeadBase):
             simplex = SimplexRandom(func=self.func, npop=npar + 1, xpar=x,
                                     xmin=self.xmin, xmax=self.xmax,
                                     step=None, seed=None, factor=factor)
-            result = self.optimize(x, simplex, maxnfev, tol,
-                                   finalsimplex, verbose)
-            # print('MyNelderMead7::__call__ result =', result)
-            return result
+            return self.optimize(x, simplex, maxnfev, tol,
+                                 finalsimplex, verbose)
 
     def __call__(self, fcn, x, xmin, xmax, tol=1.0e-6,  maxnfev=None,
                  step=None, finalsimplex=1, verbose=0):
         my_nm_7 = NelderMead7.MyNelderMead7(fcn, xmin, xmax)
         if maxnfev is None:
             maxnfev = 512 * len(x)
-        result = my_nm_7(x, maxnfev, tol, step, finalsimplex, verbose)
-        return result
+        return my_nm_7(x, maxnfev, tol, step, finalsimplex, verbose)
 
 
 class nmNcores(MyNcores):

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -20,7 +20,7 @@
 
 import numpy as np
 
-from sherpa.utils import Knuth_close, func_counter
+from sherpa.utils import Knuth_close, FuncCounter
 from sherpa.utils.parallel import multi, context, run_tasks
 from sherpa.utils.random import uniform
 
@@ -70,17 +70,34 @@ class MyNcores:
 
 
 class Opt:
+    """Base optimisation class.
 
+    .. versionchanged:: 4.17.0
+       The class structure has been changed (e.g. `nfev` is now a
+       scalar and not a single-element list).
+
+    """
+
+    # QUS: we support xmin or xmax being None, but do we ever use
+    # this capability?
+    #
     def __init__(self, func, xmin, xmax):
         self.npar = len(xmin)
-        self.nfev, self.func = \
-            self.func_counter_bounds_wrappers(func, self.npar, xmin, xmax)
         self.xmin = np.asarray(xmin)
         self.xmax = np.asarray(xmax)
+        self.func_count = FuncCounter(func)
+        self.func = self.func_bounds(self.func_count, self.npar, xmin, xmax)
+
+    @property
+    def nfev(self):
+        return self.func_count.nfev
 
     def _outside_limits(self, x, xmin, xmax):
         return (np.any(x < xmin) or np.any(x > xmax))
 
+    # We should be able to take these parameters from the class, or
+    # re-write this logic.
+    #
     def func_bounds(self, func, npar, xmin=None, xmax=None):
         """In order to keep the current number of function evaluations:
         func_counter should be called before func_bounds. For example,
@@ -112,12 +129,6 @@ class Opt:
             return func(x, *args)
 
         return func_bounds_wrapper
-
-    def func_counter_bounds_wrappers(self, func, npar, xmin, xmax):
-        """Wraps the calls to func_counter then func_bounds"""
-        nfev, afunc = func_counter(func)
-        myfunc = self.func_bounds(afunc, npar, xmin, xmax)
-        return nfev, myfunc
 
 
 class SimplexBase:

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -3221,16 +3221,6 @@ def list_to_open_interval(arg):
     return f'({arg[0]:e}, {arg[1]:e})'
 
 
-def mysgn(arg):
-    if arg == 0.0:
-        return 0
-
-    if arg < 0.0:
-        return -1
-
-    return 1
-
-
 class OutOfBoundErr(Exception):
     """Indicate an out-of-bounds exception in the error analysis"""
     # Should this just move to sherpa.estmethods?
@@ -3276,7 +3266,7 @@ class QuadEquaRealRoot:
                 return [0.0, 0.0]
 
             # a * x^2 + 0 * x + c = 0
-            if mysgn(a) == mysgn(c):
+            if np.sign(a) == np.sign(c):
                 return [None, None]
 
             answer = np.sqrt(c / a)
@@ -3292,7 +3282,7 @@ class QuadEquaRealRoot:
         discriminant = b * b - 4.0 * a * c
         debug("disc=%s", discriminant)
         sqrt_disc = np.sqrt(discriminant)
-        t = - (b + mysgn(b) * sqrt_disc) / 2.0
+        t = - (b + np.sign(b) * sqrt_disc) / 2.0
         return [c / t, t / a]
 
 
@@ -3358,7 +3348,7 @@ def bisection(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=48, tol=1.0e-6):
         if abs(fb) <= tol:
             return [[xb, fb], [[xb, fb], [xb, fb]], nfev[0]]
 
-        if mysgn(fa) == mysgn(fb):
+        if np.sign(fa) == np.sign(fb):
             # TODO: is this a useful message for the user?
             warning('%s: %s fa * fb < 0 is not met', __name__, fcn.__name__)
             return [[None, None], [[None, None], [None, None]], nfev[0]]
@@ -3373,7 +3363,7 @@ def bisection(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=48, tol=1.0e-6):
                 if abs(xa - xb) < min(tol * abs(xb), tol / 10.0):
                     return [[xc, fc], [[xa, fa], [xb, fb]], nfev[0]]
 
-                if mysgn(fa) != mysgn(fc):
+                if np.sign(fa) != np.sign(fc):
                     xb, fb = xc, fc
                 else:
                     xa, fa = xc, fc
@@ -3586,10 +3576,10 @@ def demuller(fcn, xa, xb, xc, fa=None, fb=None, fc=None, args=(),
             discriminant = max(C * C - 4.0 * fc * B, 0.0)
 
             if is_nan(B) or is_nan(C) or \
-                    0.0 == C + mysgn(C) * np.sqrt(discriminant):
+                    0.0 == C + np.sign(C) * np.sqrt(discriminant):
                 return [[None, None], [[None, None], [None, None]], nfev[0]]
 
-            xd = xc - 2.0 * fc / (C + mysgn(C) * np.sqrt(discriminant))
+            xd = xc - 2.0 * fc / (C + np.sign(C) * np.sqrt(discriminant))
 
             fd = myfcn(xd, *args)
             # print 'fd(%e)=%e' % (xd, fd)
@@ -3677,7 +3667,7 @@ def new_muller(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.e-6):
         if abs(fb) <= tol:
             return [[xb, fb], [[xb, fb], [xb, fb]], nfev[0]]
 
-        if mysgn(fa) == mysgn(fb):
+        if np.sign(fa) == np.sign(fb):
             warning('%s: %s fa * fb < 0 is not met', __name__, fcn.__name__)
             return [[None, None], [[None, None], [None, None]], nfev[0]]
 
@@ -3694,36 +3684,36 @@ def new_muller(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.e-6):
 
             discriminant = max(C * C - 4.0 * fc * B, 0.0)
 
-            xd = xc - 2.0 * fc / (C + mysgn(C) * np.sqrt(discriminant))
+            xd = xc - 2.0 * fc / (C + np.sign(C) * np.sqrt(discriminant))
 
             fd = myfcn(xd, *args)
             # print 'fd(%e)=%e' % (xd, fd)
             if abs(fd) <= tol:
                 return [[xd, fd], [[xa, fa], [xb, fb]], nfev[0]]
 
-            if mysgn(fa) != mysgn(fc):
+            if np.sign(fa) != np.sign(fc):
                 xb, fb = xc, fc
                 continue
 
-            if mysgn(fd) != mysgn(fc) and xc < xd:
+            if np.sign(fd) != np.sign(fc) and xc < xd:
                 xa, fa = xc, fc
                 xb, fb = xd, fd
                 continue
 
-            if mysgn(fb) != mysgn(fd):
+            if np.sign(fb) != np.sign(fd):
                 xa, fa = xd, fd
                 continue
 
-            if mysgn(fa) != mysgn(fd):
+            if np.sign(fa) != np.sign(fd):
                 xb, fb = xd, fd
                 continue
 
-            if mysgn(fc) != mysgn(fd) and xd < xc:
+            if np.sign(fc) != np.sign(fd) and xd < xc:
                 xa, fa = xd, fd
                 xb, fb = xc, fc
                 continue
 
-            if mysgn(fc) != mysgn(fd):
+            if np.sign(fc) != np.sign(fd):
                 xa, fa = xc, fc
                 continue
 
@@ -3811,7 +3801,7 @@ def apache_muller(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
         if abs(fb) <= tol:
             return [[xb, fb], [[xb, fb], [xb, fb]], nfev[0]]
 
-        if mysgn(fa) == mysgn(fb):
+        if np.sign(fa) == np.sign(fb):
             warning('%s: %s fa * fb < 0 is not met', __name__, fcn.__name__)
             return [[None, None], [[None, None], [None, None]], nfev[0]]
 
@@ -3834,7 +3824,7 @@ def apache_muller(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
             B = tran[0]
             C = tran[1]
             discriminant = max(C * C - 4.0 * fc * B, 0.0)
-            den = mysgn(C) * np.sqrt(discriminant)
+            den = np.sign(C) * np.sqrt(discriminant)
             xplus = xc - 2.0 * fc / (C + den)
             if C != den:
                 xminus = xc - 2.0 * fc / (C - den)
@@ -3886,7 +3876,7 @@ def apache_muller(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
                 # print 'MullerBound() fmid(%.14e)=%.14e' % (xmid,fmid)
                 if abs(fmid) <= tol:
                     return [[xmid, fmid], [[xa, fa], [xb, fb]], nfev[0]]
-                if mysgn(fa) + mysgn(fmid) == 0:
+                if np.sign(fa) + np.sign(fmid) == 0:
                     xb = xmid
                     fb = fmid
                 else:
@@ -4007,7 +3997,7 @@ def zeroin(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.0e-2):
         if abs(fb) <= tol:
             return [[xb, fb], [[xa, fa], [xb, fb]], nfev[0]]
 
-        if mysgn(fa) == mysgn(fb):
+        if np.sign(fa) == np.sign(fb):
             warning('%s: %s fa * fb < 0 is not met', __name__, fcn.__name__)
             return [[None, None], [[None, None], [None, None]], nfev[0]]
 
@@ -4030,13 +4020,13 @@ def zeroin(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.0e-2):
                 return [[xb, fb], [[xa, fa], [xb, fb]], nfev[0]]
 
             if abs(new_step) <= tol_act:
-                if mysgn(fb) != mysgn(fa):
+                if np.sign(fb) != np.sign(fa):
                     tmp = apache_muller(fcn, xa, xb, fa, fb, args=args,
                                         maxfev=maxfev - nfev[0], tol=tol)
                     tmp[-1] += nfev[0]
                     return tmp
 
-                if mysgn(fb) != mysgn(fc):
+                if np.sign(fb) != np.sign(fc):
                     tmp = apache_muller(fcn, xb, xc, fb, fc, args=args,
                                         maxfev=maxfev - nfev[0], tol=tol)
                     tmp[-1] += nfev[0]

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -35,7 +35,6 @@ import sys
 from types import FunctionType, MethodType
 
 import numpy as np
-import numpy.fft
 
 # Note: _utils.gsl_fcmp and _utils.ndtri are not exported from
 #       this module; is this intentional?

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -33,6 +33,7 @@ import pydoc
 import string
 import sys
 from types import FunctionType, MethodType
+import warnings
 
 import numpy as np
 
@@ -3101,6 +3102,17 @@ def func_counter_history(func, history):
 
 
 def is_in(arg, seq):
+    """DEPRECATED.
+
+    .. deprecated:: 4.17.0
+       Use the Python `in` operator instead.
+
+    """
+    # This is FutureWarning rather than DeprecationWarning to make
+    # sure users see the message.
+    #
+    warnings.warn("is_in is deprecated in 4.17.0: use Python's in instead",
+                  FutureWarning)
     for x in seq:
         if arg == x:
             return True

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -18,8 +18,11 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-"""
-Objects and utilities used by multiple Sherpa subpackages.
+"""Objects and utilities used by multiple Sherpa subpackages.
+
+Code in this module should not be considered stable, as it may be
+moved, changed, or removed.
+
 """
 
 import inspect

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -3637,19 +3637,6 @@ def new_muller(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.e-6):
         If any of those values is not available, ``None`` will be returned
         instead.
     '''
-    # This function does not appear to be used
-    def regula_falsi(x0, x1, f0, f1):
-        if f0 < f1:
-            xl, fl = x0, f0
-            xh, fh = x1, f1
-        else:
-            xl, fl = x1, f1
-            xh, fh = x0, f0
-        x = xl + (xh - xl) * fl / (fl - fh)
-        if is_sequence(x0, x, x1):
-            return x
-
-        return (x0 + x1) / 2.0
 
     history = [[], []]
     nfev, myfcn = func_counter_history(fcn, history)


### PR DESCRIPTION
# Summary

Rework sherpa.utils and mark some symbols as deprecated - `func_counter`, `is_in`, and `mysgn` - along with suggested replacements.

# Details

This is a subset of the changes in #2015 and updated so that they generally do not remove the function, but 

a) replace the use of the function elsewhere in Sherpa
b) mark it as deprecated so that users will know if they ever use the symbol

These are generally very low-level routines which we do not explicitly mark as export from `sherpa.utils`, but someone may have tried to use them.

Most of the replacements are "better" - that is, they can be replaced by standard code, whether from Python or NumPy, but the `func_counter` change is a bit more, since we replace a decorator with a class, as it is nicer to just access the `nfev` field of the object rather than have a magically-updated `nfev` array where we have to remember to access the first element. The decorator could have been re-written to store the data in the callable, but then it's essentially the same as the class approach. At this point I think it becomes a style issue - some very basic tests suggests there's not much difference in run time (and I'd imagine it depends on exactly is being done and what Python version is in use).

# Example

Here's an example of the warning message you get:

```
>>> from sherpa.utils import is_in
>>> is_in(23, [2, 3, 4])
/home/dburke/sherpa/sherpa-conda/sherpa/utils/__init__.py:3137: FutureWarning: is_in is deprecated in 4.17.0: use Python's in instead
  warnings.warn("is_in is deprecated in 4.17.0: use Python's in instead",
False
>>> is_in(23, [2, 3, 4])
False
```

I decided to go with `FutureWarning` rather than `DeprecationWarning` because I was concerned that users would not see it, but this can be changed (my eyes glaze over when trying to work out what warnings are hidden by default). 