### PR TITLE
Address an error introduced in PR 2025

### DIFF
--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1799,9 +1799,8 @@ def multinormal_pdf(x, mu, sigma):
     coeff = 1.0 / (np.power(2.0 * np.pi, rank / 2.0) *
                    np.sqrt(np.abs(np.linalg.det(sigma))))
 
-    # See issue #2026 - remove use of matrix
-    xmu = np.asmatrix(x - mu)
-    invsigma = np.asmatrix(np.linalg.inv(sigma))
+    xmu = np.asarray(x - mu)
+    invsigma = np.asarray(np.linalg.inv(sigma))
 
     # The matrix multiplication looks backwards, but mu and x
     # are passed in already transposed.
@@ -1809,7 +1808,8 @@ def multinormal_pdf(x, mu, sigma):
     #  mu = [[a,b,c]]
     #   x = [[d,e,f]]
     #
-    return float(coeff * np.exp(-0.5 * ((xmu * invsigma) * xmu.T)))
+    out = coeff * np.exp(-0.5 * ((xmu @ invsigma) @ xmu.T))
+    return float(out)
 
 
 def multit_pdf(x, mu, sigma, dof):
@@ -1859,9 +1859,8 @@ def multit_pdf(x, mu, sigma, dof):
                  np.power(np.pi, rank / 2.0) *
                  np.sqrt(np.abs(np.linalg.det(sigma)))))
 
-    # See issue #2026 - remove use of matrix
-    xmu = np.asmatrix(x - mu)
-    invsigma = np.asmatrix(np.linalg.inv(sigma))
+    xmu = np.asarray(x - mu)
+    invsigma = np.asarray(np.linalg.inv(sigma))
 
     # The matrix multiplication looks backwards, but mu and x
     # are passed in already transposed.
@@ -1869,8 +1868,9 @@ def multit_pdf(x, mu, sigma, dof):
     #  mu = [[a,b,c]]
     #   x = [[d,e,f]]
     #
-    term = 1.0 + 1.0 / n * ((xmu * invsigma) * xmu.T)
-    return float(coeff * np.power(term, -npr / 2.0))
+    term = 1.0 + 1.0 / n * ((xmu @ invsigma) @ xmu.T)
+    out = coeff * np.power(term, -npr / 2.0)
+    return float(out)
 
 
 def dataspace1d(start, stop, step=1, numbins=None):

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1798,6 +1798,8 @@ def multinormal_pdf(x, mu, sigma):
     rank = mu.size
     coeff = 1.0 / (np.power(2.0 * np.pi, rank / 2.0) *
                    np.sqrt(np.abs(np.linalg.det(sigma))))
+
+    # See issue #2026 - remove use of matrix
     xmu = np.asmatrix(x - mu)
     invsigma = np.asmatrix(np.linalg.inv(sigma))
 
@@ -1851,13 +1853,15 @@ def multit_pdf(x, mu, sigma, dof):
         raise ValueError("sigma is not symmetric")
 
     rank = mu.size
-    np = float(n + rank)
-    coeff = (gamma(np / 2.0) /
+    npr = float(n + rank)
+    coeff = (gamma(npr / 2.0) /
              (gamma(n / 2.0) * np.power(n, rank / 2.0) *
                  np.power(np.pi, rank / 2.0) *
                  np.sqrt(np.abs(np.linalg.det(sigma)))))
+
+    # See issue #2026 - remove use of matrix
     xmu = np.asmatrix(x - mu)
-    invsigma = np.asmattix(np.linalg.inv(sigma))
+    invsigma = np.asmatrix(np.linalg.inv(sigma))
 
     # The matrix multiplication looks backwards, but mu and x
     # are passed in already transposed.
@@ -1866,7 +1870,7 @@ def multit_pdf(x, mu, sigma, dof):
     #   x = [[d,e,f]]
     #
     term = 1.0 + 1.0 / n * ((xmu * invsigma) * xmu.T)
-    return float(coeff * np.power(term, -np / 2.0))
+    return float(coeff * np.power(term, -npr / 2.0))
 
 
 def dataspace1d(start, stop, step=1, numbins=None):

--- a/sherpa/utils/tests/test_utils_unit.py
+++ b/sherpa/utils/tests/test_utils_unit.py
@@ -603,12 +603,7 @@ def test_multinormal_pdf_invalid_input(x, mu, sigma, eclass, emsg):
 def test_multinormal_pdf(x, mu, sigma, expected):
     """Very basic regression test"""
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore",
-                                message="the matrix subclass",
-                                category=PendingDeprecationWarning)
-        out = multinormal_pdf(x, mu, sigma)
-
+    out = multinormal_pdf(x, mu, sigma)
     assert out == pytest.approx(expected)
 
 
@@ -648,10 +643,5 @@ def test_multit_pdf_invalid_input(x, mu, sigma, eclass, emsg):
 def test_multit_pdf(x, mu, sigma, dof, expected):
     """Very basic regression test"""
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore",
-                                message="the matrix subclass",
-                                category=PendingDeprecationWarning)
-        out = multit_pdf(x, mu, sigma, dof)
-
+    out = multit_pdf(x, mu, sigma, dof)
     assert out == pytest.approx(expected)

--- a/sherpa/utils/tests/test_utils_unit.py
+++ b/sherpa/utils/tests/test_utils_unit.py
@@ -612,7 +612,6 @@ def test_multinormal_pdf(x, mu, sigma, expected):
     assert out == pytest.approx(expected)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("x,mu,sigma,eclass,emsg",
                          [([1, 2], 3, [3], TypeError, "x and mu sizes do not match"),
                           ([3], [4, 5], [3], TypeError, "x and mu sizes do not match"),
@@ -637,7 +636,6 @@ def test_multit_pdf_invalid_input(x, mu, sigma, eclass, emsg):
 
 # The values were calculated using CIAO 4.16 on a Linux x86_64 OS.
 #
-@pytest.mark.xfail
 @pytest.mark.parametrize("x,mu,sigma,dof,expected",
                          [([2, 1], [0.5, 0.7], [[1, 0], [0, 1]], 1,
                            0.02607356594580531),

--- a/sherpa/utils/tests/test_utils_unit.py
+++ b/sherpa/utils/tests/test_utils_unit.py
@@ -17,6 +17,9 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+
+import warnings
+
 import numpy
 from numpy.testing import assert_almost_equal, assert_array_equal, \
     assert_array_almost_equal
@@ -25,7 +28,7 @@ import pytest
 
 from sherpa.utils import _utils, is_binary_file, pad_bounding_box, \
     get_fwhm, histogram1d, histogram2d, dataspace1d, dataspace2d, \
-    interpolate, bool_cast
+    interpolate, bool_cast, multinormal_pdf, multit_pdf
 from sherpa.utils.testing import requires_data
 
 
@@ -566,3 +569,91 @@ def test_bool_cast_invalid(arg, badval):
     emsg = arg if badval is None else badval
     with pytest.raises(TypeError, match=f"^unknown boolean value: '{emsg}'$"):
         bool_cast(arg)
+
+
+@pytest.mark.parametrize("x,mu,sigma,eclass,emsg",
+                         [([1, 2], 3, [3], TypeError, "x and mu sizes do not match"),
+                          ([3], [4, 5], [3], TypeError, "x and mu sizes do not match"),
+                          # This one is not explicitly checked for, so the
+                          # error message may change with NumPy; so we may
+                          # decide not to test it if it needs changing
+                          ([2, 3], [3, 4], [2, 3],
+                           ValueError, "diag requires an array of at least two dimensions"),
+                          ([2, 3, 4], [3, 4, 6], [[2, 3], [3, 4]],
+                           TypeError, "sigma shape does not match x"),
+                          ([2, 3], [3, 4], [[1, 2], [3, 4]],
+                           ValueError, "sigma is not positive definite"),
+                          ([2, 3], [3, 4], [[1, -2j], [2j, 5]],
+                           ValueError, "sigma is not symmetric")
+                          ])
+def test_multinormal_pdf_invalid_input(x, mu, sigma, eclass, emsg):
+    """Minimal test of invalid input"""
+
+    with pytest.raises(eclass, match=emsg):
+        multinormal_pdf(x, mu, sigma)
+
+
+# The values were calculated using CIAO 4.16 on a Linux x86_64 OS.
+#
+@pytest.mark.parametrize("x,mu,sigma,expected",
+                         [([2, 1], [0.5, 0.7], [[1, 0], [0, 1]],
+                           0.049396432874713896),
+                          ([1, 2], [0.5, 0.7], [[1, 0], [0, 1]],
+                           0.06033293935644923)])
+def test_multinormal_pdf(x, mu, sigma, expected):
+    """Very basic regression test"""
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore",
+                                message="the matrix subclass",
+                                category=PendingDeprecationWarning)
+        out = multinormal_pdf(x, mu, sigma)
+
+    assert out == pytest.approx(expected)
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize("x,mu,sigma,eclass,emsg",
+                         [([1, 2], 3, [3], TypeError, "x and mu sizes do not match"),
+                          ([3], [4, 5], [3], TypeError, "x and mu sizes do not match"),
+                          # This one is not explicitly checked for, so the
+                          # error message may change with NumPy; so we may
+                          # decide not to test it if it needs changing
+                          ([2, 3], [3, 4], [2, 3],
+                           ValueError, "diag requires an array of at least two dimensions"),
+                          ([2, 3, 4], [3, 4, 6], [[2, 3], [3, 4]],
+                           TypeError, "sigma shape does not match x"),
+                          ([2, 3], [3, 4], [[1, 2], [3, 4]],
+                           ValueError, "sigma is not positive definite"),
+                          ([2, 3], [3, 4], [[1, -2j], [2j, 5]],
+                           ValueError, "sigma is not symmetric")
+                          ])
+def test_multit_pdf_invalid_input(x, mu, sigma, eclass, emsg):
+    """Minimal test of invalid input"""
+
+    with pytest.raises(eclass, match=emsg):
+        multit_pdf(x, mu, sigma, dof=1)
+
+
+# The values were calculated using CIAO 4.16 on a Linux x86_64 OS.
+#
+@pytest.mark.xfail
+@pytest.mark.parametrize("x,mu,sigma,dof,expected",
+                         [([2, 1], [0.5, 0.7], [[1, 0], [0, 1]], 1,
+                           0.02607356594580531),
+                          ([1, 2], [0.5, 0.7], [[1, 0], [0, 1]], 1,
+                           0.03157178495439245),
+                          ([2, 1], [0.5, 0.7], [[1, 0], [0, 1]], 2,
+                           0.033798751957335116),
+                          ([1, 2], [0.5, 0.7], [[1, 0], [0, 1]], 2,
+                           0.04100980264678175)])
+def test_multit_pdf(x, mu, sigma, dof, expected):
+    """Very basic regression test"""
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore",
+                                message="the matrix subclass",
+                                category=PendingDeprecationWarning)
+        out = multit_pdf(x, mu, sigma, dof)
+
+    assert out == pytest.approx(expected)


### PR DESCRIPTION
# Summary

Fix an error made when addressing NumPy 2.0 changes in issue #2025.

# Details

We first add some minimal tests of the multit_pdf and multinormal_pdf routines (we could perhaps remove these, but for now I leave them in as they might be useful and we don't want to break anyone that uses Sherpa if we can help it). These tests use values calculated using CIAO 4.16 on Linux x86_64. That is, they are not "from first principles" tests, because I did not wite the code or design the interface or have time to investigate too deeply.

We then fix the error added in #2025 - there's two errors

- the routine was using a variable called `np` but we now `import numpy as np`, which breaks things -> the variable is now called `npr`
- to address issues over the matrix call we had switched to `np.asmatrix` but there was a typo in one of the calls and I'd said `np.asmattix`

After fixing things I then go and address issue #2026 where we noted that code now complains about the use of NumPy matrices because we should be using arrays. Fortunately the fixes here are simple as all we need to is make sure to use `@` to indicate matrix multiplication (this syntax was not available when the code here was written). I note that this only addresses the matrix code in these two routines, not in all of Sherpa, which is why we ar enot closing the issue.