### PR TITLE
Simple typing support for sherpa.data

### DIFF
--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -28,7 +28,7 @@ import pytest
 from sherpa.astro.ui.utils import Session
 from sherpa.astro.data import Data1D, DataARF, DataPHA, DataRMF, DataIMG, DataIMGInt
 from sherpa.astro.instrument import create_arf, create_delta_rmf
-from sherpa.models.basic import Gauss2D
+from sherpa.models.basic import Gauss1D, Gauss2D
 from sherpa.utils import parse_expr
 from sherpa.utils.err import ArgumentTypeErr, DataErr
 from sherpa.utils.numeric_types import SherpaFloat
@@ -36,10 +36,10 @@ from sherpa.utils.testing import requires_data, requires_fits, \
     requires_group, requires_region
 
 
-EMPTY_DATA_OBJECTS = [(DataPHA, [None] * 2),
-                      (DataIMG, [None] * 3),
-                      (DataIMGInt, [None] * 5)]
-
+EMPTY_DATA_OBJECTS_1D = [(DataPHA, [None] * 2)]
+EMPTY_DATA_OBJECTS_2D = [(DataIMG, [None] * 3),
+                         (DataIMGInt, [None] * 5)]
+EMPTY_DATA_OBJECTS = EMPTY_DATA_OBJECTS_1D + EMPTY_DATA_OBJECTS_2D
 
 def _monotonic_warning(response_type, filename):
     return UserWarning("The {} '{}' has a non-monotonic ENERG_LO array".format(response_type, filename))
@@ -3205,7 +3205,7 @@ def test_data_can_not_set_dep_to_scalar_when_empty(data_class, args):
         data.set_dep(2)
 
 
-@pytest.mark.parametrize("data_class,args", EMPTY_DATA_OBJECTS[1:])
+@pytest.mark.parametrize("data_class,args", EMPTY_DATA_OBJECTS_2D)
 @pytest.mark.parametrize("index", ["x0", "x1"])
 def test_data_empty_get_x_2d(data_class, args, index):
     """What happens when there's no data?
@@ -3814,3 +3814,189 @@ def test_pha_group_xxx_with_background(caplog):
     assert bkg.grouped
 
     assert len(caplog.records) == 0
+
+
+def test_eval_model_when_empty_datapha():
+    """This is a regression test."""
+
+    def mdl(*args):
+        assert len(args) == 1
+        assert args[0] is None
+        return [-9]  # easy to check for
+
+    mdl.ndim = 1
+    data = DataPHA("empty", None, None)
+    resp = data.eval_model(mdl)
+    assert resp == pytest.approx([-9])
+
+
+def test_eval_model_to_fit_when_empty_datapha():
+    """This is a regression test."""
+
+    data = DataPHA("empty", None, None)
+    with pytest.raises(DataErr,
+                       match="The size of 'empty' has not been set"):
+        _ = data.eval_model_to_fit(Gauss1D())
+
+
+@pytest.mark.parametrize("data_class,args", EMPTY_DATA_OBJECTS_2D)
+@pytest.mark.parametrize("funcname", ["eval_model", "eval_model_to_fit"])
+def test_eval_model_when_empty_2d(data_class, args, funcname):
+    """This is a regression test."""
+
+    def mdl(*args):
+        assert len(args) > 1
+        assert args[0] is None
+        return [-9]  # easy to check for
+
+    mdl.ndim = 2
+    data = data_class("empty", *args)
+    func = getattr(data, funcname)
+    resp = func(mdl)
+    assert resp == pytest.approx([-9])
+
+
+def test_eval_model_when_all_ignored_datapha():
+    """This is a regression test."""
+
+    def mdl(*args):
+        assert len(args) == 1
+        assert args[0] is not None
+        return [-9]  # easy to check for
+
+    data = DataPHA("x", [1, 2, 3], [3, 2, 7])
+    data.ignore()
+    resp = data.eval_model(mdl)
+    assert resp == pytest.approx([-9])
+
+
+def test_eval_model_to_fit_when_all_ignored_datapha():
+    """This is a regression test."""
+
+    data = DataPHA("x", [1, 2, 3], [3, 2, 7])
+    data.ignore()
+    with pytest.raises(DataErr,
+                       match="mask excludes all data"):
+        _ = data.eval_model_to_fit(Gauss1D())
+
+
+def test_eval_model_when_all_ignored_dataimg():
+    """This is a regression test."""
+
+    def mdl(*args):
+        assert len(args) > 1
+        assert args[0] is not None
+        return [-9]  # easy to check for
+
+    data = DataIMG("x", [1, 2, 1, 2], [1, 1, 2, 2], [3, 4, 5, 8])
+    data.ignore()
+    resp = data.eval_model(mdl)
+    assert resp == pytest.approx([-9])
+
+
+def test_eval_model_to_fit_when_all_ignored_dataimg():
+    """This is a regression test."""
+
+    data = DataIMG("x", [1, 2, 1, 2], [1, 1, 2, 2], [3, 4, 5, 8])
+    data.ignore()
+    with pytest.raises(DataErr,
+                       match="mask excludes all data"):
+        _ = data.eval_model_to_fit(Gauss2D())
+
+
+def test_to_guess_when_empty_datapha():
+    """This is a regression test."""
+
+    data = DataPHA("empty", None, None)
+    # This is not a nice error case, so catch it in case we decide to
+    # change the code.
+    #
+    with pytest.raises(TypeError,
+                       match=r"unsupported operand type\(s\) for \+: 'NoneType' and 'int'"):
+        _ = data.to_guess()
+
+
+@pytest.mark.parametrize("data_class,args", EMPTY_DATA_OBJECTS_2D)
+def test_to_guess_when_empty_2d(data_class, args):
+    """This is a regression test."""
+
+    data = data_class("empty", *args)
+    resp = data.to_guess()
+
+    # Ensure there are n None values, where n is the number of
+    # independent + dependent axes - ie len(args)
+    #
+    assert len(resp) == len(args)
+    for r in resp:
+        assert r is None
+
+
+def test_to_guess_when_all_ignored_datapha():
+    """This is a regression test."""
+
+    data = DataPHA("x", [1, 2, 3], [2, 1, 3])
+    data.ignore()
+    with pytest.raises(DataErr,
+                       match="mask excludes all data"):
+        _ = data.to_guess()
+
+
+def test_to_guess_when_all_ignored_dataimg():
+    """This is a regression test."""
+
+    data = DataIMG("x", [1, 1, 2, 2], [1, 2, 1, 2], [3, 40, 7, 12])
+    data.ignore()
+    with pytest.raises(DataErr,
+                       match="mask excludes all data"):
+        _ = data.to_guess()
+
+
+def test_get_dims_when_empty_datapha():
+    """This is a regression test."""
+
+    data = DataPHA("empty", None, None)
+    # This is not a nice error case, so catch it in case we decide to
+    # change the code.
+    #
+    with pytest.raises(TypeError,
+                       match=r"object of type 'NoneType' has no len\(\)"):
+        _ = data.get_dims()
+
+
+@pytest.mark.parametrize("data_class,args", EMPTY_DATA_OBJECTS_2D)
+def test_get_dims_when_empty_2d(data_class, args):
+    """This is a regression test."""
+
+    data = data_class("empty", *args)
+    # This is not a nice error case, so catch it in case we decide to
+    # change the code.
+    #
+    with pytest.raises(TypeError,
+                       match=r"object of type 'NoneType' has no len\(\)"):
+        _ = data.get_dims()
+
+
+def test_get_filter_when_empty_datapha():
+    """This is a regression test."""
+
+    data = DataPHA("empty", None, None)
+    # This is not a nice error case, so catch it in case we decide to
+    # change the code.
+    #
+    with pytest.raises(TypeError,
+                       match=r"object of type 'NoneType' has no len\(\)"):
+        _ = data.get_filter()
+
+
+@pytest.mark.parametrize("data_class,args", EMPTY_DATA_OBJECTS_2D)
+def test_get_filter_when_empty_2d(data_class, args):
+    """This is a regression test.
+
+    Although Data2D hard-codes get_filter, the DataIMG class does
+    change the result (techncally only if region support is availablem
+    but for this case it doesn't matter).
+
+    """
+
+    data = data_class("empty", *args)
+    assert data.get_filter() == ''

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -3993,7 +3993,7 @@ def test_get_filter_when_empty_2d(data_class, args):
     """This is a regression test.
 
     Although Data2D hard-codes get_filter, the DataIMG class does
-    change the result (techncally only if region support is availablem
+    change the result (technically only if region support is available
     but for this case it doesn't matter).
 
     """

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -739,7 +739,7 @@ class Filter():
         ignore = bool_cast(ignore)
         for vals, label in zip([mins, maxes, axislist],
                                ['lower bound', 'upper bound', 'grid']):
-            if any([isinstance(val, str) for val in vals]):
+            if any(isinstance(val, str) for val in vals):
                 raise DataErr('typecheck', label)
 
         mask = filter_bins(mins, maxes, axislist, integrated=integrated)

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -115,20 +115,20 @@ dependent axis (``y``) then filter to select only those values between
 >>> d1.ignore(520, 530)
 
 """
+
+from abc import ABCMeta
 import logging
 import warnings
-from abc import ABCMeta
 
 import numpy as np
 
 from sherpa.models.regrid import EvaluationSpace1D, IntegratedAxis, PointAxis
+from sherpa.utils import NoNewAttributesAfterInit, formatting, \
+    print_fields, create_expr, create_expr_integrated, \
+    calc_total_error, bool_cast, filter_bins
 from sherpa.utils.err import DataErr
-from sherpa.utils import NoNewAttributesAfterInit, \
-    print_fields, create_expr, create_expr_integrated, calc_total_error, bool_cast, \
-    filter_bins
-from sherpa.utils.parallel import parallel_map_funcs
-from sherpa.utils import formatting
 from sherpa.utils.numeric_types import SherpaFloat
+from sherpa.utils.parallel import parallel_map_funcs
 
 
 warning = logging.getLogger(__name__).warning

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1084,7 +1084,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
 
         """
 
-        # This is currently a no-op. It may be over-ridden by a
+        # This is currently a no-op. It may be overridden by a
         # subclass.
         #
         pass

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1234,8 +1234,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
         ...
 
     def get_y(self, filter=False, yfunc=None, use_evaluation_space=False):
-        """
-        Return dependent axis in N-D view of dependent variable
+        """Return dependent axis in N-D view of dependent variable
 
         Parameters
         ----------
@@ -1245,6 +1244,10 @@ class Data(NoNewAttributesAfterInit, BaseData):
 
         Returns
         -------
+        y: array or (array, array) or None
+            If yfunc is not None and the dependent axis is set then
+            the return value is (y, y2) where y2 is yfunc evaluated on
+            the independent axis.
 
         """
         y = self.get_dep(filter)
@@ -1446,7 +1449,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
         self.notice(*args, **kwargs)
 
     def _can_apply_model(self, modelfunc: ModelFunc) -> None:
-        """Check we model dimensions match."""
+        """Check if model dimensions match data dimensions."""
 
         # Should this also check whether the independent axis is set?
         mdim = getattr(modelfunc, "ndim", None)
@@ -1741,7 +1744,7 @@ class Data1D(Data):
 
     def get_y(self, filter=False, yfunc=None,
               use_evaluation_space=False):
-        """Return dependent axis in N-D view of dependent variable.
+        """Return the dependent axis.
 
         Parameters
         ----------
@@ -1751,7 +1754,10 @@ class Data1D(Data):
 
         Returns
         -------
-        y : array or None
+        y : array or (array, array) or None
+            If yfunc is not None and the dependent axis is set then
+            the return value is (y, y2) where y2 is yfunc evaluated on
+            the independent axis.
 
         """
         y = self.get_dep(filter)

--- a/sherpa/utils/types.py
+++ b/sherpa/utils/types.py
@@ -1,0 +1,55 @@
+#
+#  Copyright (C) 2024
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Useful types for Sherpa.
+
+This module should be considered an internal module as its contents is
+likely to change as types get added to Sherpa and the typing ecosystem
+in Python matures.
+
+"""
+
+from typing import Callable, Sequence, Union
+
+import numpy as np
+
+
+# Some of these may change to TypeAlias (once Python 3.10 is the
+# minimum) and then type/TypeAliasType once Python 3.12 is the
+# minimum.
+#
+
+# Try to be generic when using arrays as input or output. There is no
+# attempt to encode the data type or shape for ndarrays at this time.
+#
+ArrayType = Union[Sequence[float], np.ndarray]
+
+# Represent statistic evaluation, per-bin.
+#
+StatErrFunc = Callable[..., ArrayType]
+
+# Represent model evaluation. Using a Protocol may be better, but
+# for now keep with a Callable. Ideally the model would just
+# return an ndarray but
+#
+# - an ArithmeticConstantModel can return a scalar
+# - models could return a sequence rather than a ndarray
+#
+ModelFunc = Callable[..., ArrayType]

--- a/sherpa/utils/types.py
+++ b/sherpa/utils/types.py
@@ -20,7 +20,7 @@
 
 """Useful types for Sherpa.
 
-This module should be considered an internal module as its contents is
+This module should be considered an internal module as its contents are
 likely to change as types get added to Sherpa and the typing ecosystem
 in Python matures.
 


### PR DESCRIPTION
# Summary

Add some basic typing rules to the sherpa.data module.

# Details

I actually want to be working on #2022 but to do that I want to clean up the code and add typing statements where possible. This is unfortunately a large job so I'm trying to break things up to be easier to review and less invasive.

I've got various versions of this in different PRs so I've decided to create a sherpa.utils.types module so we can provide a common vocabulary where possible. This is intended as an internal module - i.e. should not be relied-upon by external code - since

1. our understanding of what useful types are will change
2. as the typing ecosystem "matures" in Python things will change (e.g. TypeAlias in Python 3.10 and then this being subsumed by TypeAliasType/type in 3.12)

I will say that although this is annoying to do - since some code which is "obvious" is hard to type well, and so we just don't at the moment [*] - it does help point out some corner cases (e.g. what should the data objects do when a routine is called but the independent or dependent axis has not been set).

[*] it also depends on what code you use to do the type checking