### PR TITLE
Bump Xspec 12.14.0h tests to 12.14.0i

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -30,7 +30,7 @@ jobs:
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
-            xspec-version: 12.14.0h
+            xspec-version: 12.14.0i
 
           - name: Linux Minimum Setup (Python 3.9)
             os: ubuntu-latest

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -54,7 +54,7 @@ jobs:
             test-data: submodule
             matplotlib-version: 3
             bokeh-version: 3
-            xspec-version: 12.14.0h
+            xspec-version: 12.14.0i
 
           - name: Linux Full Build (Python 3.10)
             os: ubuntu-latest


### PR DESCRIPTION
Summary
========
Bumps xspec 12.14.0h to 12.14.0i for testing.

Details
=====
Bumps xspec 12.14.0h to 12.14.0i for testing due to issues noted with XSbvvnei in #2052.