### PR TITLE
CI: update the weekly arch run to add ppc64le and to use a supported python version

### DIFF
--- a/.github/workflows/ci-pip-arch.yml
+++ b/.github/workflows/ci-pip-arch.yml
@@ -45,7 +45,9 @@ jobs:
       uses: uraimo/run-on-arch-action@v2
       with:
         arch: ${{ matrix.arch }}
-        distro: ubuntu_rolling
+        # distro: ubuntu_rolling
+        # ubuntu 22.04 uses Python 3.10
+        distro: ubuntu22.04
 
         shell: /bin/bash
 
@@ -82,7 +84,5 @@ jobs:
           #
           sed -i.orig "s|#configure=None|configure=--disable-maintainer-mode --enable-stuberrorlib --disable-shared --enable-shared=libgrp,stklib --disable-dependency-tracking|" setup.cfg
 
-          pip3 install -e .
-          pip3 install pytest
-          pip3 install pytest-xdist  # not really needed here
+          pip3 install -e .[test]
           python3 -m pytest

--- a/.github/workflows/ci-pip-arch.yml
+++ b/.github/workflows/ci-pip-arch.yml
@@ -19,14 +19,7 @@ jobs:
       matrix:
         include:
           - arch: aarch64
-
-          # The tests on ppc64le fail rather spectacularly,
-          # and it's not obvious why, so skip for now. AstroPy also
-          # see some interesting errors so maybe there are problems
-          # with the emulation or NumPy or ...
-          # https://github.com/astropy/astropy/pull/11697
-          #
-          # - arch: ppc64le
+          - arch: ppc64le
 
           # We currently do not have any user requests for this
           # architecture.


### PR DESCRIPTION
# Aim

Support the weekly test builds using aarch64 and ppc46le architectures. This support is considered experimental.

# Details

It looks like the ubuntu_rolling dockerfile has bumped the Python version to 3.12, which we currently do not support. Switch to the 22.04 LTS which uses Python 3.10.

Also update the installation to take advantage of recent changes in the build infrastructure (mainly that we now have a test installation option).

In doing this I noted that the ppc64le architecture can be turned back on - as noted in the AstroPy reports 

- https://github.com/astropy/astropy/pull/11697
- https://github.com/astropy/astropy/pull/14310

this looks like it was down to some "behind the scenes" issue in the build/emulation and not in out code base.