### PR TITLE
Allow a file handle or Path object to be sent to the outfile parameter of fit

### DIFF
--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015, 2016, 2019, 2021, 2023
+#  Copyright (C) 2015, 2016, 2019, 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -50,9 +50,9 @@ except ImportError:
 
 from sherpa.data import Data, Data1D, Data1DInt, Data2D, Data2DInt
 from sherpa.models.basic import UserModel
-# from sherpa.models.parameter import Parameter
 import sherpa.utils
 from sherpa.utils.err import ArgumentErr
+from sherpa.utils.types import IdType
 
 
 logger = logging.getLogger(__name__)
@@ -65,7 +65,6 @@ string_types = (str, )
 #
 
 OutType = TypedDict("OutType", {"imports": set[str], "main": list[str]})
-IdType = Union[int, str]
 MaybeIdType = Optional[IdType]
 DataType = Union[Data1D, Data2D]
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -40,7 +40,7 @@ from sherpa.data import Data1D, Data1DAsymmetricErrs, Data2D, Data2DInt
 import sherpa.astro.all
 import sherpa.astro.plot
 from sherpa.astro.ui import serialize
-from sherpa.fit import Fit
+from sherpa.fit import Fit, FitResults
 from sherpa.sim import NormalParameterSampleFromScaleMatrix
 from sherpa.stats import Cash, CStat, WStat
 from sherpa.models.basic import TableModel
@@ -10973,7 +10973,11 @@ class Session(sherpa.ui.utils.Session):
     # DOC-TODO: existing docs suggest that bkg_only can be set, but looking
     # at the code it is always set to False.
     #
-    def fit(self, id=None, *otherids, **kwargs):
+    def fit(self,
+            id: Optional[sherpa.ui.utils.IdType] = None,
+            *otherids: sherpa.ui.utils.IdType,
+            **kwargs
+            ) -> FitResults:
         # pylint: disable=W1113
         """Fit a model to one or more data sets.
 
@@ -10986,6 +10990,10 @@ class Session(sherpa.ui.utils.Session):
         fit. The final fit results are displayed to the screen and can
         be retrieved with `get_fit_results`.
 
+        .. versionchanged:: 4.17.0
+           The outfile parameter can now be sent a Path object or a
+           file handle instead of a string.
+
         Parameters
         ----------
         id : int or str, optional
@@ -10993,13 +11001,14 @@ class Session(sherpa.ui.utils.Session):
            all data sets with an associated model are fit simultaneously.
         *otherids : sequence of int or str, optional
            Other data sets to use in the calculation.
-        outfile : str, optional
+        outfile : str, Path, IO object, or None, optional
            If set, then the fit results will be written to a file with
            this name. The file contains the per-iteration fit results.
         clobber : bool, optional
            This flag controls whether an existing file can be
-           overwritten (``True``) or if it raises an exception (``False``,
-           the default setting).
+           overwritten (``True``) or if it raises an exception
+           (``False``, the default setting). This is only used if
+           `outfile` is set to a string or Path object.
 
         Raises
         ------
@@ -11035,6 +11044,9 @@ class Session(sherpa.ui.utils.Session):
         `fit_bkg` function can be used to fit models to just the
         background data.
 
+        If outfile is sent a file handle then it is not closed by this
+        routine.
+
         Examples
         --------
 
@@ -11057,11 +11069,24 @@ class Session(sherpa.ui.utils.Session):
 
         >>> fit('jet', outfile='jet.fit', clobber=True)
 
+        Store the per-iteration values in a StringIO object and
+        extract the data into the variable txt (this avoids the need
+        to create a file):
+
+        >>> from io import StringIO
+        >>> out = StringIO()
+        >>> fit(outfile=out)
+        >>> txt = out.getvalue()
+
         """
         kwargs['bkg_only'] = False
         self._fit(id, *otherids, **kwargs)
 
-    def fit_bkg(self, id=None, *otherids, **kwargs):
+    def fit_bkg(self,
+                id: Optional[sherpa.ui.utils.IdType] = None,
+                *otherids: sherpa.ui.utils.IdType,
+                **kwargs
+                ) -> FitResults:
         # pylint: disable=W1113
         """Fit a model to one or more background PHA data sets.
 
@@ -11071,6 +11096,10 @@ class Session(sherpa.ui.utils.Session):
         these parameters are well defined before performing a
         simultaneous source and background fit.
 
+        .. versionchanged:: 4.17.0
+           The outfile parameter can now be sent a Path object or a
+           file handle instead of a string.
+
         Parameters
         ----------
         id : int or str, optional
@@ -11079,13 +11108,14 @@ class Session(sherpa.ui.utils.Session):
            model are fit simultaneously.
         *otherids : sequence of int or str, optional
            Other data sets to use in the calculation.
-        outfile : str, optional
+        outfile : str, Path, IO object, or None, optional
            If set, then the fit results will be written to a file with
            this name. The file contains the per-iteration fit results.
         clobber : bool, optional
            This flag controls whether an existing file can be
-           overwritten (``True``) or if it raises an exception (``False``,
-           the default setting).
+           overwritten (``True``) or if it raises an exception
+           (``False``, the default setting). This is only used if
+           `outfile` is set to a string or Path object.
 
         Raises
         ------
@@ -11105,6 +11135,9 @@ class Session(sherpa.ui.utils.Session):
         This is only for PHA data sets where the background is being
         modelled, rather than subtracted from the data.
 
+        If outfile is sent a file handle then it is not closed by this
+        routine.
+
         Examples
         --------
 
@@ -11119,6 +11152,15 @@ class Session(sherpa.ui.utils.Session):
 
         >>> fit_bkg(1, 2)
         >>> fit(1, 2)
+
+        Store the per-iteration values in a StringIO object and
+        extract the data into the variable txt (this avoids the need
+        to create a file):
+
+        >>> from io import StringIO
+        >>> out = StringIO()
+        >>> fit_bkg(outfile=out)
+        >>> txt = out.getvalue()
 
         """
         kwargs['bkg_only'] = True

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -36,6 +36,7 @@ from sherpa.utils import sao_arange, send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
     IdentifierErr, ImportErr, IOErr, ModelErr
 from sherpa.utils.numeric_types import SherpaFloat
+from sherpa.utils.types import IdType
 from sherpa.data import Data1D, Data1DAsymmetricErrs, Data2D, Data2DInt
 import sherpa.astro.all
 import sherpa.astro.plot
@@ -10974,8 +10975,8 @@ class Session(sherpa.ui.utils.Session):
     # at the code it is always set to False.
     #
     def fit(self,
-            id: Optional[sherpa.ui.utils.IdType] = None,
-            *otherids: sherpa.ui.utils.IdType,
+            id: Optional[IdType] = None,
+            *otherids: IdType,
             **kwargs
             ) -> FitResults:
         # pylint: disable=W1113
@@ -11083,8 +11084,8 @@ class Session(sherpa.ui.utils.Session):
         self._fit(id, *otherids, **kwargs)
 
     def fit_bkg(self,
-                id: Optional[sherpa.ui.utils.IdType] = None,
-                *otherids: sherpa.ui.utils.IdType,
+                id: Optional[IdType] = None,
+                *otherids: IdType,
                 **kwargs
                 ) -> FitResults:
         # pylint: disable=W1113

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -627,7 +627,16 @@ class IterCallback:
 # NoNewAttributesAfterInit.
 #
 class IterFit:
-    """Support iterative fitting schemes."""
+    """Support iterative fitting schemes.
+
+    This class is highly coupled to `Fit`.
+
+    .. versionchanged:: 4.17.0
+       Several internal fields have been removed as they are now
+       handled by the IterCallback class and the changes to the
+       _get_callback routine.
+
+    """
 
     def __init__(self, data, model, stat, method, itermethod_opts=None):
         if itermethod_opts is None:
@@ -660,7 +669,6 @@ class IterFit:
 
         # Options to send to iterative fitting method
         self.itermethod_opts = itermethod_opts
-        self.iterate = False
         self.funcs = {'sigmarej': self.sigmarej}
         self.current_func = None
         try:
@@ -673,8 +681,6 @@ class IterFit:
                 self.current_func = self.funcs[iname]
             except KeyError:
                 raise ValueError(f"{iname} is not an iterative fitting method") from None
-
-            self.iterate = True
 
     # SIGINT (i.e., typing ctrl-C) can dump the user to the Unix prompt,
     # when signal is sent from G95 compiled code.  What we want is to
@@ -930,7 +936,7 @@ class IterFit:
         if statkwargs is None:
             statkwargs = {}
 
-        if not self.iterate:
+        if self.current_func is None:
             return self.method.fit(statfunc, pars, parmins, parmaxes,
                                    statargs, statkwargs)
 

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -24,8 +24,6 @@ import os
 import signal
 
 import numpy as np
-from numpy import arange, array, iterable, sqrt, where, \
-    ones_like, isnan, isinf
 
 from sherpa.utils import NoNewAttributesAfterInit, print_fields, erf, \
     bool_cast, is_iterable, list_to_open_interval, sao_fcmp
@@ -364,7 +362,7 @@ class FitResults(NoNewAttributesAfterInit):
             out.extend(f'   {name:<12s}   {val:<12g}'
                        for name, val in zip(self.parnames, self.parvals))
         else:
-            covar_err = sqrt(self.covar.diagonal())
+            covar_err = np.sqrt(self.covar.diagonal())
             out.extend(f'   {name:<12s}   {val:<12g} +/- {covarerr:<12g}'
                        for name, val, covarerr in zip(self.parnames,
                                                       self.parvals,
@@ -437,7 +435,7 @@ class ErrorEstResults(NoNewAttributesAfterInit):
         self.fitname = type(fit.method).__name__.lower()
         self.statname = type(fit.stat).__name__.lower()
         self.sigma = fit.estmethod.sigma
-        self.percent = erf(self.sigma / sqrt(2.0)) * 100.0
+        self.percent = erf(self.sigma / np.sqrt(2.0)) * 100.0
         self.parnames = tuple(p.fullname for p in parlist if not p.frozen)
         self.parvals = tuple(p.val for p in parlist if not p.frozen)
         self.parmins = ()
@@ -758,11 +756,11 @@ class IterFit(NoNewAttributesAfterInit):
         for d in self.data.datasets:
             # If there's no filter, create a filter that is
             # all True
-            if not iterable(d.mask):
+            if not np.iterable(d.mask):
                 mask_original.append(d.mask)
-                d.mask = ones_like(array(d.get_dep(False), dtype=bool))
+                d.mask = np.ones_like(np.array(d.get_dep(False), dtype=bool))
             else:
-                mask_original.append(array(d.mask))
+                mask_original.append(np.array(d.mask))
 
         # QUS: why is teardown being called now when the model can be
         #      evaluated multiple times in the following loop?
@@ -832,7 +830,7 @@ class IterFit(NoNewAttributesAfterInit):
                             hasattr(d, "get_background")):
                         for bid in d.background_ids:
                             b = d.get_background(bid)
-                            if iterable(b.mask) and iterable(d.mask):
+                            if np.iterable(b.mask) and np.iterable(d.mask):
                                 if len(b.mask) == len(d.mask):
                                     b.mask = d.mask
 
@@ -1119,10 +1117,10 @@ class Fit(NoNewAttributesAfterInit):
         #       investigated if it is possible to pass that check
         #       but fail the following.
         #
-        if not iterable(dep) or len(dep) == 0:
+        if not np.iterable(dep) or len(dep) == 0:
             raise FitErr('nobins')
 
-        if ((iterable(staterror) and 0.0 in staterror) and
+        if ((np.iterable(staterror) and 0.0 in staterror) and
                 isinstance(self.stat, Chi2) and
                 type(self.stat) != Chi2 and
                 type(self.stat) != Chi2ModVar):
@@ -1267,11 +1265,11 @@ class Fit(NoNewAttributesAfterInit):
             thawedpars[idx].frozen = True
             self.current_frozen = idx
 
-            keep_pars = ones_like(pars)
+            keep_pars = np.ones_like(pars)
             keep_pars[idx] = 0
-            current_pars = pars[where(keep_pars)]
-            current_parmins = parmins[where(keep_pars)]
-            current_parmaxes = parmaxes[where(keep_pars)]
+            current_pars = pars[np.where(keep_pars)]
+            current_parmins = parmins[np.where(keep_pars)]
+            current_parmaxes = parmaxes[np.where(keep_pars)]
             return (current_pars, current_parmins, current_parmaxes)
 
         def thaw_par(idx):
@@ -1297,11 +1295,11 @@ class Fit(NoNewAttributesAfterInit):
                 return
 
             name = thawedpars[idx].fullname
-            if isnan(lower) or isinf(lower):
+            if np.isnan(lower) or np.isinf(lower):
                 info("%s \tlower bound: -----", name)
             else:
                 info("%s \tlower bound: %g", name, lower[0])
-            if isnan(upper) or isinf(upper):
+            if np.isnan(upper) or np.isinf(upper):
                 info("%s \tupper bound: -----", name)
             else:
                 info("%s \tupper bound: %g", name, upper[0])
@@ -1318,7 +1316,7 @@ class Fit(NoNewAttributesAfterInit):
             dep, staterror, syserror = self.data.to_fit(
                 self.stat.calc_staterror)
 
-            if not iterable(dep) or len(dep) == 0:
+            if not np.iterable(dep) or len(dep) == 0:
                 raise FitErr('nobins')
 
             # For chi-squared and C-stat, reduced statistic is
@@ -1407,10 +1405,10 @@ class Fit(NoNewAttributesAfterInit):
                 if not match:
                     raise EstErr('noparameter', p.fullname)
 
-            parnums = array(parnums)
+            parnums = np.array(parnums)
         else:
             parlist = self.model.get_thawed_pars()
-            parnums = arange(len(startpars))
+            parnums = np.arange(len(startpars))
 
         # If we are here, we are ready to try to derive confidence limits.
         # General rule:  if failure because a hard limit was hit, find
@@ -1525,7 +1523,7 @@ def html_fitresults(fit):
     rows = []
     if has_covar:
         for pname, pval, perr in zip(fit.parnames, fit.parvals,
-                                     sqrt(fit.covar.diagonal())):
+                                     np.sqrt(fit.covar.diagonal())):
             rows.append((pname, f'{pval:12g}',
                          f'&#177; {perr:12g}'))
     else:

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -576,12 +576,15 @@ class IterFit:
         # collections of data and models -- so, put data and
         # models into the objects needed for simultaneous fitting,
         # if they are not already in such objects.
-        self.data = data
-        if type(data) is not DataSimulFit:
+        #
+        if isinstance(data, DataSimulFit):
+            self.data = data
+        else:
             self.data = DataSimulFit('simulfit data', (data,))
 
-        self.model = model
-        if type(model) is not SimulFitModel:
+        if isinstance(model, SimulFitModel):
+            self.model = model
+        else:
             self.model = SimulFitModel('simulfit model', (model,))
 
         self.stat = stat

--- a/sherpa/sim/tests/test_sim.py
+++ b/sherpa/sim/tests/test_sim.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2016, 2018, 2020, 2021, 2023
+#  Copyright (C) 2011, 2016, 2018, 2020, 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -19,8 +19,9 @@
 #
 
 from collections import namedtuple
+from io import StringIO
 
-import numpy
+import numpy as np
 
 import pytest
 
@@ -36,9 +37,9 @@ from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.parallel import _multi, _ncpus
 
 
-_max = numpy.finfo(numpy.float32).max
-_tiny = numpy.finfo(numpy.float32).tiny
-_eps = numpy.finfo(numpy.float32).eps
+_max = np.finfo(np.float32).max
+_tiny = np.finfo(np.float32).tiny
+_eps = np.finfo(np.float32).eps
 
 
 _fit_results_bench = {
@@ -51,7 +52,7 @@ _fit_results_bench = {
     'statval': 8483.0287367571564,
     'parnames': ['p1.gamma', 'p1.ampl', 'g1.fwhm',
                  'g1.pos', 'g1.ampl'],
-    'parvals': numpy.array(
+    'parvals': np.array(
         [1.0701938169914813,
          9.1826254677279469,
          2.5862083052721028,
@@ -59,8 +60,8 @@ _fit_results_bench = {
          47.262657692418749])
     }
 
-_x = numpy.arange(0.1, 10.1, 0.1)
-_y = numpy.array(
+_x = np.arange(0.1, 10.1, 0.1)
+_y = np.array(
     [114, 47, 35, 30, 40, 27, 30, 26, 24, 20, 26, 35,
      29, 28, 34, 36, 43, 39, 33, 47, 44, 46, 53, 56,
      52, 53, 49, 57, 49, 36, 33, 42, 49, 45, 42, 32,
@@ -71,7 +72,7 @@ _y = numpy.array(
      0,  1,  0,  1,  1,  0,  1,  1,  1,  1,  1,  1,
      1,  0,  1,  0]
     )
-_err = numpy.ones(100) * 0.4
+_err = np.ones(100) * 0.4
 
 
 @pytest.fixture
@@ -125,10 +126,10 @@ def setup():
     out.results = results
     out.covresults = fit.est_errors()
     out.dof = results.dof
-    out.mu = numpy.array(results.parvals)
-    out.cov = numpy.array(out.covresults.extra_output)
+    out.mu = np.array(results.parvals)
+    out.cov = np.array(out.covresults.extra_output)
     out.num = 10
-    out.rng = numpy.random.RandomState(23)
+    out.rng = np.random.RandomState(23)
     return out
 
 
@@ -139,7 +140,7 @@ def setup():
 # There are also some tests that check we return a subset of the
 # information (e.g. all-but-the-first column).
 #
-EXPECTED_T = numpy.asarray(
+EXPECTED_T = np.asarray(
     [[8.48554745e+03, 1.06405130, 9.27921234, 2.58664931, 2.59985055, 4.72032018e+01],
      [8.49039767e+03, 1.07407403, 9.05126945, 2.59679740, 2.60386838, 4.73836300e+01],
      [8.48487406e+03, 1.07593411, 9.09514664, 2.59122066, 2.60017483, 4.72314632e+01],
@@ -151,7 +152,7 @@ EXPECTED_T = numpy.asarray(
      [8.48414894e+03, 1.07225846, 9.13799921, 2.58982250, 2.59983239, 4.71818523e+01],
      [8.48467565e+03, 1.07387648, 9.12069098, 2.59440151, 2.60188040, 4.71716468e+01]])
 
-EXPECTED_UNIFORM = numpy.asarray(
+EXPECTED_UNIFORM = np.asarray(
     [[8.92261355e+03, 1.07123512, 8.57093063, 2.61429088, 2.61114484, 4.73497877e+01],
      [9.82725325e+03, 1.09710009, 9.65477406, 2.59719719, 2.60793168, 4.75320785e+01],
      [9.26055735e+03, 1.08617397, 9.65589944, 2.55228604, 2.59058740, 4.74161153e+01],
@@ -163,7 +164,7 @@ EXPECTED_UNIFORM = numpy.asarray(
      [8.50393051e+03, 1.07730034, 8.93027393, 2.61841172, 2.59182705, 4.72459725e+01],
      [8.65618143e+03, 1.06489218, 8.92190134, 2.57999046, 2.60300976, 4.77114146e+01]])
 
-EXPECTED_NORMAL = numpy.asarray(
+EXPECTED_NORMAL = np.asarray(
     [[8.48932906e+03, 1.07521274, 9.12922751, 2.58401110, 2.60674560, 4.72643098e+01],
      [8.51403222e+03, 1.07038805, 9.28561349, 2.59758807, 2.60327743, 4.73778582e+01],
      [8.49257783e+03, 1.06434242, 9.23215258, 2.59206666, 2.60425951, 4.73144299e+01],
@@ -175,7 +176,7 @@ EXPECTED_NORMAL = numpy.asarray(
      [8.75384863e+03, 1.06024498, 8.90014878, 2.58809846, 2.60381520, 4.72108582e+01],
      [8.51787451e+03, 1.08352963, 9.03835426, 2.57289213, 2.60153812, 4.71947163e+01]])
 
-EXPECTED_NORMAL2 = numpy.asarray(
+EXPECTED_NORMAL2 = np.asarray(
     [[8.48548565e+03, 1.06412678, 9.27802554, 2.58664389, 2.59987229, 4.72039324e+01],
      [8.49055139e+03, 1.07411404, 9.04991502, 2.59690659, 2.60389156, 4.73848773e+01],
      [8.48477491e+03, 1.07577639, 9.09755020, 2.59108294, 2.60021453, 4.72323203e+01],
@@ -201,7 +202,7 @@ def test_cauchy(setup):
 
     expected = [1.04452632, 9.58622941, 2.58805112, 2.59422687, 47.01421166]
 
-    assert out == pytest.approx(numpy.asarray(expected))
+    assert out == pytest.approx(np.asarray(expected))
 
 
 def test_parameter_scale_vector_checks_scale_iterable(setup):
@@ -212,7 +213,7 @@ def test_parameter_scale_vector_checks_scale_iterable(setup):
         sim.ParameterScaleVector().get_scales(setup.fit, myscales=3)
 
 
-@pytest.mark.parametrize("scales", [3, numpy.asarray([3])])
+@pytest.mark.parametrize("scales", [3, np.asarray([3])])
 def test_parameter_scale_matrix_checks_scale_iterable(scales, setup):
     """Error check"""
 
@@ -224,7 +225,7 @@ def test_parameter_scale_matrix_checks_scale_iterable(scales, setup):
 def test_parameter_scale_matrix_checks_scale_positive_definite(setup):
     """Error check"""
 
-    scales = numpy.arange(-10, 15).reshape(5, 5)
+    scales = np.arange(-10, 15).reshape(5, 5)
     with pytest.raises(TypeError,
                        match="^The covariance matrix is not positive definite$"):
         sim.ParameterScaleMatrix().get_scales(setup.fit, myscales=scales)
@@ -236,7 +237,7 @@ def test_parameter_scale_vector(setup):
 
     expected = [0.00752475, 0.15368132, 0.01088586, 0.00362169, 0.12308473]
 
-    assert out == pytest.approx(numpy.asarray(expected))
+    assert out == pytest.approx(np.asarray(expected))
 
 
 def test_parameter_scale_matrix(setup):
@@ -249,7 +250,7 @@ def test_parameter_scale_matrix(setup):
                 [-1.41279846e-05,  3.07465479e-04, -1.78172521e-05,  1.31166529e-05,  -8.41924293e-05],
                 [ 3.89927955e-04, -7.64855819e-03, -8.27934918e-05, -8.41924293e-05,   1.51498514e-02]]
 
-    assert out == pytest.approx(numpy.asarray(expected))
+    assert out == pytest.approx(np.asarray(expected))
 
 
 def test_parameter_sample_checks_clip_argument(setup):
@@ -258,7 +259,7 @@ def test_parameter_sample_checks_clip_argument(setup):
     obj = sim.NormalParameterSampleFromScaleVector()
     with pytest.raises(ValueError,
                        match="^invalid clip argument: sent max$"):
-        obj.clip(setup.fit, numpy.arange(20).reshape(4, 5),
+        obj.clip(setup.fit, np.arange(20).reshape(4, 5),
                  clip="max")
 
 
@@ -349,19 +350,19 @@ def test_t_sample(setup):
     assert out == pytest.approx(EXPECTED_T)
 
 
-RATIOS_ONE = numpy.asarray([2.43733721, 3.52628288, 4.18396336, 1.73659659, 3.70862308, 2.19009678,
-                            0.99262327, 2.47817863, 4.29140984, 8.66538795, 0.75845443, 2.19029536,
-                            1.08725896, 1.58262032, 2.91657742, 0.70781436, 0.79954232, 2.5850919,
-                            2.0543363,  0.4747516,  8.69094441, 2.35362447, 2.23331886, 4.20676696,
-                            3.56214367])
+RATIOS_ONE = np.asarray([2.43733721, 3.52628288, 4.18396336, 1.73659659, 3.70862308, 2.19009678,
+                         0.99262327, 2.47817863, 4.29140984, 8.66538795, 0.75845443, 2.19029536,
+                         1.08725896, 1.58262032, 2.91657742, 0.70781436, 0.79954232, 2.5850919,
+                         2.0543363,  0.4747516,  8.69094441, 2.35362447, 2.23331886, 4.20676696,
+                         3.56214367])
 
-RATIOS_TWO = numpy.asarray([1.74752217e+00, 4.15056013,  3.96667032e+00, 1.45119325e+00,
-                            1.99113224e+00, 4.60875346,  2.61179034e+00, 2.52248040e-01,
-                            2.59828000e+00, 3.45398280,  5.44372792e+00, 5.62797204e+00,
-                            6.80978133e+00, 1.06134553, -1.42108547e-12, 2.07549322e+00,
-                            1.14993770e+00, 5.88951206,  2.61912975e+00, 1.31001158e+00,
-                            4.63278539e-01, 2.21026052,  3.12162630e+00, 1.83602835e+00,
-                            6.28386219e+00])
+RATIOS_TWO = np.asarray([1.74752217e+00, 4.15056013,  3.96667032e+00, 1.45119325e+00,
+                         1.99113224e+00, 4.60875346,  2.61179034e+00, 2.52248040e-01,
+                         2.59828000e+00, 3.45398280,  5.44372792e+00, 5.62797204e+00,
+                         6.80978133e+00, 1.06134553, -1.42108547e-12, 2.07549322e+00,
+                         1.14993770e+00, 5.88951206,  2.61912975e+00, 1.31001158e+00,
+                         4.63278539e-01, 2.21026052,  3.12162630e+00, 1.83602835e+00,
+                         6.28386219e+00])
 
 
 def test_lrt(setup):
@@ -442,9 +443,38 @@ def test_mh(setup):
 
     setup.fit.method = NelderMead()
     setup.fit.stat = Cash()
-    setup.fit.fit()
+
+    # As part of investigating #2063 we now check the fit output
+    out = StringIO()
+    setup.fit.fit(outfile=out)
+
     results = setup.fit.est_errors()
     cov = results.extra_output
+
+    # Note when the covariance changes; this is more just as a check
+    # hence not a full check.
+    #
+    diag = np.asarray([5.66172700e-05, 2.36172341e-02,
+                       1.18497835e-04, 1.31162722e-05,
+                       1.51499561e-02])
+    assert np.diag(cov) == pytest.approx(diag)
+
+    # Check outfile; expect
+    #     nfev statistic pl.gamma pl.ampl g1.fwhm g1.pos g1.ampl
+    #
+    # Note that #2063 shows up with the change in stat value in the
+    # last row.
+    #
+    row0 = np.asarray([0, 8483.029, 1.070194, 9.182625, 2.586208, 2.601620, 47.26266])
+    row18 = np.asarray([18, 8483.061, 1.070181, 9.182894, 2.586192, 2.601625, 47.27891])
+    row19 = np.asarray([19, -8975.692, 1.070181, 9.182894, 2.586192, 2.601625, 47.26259])
+
+    out.seek(0)
+    fitvals = np.loadtxt(out)
+    assert fitvals.shape == (20, 7)
+    assert fitvals[0] == pytest.approx(row0)
+    assert fitvals[18] == pytest.approx(row18)
+    assert fitvals[19] == pytest.approx(row19)
 
     mcmc = sim.MCMC()
     for par in setup.fit.model.pars:
@@ -471,7 +501,7 @@ def test_mh(setup):
     assert accept.min() == 0
     assert accept.max() == 1
 
-    means = numpy.asarray([1.06395549, 9.30548196, 2.60004412, 2.60501078, 47.2794224])
+    means = np.asarray([1.06395549, 9.30548196, 2.60004412, 2.60501078, 47.2794224])
     assert params.mean(axis=1) == pytest.approx(means)
 
 
@@ -479,9 +509,38 @@ def test_metropolisMH(setup):
 
     setup.fit.method = NelderMead()
     setup.fit.stat = CStat()
-    results = setup.fit.fit()
+
+    # As part of investigating #2063 we now check the fit output
+    out = StringIO()
+    setup.fit.fit(outfile=out)
+
     results = setup.fit.est_errors()
     cov = results.extra_output
+
+    # Note when the covariance changes; this is more just as a check
+    # hence not a full check.
+    #
+    diag = np.asarray([5.66172700e-05, 2.36172341e-02,
+                       1.18497835e-04, 1.31162722e-05,
+                       1.51499561e-02])
+    assert np.diag(cov) == pytest.approx(diag)
+
+    # Check outfile; expect
+    #     nfev statistic pl.gamma pl.ampl g1.fwhm g1.pos g1.ampl
+    #
+    # Note that #2063 shows up with the change in stat value in the
+    # last row.
+    #
+    row0 = np.asarray([0, 8483.029, 1.070194, 9.182625, 2.586208, 2.601620, 47.26266])
+    row18 = np.asarray([18, 8483.061, 1.070181, 9.182894, 2.586192, 2.601625, 47.27891])
+    row19 = np.asarray([19, 98.8396, 1.070181, 9.182894, 2.586192, 2.601625, 47.26259])
+
+    out.seek(0)
+    fitvals = np.loadtxt(out)
+    assert fitvals.shape == (20, 7)
+    assert fitvals[0] == pytest.approx(row0)
+    assert fitvals[18] == pytest.approx(row18)
+    assert fitvals[19] == pytest.approx(row19)
 
     mcmc = sim.MCMC()
     mcmc.set_sampler('MetropolisMH')
@@ -500,5 +559,5 @@ def test_metropolisMH(setup):
     assert accept.min() == 0
     assert accept.max() == 1
 
-    means = numpy.asarray([1.06662892, 9.11099236, 2.57373044, 2.60959292, 48.00777618])
+    means = np.asarray([1.06662892, 9.11099236, 2.57373044, 2.60959292, 48.00777618])
     assert params.mean(axis=1) == pytest.approx(means)

--- a/sherpa/sim/tests/test_sim.py
+++ b/sherpa/sim/tests/test_sim.py
@@ -454,27 +454,25 @@ def test_mh(setup):
     # Note when the covariance changes; this is more just as a check
     # hence not a full check.
     #
-    diag = np.asarray([5.66172700e-05, 2.36172341e-02,
-                       1.18497835e-04, 1.31162722e-05,
-                       1.51499561e-02])
+    diag = np.asarray([1.68857268e-03, 6.48507899e-01,
+                       9.22029508e-03, 1.88340111e-03,
+                       3.22767792e+00])
     assert np.diag(cov) == pytest.approx(diag)
 
     # Check outfile; expect
     #     nfev statistic pl.gamma pl.ampl g1.fwhm g1.pos g1.ampl
     #
-    # Note that #2063 shows up with the change in stat value in the
-    # last row.
-    #
-    row0 = np.asarray([0, 8483.029, 1.070194, 9.182625, 2.586208, 2.601620, 47.26266])
-    row18 = np.asarray([18, 8483.061, 1.070181, 9.182894, 2.586192, 2.601625, 47.27891])
-    row19 = np.asarray([19, -8975.692, 1.070181, 9.182894, 2.586192, 2.601625, 47.26259])
+    row0 = np.asarray([0, -8975.692, 1.070194, 9.182625, 2.586208, 2.601620, 47.26266])
+    row19 = np.asarray([19, -8975.953, 1.069763, 9.219122,  2.570933, 2.586584,  47.36504])
+    row20 = row19.copy()
+    row20[0] = 20
 
     out.seek(0)
     fitvals = np.loadtxt(out)
-    assert fitvals.shape == (20, 7)
+    assert fitvals.shape == (21, 7)
     assert fitvals[0] == pytest.approx(row0)
-    assert fitvals[18] == pytest.approx(row18)
     assert fitvals[19] == pytest.approx(row19)
+    assert fitvals[20] == pytest.approx(row20)
 
     mcmc = sim.MCMC()
     for par in setup.fit.model.pars:
@@ -496,12 +494,12 @@ def test_mh(setup):
     assert len(accept) == 101
     assert params.shape == (5, 101)
 
-    assert stats.mean() == pytest.approx(-8975.050072981625)
-    assert accept.sum() == 10
+    assert stats.mean() == pytest.approx(-8970.945533198466)
+    assert accept.sum() == 81
     assert accept.min() == 0
     assert accept.max() == 1
 
-    means = np.asarray([1.06395549, 9.30548196, 2.60004412, 2.60501078, 47.2794224])
+    means = np.asarray([1.06497461, 9.2188531, 2.58191838, 2.57882817, 47.5158447])
     assert params.mean(axis=1) == pytest.approx(means)
 
 
@@ -520,27 +518,25 @@ def test_metropolisMH(setup):
     # Note when the covariance changes; this is more just as a check
     # hence not a full check.
     #
-    diag = np.asarray([5.66172700e-05, 2.36172341e-02,
-                       1.18497835e-04, 1.31162722e-05,
-                       1.51499561e-02])
+    diag = np.asarray([1.68857268e-03, 6.48507899e-01,
+                       9.22029508e-03, 1.88340111e-03,
+                       3.22767792e+00])
     assert np.diag(cov) == pytest.approx(diag)
 
     # Check outfile; expect
     #     nfev statistic pl.gamma pl.ampl g1.fwhm g1.pos g1.ampl
     #
-    # Note that #2063 shows up with the change in stat value in the
-    # last row.
-    #
-    row0 = np.asarray([0, 8483.029, 1.070194, 9.182625, 2.586208, 2.601620, 47.26266])
-    row18 = np.asarray([18, 8483.061, 1.070181, 9.182894, 2.586192, 2.601625, 47.27891])
-    row19 = np.asarray([19, 98.8396, 1.070181, 9.182894, 2.586192, 2.601625, 47.26259])
+    row0 = np.asarray([0, 98.83959, 1.070194, 9.182625, 2.586208, 2.601620, 47.26266])
+    row19 = np.asarray([19, 98.5784, 1.069763, 9.219122, 2.570933, 2.586584, 47.36504])
+    row20 = row19.copy()
+    row20[0] = 20
 
     out.seek(0)
     fitvals = np.loadtxt(out)
-    assert fitvals.shape == (20, 7)
+    assert fitvals.shape == (21, 7)
     assert fitvals[0] == pytest.approx(row0)
-    assert fitvals[18] == pytest.approx(row18)
     assert fitvals[19] == pytest.approx(row19)
+    assert fitvals[20] == pytest.approx(row20)
 
     mcmc = sim.MCMC()
     mcmc.set_sampler('MetropolisMH')
@@ -554,10 +550,10 @@ def test_metropolisMH(setup):
     assert len(accept) == 101
     assert params.shape == (5, 101)
 
-    assert stats.mean() == pytest.approx(99.75333600540445)
-    assert accept.sum() == 45
+    assert stats.mean() == pytest.approx(103.81260679391825)
+    assert accept.sum() == 50
     assert accept.min() == 0
     assert accept.max() == 1
 
-    means = np.asarray([1.06662892, 9.11099236, 2.57373044, 2.60959292, 48.00777618])
+    means = np.asarray([1.06278015, 9.21533855, 2.5736483, 2.5853907, 47.27058904])
     assert params.mean(axis=1) == pytest.approx(means)

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -90,6 +90,8 @@
 # are just representative tests.
 #
 
+from io import StringIO
+
 import numpy as np
 
 import pytest
@@ -3048,9 +3050,77 @@ def test_fit_outfile_simple_check(tmp_path, check_str):
     data = make_data(Data1D)
     mdl = Const1D("mx")
     fit = Fit(data, mdl, stat=Cash())
+    fit.fit(outfile=str(outfile))
+
+    out = outfile.read_text()
+    check_str(out,
+              ["# nfev statistic mx.c0",
+               "0.000000e+00 6.000000e+00 1.000000e+00",
+               "1.000000e+00 6.000000e+00 1.000000e+00",
+               "2.000000e+00 5.995167e+00 1.000345e+00",
+               "3.000000e+00 -3.230695e+00 2.454143e+00",
+               "4.000000e+00 -3.232515e+00 2.454991e+00",
+               "5.000000e+00 -4.073187e+00 3.250567e+00",
+               "6.000000e+00 -4.073357e+00 3.251690e+00",
+               "7.000000e+00 -4.079456e+00 3.333285e+00",
+               "8.000000e+00 -4.079455e+00 3.334435e+00",
+               "9.000000e+00 -4.079456e+00 3.333329e+00",
+               "1.000000e+01 -4.079456e+00 3.333329e+00",
+               ""])
+
+
+def test_fit_outfile_simple_check_path(tmp_path, check_str):
+    """We can send in a path object as of 4.17.0.
+
+    Actually, you could use a Path object before 4.17.0 but
+    know we make it explicit.
+    """
+
+    # tmp_path is a Path object
+    outfile = tmp_path / "sherpa-path.save"
+
+    data = make_data(Data1D)
+    mdl = Const1D("mx")
+    fit = Fit(data, mdl, stat=Cash())
     fit.fit(outfile=outfile)
 
     out = outfile.read_text()
+    check_str(out,
+              ["# nfev statistic mx.c0",
+               "0.000000e+00 6.000000e+00 1.000000e+00",
+               "1.000000e+00 6.000000e+00 1.000000e+00",
+               "2.000000e+00 5.995167e+00 1.000345e+00",
+               "3.000000e+00 -3.230695e+00 2.454143e+00",
+               "4.000000e+00 -3.232515e+00 2.454991e+00",
+               "5.000000e+00 -4.073187e+00 3.250567e+00",
+               "6.000000e+00 -4.073357e+00 3.251690e+00",
+               "7.000000e+00 -4.079456e+00 3.333285e+00",
+               "8.000000e+00 -4.079455e+00 3.334435e+00",
+               "9.000000e+00 -4.079456e+00 3.333329e+00",
+               "1.000000e+01 -4.079456e+00 3.333329e+00",
+               ""])
+
+
+def test_fit_outfile_simple_check_stringio(check_str):
+    """4.17.0 let's outfile be a file-handle/IO object.
+
+    Before 4.17.0 you could use a StringIO object but only if clobber
+    was not set.
+
+    """
+
+    # NOTE: the existing contents get over-written. In this
+    # case the new text is a lot longer than the existing
+    # text so it is completely replaced.
+    #
+    outfile = StringIO("# EXTRA HEADER LINE \n")
+
+    data = make_data(Data1D)
+    mdl = Const1D("mx")
+    fit = Fit(data, mdl, stat=Cash())
+    fit.fit(outfile=outfile)
+
+    out = outfile.getvalue()
     check_str(out,
               ["# nfev statistic mx.c0",
                "0.000000e+00 6.000000e+00 1.000000e+00",

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -47,6 +47,7 @@ from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \
     DataErr, IdentifierErr, IOErr, ModelErr, ParameterErr, PlotErr, \
     SessionErr
 from sherpa.utils.numeric_types import SherpaFloat
+from sherpa.utils.types import IdType
 
 info = logging.getLogger(__name__).info
 warning = logging.getLogger(__name__).warning
@@ -64,7 +65,6 @@ BUILTINS = sys.modules["builtins"]
 _builtin_symbols_ = tuple(BUILTINS.__dict__.keys())
 
 
-IdType = Union[int, str]
 ModelType = Union[Model, str]
 
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -35,7 +35,7 @@ import numpy as np
 from sherpa import get_config
 import sherpa.all
 from sherpa.data import Data, DataSimulFit
-from sherpa.fit import Fit
+from sherpa.fit import Fit, FitResults
 from sherpa.models.basic import TableModel
 from sherpa.models.model import Model, SimulFitModel
 from sherpa.models.template import add_interpolator, create_template_model, \
@@ -9263,7 +9263,11 @@ class Session(NoNewAttributesAfterInit):
         return f.calc_chisqr()
 
     # also in sherpa.astro.utils
-    def fit(self, id=None, *otherids, **kwargs):
+    def fit(self,
+            id: Optional[IdType] = None,
+            *otherids: IdType,
+            **kwargs
+            ) -> FitResults:
         """Fit a model to one or more data sets.
 
         Use forward fitting to find the best-fit model to one or more
@@ -9275,6 +9279,10 @@ class Session(NoNewAttributesAfterInit):
         fit. The final fit results are displayed to the screen and can
         be retrieved with `get_fit_results`.
 
+        .. versionchanged:: 4.17.0
+           The outfile parameter can now be sent a Path object or a
+           file handle instead of a string.
+
         Parameters
         ----------
         id : int or str, optional
@@ -9282,13 +9290,14 @@ class Session(NoNewAttributesAfterInit):
            all data sets with an associated model are fit simultaneously.
         *otherids : int or str, optional
            Other data sets to use in the calculation.
-        outfile : str, optional
+        outfile : str, Path, IO object, or None, optional
            If set, then the fit results will be written to a file with
            this name. The file contains the per-iteration fit results.
         clobber : bool, optional
            This flag controls whether an existing file can be
            overwritten (``True``) or if it raises an exception
-           (``False``, the default setting).
+           (``False``, the default setting). This is only used if
+           `outfile` is set to a string or Path object.
 
         Raises
         ------
@@ -9313,6 +9322,11 @@ class Session(NoNewAttributesAfterInit):
         show_fit : Summarize the fit results.
         thaw : Allow model parameters to be varied during a fit.
 
+        Notes
+        -----
+        If outfile is sent a file handle then it is not closed by this
+        routine.
+
         Examples
         --------
 
@@ -9334,6 +9348,15 @@ class Session(NoNewAttributesAfterInit):
         'jet.fit', over-writing it if it already exists:
 
         >>> fit('jet', outfile='jet.fit', clobber=True)
+
+        Store the per-iteration values in a StringIO object and
+        extract the data into the variable txt (this avoids the need
+        to create a file):
+
+        >>> from io import StringIO
+        >>> out = StringIO()
+        >>> fit(outfile=out)
+        >>> txt = out.getvalue()
 
         """
         ids, f = self._get_fit(id, otherids)

--- a/sherpa/utils/types.py
+++ b/sherpa/utils/types.py
@@ -36,6 +36,10 @@ import numpy as np
 # minimum.
 #
 
+# Represent identifiers; mainly used in the UI code.
+#
+IdType = Union[int, str]
+
 # Try to be generic when using arrays as input or output. There is no
 # attempt to encode the data type or shape for ndarrays at this time.
 #


### PR DESCRIPTION
# Summary

The fit call can now be sent a Path object or a file handle, as well as a string. Fix issue #2063 (ensure consistency when changing the statistic object used in a fit; this is not an issue for the UI code).

# Details

Partly taken from #2015, #2022.

The idea is for a user at the ui layer to be able to say things like

```python
fit(outfile=Path(...))

from io import StringIO
store = StringIO()
fit(outfile=store)
out = store,getvalue()

with open("txt.txt") as fh:
    fit(outfile=fh)
    # this is not really sensible, but you can do it
    fit(outfile=fh)
```

To do this we need to be able to send in a `Path` or file-handle-like object to the `Fit.fit` method. This does change the `IterFit` interface but this is an internal class which users do not interact with directly.

To do this I've made some minor clean up changes. This is part of trying to address #2007 and came out of #2022 - I am trying to separate things to make the PRs easier to understand and review.

One of the fun things is in trying to add typing statements for this. We could use `typing.TextIO` for this but there's actually some "interesting" discussion about this on the internet, since it's often too "large" a requirement. So I follow one piece of advice from the typing world and use a `Protocol` instead to indicate the functionality we need (`close` and `write`). 

There is a similar issue here to https://github.com/sherpa/sherpa/pull/1929#discussion_r1468170159 in that I have had to add a `close_on_exit` flag to decide whether to call `fh.close`. Normally you would say "just use a context manager" but, as with the IO case, it's not that simple. There may be a better way to do this, and if anyone has an idea please holler, but the current approach - whilst ugly - seems to work.

I have then made some changes to address review comments, including discovering and "fixing" #2063.