### PR TITLE
XSPEC: do not test bvvnei unless 12.14.0i or later is used

### DIFF
--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -117,6 +117,15 @@ def get_xspec_models():
                    "12.14.0c", "12.14.0d", "12.14.0e"]:
         remove_item(model_names, 'XSbsedov')
 
+    # The bvvnei model causes a crashe with XSPEC 12.14.0 to 12.14.0h
+    # (it should be fixed in 12.4.0i and later). The model is not
+    # present before 12.14.0.
+    #
+    if version in ["12.14.0", "12.14.0a", "12.14.0b",
+                   "12.14.0c", "12.14.0d", "12.14.0e",
+                   "12.14.0f", "12.14.0g", "12.14.0h"]:
+        remove_item(model_names, 'XSbvvnei')
+
     models = [getattr(xs, model_name) for model_name in model_names]
     models = list(filter(lambda mod: mod.version_enabled, models))
 

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -118,7 +118,7 @@ def get_xspec_models():
         remove_item(model_names, 'XSbsedov')
 
     # The bvvnei model causes a crash with XSPEC 12.14.0 to 12.14.0h
-    # (it should be fixed in 12.4.0i and later). The model is not
+    # (it should be fixed in 12.14.0i and later). The model is not
     # present before 12.14.0.
     #
     if version in ["12.14.0", "12.14.0a", "12.14.0b",

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -117,7 +117,7 @@ def get_xspec_models():
                    "12.14.0c", "12.14.0d", "12.14.0e"]:
         remove_item(model_names, 'XSbsedov')
 
-    # The bvvnei model causes a crashe with XSPEC 12.14.0 to 12.14.0h
+    # The bvvnei model causes a crash with XSPEC 12.14.0 to 12.14.0h
     # (it should be fixed in 12.4.0i and later). The model is not
     # present before 12.14.0.
     #


### PR DESCRIPTION
# Summary

Avoid testing the XSbvvnei model if XSPEC <= 12.14.0i is in use, as the model can cause a crash in this case.

# Details

Calling the XSbvvnei class can cause a seg fault (seen on macOS Intel) if XSPEC 12.14.0h is used. This turns out to be a bug fixed in XSPEC 12.14.0i, so we just skip the model if an earlier version of XSPEC is in use. This model was added in XSPEC 12.14.0.