### PR TITLE
tests: fix fake_pha test failure on crates

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_io.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_io.py
@@ -169,10 +169,14 @@ def check_fit_stats():
     # This test produces different results on macOS to Linux, hence
     # the relaxed tolerances.
     #
-    assert pl.gamma.val == pytest.approx(1.6870563856336693, rel=1e-5)
-    assert pl.ampl.val == pytest.approx(3.831373278007354e-05, rel=2e-5)
-    assert gal.nH.val == pytest.approx(0.24914805790330877, rel=3e-5)
-    assert ui.calc_stat() == pytest.approx(41.454087606314054, rel=1e-5)
+    assert pl.gamma.val == pytest.approx(1.6870563856336693,
+                                         rel=1.02e-5)
+    assert pl.ampl.val == pytest.approx(3.831373278007354e-05,
+                                        rel=2e-5)
+    assert gal.nH.val == pytest.approx(0.24914805790330877,
+                                       rel=3e-5)
+    assert ui.calc_stat() == pytest.approx(41.454087606314054,
+                                           rel=1e-5)
 
 
 @requires_xspec


### PR DESCRIPTION
# Summary

Address test failures when using crates after merging #1684 and to address a numerical tolerance issue on macOS ARM. There is no functional change here.

# Details

Turns out that crates raises a different error than pyfits, so write some horrible code to catch the differences. I do have some I/O work which might avoid the need for this, but that's a long way from getting merged, and we are always going to have odd cases like this (without using a very-restrictive I/O layer, which I don't think we want).

A check for a spectral fit had to change the relative tolerance it used from 1e-5 to 1.02e-5 for a regression test.