### PR TITLE
Avoid warning messages from AstroPy about unclosed files

### DIFF
--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -1163,14 +1163,14 @@ def _find_int_dtype(rows: Sequence[Sequence[int]]) -> type:
 
     """
 
-    maxval = 0
     for row in rows:
         if len(row) == 0:
             continue
 
-        maxval = max(maxval, np.max(row))
+        if np.max(row) > 32767:
+            return np.int32
 
-    return np.int32 if maxval > 32767 else np.int16
+    return np.int16
 
 
 def _make_int_array(rows, ncols) -> np.ndarray:

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -56,7 +56,7 @@ import os
 import re
 from typing import Any, Optional
 
-import numpy
+import numpy as np
 
 from sherpa import get_config
 from sherpa.astro.data import DataIMG, DataIMGInt, DataARF, DataRMF, \
@@ -348,8 +348,8 @@ def read_image(arg, coord='logical', dstype=DataIMG):
     data['header'] = _remove_structural_keywords(data['header'])
     axlens = data['y'].shape
 
-    x0 = numpy.arange(axlens[1], dtype=SherpaFloat) + 1.
-    x1 = numpy.arange(axlens[0], dtype=SherpaFloat) + 1.
+    x0 = np.arange(axlens[1], dtype=SherpaFloat) + 1.
+    x1 = np.arange(axlens[0], dtype=SherpaFloat) + 1.
     x0, x1 = reshape_2d_arrays(x0, x1)
 
     data['y'] = data['y'].ravel()
@@ -587,7 +587,7 @@ def read_pha(arg, use_errors=False, use_background=False):
                     if output_once:
                         info("read background file %s", data['backfile'])
 
-                if numpy.iterable(bkg_datasets):
+                if np.iterable(bkg_datasets):
                     for bkg_dataset in bkg_datasets:
                         if bkg_dataset.get_response() == (None, None) and \
                            rmf is not None:
@@ -694,7 +694,7 @@ def _pack_image(dataset):
     # Data2D does not have a header
     header = getattr(dataset, "header", {})
 
-    data['pixels'] = numpy.asarray(dataset.get_img())
+    data['pixels'] = np.asarray(dataset.get_img())
     data['sky'] = getattr(dataset, 'sky', None)
     data['eqpos'] = getattr(dataset, 'eqpos', None)
 
@@ -958,7 +958,7 @@ def _pack_pha(dataset):
             header[uname] = 1.0
             return
 
-        if numpy.isscalar(val):
+        if np.isscalar(val):
             header[uname] = val
         else:
             data[colname] = val
@@ -1043,18 +1043,18 @@ def _pack_pha(dataset):
         #
         data[column] = vals.astype(dtype)
 
-    convert("CHANNEL", numpy.int32)
-    convert("GROUPING", numpy.int16)
-    convert("QUALITY", numpy.int16)
+    convert("CHANNEL", np.int32)
+    convert("GROUPING", np.int16)
+    convert("QUALITY", np.int16)
 
     # COUNTS has to deal with integer or floating-point.
     #
     try:
         vals = data["COUNTS"]
-        if numpy.issubdtype(vals.dtype, numpy.integer):
-            vals = vals.astype(numpy.int32)
-        elif numpy.issubdtype(vals.dtype, numpy.floating):
-            vals = vals.astype(numpy.float32)
+        if np.issubdtype(vals.dtype, np.integer):
+            vals = vals.astype(np.int32)
+        elif np.issubdtype(vals.dtype, np.floating):
+            vals = vals.astype(np.float32)
         else:
             raise DataErr("ogip-error", "PHA dataset",
                           dataset.name,
@@ -1140,9 +1140,9 @@ def _pack_arf(dataset):
     # data type meets the FITS standard (Real4).
     #
     data = {}
-    data["ENERG_LO"] = dataset.energ_lo.astype(numpy.float32)
-    data["ENERG_HI"] = dataset.energ_hi.astype(numpy.float32)
-    data["SPECRESP"] = dataset.specresp.astype(numpy.float32)
+    data["ENERG_LO"] = dataset.energ_lo.astype(np.float32)
+    data["ENERG_HI"] = dataset.energ_hi.astype(np.float32)
+    data["SPECRESP"] = dataset.specresp.astype(np.float32)
 
     # Chandra files can have BIN_LO/HI values, so copy
     # across if both set.
@@ -1184,8 +1184,8 @@ def _make_int_array(rows, ncols):
 
         maxval = max(maxval, row.max())
 
-    dtype = numpy.int32 if maxval > 32767 else numpy.int16
-    out = numpy.zeros((nrows, ncols), dtype=dtype)
+    dtype = np.int32 if maxval > 32767 else np.int16
+    out = np.zeros((nrows, ncols), dtype=dtype)
     for idx, row in enumerate(rows):
         if len(row) == 0:
             continue
@@ -1215,7 +1215,7 @@ def _make_float32_array(rows, ncols):
     """
 
     nrows = len(rows)
-    out = numpy.zeros((nrows, ncols), dtype=numpy.float32)
+    out = np.zeros((nrows, ncols), dtype=np.float32)
     for idx, row in enumerate(rows):
         out[idx, 0:len(row)] = row
 
@@ -1246,12 +1246,12 @@ def _make_int_vlf(rows):
 
         maxval = max(maxval, row.max())
 
-    dtype = numpy.int32 if maxval > 32767 else numpy.int16
+    dtype = np.int32 if maxval > 32767 else np.int16
     out = []
     for row in rows:
-        out.append(numpy.asarray(row, dtype=dtype))
+        out.append(np.asarray(row, dtype=dtype))
 
-    return numpy.asarray(out, dtype=object)
+    return np.asarray(out, dtype=object)
 
 
 def _reconstruct_rmf(rmf):
@@ -1310,9 +1310,9 @@ def _reconstruct_rmf(rmf):
             matrix_size.add(0)
 
             # Convert from [] to numpy empty list
-            f_chan[-1] = numpy.asarray([], dtype=numpy.int32)
-            n_chan[-1] = numpy.asarray([], dtype=numpy.int32)
-            matrix[-1] = numpy.asarray([], dtype=numpy.float32)
+            f_chan[-1] = np.asarray([], dtype=np.int32)
+            n_chan[-1] = np.asarray([], dtype=np.int32)
+            matrix[-1] = np.asarray([], dtype=np.float32)
             continue
 
         # Grab the next ng elements from rmf.f_chan/n_chan
@@ -1323,7 +1323,7 @@ def _reconstruct_rmf(rmf):
             # ensure this is an integer and not a floating-point number
             # which can happen when rmf.n_chan is stored as Unt64.
             #
-            end = start + rmf.n_chan[idx].astype(numpy.int32)
+            end = start + rmf.n_chan[idx].astype(np.int32)
             mdata = rmf.matrix[start:end]
 
             f_chan[-1].append(rmf.f_chan[idx])
@@ -1337,18 +1337,18 @@ def _reconstruct_rmf(rmf):
         # converting to 4-byte integer here, which can later be
         # downcast.
         #
-        f_chan[-1] = numpy.asarray(f_chan[-1], dtype=numpy.int32)
-        n_chan[-1] = numpy.asarray(n_chan[-1], dtype=numpy.int32)
+        f_chan[-1] = np.asarray(f_chan[-1], dtype=np.int32)
+        n_chan[-1] = np.asarray(n_chan[-1], dtype=np.int32)
 
         # Ensure the matrix is Real-4
-        matrix[-1] = numpy.asarray(matrix[-1], dtype=numpy.float32)
+        matrix[-1] = np.asarray(matrix[-1], dtype=np.float32)
         matrix_size.add(matrix[-1].size)
 
         numelt += sum(n_chan[-1])
 
     # N_GRP should be 2-byte integer.
     #
-    n_grp = numpy.asarray(n_grp, dtype=numpy.int16)
+    n_grp = np.asarray(n_grp, dtype=np.int16)
     numgrp = n_grp.sum()
 
     # Can we convert F_CHAN/N_CHAN to fixed-length if either:
@@ -1370,7 +1370,7 @@ def _reconstruct_rmf(rmf):
         ny = matrix_size.pop()
         matrix = _make_float32_array(matrix, ny)
     else:
-        matrix = numpy.asarray(matrix, dtype=object)
+        matrix = np.asarray(matrix, dtype=object)
 
     return {"N_GRP": n_grp,
             "F_CHAN": f_chan,
@@ -1512,11 +1512,11 @@ def _pack_rmf(dataset):
 
     # TODO: is this correct?
     nchan = dataset.offset + dataset.detchans - 1
-    dchan = numpy.int32 if nchan > 32767 else numpy.int16
+    dchan = np.int32 if nchan > 32767 else np.int16
     ebounds_data = {
-        "CHANNEL": numpy.arange(dataset.offset, nchan + 1, dtype=dchan),
-        "E_MIN": dataset.e_min.astype(numpy.float32),
-        "E_MAX": dataset.e_max.astype(numpy.float32)
+        "CHANNEL": np.arange(dataset.offset, nchan + 1, dtype=dchan),
+        "E_MIN": dataset.e_min.astype(np.float32),
+        "E_MAX": dataset.e_max.astype(np.float32)
         }
 
     return [(matrix_data, matrix_header),

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -92,9 +92,6 @@ else:
     if ogip_emin <= 0.0:
         raise ValueError(emsg)
 
-backend = None
-'''Currently active backend module for astronomy specific I/O.'''
-
 for iotry in io_opt:
     try:
         backend = importlib.import_module('.' + iotry,

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -64,6 +64,7 @@ from sherpa.astro.data import DataIMG, DataIMGInt, DataARF, DataRMF, \
 from sherpa.astro.utils import reshape_2d_arrays
 from sherpa.data import Data, Data1D, Data2D, Data2DInt
 from sherpa.io import _check_args
+from sherpa.utils import is_subclass
 from sherpa.utils.err import ArgumentErr, DataErr, IOErr
 from sherpa.utils.numeric_types import SherpaFloat
 
@@ -162,7 +163,7 @@ def read_arrays(*args):
     if len(largs) == 0:
         raise IOErr('noarrays')
 
-    if sherpa.io._is_subclass(largs[-1], Data):
+    if is_subclass(largs[-1], Data):
         dstype = largs.pop()
     else:
         dstype = Data1D

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -64,7 +64,7 @@ from sherpa.astro.data import DataIMG, DataIMGInt, DataARF, DataRMF, \
 # leads to circular imports
 # from sherpa.astro.instrument import ARF1D, RMF1D
 from sherpa.astro.utils import reshape_2d_arrays
-from sherpa.data import Data2D, Data1D, BaseData, Data2DInt
+from sherpa.data import Data, Data1D, Data2D, Data2DInt
 import sherpa.io
 from sherpa.utils.err import ArgumentErr, DataErr, IOErr
 from sherpa.utils.numeric_types import SherpaFloat
@@ -124,7 +124,7 @@ def read_arrays(*args):
     The return value defaults to a `sherpa.data.Data1D` instance,
     but this can be changed by supplying the required class
     as the last argument (anything that is derived from
-    `sherpa.data.BaseData`).
+    `sherpa.data.Data`).
 
     Parameters
     ----------
@@ -137,7 +137,7 @@ def read_arrays(*args):
 
     Returns
     -------
-    data : a sherpa.data.BaseData derived object
+    data : a sherpa.data.Data derived object
 
     Examples
     --------
@@ -164,7 +164,7 @@ def read_arrays(*args):
     if len(largs) == 0:
         raise IOErr('noarrays')
 
-    if sherpa.io._is_subclass(largs[-1], BaseData):
+    if sherpa.io._is_subclass(largs[-1], Data):
         dstype = largs.pop()
     else:
         dstype = Data1D
@@ -194,11 +194,11 @@ def read_table(arg, ncols=2, colkeys=None, dstype=Data1D):
         If given, select these columns from the file.
     dstype : optional
         The data type to create (it is expected to follow the
-        `sherpa.data.BaseData` interface).
+        `sherpa.data.Data` interface).
 
     Returns
     -------
-    data : a sherpa.data.BaseData derived object
+    data : a sherpa.data.Data derived object
 
     See Also
     --------
@@ -252,7 +252,7 @@ def read_ascii(filename, ncols=2, colkeys=None, dstype=Data1D, **kwargs):
         If given, select these columns from the file.
     dstype : optional
         The data type to create (it is expected to follow the
-        `sherpa.data.BaseData` interface).
+        `sherpa.data.Data` interface).
     **kwargs
         The remaining arguments are passed through to the
         ``get_ascii_data`` routine of the I/O backend. It is
@@ -262,7 +262,7 @@ def read_ascii(filename, ncols=2, colkeys=None, dstype=Data1D, **kwargs):
 
     Returns
     -------
-    data : a sherpa.data.BaseData derived object
+    data : a sherpa.data.Data derived object
 
     Examples
     --------
@@ -316,11 +316,11 @@ def read_image(arg, coord='logical', dstype=DataIMG):
         coordinate system.
     dstype : optional
         The data type to create (it is expected to follow the
-        `sherpa.data.BaseData` interface).
+        `sherpa.data.Data` interface).
 
     Returns
     -------
-    data : a sherpa.data.BaseData derived object
+    data : a sherpa.data.Data derived object
 
     See Also
     --------
@@ -482,7 +482,7 @@ def _read_ancillary(data, key, label, dname,
 
     Returns
     -------
-    data : None or a sherpa.data.BaseData derived object
+    data : None or a sherpa.data.Data derived object
 
     """
 

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2011, 2015, 2016, 2019 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -20,34 +20,32 @@
 
 from collections import defaultdict
 import logging
-import os.path
+import os
+from typing import Any, Optional, Sequence, Union
 
-import numpy
+import numpy as np
 
-from pycrates import CrateDataset, CrateKey, CrateData, TABLECrate, \
-    IMAGECrate, WCSTANTransform, RMFCrateDataset, \
-    PHACrateDataset  # type: ignore
+from pycrates import CrateDataset, IMAGECrate, TABLECrate  # type: ignore
 import pycrates  # type: ignore
-# work around missing TLMIN support in crates CIAO 4.15
-import cxcdm  # type: ignore
+import pytransform  # type: ignore
 
-from sherpa.astro.io.xstable import TableHDU
 from sherpa.astro.utils import resp_init
 from sherpa.utils import is_binary_file
 from sherpa.utils.err import ArgumentTypeErr, IOErr
 from sherpa.utils.numeric_types import SherpaInt, SherpaUInt, \
     SherpaFloat
 
+from .xstable import HeaderItem, TableHDU
 
 warning = logging.getLogger(__name__).warning
 error = logging.getLogger(__name__).error
 info = logging.getLogger(__name__).info
 
-transformstatus = False
 try:
-    from sherpa.astro.io.wcs import WCS
-    transformstatus = True
+    from .wcs import WCS
+    HAS_TRANSFORM = True
 except ImportError:
+    HAS_TRANSFORM = False
     warning('failed to import WCS module; WCS routines will not be '
             'available')
 
@@ -58,21 +56,31 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'set_arf_data', 'set_rmf_data', 'set_hdus')
 
 
-string_types = (str, )
+CrateType = Union[TABLECrate, IMAGECrate]
+KeyType = Union[bool, int, str, float]
 
 
-def open_crate_dataset(filename, crateType=CrateDataset, mode='r'):
-    """
-    checked for new crates
-    """
-    return crateType(filename, mode=mode)
+def open_crate(filename: str,
+               mode: str = "r") -> CrateType:
+    """Get the "most interesting" block of the file.
 
+    Parameters
+    ----------
+    filename : str
+    mode : str
 
-def open_crate(filename, crateType=CrateDataset, mode='r'):
+    Returns
+    -------
+    crate : IMAGECrate or TABLECrate
+
+    Notes
+    -----
+    This routine could just be inlined where necessary, but it is
+    useful because it allows the code to provide unified behaviour
+    when crates can not read a file because of an unknown datatype.
+
     """
-    checked for new crates
-    """
-    dataset = open_crate_dataset(filename, crateType, mode)
+    dataset = CrateDataset(filename, mode=mode)
     current = dataset.get_current_crate()
     try:
         return dataset.get_crate(current)
@@ -84,11 +92,10 @@ def open_crate(filename, crateType=CrateDataset, mode='r'):
         raise IOErr("openfailed", emsg) from exc
 
 
-def get_filename_from_dmsyntax(filename, blockname=None):
+def get_filename_from_dmsyntax(filename: str) -> str:
+    """What is the filename to use?"""
 
-    arg = str(filename)
-    isbinary = True
-    colnames = True
+    out = filename
     dmsyn = ''
 
     if '[' in filename and ']' in filename:
@@ -98,28 +105,36 @@ def get_filename_from_dmsyntax(filename, blockname=None):
             dmsyn = parts.pop(0).lower()
 
     if not is_binary_file(filename):
-        isbinary = False
-        # TODO: set encoding='UTF-8' or maybe 'ascii'
-        with open(filename, mode='r') as fh:
+        colnames = True
+
+        # Crates only guarantees to support ASCII-like variants but it
+        # should be okay to use a less-restrictive encoding here.
+        #
+        with open(filename, mode='r', encoding="UTF8") as fh:
             last = None
             line = fh.readline().strip()
-            while len(line) > 0 and line[0] in '#%':
+            while len(line) > 0 and line.startswith("#"):
                 last = line
                 line = fh.readline().strip()
-            if (last is not None and
-                    (len(last.strip('#').strip().split(' ')) != len(line.strip().split(' ')))):
+
+        # Check whether we have a header line and an actual data line
+        # and, if so, whether they match.
+        #
+        if last is not None:
+            cols_header = last.strip('#').strip().split(' ')
+            cols_data = line.strip().split(' ')
+            if len(cols_header) != len(cols_data):
                 colnames = False
 
-    if blockname is not None:
-        arg += f"[{str(blockname).upper()}]"
+        if not colnames and 'cols' not in dmsyn:
+            out += "[opt colnames=none]"
 
-    if not isbinary and not colnames and 'cols' not in dmsyn:
-        arg += "[opt colnames=none]"
-
-    return arg
+    return out
 
 
-def _try_key(crate, name, dtype=str):
+def _try_key(crate: CrateType,
+             name: str,
+             dtype: type = str) -> Optional[KeyType]:
     """Access the key from the crate returning None if it does not exist.
 
     There's no way to differentiate between a key that does not exist
@@ -166,51 +181,50 @@ def _try_key(crate, name, dtype=str):
     return dtype(value)
 
 
-def _get_meta_data(crate):
+def _get_meta_data(crate: CrateType) -> dict[str, KeyType]:
+    """Retrieve the header information from the crate.
+
+    This loses the "specialized" keywords like HISTORY and COMMENT.
+
     """
-    checked for new crates
-    """
+
     meta = {}
-    names = crate.get_keynames()
-    if names is not None:
-        for name in names:
-            val = crate.get_key(name).value
-
-            # empty numpy strings are not recognized by load pickle!
-            if type(val) is numpy.str_ and val == '':
-                val = ''
-
-            meta[name] = val
+    for name in crate.get_keynames():
+        val = crate.get_key(name).value
+        meta[name] = val
 
     return meta
 
 
-def _set_key(crate, name, val, fix_type=False, dtype=str):
-    """
-    checked for new crates
-    """
-    key = CrateKey()
-    key.name = str(name).strip().upper()
+def _set_key(crate: CrateType,
+             name: str,
+             val: KeyType,
+             fix_type: bool = False,
+             dtype: type = str) -> None:
+    """Add a key + value to the header."""
 
-    if fix_type:
-        key.value = dtype(val)
-    else:
-        key.value = val
-
+    key = pycrates.CrateKey()
+    key.name = name.upper()
+    key.value = dtype(val) if fix_type else val
     crate.add_key(key)
 
 
-def _set_column(crate, name, val):
-    """
-    checked for new crates
-    """
-    col = CrateData()
+# The typing for this is not ideal.
+#
+def _set_column(crate: TABLECrate,
+                name: str,
+                val: Any) -> None:
+    """Add a column to the table crate."""
+
+    col = pycrates.CrateData()
     col.name = name.upper()
-    col.values = numpy.array(val)
+    col.values = np.array(val)
     crate.add_column(col)
 
 
-def _require_key(crate, name, dtype=str):
+def _require_key(crate: CrateType,
+                 name: str,
+                 dtype: type = str) -> KeyType:
     """Access the key from the crate, erroring out if it does not exist.
 
     There's no way to differentiate between a key that does not exist
@@ -242,38 +256,25 @@ def _require_key(crate, name, dtype=str):
     return key
 
 
-def _try_col(crate, colname, make_copy=False, fix_type=False,
-             dtype=SherpaFloat):
-    """
-    checked for new crates
-    """
+def _try_col(crate: TABLECrate,
+             colname: str,
+             make_copy: bool = False,
+             fix_type: bool = False,
+             dtype: type = SherpaFloat) -> Optional[np.ndarray]:
+    """Return the column data or None (if it does not exist)."""
 
     try:
-        col = crate.get_column(colname)
-    except ValueError:
+        return _require_col(crate, colname, make_copy=make_copy,
+                            fix_type=fix_type, dtype=dtype)
+    except IOErr:
         return None
 
-    if col.is_varlen():
-        values = col.get_fixed_length_array()
-    else:
-        values = col.values
 
-    if make_copy:
-        # Make a copy if a filename passed in
-        data = numpy.array(values).ravel()
-
-    else:
-        # Use a reference if a crate passed in
-        data = numpy.asarray(values).ravel()
-
-    if fix_type:
-        data = data.astype(dtype)
-
-    return data
-
-
+# This is surprisingly hard to type (because of column_stack) so skip
+# it.
+#
 def _require_tbl_col(crate, colname, cnames, make_copy=False,
-                     fix_type=False, dtype=SherpaFloat):
+                     fix_type=False):
     """
     checked for new crates
     """
@@ -285,18 +286,22 @@ def _require_tbl_col(crate, colname, cnames, make_copy=False,
 
     if make_copy:
         # Make a copy if a filename passed in
-        data = numpy.array(col.values)
+        data = np.array(col.values)
     else:
         # Use a reference if a crate passed in
-        data = numpy.asarray(col.values)
+        data = np.asarray(col.values)
 
     if fix_type:
-        data = data.astype(dtype)
+        data = data.astype(SherpaFloat)
 
-    return numpy.column_stack(data)
+    return np.column_stack(data)
 
 
-def _try_key_list(crate, keyname, num, dtype=SherpaFloat, fix_type=False):
+def _try_key_list(crate: CrateType,
+                  keyname: str,
+                  num: int,
+                  dtype: type = SherpaFloat,
+                  fix_type: bool = False) -> Optional[np.ndarray]:
     """
     checked for new crates
     """
@@ -304,26 +309,43 @@ def _try_key_list(crate, keyname, num, dtype=SherpaFloat, fix_type=False):
         return None
 
     key = crate.get_key(keyname)
-
-    # Make a copy of the data, since we don't know that pycrates will
-    # do something sensible wrt reference counting
-    key = numpy.array([key.value] * num)
-
+    keys = np.full(num, key.value)
     if fix_type:
-        key = key.astype(dtype)
+        keys = keys.astype(dtype)
 
-    return key
+    return keys
 
 
-def _try_col_list(crate, colname, num, make_copy=False, fix_type=False,
-                  dtype=SherpaFloat):
+def _try_col_list(crate: TABLECrate,
+                  colname: str,
+                  num: int,
+                  make_copy: bool = False,
+                  fix_type: bool = False) -> np.ndarray:
     """
     checked for the new crates
     """
-    if not crate.column_exists(colname):
-        return numpy.array([None] * num)
 
-    col = crate.get_column(colname)
+    try:
+        return _require_col_list(crate, colname,
+                                 make_copy=make_copy,
+                                 fix_type=fix_type)
+    except IOErr:
+        return np.full(num, None)
+
+
+def _require_col_list(crate: TABLECrate,
+                      colname: str,
+                      make_copy: bool = False,
+                      fix_type: bool = False) -> np.ndarray:
+    """
+    check for new crates
+    """
+
+    try:
+        col = crate.get_column(colname)
+    except ValueError:
+        raise IOErr("reqcol", colname, crate.get_filename()) from None
+
     if col.is_varlen():
         values = col.get_fixed_length_array()
     else:
@@ -331,75 +353,85 @@ def _try_col_list(crate, colname, num, make_copy=False, fix_type=False,
 
     if make_copy:
         # Make a copy if a filename passed in
-        col = numpy.array(values)
+        col = np.array(values)
     else:
         # Use a reference if a crate passed in
-        col = numpy.asarray(values)
+        col = np.asarray(values)
 
     if fix_type:
-        col = col.astype(dtype)
+        col = col.astype(SherpaFloat)
 
     return col
 
 
-def _require_col_list(crate, colname, num, make_copy=False, fix_type=False,
-                      dtype=SherpaFloat):
-    """
-    check for new crates
-    """
+def _require_col(crate: TABLECrate,
+                 colname: str,
+                 make_copy: bool = False,
+                 fix_type: bool = False,
+                 label: Optional[str] = None,
+                 dtype: type = SherpaFloat) -> np.ndarray:
+    """Return the column data or error out."""
 
-    # _try_col_list returns [None] * num if the column doesn't exist
-    # which is awkward to check for so use an explicit check.
-    #
-    if not crate.column_exists(colname):
-        raise IOErr('badcol', colname)
-    return _try_col_list(crate, colname, num, make_copy, fix_type, dtype)
+    try:
+        col = crate.get_column(colname)
+    except ValueError:
+        msg = colname if label is None else label
+        raise IOErr("reqcol", msg, crate.get_filename()) from None
 
-
-def _require_col(crate, colname, make_copy=False, fix_type=False,
-                 dtype=SherpaFloat):
-    """
-    checked for new crates
-    """
-    data = _try_col(crate, colname, make_copy, fix_type, dtype)
-    if data is None:
-        raise IOErr('badcol', colname)
-    return data
-
-
-def _try_image(crate, make_copy=False, fix_type=False, dtype=SherpaFloat):
-    """
-    checked for new crates
-    """
+    if col.is_varlen():
+        values = col.get_fixed_length_array()
+    else:
+        values = col.values
 
     if make_copy:
         # Make a copy if a filename passed in
-        dat = pycrates.copy_piximgvals(crate).squeeze()
+        data = np.array(values).ravel()
+
     else:
         # Use a reference if a crate passed in
-        dat = pycrates.get_piximgvals(crate).squeeze()
+        data = np.asarray(values).ravel()
 
     if fix_type:
-        dat = dat.astype(dtype)
+        data = data.astype(dtype)
 
-    # FITS standard is FORTRAN filling, Sherpa is c-style
-#    return dat.reshape(dat.shape[::-1])
-
-    # Crates now returns image in c-style filling
-    return dat
+    return data
 
 
-def _require_image(crate, make_copy=False, fix_type=False, dtype=SherpaFloat):
+
+def _require_image(crate: IMAGECrate,
+                   filename: str,
+                   make_copy: bool = False,
+                   fix_type: bool = False) -> np.ndarray:
+    """Return the image pixel data.
+
+    Note that "extra" dimensions - e.g. radio cube data where all but
+    the first two dimensions are 1 - will be removed by this call.
+
     """
-    checked for new crates
-    """
-    dat = _try_image(crate, make_copy, fix_type, dtype)
-    if dat is None:
-        raise IOErr('badimg', crate.get_filename())
-    return dat
+
+    try:
+        img = crate.get_image()
+    except LookupError:
+        raise IOErr("badimg", filename) from None
+
+    if make_copy:
+        dat = img.values.copy()
+    else:
+        dat = img.values
+
+    # This is presumably to convert [n, m, 1, 1] to [n, m] but it's
+    # not-at-all obvious why we need it (or, rather, we should
+    # probably handle extra dimensions better).
+    #
+    out = dat.squeeze()
+    if fix_type:
+        out = out.astype(SherpaFloat)
+
+    return out
 
 
-def _get_crate_by_blockname(dataset, blkname):
+def _get_crate_by_blockname(dataset: CrateDataset,
+                            blkname: str) -> Optional[CrateType]:
     """Select the given block name.
 
     Parameters
@@ -433,7 +465,6 @@ def _get_crate_by_blockname(dataset, blkname):
 
 def read_table_blocks(arg, make_copy=False):
 
-    filename = ''
     dataset = None
     if isinstance(arg, TABLECrate):
         filename = arg.get_filename()
@@ -441,33 +472,29 @@ def read_table_blocks(arg, make_copy=False):
     elif isinstance(arg, CrateDataset):
         filename = arg.get_filename()
         dataset = arg
-    elif isinstance(arg, string_types):
+    elif isinstance(arg, str):
         filename = arg
         dataset = CrateDataset(arg)
     else:
         raise IOErr('badfile', arg, "CrateDataset obj")
 
-    # index of block number starts at 1
-    blockidx = numpy.arange(dataset.get_ncrates()) + 1
-
     cols = {}
     hdr = {}
-
-    for ii in blockidx:
-        crate = dataset.get_crate(ii)
-        hdr[ii] = {}
+    for idx in range(1, dataset.get_ncrates() + 1):
+        crate = dataset.get_crate(idx)
+        hdr[idx] = {}
         names = crate.get_keynames()
         for name in names:
-            hdr[ii][name] = _try_key(crate, name)
+            hdr[idx][name] = _try_key(crate, name)
 
-        cols[ii] = {}
+        cols[idx] = {}
         # skip over primary
         if crate.name == 'PRIMARY':
             continue
 
         names = crate.get_colnames()
         for name in names:
-            cols[ii][name] = crate.get_column(name).values
+            cols[idx][name] = crate.get_column(name).values
 
     return filename, cols, hdr
 
@@ -477,14 +504,9 @@ def get_header_data(arg, blockname=None, hdrkeys=None):
     checked for new crates
     """
 
-    if type(arg) == str:
-
-        # arg = get_filename_from_dmsyntax(arg, blockname)
+    if isinstance(arg, str):
         arg = get_filename_from_dmsyntax(arg)
         tbl = open_crate(arg)
-
-        # Make a copy of the data, since we don't know that pycrates will
-        # do something sensible wrt reference counting
     elif isinstance(arg, TABLECrate):
         tbl = arg
     else:
@@ -525,18 +547,18 @@ def get_column_data(*args):
 
     cols = []
     for arg in args:
-        if isinstance(arg, CrateData):
+        if isinstance(arg, pycrates.CrateData):
             # vals = arg.get_values()
             vals = arg.values
 
-        elif arg is None or isinstance(arg, (numpy.ndarray, list, tuple)):
+        elif arg is None or isinstance(arg, (np.ndarray, list, tuple)):
             vals = arg
         else:
             raise IOErr('badarray', arg)
 
         if arg is not None:
-            vals = numpy.asanyarray(vals)
-            for col in numpy.atleast_2d(vals.T):
+            vals = np.asanyarray(vals)
+            for col in np.atleast_2d(vals.T):
                 cols.append(col)
         else:
             cols.append(vals)
@@ -552,9 +574,8 @@ def get_ascii_data(filename, ncols=2, colkeys=None, **kwargs):
 def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
                    blockname=None, hdrkeys=None):
     """Read columns from a file or crate."""
-    filename = ''
-    if type(arg) == str:
 
+    if isinstance(arg, str):
         arg = get_filename_from_dmsyntax(arg)
         tbl = open_crate(arg)
         if not isinstance(tbl, TABLECrate):
@@ -562,8 +583,6 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
 
         filename = tbl.get_filename()
 
-        # Make a copy of the data, since we don't know that pycrates will
-        # do something sensible wrt reference counting
     elif isinstance(arg, TABLECrate):
         tbl = arg
         filename = arg.get_filename()
@@ -576,6 +595,8 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
     # in memory.  This is a work-around to open the CrateDataset without
     # DM syntax and iterate through the crates looking for the block
     # name that matches.
+    #
+    # Is this still a valid issue with crates?
     if blockname is not None:
         crate = _get_crate_by_blockname(tbl.get_dataset(), blockname)
         tbl = crate or tbl
@@ -585,7 +606,7 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
     if colkeys is not None:
         colkeys = [str(name).strip() for name in list(colkeys)]
 
-    elif (type(arg) == str and (not os.path.isfile(arg))
+    elif (isinstance(arg, str) and (not os.path.isfile(arg))
           and '[' in arg and ']' in arg):
         colkeys = cnames
 
@@ -601,7 +622,9 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
 
     cols = []
     for name in colkeys:
-        for col in _require_tbl_col(tbl, name, cnames, make_copy, fix_type):
+        for col in _require_tbl_col(tbl, name, cnames,
+                                    make_copy=make_copy,
+                                    fix_type=fix_type):
             cols.append(col)
 
     hdr = {}
@@ -614,10 +637,9 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=True, fix_type=True,
 
 def get_image_data(arg, make_copy=True, fix_type=True):
     """Read image data from a file or crate"""
-    filename = ''
-    if type(arg) == str:
-        img = open_crate(arg)
 
+    if isinstance(arg, str):
+        img = open_crate(arg)
         if not isinstance(img, IMAGECrate):
             raise IOErr('badfile', arg, "IMAGECrate obj")
 
@@ -633,39 +655,41 @@ def get_image_data(arg, make_copy=True, fix_type=True):
 
     data = {}
 
-    data['y'] = _require_image(img, make_copy, fix_type)
+    data['y'] = _require_image(img, filename, make_copy=make_copy,
+                               fix_type=fix_type)
 
-    sky = None
-    skynames = ['SKY', 'sky', 'pos', 'POS']
-    names = img.get_axisnames()
+    if HAS_TRANSFORM:
+        sky = None
+        skynames = ['SKY', 'sky', 'pos', 'POS']
+        names = img.get_axisnames()
 
-    # find the SKY name using the set intersection
-    inter = list(set(names) & set(skynames))
-    if inter:
-        sky = img.get_transform(inter[0])
+        # find the SKY name using the set intersection
+        inter = list(set(names) & set(skynames))
+        if inter:
+            sky = img.get_transform(inter[0])
 
-    wcs = None
-    if 'EQPOS' in names:
-        wcs = img.get_transform('EQPOS')
+        wcs = None
+        if 'EQPOS' in names:
+            wcs = img.get_transform('EQPOS')
 
-    if sky is not None and transformstatus:
-        linear = WCSTANTransform()
-        linear.set_name("LINEAR")
-        linear.set_transform_matrix(sky.get_transform_matrix())
-        cdelt = numpy.array(linear.get_parameter_value('CDELT'))
-        crpix = numpy.array(linear.get_parameter_value('CRPIX'))
-        crval = numpy.array(linear.get_parameter_value('CRVAL'))
-        data['sky'] = WCS('physical', 'LINEAR', crval, crpix, cdelt)
+        if sky is not None:
+            linear = pytransform.WCSTANTransform()
+            linear.set_name("LINEAR")
+            linear.set_transform_matrix(sky.get_transform_matrix())
+            cdelt = np.array(linear.get_parameter_value('CDELT'))
+            crpix = np.array(linear.get_parameter_value('CRPIX'))
+            crval = np.array(linear.get_parameter_value('CRVAL'))
+            data['sky'] = WCS('physical', 'LINEAR', crval, crpix, cdelt)
 
-    if wcs is not None and transformstatus:
-        cdelt = numpy.array(wcs.get_parameter_value('CDELT'))
-        crpix = numpy.array(wcs.get_parameter_value('CRPIX'))
-        crval = numpy.array(wcs.get_parameter_value('CRVAL'))
-        crota = SherpaFloat(wcs.get_parameter_value('CROTA'))
-        equin = SherpaFloat(wcs.get_parameter_value('EQUINOX'))
-        epoch = SherpaFloat(wcs.get_parameter_value('EPOCH'))
-        data['eqpos'] = WCS('world', 'WCS', crval, crpix, cdelt,
-                            crota, epoch, equin)
+        if wcs is not None:
+            cdelt = np.array(wcs.get_parameter_value('CDELT'))
+            crpix = np.array(wcs.get_parameter_value('CRPIX'))
+            crval = np.array(wcs.get_parameter_value('CRVAL'))
+            crota = SherpaFloat(wcs.get_parameter_value('CROTA'))
+            equin = SherpaFloat(wcs.get_parameter_value('EQUINOX'))
+            epoch = SherpaFloat(wcs.get_parameter_value('EPOCH'))
+            data['eqpos'] = WCS('world', 'WCS', crval, crpix, cdelt,
+                                crota, epoch, equin)
 
     data['header'] = _get_meta_data(img)
     for key in ['CTYPE1P', 'CTYPE2P', 'WCSNAMEP', 'CDELT1P',
@@ -678,8 +702,8 @@ def get_image_data(arg, make_copy=True, fix_type=True):
 
 def get_arf_data(arg, make_copy=True):
     """Read an ARF from a file or crate"""
-    filename = ''
-    if type(arg) == str:
+
+    if isinstance(arg, str):
         arf = open_crate(arg)
         if not isinstance(arf, TABLECrate):
             raise IOErr('badfile', arg, "ARFCrate obj")
@@ -697,16 +721,15 @@ def get_arf_data(arg, make_copy=True):
 
     data = {}
 
-    if not arf.column_exists('ENERG_LO'):
-        raise IOErr('reqcol', 'ENERG_LO', filename)
-    if not arf.column_exists('ENERG_HI'):
-        raise IOErr('reqcol', 'ENERG_HI', filename)
-    if not arf.column_exists('SPECRESP'):
-        raise IOErr('reqcol', 'SPECRESP', filename)
-
-    data['energ_lo'] = _require_col(arf, 'ENERG_LO', make_copy, fix_type=True)
-    data['energ_hi'] = _require_col(arf, 'ENERG_HI', make_copy, fix_type=True)
-    data['specresp'] = _require_col(arf, 'SPECRESP', make_copy, fix_type=True)
+    data['energ_lo'] = _require_col(arf, 'ENERG_LO',
+                                    make_copy=make_copy,
+                                    fix_type=True)
+    data['energ_hi'] = _require_col(arf, 'ENERG_HI',
+                                    make_copy=make_copy,
+                                    fix_type=True)
+    data['specresp'] = _require_col(arf, 'SPECRESP',
+                                    make_copy=make_copy,
+                                    fix_type=True)
     data['bin_lo'] = _try_col(arf, 'BIN_LO', make_copy, fix_type=True)
     data['bin_hi'] = _try_col(arf, 'BIN_HI', make_copy, fix_type=True)
     data['exposure'] = _try_key(arf, 'EXPOSURE', dtype=SherpaFloat)
@@ -774,9 +797,9 @@ def _find_matrix_blocks(filename: str,
 
 def get_rmf_data(arg, make_copy=True):
     """Read a RMF from a file or crate"""
-    filename = ''
-    if type(arg) == str:
-        rmfdataset = open_crate_dataset(arg, RMFCrateDataset)
+
+    if isinstance(arg, str):
+        rmfdataset = pycrates.RMFCrateDataset(arg, mode="r")
         if pycrates.is_rmf(rmfdataset) != 1:
             raise IOErr('badfile', arg, "RMFCrateDataset obj")
 
@@ -825,11 +848,13 @@ def get_rmf_data(arg, make_copy=True):
         raise IOErr('reqcol', 'N_CHAN', filename)
 
     data = {}
-    data['detchans'] = _require_key(rmf, 'DETCHANS', SherpaInt)
-    data['energ_lo'] = _require_col(rmf, 'ENERG_LO', make_copy, fix_type=True)
-    data['energ_hi'] = _require_col(rmf, 'ENERG_HI', make_copy, fix_type=True)
-    data['n_grp'] = _require_col(
-        rmf, 'N_GRP', make_copy, dtype=SherpaUInt, fix_type=True)
+    data['detchans'] = _require_key(rmf, 'DETCHANS', dtype=SherpaInt)
+    data['energ_lo'] = _require_col(rmf, 'ENERG_LO',
+                                    make_copy=make_copy, fix_type=True)
+    data['energ_hi'] = _require_col(rmf, 'ENERG_HI',
+                                    make_copy=make_copy, fix_type=True)
+    data['n_grp'] = _require_col(rmf, 'N_GRP', make_copy=make_copy,
+                                 dtype=SherpaUInt, fix_type=True)
 
     f_chan = rmf.get_column('F_CHAN')
     offset = f_chan.get_tlmin()
@@ -837,13 +862,9 @@ def get_rmf_data(arg, make_copy=True):
     fcbuf = _require_col(rmf, 'F_CHAN', make_copy)
     ncbuf = _require_col(rmf, 'N_CHAN', make_copy)
 
-    respbuf = _require_col_list(rmf, 'MATRIX', 1, make_copy)
+    respbuf = _require_col_list(rmf, 'MATRIX', make_copy=make_copy)
 
-    # ebounds = None
-    # if rmfdataset.get_current_crate() < rmfdataset.get_ncrates():
-    #    ebounds = rmfdataset.get_crate(rmfdataset.get_current_crate() + 1)
     ebounds = _get_crate_by_blockname(rmfdataset, 'EBOUNDS')
-
     if ebounds is None:
         ebounds = rmfdataset.get_crate(3)
 
@@ -861,10 +882,10 @@ def get_rmf_data(arg, make_copy=True):
         # data['header'].update(_get_meta_data(ebounds))
 
     if offset < 0:
-        error("Failed to locate TLMIN keyword for F_CHAN" +
-              f" column in RMF file '{filename}'; " +
-              'Update the offset value in the RMF data set to' +
-              ' appropriate TLMIN value prior to fitting')
+        error("Failed to locate TLMIN keyword for F_CHAN "
+              "column in RMF file '%s'; "
+              'Update the offset value in the RMF data set to '
+              'appropriate TLMIN value prior to fitting', filename)
 
     if offset < 0 and channel is not None:
         offset = channel.get_tlmin()
@@ -903,9 +924,9 @@ def get_rmf_data(arg, make_copy=True):
 
 def get_pha_data(arg, make_copy=True, use_background=False):
     """Read PHA data from a file or crate"""
-    filename = ''
-    if type(arg) == str:
-        phadataset = open_crate_dataset(arg, PHACrateDataset)
+
+    if isinstance(arg, str):
+        phadataset = pycrates.PHACrateDataset(arg, mode="r")
         if pycrates.is_pha(phadataset) != 1:
             raise IOErr('badfile', arg, "PHACrateDataset obj")
 
@@ -939,8 +960,8 @@ def get_pha_data(arg, make_copy=True, use_background=False):
 
         # Used to read BKGs found in an additional block of
         # Chandra Level 3 PHA files
-        for ii in range(phadataset.get_ncrates()):
-            block = phadataset.get_crate(ii + 1)
+        for idx in range(phadataset.get_ncrates()):
+            block = phadataset.get_crate(idx + 1)
             if _try_key(block, 'HDUCLAS2') == 'BKG':
                 pha = block
 
@@ -981,11 +1002,9 @@ def get_pha_data(arg, make_copy=True, use_background=False):
 
         # Columns
 
-        if not pha.column_exists('CHANNEL'):
-            raise IOErr('reqcol', 'CHANNEL', filename)
-
-        data['channel'] = _require_col(
-            pha, 'CHANNEL', make_copy, fix_type=True)
+        data['channel'] = _require_col(pha, 'CHANNEL',
+                                       make_copy=make_copy,
+                                       fix_type=True)
         # Make sure channel numbers, not indices
         if int(data['channel'][0]) == 0 or pha.get_column('CHANNEL').get_tlmin() == 0:
             data['channel'] = data['channel'] + 1
@@ -993,13 +1012,14 @@ def get_pha_data(arg, make_copy=True, use_background=False):
         data['counts'] = None
         staterror = _try_col(pha, 'STAT_ERR', make_copy)
         if pha.column_exists('COUNTS'):
-            data['counts'] = _require_col(
-                pha, 'COUNTS', make_copy, fix_type=True)
+            data['counts'] = _require_col(pha, 'COUNTS',
+                                          make_copy=make_copy,
+                                          fix_type=True)
         else:
-            if not pha.column_exists('RATE'):
-                raise IOErr('reqcol', 'COUNTS or RATE', filename)
-            data['counts'] = _require_col(
-                pha, 'RATE', make_copy, fix_type=True) * data['exposure']
+            data['counts'] = _require_col(pha, 'RATE', label="COUNTS or RATE",
+                                          make_copy=make_copy,
+                                          fix_type=True)
+            data['counts'] *= data['exposure']
             if staterror is not None:
                 staterror *= data['exposure']
 
@@ -1047,26 +1067,28 @@ def get_pha_data(arg, make_copy=True, use_background=False):
 
         # Columns
 
-        if not pha.column_exists('CHANNEL'):
-            raise IOErr('reqcol', 'CHANNEL', filename)
-
-        channel = _require_col_list(
-            pha, 'CHANNEL', num, make_copy, fix_type=True)
+        channel = _require_col_list(pha, 'CHANNEL',
+                                    make_copy=make_copy,
+                                    fix_type=True)
         # Make sure channel numbers, not indices
-        for ii in range(num):
-            if int(channel[ii][0]) == 0:
-                channel[ii] += 1
+        for idx in range(num):
+            if int(channel[idx][0]) == 0:
+                channel[idx] += 1
+
+        staterror = _try_col_list(pha, 'STAT_ERR', num=num,
+                                  make_copy=make_copy)
 
         counts = None
-        staterror = _try_col_list(pha, 'STAT_ERR', num, make_copy)
         if pha.column_exists('COUNTS'):
-            counts = _require_col_list(
-                pha, 'COUNTS', num, make_copy, fix_type=True)
+            counts = _require_col_list(pha, 'COUNTS',
+                                       make_copy=make_copy, fix_type=True)
+
         else:
             if not pha.column_exists('RATE'):
                 raise IOErr('reqcol', 'COUNTS or RATE', filename)
-            counts = _require_col_list(
-                pha, 'RATE', num, make_copy, fix_type=True) * exposure
+            counts = _require_col_list(pha, 'RATE',
+                                       make_copy=make_copy, fix_type=True)
+            counts *= exposure
             if staterror is not None:
                 staterror *= exposure
 
@@ -1142,7 +1164,7 @@ def get_pha_data(arg, make_copy=True, use_background=False):
 # Write/Pack Functions #
 #
 
-def check_clobber(filename, clobber):
+def check_clobber(filename: str, clobber: bool) -> None:
     """Error out if the file exists and clobber is not set."""
 
     if clobber or not os.path.isfile(filename):
@@ -1151,8 +1173,33 @@ def check_clobber(filename, clobber):
     raise IOErr("filefound", filename)
 
 
+def write_dataset(dataset: Union[TABLECrate, IMAGECrate, CrateDataset],
+                  filename: str,
+                  *,
+                  ascii: bool) -> None:
+    """Write out the data."""
+
+    if ascii and '[' not in filename and ']' not in filename:
+        filename += "[opt kernel=text/simple]"
+
+        # For CIAO 4.15-era crates, if this is a CrateDataset and the
+        # first block is a "empty" image then the code will fail when
+        # writing out as an ASCII file. So this will remove such a
+        # block.
+        #
+        try:
+            cr = dataset.get_crate(1)
+        except AttributeError:
+            cr = None
+
+        if isinstance(cr, IMAGECrate) and cr.get_image().values.size == 0:
+            dataset.delete_crate(1)
+
+    dataset.write(filename, clobber=True)
+
+
 def set_image_data(filename, data, header, ascii=False, clobber=False,
-                   packup=False):
+                   packup=False) -> Optional[IMAGECrate]:
 
     if not packup:
         check_clobber(filename, clobber)
@@ -1160,10 +1207,7 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
     img = IMAGECrate()
 
     # Write Image Header Keys
-    for key, value in header.items():
-        if value is None:
-            continue
-        _set_key(img, key, value)
+    _update_header(img, header, skip_if_known=False)
 
     # Write Image WCS Header Keys
     if data['eqpos'] is not None:
@@ -1192,7 +1236,7 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
         if data['eqpos'] is not None:
             # Simply the inverse of read transformations in get_image_data
             cdeltw = cdeltw * cdeltp
-            crpixw = ((crpixw - crvalp) / cdeltp + crpixp)
+            crpixw = (crpixw - crvalp) / cdeltp + crpixp
 
     if data['eqpos'] is not None:
         _set_key(img, 'MTYPE2', 'EQPOS   ')
@@ -1208,7 +1252,7 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
         _set_key(img, 'EQUINOX', equin)
 
     # Write Image pixel values
-    pix_col = CrateData()
+    pix_col = pycrates.CrateData()
     pix_col.values = data['pixels']
     img.add_image(pix_col)
 
@@ -1220,37 +1264,31 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
         raise IOErr('writenoimg')
 
     img.write(filename, clobber=True)
+    return None
 
 
 def set_table_data(filename, data, col_names, header=None,
-                   ascii=False, clobber=False, packup=False):
+                   ascii=False, clobber=False, packup=False) -> Optional[TABLECrate]:
 
     if not packup:
         check_clobber(filename, clobber)
 
     tbl = TABLECrate()
     hdr = {} if header is None else header
-    try:
-        for name in col_names:
-            _set_column(tbl, name, data[name])
+    for name in col_names:
+        _set_column(tbl, name, data[name])
 
-        for key, value in hdr.items():
-            if value is None:
-                continue
-            _set_key(tbl, key, value)
+    _update_header(tbl, hdr, skip_if_known=False)
 
-    finally:
-        if packup:
-            return tbl
+    if packup:
+        return tbl
 
-        if ascii and '[' not in filename and ']' not in filename:
-            filename += "[opt kernel=text/simple]"
-
-        tbl.write(filename, clobber=True)
+    write_dataset(tbl, filename, ascii=ascii)
+    return None
 
 
 def set_arf_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False, packup=False):
+                 ascii=False, clobber=False, packup=False) -> Optional[TABLECrate]:
     """Create an ARF"""
 
     if header is None:
@@ -1262,7 +1300,8 @@ def set_arf_data(filename, data, col_names, header=None,
 
 
 def set_pha_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False, packup=False):
+                 ascii=False, clobber=False, packup=False
+                 ) -> Optional[pycrates.PHACrateDataset]:
     """Create a PHA dataset/file"""
 
     if header is None:
@@ -1271,57 +1310,38 @@ def set_pha_data(filename, data, col_names, header=None,
     if not packup:
         check_clobber(filename, clobber)
 
-    phadataset = PHACrateDataset()
+    phadataset = pycrates.PHACrateDataset()
 
     # FIXME: Placeholder for pycrates2 bug
     phadataset.set_rw_mode('rw')
 
     pha = TABLECrate()
     pha.name = "SPECTRUM"
-    try:
 
-        # Write header values using CrateKey objects
-        for key in header.keys():
-            if header[key] is None:
-                continue
-            _set_key(pha, key, header[key])
+    _update_header(pha, header, skip_if_known=False)
 
-        # Write column values using CrateData objects
-        for name in col_names:
-            if data[name] is None:
-                continue
-            _set_column(pha, name, data[name])
+    # Write column values using CrateData objects
+    for name in col_names:
+        if data[name] is None:
+            continue
+        _set_column(pha, name, data[name])
 
-    finally:
-        phadataset.add_crate(pha)
+    phadataset.add_crate(pha)
 
-        if packup:
-            return phadataset
+    if packup:
+        return phadataset
 
-        if ascii and '[' not in filename and ']' not in filename:
-            filename += "[opt kernel=text/simple]"
-
-        phadataset.write(filename, clobber=True)
+    write_dataset(phadataset, filename, ascii=ascii)
+    return None
 
 
-def _update_header(cr, header):
-    """Update the header of the crate.
-
-    Unlike the dict update method, this is left biased, in that
-    it prefers the keys in the existing header (this is so that
-    structural keywords are not over-written by invalid data from
-    a previous FITS file), and to drop elements which are set
-    to None.
-
-    Parameters
-    ----------
-    cr : Crate
-    header : dict[str, Any]
-
-    """
+def _update_header(cr: CrateType,
+                   header: dict[str, Optional[KeyType]],
+                   skip_if_known: bool = True) -> None:
+    """Update the header of the crate."""
 
     for key, value in header.items():
-        if cr.key_exists(key):
+        if skip_if_known and cr.key_exists(key):
             continue
 
         if value is None:
@@ -1372,7 +1392,7 @@ def set_rmf_data(filename, blocks, clobber=False):
     # here.
     #
     def mkcol(name, vals, units=None):
-        col = CrateData()
+        col = pycrates.CrateData()
         col.name = name
         col.values = vals
         col.unit = units
@@ -1381,7 +1401,7 @@ def set_rmf_data(filename, blocks, clobber=False):
     # Does RMFCrateDataset offer us anything above creating a
     # CrateDataset manually?
     #
-    ds = RMFCrateDataset()
+    ds = pycrates.RMFCrateDataset()
     matrix_cr = ds.get_crate("MATRIX")
     ebounds_cr = ds.get_crate("EBOUNDS")
 
@@ -1393,10 +1413,11 @@ def set_rmf_data(filename, blocks, clobber=False):
     matrix_cr.add_column(mkcol("MATRIX", matrix_data["MATRIX"]))
 
     # Crates does not have a good API for setting the subspace of an
-    # item. So we manually add the correct TLMIN value after the
-    # file has been written out with the cxcdm module.
+    # item. So we manually add the correct TLMIN value to the header
+    # directly, as this appears to work.
     #
     # matrix_cr.F_CHAN._set_tlmin(matrix_data["OFFSET"])
+    matrix_header["TLMIN4"] = int(matrix_data["OFFSET"])
 
     ebounds_cr.add_column(mkcol("CHANNEL", ebounds_data["CHANNEL"]))
     ebounds_cr.add_column(mkcol("E_MIN", ebounds_data["E_MIN"], units="keV"))
@@ -1409,85 +1430,61 @@ def set_rmf_data(filename, blocks, clobber=False):
 
     ds.write(filename, clobber=True)
 
-    # Add the TLMIN value for the F_CHAN column
-    ds = cxcdm.dmDatasetOpen(filename, update=True)
-    bl = cxcdm.dmBlockOpen("MATRIX", ds, update=True)
-    col = cxcdm.dmTableOpenColumn(bl, "F_CHAN")
-
-    # The lo and hi vals must have the same type, so force them to be
-    # int (so we do not have to worry about whether this should be
-    # Int16 or Int32). The OFFSET value should be an int, but let's
-    # convert it too to make sure.
-    #
-    lval, hval = cxcdm.dmDescriptorGetRange(col)
-    cxcdm.dmDescriptorSetRange(col, int(matrix_data["OFFSET"]), int(hval))
-    cxcdm.dmBlockClose(bl)
-    cxcdm.dmDatasetClose(ds)
-
 
 def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
 
+    # Historically the clobber command has been checked before
+    # processing the data, so do so here.
+    #
     check_clobber(filename, clobber)
 
-    if not numpy.iterable(args) or len(args) == 0:
-        raise IOErr('noarrayswrite')
+    # Check args is a sequence of sequences (although not a complete
+    # check).
+    #
+    try:
+        size = len(args[0])
+    except (TypeError, IndexError) as exc:
+        raise IOErr('noarrayswrite') from exc
 
-    if not numpy.iterable(args[0]):
-        raise IOErr('noarrayswrite')
+    for arg in args[1:]:
+        try:
+            argsize = len(arg)
+        except (TypeError, IndexError) as exc:
+            raise IOErr('noarrayswrite') from exc
 
-    size = len(args[0])
-    for arg in args:
-        if not numpy.iterable(arg):
-            raise IOErr('noarrayswrite')
-
-        if len(arg) != size:
+        if argsize != size:
             raise IOErr('arraysnoteq')
 
-    if ascii and '[' not in filename and ']' not in filename:
-        filename += "[opt kernel=text/simple]"
+    nargs = len(args)
+    if fields is None:
+        fieldnames = [f'col{idx + 1}' for idx in range(nargs)]
+    elif nargs == len(fields):
+        fieldnames = fields
+    else:
+        raise IOErr('wrongnumcols', nargs, len(fields))
 
     tbl = TABLECrate()
-
-    if fields is None:
-        fields = [f'col{ii + 1}' for ii in range(len(args))]
-
-    if len(args) != len(fields):
-        raise IOErr('wrongnumcols', len(args), len(fields))
-
-    for val, name in zip(args, fields):
+    for val, name in zip(args, fieldnames):
         _set_column(tbl, name, val)
 
-    tbl.write(filename, clobber=True)
+    write_dataset(tbl, filename, ascii=ascii)
 
 
-def _add_header(cr, header):
-    """Add the header keywords to the crate.
+def _add_header(cr: CrateType,
+                header: Sequence[HeaderItem]) -> None:
+    """Add the header keywords to the crate."""
 
-    Parameters
-    ----------
-    cr : TABLECrate or IMAGECrate
-    header : list of sherpa.astro.io.xstable.HeaderItem
-
-    """
-
-    for hdr in header:
-        key = (hdr.name, hdr.value, hdr.unit, hdr.desc)
-        cr.add_key(CrateKey(key))
+    for item in header:
+        key = pycrates.CrateKey()
+        key.name = item.name
+        key.value = item.value
+        key.unit = item.unit
+        key.desc = item.desc
+        cr.add_key(key)
 
 
 def _create_primary_crate(hdu: TableHDU) -> IMAGECrate:
-    """Create the primary block
-
-    Parameters
-    ----------
-    hdu : TableHDU
-       Any data is ignored.
-
-    Returns
-    -------
-    out : IMAGECrate
-
-    """
+    """Create the primary block."""
 
     out = IMAGECrate()
     out.name = "PRIMARY"
@@ -1495,8 +1492,8 @@ def _create_primary_crate(hdu: TableHDU) -> IMAGECrate:
     # For some reason we need to add an empty image
     # (CIAO 4.15).
     #
-    null = CrateData()
-    null.values = numpy.asarray([], dtype=numpy.uint8)
+    null = pycrates.CrateData()
+    null.values = np.asarray([], dtype=np.uint8)
     out.add_image(null)
 
     _add_header(out, hdu.header)
@@ -1504,17 +1501,7 @@ def _create_primary_crate(hdu: TableHDU) -> IMAGECrate:
 
 
 def _create_table_crate(hdu: TableHDU) -> TABLECrate:
-    """Create a table block
-
-    Parameters
-    ----------
-    hdu : TableHDU
-
-    Returns
-    -------
-    out : TABLECrate
-
-    """
+    """Create a table block."""
 
     if hdu.data is None:
         raise ValueError("No column data to write out")
@@ -1523,7 +1510,7 @@ def _create_table_crate(hdu: TableHDU) -> TABLECrate:
     out.name = hdu.name
 
     for col in hdu.data:
-        cdata = CrateData()
+        cdata = pycrates.CrateData()
         cdata.name = col.name
         cdata.desc = col.desc
         cdata.unit = col.unit
@@ -1534,7 +1521,7 @@ def _create_table_crate(hdu: TableHDU) -> TABLECrate:
     return out
 
 
-def _validate_block_names(hdulist: list[TableHDU]) -> list[TableHDU]:
+def _validate_block_names(hdulist: Sequence[TableHDU]) -> list[TableHDU]:
     """Ensure the block names are "independent".
 
     Crates will correctly handle the case when blocks are numbered
@@ -1553,7 +1540,7 @@ def _validate_block_names(hdulist: list[TableHDU]) -> list[TableHDU]:
     # If the names are unique do nothing
     #
     if len(multi) == 0:
-        return hdulist
+        return list(hdulist)
 
     out = [hdulist[0]]
     extvers: dict[str, int] = defaultdict(int)
@@ -1574,7 +1561,7 @@ def _validate_block_names(hdulist: list[TableHDU]) -> list[TableHDU]:
 
 
 def set_hdus(filename: str,
-             hdulist: list[TableHDU],
+             hdulist: Sequence[TableHDU],
              clobber: bool = False) -> None:
     """Write out multiple HDUS to a single file.
 

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -126,12 +126,11 @@ def _get_meta_data(hdu: HDUType) -> dict[str, KeyType]:
 def _add_keyword(hdrlist: fits.Header,
                  name: str,
                  val: Any) -> None:
-    """Add the name,val pair to hdulist."""
+    """Add the name,val pair to hdulist.
 
-    # This used to special case name = { "", "COMMENT", "HEADER" } as
-    # the AstroPy code could return a list of strings, but it turns
-    # out the code does not need to worry about this issue.
-    #
+    Ensures that the name is upper-case.
+    """
+
     name = name.upper()
     hdrlist.append(fits.Card(name, val))
 
@@ -356,11 +355,11 @@ def _find_binary_table(tbl: fits.HDUList,
     is not None then the name of the block has to match (case-insensitive
     match), and any spaces are removed from blockname before checking.
 
-    Throws an exception if there aren't any.
+    Throws an exception if there isn't a matching HDU.
     """
 
     # This behaviour appears odd:
-    # - if blockname is no set then find the first table block
+    # - if blockname is not set then find the first table block
     #   (this seems okay)
     # - if blockname is set then loop through the tables and
     #   find the first block which is either a table or matches

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2011, 2015 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -39,33 +39,33 @@ References
 
 import logging
 import os
+from typing import Any, Optional, Sequence, Union
 import warnings
 
-import numpy
+import numpy as np
 
 from astropy.io import fits  # type: ignore
 from astropy.io.fits.column import _VLF  # type: ignore
 from astropy.table import Table  # type: ignore
 
 
-from sherpa.astro.io.xstable import TableHDU
-from sherpa.utils.err import ArgumentTypeErr, IOErr
 import sherpa.utils
-from sherpa.utils.err import IOErr
+from sherpa.utils.err import ArgumentTypeErr, IOErr
 from sherpa.utils.numeric_types import SherpaInt, SherpaUInt, \
     SherpaFloat
 from sherpa.io import get_ascii_data, write_arrays
 
+from .xstable import HeaderItem, TableHDU
 
 warning = logging.getLogger(__name__).warning
 error = logging.getLogger(__name__).error
 
-transformstatus = False
 try:
-    from sherpa.astro.io.wcs import WCS
-    transformstatus = True
+    from .wcs import WCS
+    HAS_TRANSFORM = True
 except ImportError:
-    warning('failed to import WCS module; WCS routines will not be ' +
+    HAS_TRANSFORM = False
+    warning('failed to import WCS module; WCS routines will not be '
             'available')
 
 __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
@@ -75,12 +75,9 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'set_arf_data', 'set_rmf_data', 'set_hdus')
 
 
-def _has_hdu(hdulist, name):
-    try:
-        hdulist[name]
-    except (KeyError, IndexError):
-        return False
-    return True
+DatasetType = Union[str, fits.HDUList]
+HDUType = Union[fits.PrimaryHDU, fits.BinTableHDU]
+KeyType = Union[bool, int, str, float]
 
 
 def _try_key(hdu, name, *, fix_type=False, dtype=SherpaFloat):
@@ -104,11 +101,13 @@ def _try_key(hdu, name, *, fix_type=False, dtype=SherpaFloat):
 def _require_key(hdu, name, *, fix_type=False, dtype=SherpaFloat):
     value = _try_key(hdu, name, fix_type=fix_type, dtype=dtype)
     if value is None:
-        raise IOErr('nokeyword', hdu._file.name, name)
+        raise IOErr('nokeyword',
+                    hdu._file.name if hdu._file is not None else "unknown",
+                    name)
     return value
 
 
-def _get_meta_data(hdu):
+def _get_meta_data(hdu: HDUType) -> dict[str, KeyType]:
     # If the header keywords are not specified correctly then
     # astropy will error out when we try to access it. Since
     # this is not an uncommon problem, there is a verify method
@@ -119,43 +118,22 @@ def _get_meta_data(hdu):
 
     meta = {}
     for key, val in hdu.header.items():
-        # empty numpy strings are not recognized by load pickle!
-        if isinstance(val, numpy.str_) and val == '':
-            val = ''
-
         meta[key] = val
 
     return meta
 
 
-# Note: it is not really WCS specific, but leave the name alone for now.
-def _get_wcs_key(hdu, key0, key1):
-    """Return the pair of keyword values as an array of values of
-    the requested datatype. If either key is missing then return
-    ().
-    """
-
-    val1 = _try_key(hdu, key0)
-    if val1 is None:
-        return ()
-
-    val2 = _try_key(hdu, key1)
-    if val2 is None:
-        return ()
-
-    return numpy.array([val1, val2], dtype=SherpaFloat)
-
-
-def _add_keyword(hdrlist, name, val):
+def _add_keyword(hdrlist: fits.Header,
+                 name: str,
+                 val: Any) -> None:
     """Add the name,val pair to hdulist."""
-    name = str(name).upper()
-    if name in ['', 'COMMENT', 'HISTORY']:
-        # The values are assumed to be an array of strings
-        for v in val:
-            hdrlist.append(fits.Card(name, v))
 
-    else:
-        hdrlist.append(fits.Card(name, val))
+    # This used to special case name = { "", "COMMENT", "HEADER" } as
+    # the AstroPy code could return a list of strings, but it turns
+    # out the code does not need to worry about this issue.
+    #
+    name = name.upper()
+    hdrlist.append(fits.Card(name, val))
 
 
 def _try_col(hdu, name, *, dtype=SherpaFloat, fix_type=False):
@@ -165,9 +143,9 @@ def _try_col(hdu, name, *, dtype=SherpaFloat, fix_type=False):
         return None
 
     if isinstance(col, _VLF):
-        col = numpy.concatenate([numpy.asarray(row) for row in col])
+        col = np.concatenate([np.asarray(row) for row in col])
     else:
-        col = numpy.asarray(col).ravel()
+        col = np.asarray(col).ravel()
 
     if fix_type:
         col = col.astype(dtype)
@@ -182,26 +160,26 @@ def _try_tbl_col(hdu, name, *, dtype=SherpaFloat, fix_type=False):
         return (None, )
 
     if isinstance(col, _VLF):
-        col = numpy.concatenate([numpy.asarray(row) for row in col])
+        col = np.concatenate([np.asarray(row) for row in col])
     else:
-        col = numpy.asarray(col)
+        col = np.asarray(col)
 
     if fix_type:
         col = col.astype(dtype)
 
-    return numpy.column_stack(col)
+    return np.column_stack(col)
 
 
 def _try_vec(hdu, name, *, size=2, dtype=SherpaFloat, fix_type=False):
     try:
         col = hdu.data.field(name)
     except KeyError:
-        return numpy.array([None] * size)
+        return np.full(size, None)
 
     if isinstance(col, _VLF):
-        col = numpy.concatenate([numpy.asarray(row) for row in col])
+        col = np.concatenate([np.asarray(row) for row in col])
     else:
-        col = numpy.asarray(col)
+        col = np.asarray(col)
 
     if fix_type:
         return col.astype(dtype)
@@ -225,7 +203,7 @@ def _require_tbl_col(hdu, name, *, dtype=SherpaFloat, fix_type=False):
 
 def _require_vec(hdu, name, *, size=2, dtype=SherpaFloat, fix_type=False):
     col = _try_vec(hdu, name, size=size, dtype=dtype, fix_type=fix_type)
-    if numpy.equal(col, None).any():
+    if np.equal(col, None).any():
         raise IOErr('reqcol', name, hdu._file.name)
     return col
 
@@ -243,7 +221,7 @@ def _try_vec_or_key(hdu, name, size, *, dtype=SherpaFloat, fix_type=False):
         return col
 
     got = _try_key(hdu, name, fix_type=fix_type, dtype=dtype)
-    return numpy.array([got] * size)
+    return np.full(size, got)
 
 
 # Read Functions
@@ -253,7 +231,7 @@ def _try_vec_or_key(hdu, name, size, *, dtype=SherpaFloat, fix_type=False):
 # and 'foo.fits.gz' exists, then it will use this). This requires some
 # effort to emulate with the astropy backend.
 
-def _infer_and_check_filename(filename):
+def _infer_and_check_filename(filename: str) -> str:
     if os.path.exists(filename):
         return filename
 
@@ -265,19 +243,8 @@ def _infer_and_check_filename(filename):
     raise IOErr('filenotfound', filename)
 
 
-def is_binary_file(filename):
+def is_binary_file(filename: str) -> bool:
     """Do we think the file contains binary data?
-
-    Parameters
-    ----------
-    filename : str
-       The file name.
-
-    Returns
-    -------
-    flag : bool
-       ``True`` if the file appears to contain binary data,
-       ``False`` otherwise.
 
     Notes
     -----
@@ -289,7 +256,7 @@ def is_binary_file(filename):
     return sherpa.utils.is_binary_file(fname)
 
 
-def open_fits(filename):
+def open_fits(filename: str) -> fits.HDUList:
     """Try and open filename as a FITS file.
 
     Parameters
@@ -324,76 +291,67 @@ def open_fits(filename):
 
 def read_table_blocks(arg, make_copy=False):
 
-    if isinstance(arg, fits.HDUList):
-        filename = arg[0]._file.name
-        hdus = arg
-    elif isinstance(arg, str) and is_binary_file(arg):
-        filename = arg
-        hdus = open_fits(arg)
-    else:
-        raise IOErr('badfile', arg,
-                    "a binary FITS table or a BinTableHDU list")
+    # This sets nobinary=True to match the original version of
+    # the code, which did not use _get_file_contents.
+    #
+    hdus, filename, close = _get_file_contents(arg,
+                                               exptype="BinTableHDU",
+                                               nobinary=True)
 
     cols = {}
     hdr = {}
+    try:
+        for blockidx, hdu in enumerate(hdus, 1):
+            hdr[blockidx] = {}
+            header = hdu.header
+            if header is not None:
+                for key in header.keys():
+                    hdr[blockidx][key] = header[key]
 
-    for ii, hdu in enumerate(hdus):
-        blockidx = ii + 1
+            # skip over primary, hdu.data is None
 
-        hdr[blockidx] = {}
-        header = hdu.header
-        if header is not None:
-            for key in header.keys():
-                hdr[blockidx][key] = header[key]
+            cols[blockidx] = {}
+            recarray = hdu.data
+            if recarray is not None:
+                for colname in recarray.names:
+                    cols[blockidx][colname] = recarray[colname]
 
-        # skip over primary, hdu.data is None
-
-        cols[blockidx] = {}
-        recarray = hdu.data
-        if recarray is not None:
-            for colname in recarray.names:
-                cols[blockidx][colname] = recarray[colname]
+    finally:
+        if close:
+            hdus.close()
 
     return filename, cols, hdr
 
 
-# TODO @DougBurke comments:
-# Is the check for a binary file even useful here; perhaps the code should just try and open the file
-# and we deal with the error (it's "more pythonic")
-#
-# If we do want to include a binary-file check, then all the callers of
-# _get_file_contents should be reviewed to see if they should include the binary-file check
-#
-# the exptype argument lets the error message be changed; however, does this make sense since the code that does call
-# this function with exptype="BinTableHDU" aren't guaranteed that there is a binary table in the file (very likely,
-# but it is possible to write a FITS file with only a PrimaryHDU or have an ImageHDU [or whatever it's called]
-# falling it [*]).
-# I haven't checked the FITS standard to see if either of these are valid, but that doesn't mean that they
-# can't be created. It could be that astropy will error out if it reads such a file, but I haven't checked this either.
-def _get_file_contents(arg, exptype="PrimaryHDU", nobinary=False):
-    """arg is a filename or a list of HDUs, with the first
-    one a PrimaryHDU. The return value is the list of
-    HDUs and the filename.
+def _get_file_contents(arg: DatasetType,
+                       exptype: str = "PrimaryHDU",
+                       nobinary: bool = False) -> tuple[fits.HDUList, str, bool]:
+    """Read in the contents if needed.
 
     Set nobinary to True to avoid checking that the input
     file is a binary file (via the is_binary_file routine).
+    Is this needed?
     """
 
     if isinstance(arg, str) and (not nobinary or is_binary_file(arg)):
         tbl = open_fits(arg)
         filename = arg
+        close = True
     elif isinstance(arg, fits.HDUList) and len(arg) > 0 and \
             isinstance(arg[0], fits.PrimaryHDU):
         tbl = arg
-        filename = tbl[0]._file.name
+        filename = arg._file.name if arg._file is not None else "unknown"
+        close = False
     else:
         msg = f"a binary FITS table or a {exptype} list"
         raise IOErr('badfile', arg, msg)
 
-    return (tbl, filename)
+    return (tbl, filename, close)
 
 
-def _find_binary_table(tbl, filename, blockname=None):
+def _find_binary_table(tbl: fits.HDUList,
+                       filename: str,
+                       blockname: Optional[str] = None) -> fits.BinTableHDU:
     """Return the first binary table extension we find. If blockname
     is not None then the name of the block has to match (case-insensitive
     match), and any spaces are removed from blockname before checking.
@@ -401,13 +359,21 @@ def _find_binary_table(tbl, filename, blockname=None):
     Throws an exception if there aren't any.
     """
 
+    # This behaviour appears odd:
+    # - if blockname is no set then find the first table block
+    #   (this seems okay)
+    # - if blockname is set then loop through the tables and
+    #   find the first block which is either a table or matches
+    #   blockname
+    #   (why the "is table" check; why not only match the blockname?)
+    #
     if blockname is None:
         for hdu in tbl:
             if isinstance(hdu, fits.BinTableHDU):
                 return hdu
 
     else:
-        blockname = str(blockname).strip().lower()
+        blockname = blockname.strip().lower()
         for hdu in tbl:
             if hdu.name.lower() == blockname or \
                     isinstance(hdu, fits.BinTableHDU):
@@ -419,7 +385,7 @@ def _find_binary_table(tbl, filename, blockname=None):
 def get_header_data(arg, blockname=None, hdrkeys=None):
     """Read in the header data."""
 
-    tbl, filename = _get_file_contents(arg, exptype="BinTableHDU")
+    tbl, filename, close = _get_file_contents(arg, exptype="BinTableHDU")
 
     hdr = {}
     try:
@@ -434,7 +400,8 @@ def get_header_data(arg, blockname=None, hdrkeys=None):
             hdr[key] = _require_key(hdu, key, dtype=str)
 
     finally:
-        tbl.close()
+        if close:
+            tbl.close()
 
     return hdr
 
@@ -449,11 +416,11 @@ def get_column_data(*args):
 
     cols = []
     for arg in args:
-        if arg is not None and not isinstance(arg, (numpy.ndarray, list, tuple)):
+        if arg is not None and not isinstance(arg, (np.ndarray, list, tuple)):
             raise IOErr('badarray', arg)
         if arg is not None:
-            vals = numpy.asanyarray(arg)
-            for col in numpy.atleast_2d(vals.T):
+            vals = np.asanyarray(arg)
+            for col in np.atleast_2d(vals.T):
                 cols.append(col)
         else:
             cols.append(arg)
@@ -467,7 +434,7 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=False, fix_type=False,
     arg is a filename or a HDUList object.
     """
 
-    tbl, filename = _get_file_contents(arg, exptype="BinTableHDU")
+    tbl, filename, close = _get_file_contents(arg, exptype="BinTableHDU")
 
     try:
         hdu = _find_binary_table(tbl, filename, blockname)
@@ -496,7 +463,8 @@ def get_table_data(arg, ncols=1, colkeys=None, make_copy=False, fix_type=False,
                 hdr[key] = _require_key(hdu, key)
 
     finally:
-        tbl.close()
+        if close:
+            tbl.close()
 
     return colkeys, cols, filename, hdr
 
@@ -505,7 +473,7 @@ def get_image_data(arg, make_copy=False):
     """
     arg is a filename or a HDUList object
     """
-    hdu, filename = _get_file_contents(arg)
+    hdus, filename, close = _get_file_contents(arg)
 
     #   FITS uses logical-to-world where we use physical-to-world.
     #   For all transforms, update their physical-to-world
@@ -540,47 +508,57 @@ def get_image_data(arg, make_copy=False):
     try:
         data = {}
 
-        img = hdu[0]
-        if hdu[0].data is None:
-            img = hdu[1]
-            if hdu[1].data is None:
-                raise IOErr('badimg', '')
+        # Look for data in the primary or first block.
+        #
+        img = hdus[0]
+        if img.data is None:
+            img = hdus[1]
+            if img.data is None:
+                raise IOErr('badimg', filename)
 
-        data['y'] = numpy.asarray(img.data)
+        if not isinstance(img, (fits.PrimaryHDU, fits.ImageHDU)):
+            raise IOErr("badimg", filename)
 
-        cdeltp = _get_wcs_key(img, 'CDELT1P', 'CDELT2P')
-        crpixp = _get_wcs_key(img, 'CRPIX1P', 'CRPIX2P')
-        crvalp = _get_wcs_key(img, 'CRVAL1P', 'CRVAL2P')
-        cdeltw = _get_wcs_key(img, 'CDELT1', 'CDELT2')
-        crpixw = _get_wcs_key(img, 'CRPIX1', 'CRPIX2')
-        crvalw = _get_wcs_key(img, 'CRVAL1', 'CRVAL2')
+        data['y'] = np.asarray(img.data)
 
-        # proper calculation of cdelt wrt PHYSICAL coords
-        if (isinstance(cdeltw, numpy.ndarray)
-                and isinstance(cdeltp, numpy.ndarray)):
-            cdeltw = cdeltw / cdeltp
+        if HAS_TRANSFORM:
 
-        # proper calculation of crpix wrt PHYSICAL coords
-        if (isinstance(crpixw, numpy.ndarray)
-                and isinstance(crvalp, numpy.ndarray)
-                and isinstance(cdeltp, numpy.ndarray)
-                and isinstance(crpixp, numpy.ndarray)):
-            crpixw = crvalp + (crpixw - crpixp) * cdeltp
+            def _get_wcs_key(key, suffix=""):
+                val1 = _try_key(img, f"{key}1{suffix}")
+                if val1 is None:
+                    return None
 
-        sky = None
-        if (transformstatus and isinstance(cdeltp, numpy.ndarray)
-                and isinstance(crpixp, numpy.ndarray)
-                and isinstance(crvalp, numpy.ndarray)):
-            sky = WCS('physical', 'LINEAR', crvalp, crpixp, cdeltp)
+                val2 = _try_key(img, f"{key}2{suffix}")
+                if val2 is None:
+                    return None
 
-        eqpos = None
-        if (transformstatus and isinstance(cdeltw, numpy.ndarray)
-                and isinstance(crpixw, numpy.ndarray)
-                and isinstance(crvalw, numpy.ndarray)):
-            eqpos = WCS('world', 'WCS', crvalw, crpixw, cdeltw)
+                return np.array([val1, val2], dtype=SherpaFloat)
 
-        data['sky'] = sky
-        data['eqpos'] = eqpos
+            cdeltp = _get_wcs_key('CDELT', 'P')
+            crpixp = _get_wcs_key('CRPIX', 'P')
+            crvalp = _get_wcs_key('CRVAL', 'P')
+            cdeltw = _get_wcs_key('CDELT')
+            crpixw = _get_wcs_key('CRPIX')
+            crvalw = _get_wcs_key('CRVAL')
+
+            # proper calculation of cdelt wrt PHYSICAL coords
+            if cdeltw is not None and cdeltp is not None:
+                cdeltw = cdeltw / cdeltp
+
+            # proper calculation of crpix wrt PHYSICAL coords
+            if (crpixw is not None and crvalp is not None and
+                cdeltp is not None and crpixp is not None):
+                crpixw = crvalp + (crpixw - crpixp) * cdeltp
+
+            if (cdeltp is not None and crpixp is not None and
+                crvalp is not None):
+                data['sky'] = WCS('physical', 'LINEAR', crvalp,
+                                  crpixp, cdeltp)
+
+            if (cdeltw is not None and crpixw is not None and
+                crvalw is not None):
+                data['eqpos'] = WCS('world', 'WCS', crvalw, crpixw,
+                                    cdeltw)
 
         data['header'] = _get_meta_data(img)
         for key in ['CTYPE1P', 'CTYPE2P', 'WCSNAMEP', 'CDELT1P',
@@ -589,12 +567,15 @@ def get_image_data(arg, make_copy=False):
             data['header'].pop(key, None)
 
     finally:
-        hdu.close()
+        if close:
+            hdus.close()
 
     return data, filename
 
 
-def _is_ogip_block(hdu, bltype1, bltype2=None):
+def _is_ogip_block(hdu: HDUType,
+                   bltype1: str,
+                   bltype2: Optional[str] = None) -> bool:
     """Does the block contain the expected HDUCLAS1 or HDUCLAS2 values?
 
     If given, we need both HDUCLAS1 and 2 to be set correctly.
@@ -609,7 +590,9 @@ def _is_ogip_block(hdu, bltype1, bltype2=None):
     return  _try_key(hdu, 'HDUCLAS2') == bltype2
 
 
-def _is_ogip_type(hdus, bltype, bltype2=None):
+def _has_ogip_type(hdus: fits.HDUList,
+                  bltype: str,
+                  bltype2: Optional[str] = None) -> Optional[HDUType]:
     """Return True if hdus[1] exists and has
     the given type (as determined by the HDUCLAS1 or HDUCLAS2
     keywords). If bltype2 is None then bltype is used for
@@ -620,9 +603,12 @@ def _is_ogip_type(hdus, bltype, bltype2=None):
     try:
         hdu = hdus[1]
     except IndexError:
-        return False
+        return None
 
-    return _is_ogip_block(hdu, bltype, bltype2)
+    if _is_ogip_block(hdu, bltype, bltype2):
+        return hdu
+
+    return None
 
 
 def get_arf_data(arg, make_copy=False):
@@ -630,18 +616,24 @@ def get_arf_data(arg, make_copy=False):
     arg is a filename or a HDUList object
     """
 
-    arf, filename = _get_file_contents(arg, exptype="BinTableHDU",
-                                       nobinary=True)
+    arf, filename, close = _get_file_contents(arg,
+                                              exptype="BinTableHDU",
+                                              nobinary=True)
 
     try:
-        if _has_hdu(arf, 'SPECRESP'):
-            hdu = arf['SPECRESP']
-        elif _has_hdu(arf, 'AXAF_ARF'):
-            hdu = arf['AXAF_ARF']
-        elif _is_ogip_type(arf, 'RESPONSE', 'SPECRESP'):
-            hdu = arf[1]
+        # Should we do the _has_ogip_type check first and only if that
+        # fails fall back to the "common" block names? Given the lack
+        # of consistency in following the OGIP standards by missions
+        # let's keep this ordering.
+        #
+        for blname in ["SPECRESP", "AXAF_ARF"]:
+            if blname in arf:
+                hdu = arf[blname]
+                break
         else:
-            raise IOErr('notrsp', filename, 'an ARF')
+            hdu = _has_ogip_type(arf, 'RESPONSE', 'SPECRESP')
+            if hdu is None:
+                raise IOErr('notrsp', filename, 'an ARF')
 
         data = {}
 
@@ -656,7 +648,8 @@ def get_arf_data(arg, make_copy=False):
         data['header'].pop('EXPOSURE', None)
 
     finally:
-        arf.close()
+        if close:
+            arf.close()
 
     return data, filename
 
@@ -682,7 +675,7 @@ RMF_BLOCK_NAMES = ["MATRIX", "SPECRESP MATRIX", "AXAF_RMF", "RSP_MATRIX"]
 
 
 def _find_matrix_blocks(filename: str,
-                        hdus: fits.HDUList) -> list[str]:
+                        hdus: fits.HDUList) -> list[fits.BinTableHDU]:
     """Report the block names that contain MATRIX data in a RMF.
 
     Parameters
@@ -716,30 +709,31 @@ def _find_matrix_blocks(filename: str,
     # possibility of RMF files with multiple MATRIX blocks (where the
     # EXTVER starts at 1 and then increases).
     #
-    blnames = []
+    blocks = []
     for hdu in hdus:
         if hdu.name in RMF_BLOCK_NAMES or \
            _is_ogip_block(hdu, "RESPONSE", "RSP_MATRIX"):
-            blnames.append(hdu)
+            blocks.append(hdu)
 
-    if not blnames:
+    if not blocks:
         raise IOErr('notrsp', filename, 'an RMF')
 
-    return blnames
+    return blocks
 
 
 def _read_rmf_data(arg):
     """Read in the data from the RMF."""
 
-    rmf, filename = _get_file_contents(arg, exptype="BinTableHDU",
-                                       nobinary=True)
+    rmf, filename, close = _get_file_contents(arg,
+                                              exptype="BinTableHDU",
+                                              nobinary=True)
 
     try:
 
         # Find all the potential matrix blocks.
         #
-        blnames = _find_matrix_blocks(filename, rmf)
-        nmat = len(blnames)
+        mblocks = _find_matrix_blocks(filename, rmf)
+        nmat = len(mblocks)
         if nmat > 1:
             # Warn the user that the multi-matrix RMF is not supported.
             #
@@ -747,7 +741,7 @@ def _read_rmf_data(arg):
                   "Sherpa only uses the first block!",
                   filename, nmat)
 
-        hdu = rmf[blnames[0]]
+        hdu = mblocks[0]
 
         # The comments note the type we want the column to be, but
         # this conversion needs to be done after cleaning up the
@@ -773,16 +767,17 @@ def _read_rmf_data(arg):
         if tlmin is not None:
             data['offset'] = tlmin
         else:
-            # QUS: should this actually be an error, rather than just
-            #      something that is logged to screen?
-            error("Failed to locate TLMIN keyword for F_CHAN" +
-                  f" column in RMF file '{filename}'; " +
-                  'Update the offset value in the RMF data set to' +
-                  ' appropriate TLMIN value prior to fitting')
+            error("Failed to locate TLMIN keyword for F_CHAN "
+                  "column in RMF file '%s'; "
+                  'Update the offset value in the RMF data set to '
+                  'appropriate TLMIN value prior to fitting', filename)
 
-        if _has_hdu(rmf, 'EBOUNDS'):
-            # This should probably error out if E_MIN/MAX are not present.
+        try:
             hdu = rmf['EBOUNDS']
+        except KeyError:
+            hdu = None
+
+        if hdu is not None:
             data['e_min'] = _try_col(hdu, 'E_MIN', fix_type=True)
             data['e_max'] = _try_col(hdu, 'E_MAX', fix_type=True)
 
@@ -797,7 +792,8 @@ def _read_rmf_data(arg):
             data['e_min'] = None
             data['e_max'] = None
     finally:
-        rmf.close()
+        if close:
+            rmf.close()
 
     return data, filename
 
@@ -858,8 +854,8 @@ def get_rmf_data(arg, make_copy=False):
     if numelt == matrix.size:
         if isinstance(matrix, _VLF):
             # case a
-            matrix = numpy.concatenate([numpy.asarray(row)
-                                        for row in matrix])
+            matrix = np.concatenate([np.asarray(row)
+                                     for row in matrix])
         else:
             # case c
             matrix = matrix.flatten()
@@ -867,9 +863,9 @@ def get_rmf_data(arg, make_copy=False):
     else:
         # cases b or d; assume we can use the same logic
         rowdata = []
-        for mrow, ng, ncs in zip(matrix, n_grp, n_chan):
+        for mrow, ncs in zip(matrix, n_chan):
             # Need a RMF which ng>1 to test this with.
-            if numpy.isscalar(ncs):
+            if np.isscalar(ncs):
                 ncs = [ncs]
 
             start = 0
@@ -891,7 +887,7 @@ def get_rmf_data(arg, make_copy=False):
                 rowdata.append(rdata)
                 start = end
 
-        matrix = numpy.concatenate(rowdata)
+        matrix = np.concatenate(rowdata)
 
     data['matrix'] = matrix.astype(SherpaFloat)
 
@@ -902,7 +898,7 @@ def get_rmf_data(arg, make_copy=False):
     xf_chan = []
     xn_chan = []
     for grp, fch, nch, in zip(n_grp, f_chan, n_chan):
-        if numpy.isscalar(fch):
+        if np.isscalar(fch):
             # The assumption is that grp==1 here
             xf_chan.append(fch)
             xn_chan.append(nch)
@@ -913,18 +909,18 @@ def get_rmf_data(arg, make_copy=False):
             xf_chan.extend(fch[:grp])
             xn_chan.extend(nch[:grp])
 
-    data['f_chan'] = numpy.asarray(xf_chan, SherpaUInt)
-    data['n_chan'] = numpy.asarray(xn_chan, SherpaUInt)
+    data['f_chan'] = np.asarray(xf_chan, SherpaUInt)
+    data['n_chan'] = np.asarray(xn_chan, SherpaUInt)
 
     # Not all fields are "flattened" by this routine. In particular we
     # need to keep knowledge of these rows with 0 groups. This is why
     # we set the n_grp entry to data['n_grp'] rather than the n_grp
     # variable (which has the 0 elements removed).
     #
-    data['n_grp'] = numpy.asarray(data['n_grp'], SherpaUInt)
+    data['n_grp'] = np.asarray(data['n_grp'], SherpaUInt)
 
-    data['energ_lo'] = numpy.asarray(data['energ_lo'], SherpaFloat)
-    data['energ_hi'] = numpy.asarray(data['energ_hi'], SherpaFloat)
+    data['energ_lo'] = np.asarray(data['energ_lo'], SherpaFloat)
+    data['energ_hi'] = np.asarray(data['energ_hi'], SherpaFloat)
 
     return data, filename
 
@@ -934,15 +930,16 @@ def get_pha_data(arg, make_copy=False, use_background=False):
     arg is a filename or a HDUList object
     """
 
-    pha, filename = _get_file_contents(arg, exptype="BinTableHDU")
+    pha, filename, close = _get_file_contents(arg,
+                                              exptype="BinTableHDU")
 
     try:
-        if _has_hdu(pha, 'SPECTRUM'):
-            hdu = pha['SPECTRUM']
-        elif _is_ogip_type(pha, 'SPECTRUM'):
-            hdu = pha[1]
-        else:
-            raise IOErr('notrsp', filename, "a PHA spectrum")
+        try:
+            hdu = pha["SPECTRUM"]
+        except KeyError:
+            hdu = _has_ogip_type(pha, 'SPECTRUM')
+            if hdu is None:
+                raise IOErr('notrsp', filename, "a PHA spectrum") from None
 
         if use_background:
             for block in pha:
@@ -1081,9 +1078,9 @@ def get_pha_data(arg, make_copy=False, use_background=False):
             tlmin = _try_key(hdu, f"TLMIN{chan}", fix_type=True,
                              dtype=SherpaUInt)
 
-            for ii in range(num):
-                if int(channel[ii][0]) == 0:
-                    channel[ii] += 1
+            for idx in range(num):
+                if int(channel[idx][0]) == 0:
+                    channel[idx] += 1
 
             # if ((tlmin is not None) and tlmin == 0) or int(channel[0]) == 0:
             #     channel += 1
@@ -1091,9 +1088,9 @@ def get_pha_data(arg, make_copy=False, use_background=False):
             # Why does this convert to SherpaFloat?
             counts = try_sfloat("COUNTS")
             staterror = _try_vec(hdu, 'STAT_ERR', size=num)
-            if numpy.equal(counts, None).any():  # _try_vec can return an array of Nones
+            if np.equal(staterror, None).any():
                 counts = req_sfloat("RATE") * exposure
-                if not numpy.equal(staterror, None).any():
+                if not np.equal(staterror, None).any():
                     staterror *= exposure
 
             syserror = _try_vec(hdu, 'SYS_ERR', size=num)
@@ -1119,53 +1116,55 @@ def get_pha_data(arg, make_copy=False, use_background=False):
                           counts, staterror, syserror, background_up,
                           background_down, bin_lo, bin_hi, grouping, quality,
                           orders, parts, specnums, srcids):
-                data = {}
+                idata = {}
 
-                data['exposure'] = exposure
-                # data['poisserr'] = poisserr
-                data['backfile'] = backfile
-                data['arffile'] = arffile
-                data['rmffile'] = rmffile
+                idata['exposure'] = exposure
+                # idata['poisserr'] = poisserr
+                idata['backfile'] = backfile
+                idata['arffile'] = arffile
+                idata['rmffile'] = rmffile
 
-                data['backscal'] = bscal
-                data['backscup'] = bscup
-                data['backscdn'] = bscdn
-                data['areascal'] = arsc
+                idata['backscal'] = bscal
+                idata['backscup'] = bscup
+                idata['backscdn'] = bscdn
+                idata['areascal'] = arsc
 
-                data['channel'] = chan
-                data['counts'] = cnt
-                data['staterror'] = staterr
-                data['syserror'] = syserr
-                data['background_up'] = backup
-                data['background_down'] = backdown
-                data['bin_lo'] = binlo
-                data['bin_hi'] = binhi
-                data['grouping'] = group
-                data['quality'] = qual
-                data['header'] = _get_meta_data(hdu)
-                data['header']['TG_M'] = ordr
-                data['header']['TG_PART'] = prt
-                data['header']['SPEC_NUM'] = specnum
-                data['header']['TG_SRCID'] = srcid
+                idata['channel'] = chan
+                idata['counts'] = cnt
+                idata['staterror'] = staterr
+                idata['syserror'] = syserr
+                idata['background_up'] = backup
+                idata['background_down'] = backdown
+                idata['bin_lo'] = binlo
+                idata['bin_hi'] = binhi
+                idata['grouping'] = group
+                idata['quality'] = qual
+                idata['header'] = _get_meta_data(hdu)
+                idata['header']['TG_M'] = ordr
+                idata['header']['TG_PART'] = prt
+                idata['header']['SPEC_NUM'] = specnum
+                idata['header']['TG_SRCID'] = srcid
 
                 for key in keys:
-                    data['header'].pop(key, None)
+                    idata['header'].pop(key, None)
 
                 if syserr is not None:
                     # SYS_ERR is the fractional systematic error
-                    data['syserror'] = syserr * cnt
+                    idata['syserror'] = syserr * cnt
 
-                datasets.append(data)
+                datasets.append(idata)
 
     finally:
-        pha.close()
+        if close:
+            pha.close()
 
     return datasets, filename
 
 
 # Write Functions
 
-def _create_table(names, data):
+def _create_table(names: Sequence[str],
+                  data: dict[str, Optional[np.ndarray]]) -> Table:
     """Create a Table.
 
     The idea is that by going via a Table we let the AstroPy
@@ -1198,7 +1197,7 @@ def _create_table(names, data):
     return Table(names=colnames, data=store)
 
 
-def check_clobber(filename, clobber):
+def check_clobber(filename: str, clobber: bool) -> None:
     """Error out if the file exists and clobber is not set."""
 
     if clobber or not os.path.isfile(filename):
@@ -1208,7 +1207,7 @@ def check_clobber(filename, clobber):
 
 
 def set_table_data(filename, data, col_names, header=None,
-                   ascii=False, clobber=False, packup=False):
+                   ascii=False, clobber=False, packup=False) -> Optional[fits.BinTableHDU]:
 
     if not packup:
         check_clobber(filename, clobber)
@@ -1217,11 +1216,9 @@ def set_table_data(filename, data, col_names, header=None,
     if ascii:
         tbl.write(filename, format='ascii.commented_header',
                   overwrite=clobber)
-        return
+        return None
 
     hdu = fits.table_to_hdu(tbl)
-    if hdu.name == '':
-        tbl.name = 'HISTOGRAM'
 
     # Add in the header. We should special case the HISTORY/COMMENT
     # keywords but at the moment we do nothing.
@@ -1239,9 +1236,10 @@ def set_table_data(filename, data, col_names, header=None,
         return hdu
 
     hdu.writeto(filename, overwrite=True)
+    return None
 
 
-def _create_header(header):
+def _create_header(header: dict[str, KeyType]) -> fits.Header:
     """Create a FITS header with the contents of header,
     the Sherpa representation of the key,value store.
     """
@@ -1256,7 +1254,8 @@ def _create_header(header):
     return hdrlist
 
 
-def _update_header(hdu, header):
+def _update_header(hdu: HDUType,
+                   header: dict[str, Optional[KeyType]]) -> None:
     """Update the header of the HDU.
 
     Unlike the dict update method, this is left biased, in that
@@ -1283,7 +1282,7 @@ def _update_header(hdu, header):
 
 
 def set_arf_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False, packup=False):
+                 ascii=False, clobber=False, packup=False) -> Optional[fits.BinTableHDU]:
     """Create an ARF"""
 
     if header is None:
@@ -1295,7 +1294,7 @@ def set_arf_data(filename, data, col_names, header=None,
 
 
 def set_pha_data(filename, data, col_names, header=None,
-                 ascii=False, clobber=False, packup=False):
+                 ascii=False, clobber=False, packup=False) -> Optional[fits.BinTableHDU]:
     """Create a PHA dataset/file
 
     The header argument must be set as this routine does no validation
@@ -1311,7 +1310,7 @@ def set_pha_data(filename, data, col_names, header=None,
                           ascii=ascii, clobber=clobber, packup=packup)
 
 
-def set_rmf_data(filename, blocks, clobber=False):
+def set_rmf_data(filename, blocks, clobber=False) -> None:
     """Save the RMF data to disk.
 
     Unlike the other save_*_data calls this does not support the ascii
@@ -1352,18 +1351,18 @@ def set_rmf_data(filename, blocks, clobber=False):
     #
     def get_format(val):
         """We only bother with formats we expect"""
-        if numpy.issubdtype(val, numpy.integer):
-            if isinstance(val, numpy.int16):
+        if np.issubdtype(val, np.integer):
+            if isinstance(val, np.int16):
                 return "I"
 
             # default to Int32. AstroPy does support Int64/K but
             # this should not be needed here.
             return "J"
 
-        if not numpy.issubdtype(val, numpy.floating):
+        if not np.issubdtype(val, np.floating):
             raise ValueError(f"Unexpected value '{val}' with type {val.dtype}")
 
-        if isinstance(val,numpy.float32):
+        if isinstance(val,np.float32):
             return "E"
 
         # This should not be reached
@@ -1434,7 +1433,7 @@ def set_rmf_data(filename, blocks, clobber=False):
 
 
 def set_image_data(filename, data, header, ascii=False, clobber=False,
-                   packup=False):
+                   packup=False) -> Optional[fits.PrimaryHDU]:
 
     if not packup:
         check_clobber(filename, clobber)
@@ -1442,7 +1441,7 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
     if ascii:
         set_arrays(filename, [data['pixels'].ravel()],
                    ascii=True, clobber=clobber)
-        return
+        return None
 
     hdrlist = _create_header(header)
 
@@ -1470,12 +1469,12 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
         _add_keyword(hdrlist, 'CRVAL1P', crvalp[0])
         _add_keyword(hdrlist, 'CRVAL2P', crvalp[1])
 
-        if data['eqpos'] is not None:
+    if data['eqpos'] is not None:
+        if data['sky'] is not None:
             # Simply the inverse of read transformations in get_image_data
             cdeltw = cdeltw * cdeltp
             crpixw = (crpixw - crvalp) / cdeltp + crpixp
 
-    if data['eqpos'] is not None:
         _add_keyword(hdrlist, 'MTYPE2', 'EQPOS   ')
         _add_keyword(hdrlist, 'MFORM2', 'RA,DEC  ')
         _add_keyword(hdrlist, 'CTYPE1', 'RA---TAN')
@@ -1490,32 +1489,45 @@ def set_image_data(filename, data, header, ascii=False, clobber=False,
         _add_keyword(hdrlist, 'CUNIT2', 'deg     ')
         _add_keyword(hdrlist, 'EQUINOX', equin)
 
-    #
     img = fits.PrimaryHDU(data['pixels'], header=fits.Header(hdrlist))
     if packup:
         return img
+
     img.writeto(filename, overwrite=True)
+    return None
 
 
 def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
 
+    # Historically the clobber command has been checked before
+    # processing the data, so do so here.
+    #
     check_clobber(filename, clobber)
 
-    if not numpy.iterable(args) or len(args) == 0:
-        raise IOErr('noarrayswrite')
+    # Check args is a sequence of sequences (although not a complete
+    # check).
+    #
+    try:
+        size = len(args[0])
+    except (TypeError, IndexError) as exc:
+        raise IOErr('noarrayswrite') from exc
 
-    if not numpy.iterable(args[0]):
-        raise IOErr('noarrayswrite')
+    for arg in args[1:]:
+        try:
+            argsize = len(arg)
+        except (TypeError, IndexError) as exc:
+            raise IOErr('noarrayswrite') from exc
 
-    size = len(args[0])
-    for arg in args:
-        if not numpy.iterable(arg):
-            raise IOErr('noarrayswrite')
-        if len(arg) != size:
+        if argsize != size:
             raise IOErr('arraysnoteq')
 
-    if fields is not None and len(args) != len(fields):
-        raise IOErr("wrongnumcols", len(args), len(fields))
+    nargs = len(args)
+    if fields is None:
+        fieldnames = [f'COL{idx + 1}' for idx in range(nargs)]
+    elif nargs == len(fields):
+        fieldnames = fields
+    else:
+        raise IOErr("wrongnumcols", nargs, len(fields))
 
     if ascii:
         # Historically, the serialization doesn't quite match the
@@ -1532,24 +1544,16 @@ def set_arrays(filename, args, fields=None, ascii=True, clobber=False):
                      comment="# ", clobber=clobber)
         return
 
-    if fields is None:
-        fields = [f'COL{ii + 1}' for ii in range(len(args))]
-
-    data = dict(zip(fields, args))
-    tbl = _create_table(fields, data)
+    data = dict(zip(fieldnames, args))
+    tbl = _create_table(fieldnames, data)
     hdu = fits.table_to_hdu(tbl)
     hdu.name = 'TABLE'
     hdu.writeto(filename, overwrite=True)
 
 
-def _add_header(hdu, header):
-    """Add the header items to the HDU.
-
-    Parameters
-    ----------
-    hdu : astropy HDU
-    header : list of sherpa.astro.io.xstable.HeaderItem
-    """
+def _add_header(hdu: HDUType,
+                header: Sequence[HeaderItem]) -> None:
+    """Add the header items to the HDU."""
 
     for hdr in header:
         card = [hdr.name, hdr.value]
@@ -1563,18 +1567,7 @@ def _add_header(hdu, header):
 
 
 def _create_primary_hdu(hdu: TableHDU) -> fits.PrimaryHDU:
-    """Create a PRIMARY HDU.
-
-    Parameters
-    ----------
-    hdu : TableHDU
-       Any data is ignored.
-
-    Returns
-    -------
-    out : astropy.io.fits.PrimaryHDU
-
-    """
+    """Create a PRIMARY HDU."""
 
     out = fits.PrimaryHDU()
     _add_header(out, hdu.header)
@@ -1582,16 +1575,7 @@ def _create_primary_hdu(hdu: TableHDU) -> fits.PrimaryHDU:
 
 
 def _create_table_hdu(hdu: TableHDU) -> fits.BinTableHDU:
-    """Create a Table HDU.
-
-    Parameters
-    ----------
-    hdu : TableHDU
-
-    Returns
-    -------
-    out : fits.BinTableHDU
-    """
+    """Create a Table HDU."""
 
     if hdu.data is None:
         raise ValueError("No column data to write out")
@@ -1625,7 +1609,7 @@ def _create_table_hdu(hdu: TableHDU) -> fits.BinTableHDU:
 
 
 def set_hdus(filename: str,
-             hdulist: list[TableHDU],
+             hdulist: Sequence[TableHDU],
              clobber: bool = False) -> None:
     """Write out multiple HDUS to a single file.
 

--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -559,3 +559,21 @@ def test_read_table_pha(make_data_path):
     assert tbl.y[-1] == pytest.approx(128)
     assert tbl.y[:-1].max() == pytest.approx(78)
     assert np.argmax(tbl.y[:-1]) == 74
+
+
+@requires_data
+@requires_fits
+def test_read_ascii_3_col(make_data_path):
+    """Found when working on #1921 so explicitly test this case."""
+
+    infile = make_data_path("data1.dat")
+    tbl = io.read_ascii(infile, 3)
+    assert isinstance(tbl, Data1D)
+    assert tbl.name.find("/data1.dat")
+    assert tbl.x == pytest.approx(np.arange(0.5, 11.5))
+    assert tbl.y == pytest.approx([1.6454, 1.7236, 1.9472,
+                                   2.2348, 2.6187, 2.8642,
+                                   3.1263, 3.2073, 3.2852,
+                                   3.3092, 3.4496])
+    assert tbl.staterror == pytest.approx(0.04114 * np.ones(11))
+    assert tbl.syserror is None

--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -416,6 +416,36 @@ def test_fits_file_missing_column(make_data_path):
         io.read_table(infile, colkeys=["ra", "Foo"])
 
 
+@requires_fits
+@requires_data
+def test_get_header_data_missing_key(make_data_path):
+    """What happens if a requested key is missing?
+
+    TODO: If get_header_data is useful should we export if from
+    the io, and not backend, level?
+    """
+
+    infile = make_data_path("1838_rprofile_rmid.fits")
+    with pytest.raises(IOErr,
+                       match=" does not have a 'NOTAKEYWORD' keyword$"):
+        io.backend.get_header_data(infile, hdrkeys=["NOTAKEYWORD"])
+
+
+@requires_fits
+def test_set_arrays_not_sequence_of_seqence(tmp_path):
+    """Check this error condition.
+
+    TODO: Should set_arrays be part of the backend API?
+    """
+
+    outpath = tmp_path / 'do-not-edit.dat'
+    with pytest.raises(IOErr,
+                       match=r"^please supply array\(s\) to write to file$"):
+        io.backend.set_arrays(str(outpath),
+                              args=[np.arange(3), True],
+                              clobber=True)
+
+
 def test_read_arrays_no_data():
     """This can run even with the dummy backend"""
 

--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -595,11 +595,11 @@ def test_read_table_object(make_data_path):
     close = False
 
     if io.backend.__name__ == "sherpa.astro.io.crates_backend":
-        import pycrates
+        import pycrates  # type: ignore
         arg = pycrates.read_file(infile)
 
     elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
-        from astropy.io import fits
+        from astropy.io import fits  # type: ignore
         arg = fits.open(infile)
         close = True
 

--- a/sherpa/astro/io/tests/test_io_img.py
+++ b/sherpa/astro/io/tests/test_io_img.py
@@ -294,11 +294,11 @@ def test_read_image_object(make_data_path):
     close = False
 
     if io.backend.__name__ == "sherpa.astro.io.crates_backend":
-        import pycrates
+        import pycrates  # type: ignore
         arg = pycrates.read_file(infile)
 
     elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
-        from astropy.io import fits
+        from astropy.io import fits  # type: ignore
         arg = fits.open(infile)
         close = True
 

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -467,7 +467,7 @@ def test_pha_write_xmm_grating(make_data_path, tmp_path):
 
 
 def check_write_pha_fits_basic_roundtrip_crates(path):
-    import pycrates
+    import pycrates  # type: ignore
     ds = pycrates.CrateDataset(str(path), mode="r")
 
     assert ds.get_ncrates() == 2
@@ -527,7 +527,7 @@ def check_write_pha_fits_basic_roundtrip_crates(path):
 
 
 def check_write_pha_fits_basic_roundtrip_pyfits(path):
-    from astropy.io import fits
+    from astropy.io import fits  # type: ignore
     hdus = fits.open(str(path))
     try:
         assert len(hdus) == 2
@@ -635,7 +635,7 @@ def test_write_pha_fits_basic_roundtrip(tmp_path):
 
 
 def check_write_pha_fits_with_extras_roundtrip_crates(path, etime, bscal):
-    import pycrates
+    import pycrates  # type: ignore
     ds = pycrates.CrateDataset(str(path), mode="r")
 
     assert ds.get_ncrates() == 2
@@ -709,7 +709,7 @@ def check_write_pha_fits_with_extras_roundtrip_crates(path, etime, bscal):
 
 
 def check_write_pha_fits_with_extras_roundtrip_pyfits(path, etime, bscal):
-    from astropy.io import fits
+    from astropy.io import fits  # type: ignore
     hdus = fits.open(str(path))
     try:
         assert len(hdus) == 2
@@ -1035,7 +1035,7 @@ def test_chandra_phaII_roundtrip(make_data_path, tmp_path):
 
 
 def check_csc_pha_roundtrip_crates(path):
-    import pycrates
+    import pycrates  # type: ignore
     ds = pycrates.CrateDataset(str(path), mode="r")
 
     assert ds.get_ncrates() == 2
@@ -1089,7 +1089,7 @@ def check_csc_pha_roundtrip_crates(path):
 
 
 def check_csc_pha_roundtrip_pyfits(path):
-    from astropy.io import fits
+    from astropy.io import fits  # type: ignore
     hdus = fits.open(str(path))
     try:
         assert len(hdus) == 2
@@ -1393,11 +1393,11 @@ def test_read_pha_object(make_data_path):
     close = False
 
     if io.backend.__name__ == "sherpa.astro.io.crates_backend":
-        import pycrates
+        import pycrates  # type: ignore
         arg = pycrates.PHACrateDataset(infile, mode="r")
 
     elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
-        from astropy.io import fits
+        from astropy.io import fits  # type: ignore
         arg = fits.open(infile)
         close = True
 

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2022, 2023
+#  Copyright (C) 2020, 2021, 2022, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1375,3 +1375,77 @@ def test_read_hrci_rmf(make_data_path):
 
     assert rmf.e_min[0] == pytest.approx(0.06)
     assert rmf.e_max[-1] == pytest.approx(10)
+
+
+@requires_fits
+@requires_data
+def test_read_pha_object(make_data_path):
+    """Check we can send in a 'object'.
+
+    This support is not well advertised so it could perhaps be
+    removed, but let's add a basic test at least.
+
+    """
+
+    # Could create the "object" manually, but let's just read one in
+    #
+    infile = make_data_path("acisf01575_001N001_r0085_pha3.fits.gz")
+    close = False
+
+    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+        import pycrates
+        arg = pycrates.PHACrateDataset(infile, mode="r")
+
+    elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+        from astropy.io import fits
+        arg = fits.open(infile)
+        close = True
+
+    else:
+        assert False, f"unknown backend: {io.backend.__name__}"
+
+    try:
+        pha = io.read_pha(arg)
+
+    finally:
+        if close:
+            arg.close()
+
+    assert isinstance(pha, DataPHA)
+
+    # basic test that the data is read in (do not do a complete
+    # test)
+    assert pha.counts.max() == pytest.approx(15.0)
+    assert pha.exposure == pytest.approx(37664.157219191)
+
+    # Check we've loaded in the response and background
+    #
+    # For 4.16.0 and earlier, the crates backend "fails" because it
+    # does not load in the response or background datasets, instead
+    # saying:
+    #
+    # WARNING: File acisf01575_001N001_r0085_arf3.fits does not exist.
+    # WARNING: File acisf01575_001N001_r0085_rmf3.fits does not exist.
+    # WARNING: File acisf01575_001N001_r0085_pha3.fits does not exist.
+    #
+    # So there is an issue in handling compressed files, since the
+    # responses are saved as .gz files, although perhaps its more
+    # that the paths aren't being set up correctly. The background
+    # should be taken from the object itself, but perhaps it's
+    # easiest just to re-read it, and then we hit the same issue.
+    #
+    # For now treat this as a regression test so we can find out
+    # when it's fixed.
+    #
+    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+        assert pha.response_ids == []
+        assert pha.background_ids == []
+        return
+
+    assert len(pha.response_ids) == 1
+    assert len(pha.background_ids) == 1
+
+    assert pha.get_arf().specresp.max() == pytest.approx(711.6605834960938)
+    assert pha.get_rmf().matrix.max() == pytest.approx(0.1611403226852417)
+
+    assert pha.get_background().counts[-1] == pytest.approx(59)

--- a/sherpa/astro/io/tests/test_io_response.py
+++ b/sherpa/astro/io/tests/test_io_response.py
@@ -1272,11 +1272,11 @@ def test_read_arf_object(make_data_path):
     close = False
 
     if io.backend.__name__ == "sherpa.astro.io.crates_backend":
-        import pycrates
+        import pycrates  # type: ignore
         arg = pycrates.read_file(infile)
 
     elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
-        from astropy.io import fits
+        from astropy.io import fits  # type: ignore
         arg = fits.open(infile)
         close = True
 

--- a/sherpa/astro/io/tests/test_io_response.py
+++ b/sherpa/astro/io/tests/test_io_response.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2023
+#  Copyright (C) 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1254,3 +1254,92 @@ def test_read_multi_matrix_rmf(tmp_path, caplog):
     expected_blurry = mdl(e4lo, e4hi) @ blurry_matrix
 
     assert y == pytest.approx(expected_perfect)
+
+
+@requires_fits
+@requires_data
+def test_read_arf_object(make_data_path):
+    """Check we can send in a 'object'.
+
+    This support is not well advertised so it could perhaps be
+    removed, but let's add a basic test at least.
+
+    """
+
+    # Could create the "object" manually, but let's just read one in
+    #
+    infile = make_data_path("MNLup_2138_0670580101_EMOS1_S001_spec.arf")
+    close = False
+
+    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+        import pycrates
+        arg = pycrates.read_file(infile)
+
+    elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+        from astropy.io import fits
+        arg = fits.open(infile)
+        close = True
+
+    else:
+        assert False, f"unknown backend: {io.backend.__name__}"
+
+    try:
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter("always")
+            arf = io.read_arf(arg)
+
+    finally:
+        if close:
+            arg.close()
+
+    assert isinstance(arf, DataARF)
+    assert arf.energ_lo[0:4] == pytest.approx([1e-10, 0.005, 0.01, 0.015])
+    assert arf.energ_hi[0:4] == pytest.approx([0.005, 0.01, 0.015, 0.02])
+    assert arf.specresp.max() == pytest.approx(449.2618408203125)
+
+    assert len(ws) == 1
+    msg = ws[0].message
+    assert isinstance(msg, UserWarning)
+    msg = str(msg)
+    assert msg.startswith("The minimum ENERG_LO in the ARF '")
+    assert msg.endswith("_spec.arf' was 0 and has been replaced by 1e-10")
+
+
+@requires_fits
+@requires_data
+def test_read_rmf_object(make_data_path):
+    """Check we can send in a 'object'.
+
+    This support is not well advertised so it could perhaps be
+    removed, but let's add a basic test at least.
+
+    """
+
+    # Could create the "object" manually, but let's just read one in
+    #
+    infile = make_data_path("source.rmf")
+    close = False
+
+    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+        import pycrates
+        arg = pycrates.RMFCrateDataset(infile, mode='r')
+
+    elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+        from astropy.io import fits
+        arg = fits.open(infile)
+        close = True
+
+    else:
+        assert False, f"unknown backend: {io.backend.__name__}"
+
+    try:
+        rmf = io.read_rmf(arg)
+
+    finally:
+        if close:
+            arg.close()
+
+    assert isinstance(rmf, DataRMF)
+    assert rmf.energ_lo[0:4] == pytest.approx([0.1, 0.11, 0.12, 0.13])
+    assert rmf.energ_hi[0:4] == pytest.approx([0.11, 0.12, 0.13, 0.14])
+    assert rmf.matrix.max() == pytest.approx(0.12998242676258087)

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -32,7 +32,8 @@ import numpy as np
 import pytest
 
 from sherpa.astro import ui
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
+    IOErr
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, requires_fits, \
     requires_group, requires_xspec
@@ -99,8 +100,8 @@ def test_load_table_model_fails_with_dev_null():
     ui.clean()
     assert ui.list_model_components() == []
 
-    # The error depends on the load function
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError,
+                       match="^need at least one array to concatenate$"):
         ui.load_table_model('devnull', '/dev/null')
 
     assert ui.list_model_components() == []

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -32,7 +32,7 @@ from sherpa.astro.instrument import create_arf, create_delta_rmf, \
     create_non_delta_rmf, has_pha_response
 from sherpa.ui.utils import _check_type, _check_str_type, _is_str, \
     get_plot_prefs
-from sherpa.utils import sao_arange, send_to_pager
+from sherpa.utils import is_subclass, sao_arange, send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
     IdentifierErr, ImportErr, IOErr, ModelErr
 from sherpa.utils.numeric_types import SherpaFloat
@@ -9805,12 +9805,12 @@ class Session(sherpa.ui.utils.Session):
                 do_warning = True
                 # if type(model) in instruments:
                 # if isinstance(model, instruments):
-                if sherpa.ui.utils._is_subclass(type(model), instruments):
+                if is_subclass(type(model), instruments):
                     do_warning = False
                 for part in model:
                     # if type(part) in instruments:
                     # if isinstance(part, instruments):
-                    if sherpa.ui.utils._is_subclass(type(part), instruments):
+                    if is_subclass(type(part), instruments):
                         do_warning = False
                 if do_warning:
                     warning("PHA source model '%s' \ndoes not"
@@ -10304,12 +10304,12 @@ class Session(sherpa.ui.utils.Session):
             do_warning = True
             # if type(model) in instruments:
             # if isinstance(model, instruments):
-            if sherpa.ui.utils._is_subclass(type(model), instruments):
+            if is_subclass(type(model), instruments):
                 do_warning = False
             for part in model:
                 # if type(part) in instruments:
                 # if isinstance(part, instruments):
-                if sherpa.ui.utils._is_subclass(type(part), instruments):
+                if is_subclass(type(part), instruments):
                     do_warning = False
             if do_warning:
                 self.delete_bkg_model(id, bkg_id)

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -185,33 +185,6 @@ known_warnings = {
          ],
     ResourceWarning:
         [
-            r"unclosed file .*king_kernel.txt.* closefd=True>",
-            r"unclosed file .*phas.dat.* closefd=True>",
-            r"unclosed file .*data.txt.* closefd=True>",
-            r"unclosed file .*cstat.dat.* closefd=True>",
-            r"unclosed file .*data1.dat.* closefd=True>",
-            r"unclosed file .*aref_Cedge.fits.* closefd=True>",
-            r"unclosed file .*aref_sample.fits.* closefd=True>",
-            r"unclosed file .*/tmp.* closefd=True>",
-            # added for sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
-            r"unclosed file .*/dev/null.* closefd=True>",
-            r"unclosed file .*table.txt.* closefd=True>",
-            # tests in sherpa/astro/ui/tests/test_astro_ui_unit.py
-            # seen in some macOS test runs (e.g. pip, not conda) and python 3.8
-            r"unclosed file .*/data.dat'.* closefd=True>",
-            r"unclosed file .*/model.dat'.* closefd=True>",
-            r"unclosed file .*/resid.out'.* closefd=True>",
-
-            # It would be nice if we could find this out from first principles,
-            # rather than only finding them from random CI runs
-            r"unclosed file <_io.BufferedReader name='.*/data.dat'>",
-            r"unclosed file <_io.BufferedReader name='.*/model.dat'>",
-            r"unclosed file <_io.BufferedReader name='.*/resid.out'>",
-
-            # Does this replace the versions above?
-            r"unclosed file <_io.BufferedReader name='.*/aref_Cedge.fits'>",
-            r"unclosed file <_io.BufferedReader name='.*/aref_sample.fits'>",
-
         ],
     VisibleDeprecationWarning:
         [],

--- a/sherpa/io.py
+++ b/sherpa/io.py
@@ -27,7 +27,7 @@ import os
 
 import numpy as np
 
-from sherpa.data import Data1D, BaseData
+from sherpa.data import Data, Data1D
 from sherpa.utils import get_num_args, is_binary_file
 from sherpa.utils.err import IOErr
 from sherpa.utils.numeric_types import SherpaFloat
@@ -339,7 +339,7 @@ def read_arrays(*args):
        The data columns.
     dstype : optional
        The data type to create. It must be a subclass of
-       `sherpa.data.BaseData` and defaults to `sherpa.data.Data1D`
+       `sherpa.data.Data` and defaults to `sherpa.data.Data1D`
 
     Returns
     -------
@@ -377,7 +377,7 @@ def read_arrays(*args):
         raise IOErr('noarrays')
 
     dstype = Data1D
-    if _is_subclass(args[-1], BaseData):
+    if _is_subclass(args[-1], Data):
         dstype = args.pop()
 
     args = get_column_data(*args)

--- a/sherpa/io.py
+++ b/sherpa/io.py
@@ -28,17 +28,13 @@ import os
 import numpy as np
 
 from sherpa.data import Data, Data1D
-from sherpa.utils import get_num_args, is_binary_file
+from sherpa.utils import is_subclass, get_num_args, is_binary_file
 from sherpa.utils.err import IOErr
 from sherpa.utils.numeric_types import SherpaFloat
 
 
 __all__ = ('read_data', 'write_data', 'get_ascii_data', 'read_arrays',
            'write_arrays')
-
-
-def _is_subclass(t1, t2):
-    return isinstance(t1, type) and issubclass(t1, t2) and (t1 is not t2)
 
 
 def _check_args(size, dstype):
@@ -383,7 +379,7 @@ def read_arrays(*args):
     if len(largs) == 0:
         raise IOErr('noarrays')
 
-    if _is_subclass(largs[-1], Data):
+    if is_subclass(largs[-1], Data):
         dstype = largs.pop()
     else:
         dstype = Data1D

--- a/sherpa/io.py
+++ b/sherpa/io.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2019, 2020, 2021, 2023
+#  Copyright (C) 2007, 2015, 2016, 2019 - 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -18,9 +18,14 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+"""I/O routines for Sherpa.
+
+These routines are currently restricted to reading from ASCII files.
+"""
+
 import os
 
-import numpy
+import numpy as np
 
 from sherpa.data import Data1D, BaseData
 from sherpa.utils import get_num_args, is_binary_file
@@ -77,7 +82,7 @@ def read_file_data(filename, sep=' ', comment='#', require_floats=True):
                 rows.append(row)
 
     # rotate rows into list of columns
-    cols = numpy.column_stack(rows)
+    cols = np.column_stack(rows)
 
     # cast columns to appropriate type
     args = []
@@ -108,14 +113,14 @@ def get_column_data(*args):
 
     cols = []
     for arg in args:
-        if arg is None or isinstance(arg, (numpy.ndarray, list, tuple)):
+        if arg is None or isinstance(arg, (np.ndarray, list, tuple)):
             vals = arg
         else:
             raise IOErr('badarray', arg)
 
         if arg is not None:
-            vals = numpy.asanyarray(vals)
-            for col in numpy.atleast_2d(vals.T):
+            vals = np.asanyarray(vals)
+            for col in np.atleast_2d(vals.T):
                 cols.append(col)
         else:
             cols.append(vals)
@@ -437,20 +442,20 @@ def write_arrays(filename, args, fields=None, sep=' ', comment='#',
     if os.path.isfile(filename) and not clobber:
         raise IOErr("filefound", filename)
 
-    if not numpy.iterable(args) or len(args) == 0:
+    if not np.iterable(args) or len(args) == 0:
         raise IOErr('noarrayswrite')
 
-    if not numpy.iterable(args[0]):
+    if not np.iterable(args[0]):
         raise IOErr('noarrayswrite')
 
     size = len(args[0])
     for arg in args:
-        if not numpy.iterable(arg):
+        if not np.iterable(arg):
             raise IOErr('noarrayswrite')
         elif len(arg) != size:
             raise IOErr('arraysnoteq')
 
-    args = numpy.column_stack(numpy.asarray(args))
+    args = np.column_stack(np.asarray(args))
     lines = []
     for arg in args:
         line = [format % elem for elem in arg]

--- a/sherpa/tests/test_sherpa_io.py
+++ b/sherpa/tests/test_sherpa_io.py
@@ -64,7 +64,7 @@ def test_write_arrays_no_data(tmp_path):
 
 
 def test_get_ascii_data_irregular_data(tmp_path):
-    """What happens when the numbor of columns is not constant?"""
+    """What happens when the number of columns is not constant?"""
 
     tfile = tmp_path / "col.dat"
     tfile.write_text("23 1\n24 2\n25 3 4\n")
@@ -78,7 +78,7 @@ def test_get_ascii_data_irregular_data(tmp_path):
 
 
 def test_write_arrays_irregular_data(tmp_path):
-    """What happens when the numbor of columns is not constant?"""
+    """What happens when the number of columns is not constant?"""
 
     tfile = tmp_path / "col.dat"
     with pytest.raises(IOErr,

--- a/sherpa/tests/test_sherpa_io.py
+++ b/sherpa/tests/test_sherpa_io.py
@@ -1,0 +1,304 @@
+#
+#  Copyright (C) 2024
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Corner-case handling of the I/O code.
+
+This is named test_sherpa_io.py as there is already a test_io.py
+in the astro tree.
+
+"""
+
+import pytest
+
+from sherpa.data import Data1D
+from sherpa.io import get_ascii_data, get_column_data, read_arrays, \
+    write_arrays, write_data
+from sherpa.utils.err import IOErr
+
+
+def test_get_column_data_no_data():
+    """Regression test"""
+
+    with pytest.raises(IOErr, match="^no arrays found to be loaded$"):
+        get_column_data()
+
+
+def test_get_column_data_not_a_sequence():
+    """Regression test"""
+
+    with pytest.raises(IOErr, match="^'1' must be a Numpy array, list, or tuple$"):
+        get_column_data(1, 2, 3.4)
+
+
+def test_read_arrays_no_data():
+    """Regression test"""
+
+    with pytest.raises(IOErr, match="^no arrays found to be loaded$"):
+        read_arrays()
+
+
+def test_write_arrays_no_data(tmp_path):
+    """Regression test"""
+
+    tfile = tmp_path / 'x.dat'
+    with pytest.raises(IOErr,
+                       match=r"^please supply array\(s\) to write to file$"):
+        write_arrays(str(tfile), 23, fields=["x"])
+
+
+def test_get_ascii_data_irregular_data(tmp_path):
+    """What happens when the numbor of columns is not constant?"""
+
+    tfile = tmp_path / "col.dat"
+    tfile.write_text("23 1\n24 2\n25 3 4\n")
+
+    # The error message may well depend on the NumPy version so we do
+    # not include a match argument. NumPy 1.26 uses the message
+    #   all the input array dimensions except for the concatenation axis must match exactly, but along dimension 0, the array at index 0 has size 2 and the array at index 2 has size 3
+    #
+    with pytest.raises(ValueError):
+        get_ascii_data(str(tfile))
+
+
+def test_write_arrays_irregular_data(tmp_path):
+    """What happens when the numbor of columns is not constant?"""
+
+    tfile = tmp_path / "col.dat"
+    with pytest.raises(IOErr,
+                       match="^not all arrays are of equal length$"):
+        write_arrays(str(tfile), [[1, 2, 3], [4, 5], [6, 7, 8]],
+                     clobber=True)
+
+
+def test_get_ascii_data_not_numeric_data(tmp_path):
+    """What happens when given non-numeric data?"""
+
+    tfile = tmp_path / "col.dat"
+    tfile.write_text("23 1 foo\n24 2 bar\n25 3 baz\n")
+    with pytest.raises(ValueError,
+                       match=" could not be loaded, probably "
+                       "because it contained spurious data and/or "
+                       "strings"):
+
+        get_ascii_data(str(tfile))
+
+
+def test_write_arrays_not_numeric_data(tmp_path):
+    """What happens when given non-numeric data?"""
+
+    tfile = tmp_path / "col.dat"
+    with pytest.raises(TypeError,
+                       match="must be real number"):
+        write_arrays(str(tfile), [[23, 1, "foo"],
+                                  [24, 2, "bar"],
+                                  [25, 3, "baz"]],
+                     clobber=True)
+
+
+def test_get_ascii_data_get_one_col(tmp_path):
+    """This just checks that the test data is correct"""
+
+    tfile = tmp_path / "1col.dat"
+    tfile.write_text("# col2\n23\n24\n")
+
+    (colnames, coldata, fname) = get_ascii_data(str(tfile))
+    assert colnames == ["col2"]
+    assert len(coldata) == 1
+    assert coldata[0] == pytest.approx([23, 24])
+    assert fname.endswith("1col.dat")
+
+
+def test_get_ascii_data_more_columns_than_colnames_no_colkeys_ncols1(tmp_path):
+    """What happens if more columns than column names?"""
+
+    tfile = tmp_path / "col.dat"
+    tfile.write_text("# col2\n-0.2 23\n-0.4 24\n")
+
+    # Although ncols=1 is the default, be explicit in this test
+    (colnames, coldata, fname) = get_ascii_data(str(tfile), ncols=1)
+    assert colnames == ["col2"]
+    assert len(coldata) == 1
+    assert coldata[0] == pytest.approx([-0.2, -0.4])
+
+
+def test_get_ascii_data_more_columns_than_colnames_no_colkeys_ncols2(tmp_path):
+    """What happens if more columns than column names?"""
+
+    tfile = tmp_path / "col.dat"
+    tfile.write_text("# col2 col7\n-0.2 23 1\n-0.4 24 0\n")
+
+    (colnames, coldata, fname) = get_ascii_data(str(tfile), ncols=2)
+    assert colnames == ["col2", "col7"]
+    assert len(coldata) == 2
+    assert coldata[0] == pytest.approx([-0.2, -0.4])
+    assert coldata[1] == pytest.approx([23, 24])
+
+
+def test_get_ascii_data_more_columns_than_colnames_colkeys_ncols1(tmp_path):
+    """What happens if more columns than column names?
+
+    This also tests a mix-match between ncols and len(colkeys).
+    """
+
+    tfile = tmp_path / "col.dat"
+    tfile.write_text("# col2 col7\n-0.2 23 1\n-0.4 24 0\n")
+
+    # Although ncols=1 is the default, be explicit in this test
+    (colnames, coldata, fname) = get_ascii_data(str(tfile), ncols=1,
+                                                colkeys=["col7", "col2"])
+    assert colnames == ["col7", "col2"]
+    assert len(coldata) == 2
+    assert coldata[0] == pytest.approx([23, 24])
+    assert coldata[1] == pytest.approx([-0.2, -0.4])
+
+
+def test_get_ascii_data_more_columns_than_colnames_colkeys_ncols2(tmp_path):
+    """What happens if more columns than column names?
+
+    We need to set ncols=2 to pass the check for creating a
+    dstype=Data1D object (for some reason, when colkeys is not set,
+    then there is no check if ncols=1).
+
+    """
+
+    tfile = tmp_path / "col.dat"
+    tfile.write_text("# col2 col7\n-0.2 23 1\n-0.4 24 0\n")
+
+    (colnames, coldata, fname) = get_ascii_data(str(tfile), ncols=2,
+                                                colkeys=["col7", "col2"])
+    assert colnames == ["col7", "col2"]
+    assert len(coldata) == 2
+    assert coldata[0] == pytest.approx([23, 24])
+    assert coldata[1] == pytest.approx([-0.2, -0.4])
+
+
+def test_get_ascii_data_more_colnames_than_columns_no_colkeys_ncols1(tmp_path):
+    """What happens if more column names than columns: ncols=1?"""
+
+    tfile = tmp_path / "col.dat"
+    tfile.write_text("# col2 xcol ycol\n-0.2 23\n-0.4 24\n")
+
+    # Although ncols=1 is the default be explicit in this test
+    (colnames, coldata, fname) = get_ascii_data(str(tfile), ncols=1)
+    assert colnames == ["col2", "xcol", "ycol"]
+    assert len(coldata) == 1
+    assert coldata[0] == pytest.approx([-0.2, -0.4])
+
+
+def test_get_ascii_data_more_colnames_than_columns_no_colkeys_ncols2(tmp_path):
+    """What happens if more column names than columns: ncols=2?"""
+
+    tfile = tmp_path / "col.dat"
+    tfile.write_text("# col2 xcol ycol\n-0.2 23\n-0.4 24\n")
+
+    (colnames, coldata, fname) = get_ascii_data(str(tfile), ncols=2)
+    assert colnames == ["col2", "xcol", "ycol"]
+    assert len(coldata) == 2
+    assert coldata[0] == pytest.approx([-0.2, -0.4])
+    assert coldata[1] == pytest.approx([23, 24])
+
+
+def test_get_ascii_data_more_colnames_than_columns_colkeys_ncols1(tmp_path):
+    """What happens if more column names than columns? colkeys/ncols=1
+
+    There is also a check for specifying an invalid column name but
+    that check is not reached.
+    """
+
+    tfile = tmp_path / "col.dat"
+    tfile.write_text("# col2 xcol ycol\n-0.2 23\n-0.4 24\n")
+
+    # Although ncols=1 is the default be explicit in this test
+    with pytest.raises(IOErr,
+                       match="^Expected 2 columns but found 3$"):
+        get_ascii_data(str(tfile), ncols=1, colkeys=["col2", "col3"])
+
+
+def test_get_ascii_data_more_colnames_than_columns_colkeys_ncols2(tmp_path):
+    """What happens if more column names than columns? colkebys/ncols=2
+
+    There is also a check for specifying an invalid column name but
+    that check is not reached.
+    """
+
+    tfile = tmp_path / "col.dat"
+    tfile.write_text("# col2 xcol ycol\n-0.2 23\n-0.4 24\n")
+
+    with pytest.raises(IOErr,
+                       match="^Expected 2 columns but found 3$"):
+        get_ascii_data(str(tfile), ncols=2, colkeys=["col2", "col3"])
+
+
+def test_get_ascii_data_too_many_colkeys(tmp_path):
+    """Regression test"""
+
+    tfile = tmp_path / "1col.dat"
+    tfile.write_text("23 400\n24 -0.2\n")
+
+    with pytest.raises(IOErr,
+                       match=r"Required column 'col3' not found in \['col1'. 'col2'\]"):
+        get_ascii_data(str(tfile), ncols=3, colkeys=["col1", "col2", "col3"])
+
+
+def test_get_ascii_data_unknown_colkey(tmp_path):
+    """Regression test"""
+
+    tfile = tmp_path / "1col.dat"
+    tfile.write_text("# col2\n23\n24\n")
+
+    with pytest.raises(IOErr,
+                       match=r"Required column 'col1' not found in \['col2'\]"):
+        get_ascii_data(str(tfile), colkeys=["col1", "col2", "col3"])
+
+
+def test_write_arrays_single_column(tmp_path):
+    """What happens if do not give a list of lists?
+
+    Should this error out? Users may be relying on this behavior, so
+    we do not error out, but that seems unlikely.
+
+    """
+
+    tfile = tmp_path / "not-changed.dat"
+    with pytest.raises(IOErr,
+                       match=r"^please supply array\(s\) to write to file$"):
+        write_arrays(str(tfile), [1, 2, 3], format="<%02d>", clobber=True)
+
+
+def test_write_data_no_fields(tmp_path):
+    """Basic check of write_data with no explicit fields"""
+
+    tfile = tmp_path / "test.dat"
+
+    d = Data1D("x", [1, 2], [4, 5], syserror=[0.2, 0.3])
+    write_data(str(tfile), d,
+               format="%.1f", clobber=True)
+    assert tfile.read_text() == "#X Y SYSERROR\n1.0 4.0 0.2\n2.0 5.0 0.3\n"
+
+
+def test_write_data_with_fields(tmp_path):
+    """Basic check of write_data with fields set"""
+
+    tfile = tmp_path / "test.dat"
+
+    d = Data1D("x", [1, 2], [4, 5], syserror=[0.2, 0.3])
+    write_data(str(tfile), d, fields=["y", "syserror"],
+               format="%.1f", clobber=True)
+    assert tfile.read_text() == "#Y SYSERROR\n4.0 0.2\n5.0 0.3\n"

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -41,7 +41,7 @@ from sherpa.models.model import Model, SimulFitModel
 from sherpa.models.template import add_interpolator, create_template_model, \
     reset_interpolators
 from sherpa.plot import Plot, MultiPlot, set_backend
-from sherpa.utils import NoNewAttributesAfterInit, \
+from sherpa.utils import NoNewAttributesAfterInit, is_subclass, \
     export_method, send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \
     DataErr, IdentifierErr, IOErr, ModelErr, ParameterErr, PlotErr, \
@@ -96,10 +96,6 @@ def _is_integer(val):
 
 def _is_str(val):
     return isinstance(val, (str, ))
-
-
-def _is_subclass(t1, t2):
-    return inspect.isclass(t1) and issubclass(t1, t2) and (t1 is not t2)
 
 
 def get_plot_prefs(plotobj):
@@ -475,7 +471,7 @@ class ModelWrapper(NoNewAttributesAfterInit):
         if not isinstance(session, Session):
             raise ValueError(f"session={session} is not a Session instance")
 
-        if not _is_subclass(modeltype, Model):
+        if not is_subclass(modeltype, Model):
             raise ValueError(f"modeltype={modeltype} is not a Model class")
 
         self._session = session
@@ -866,7 +862,7 @@ class Session(NoNewAttributesAfterInit):
         for mod, base, odict in zip(modules, basetypes, objdicts):
             for name in mod.__all__:
                 cls = getattr(mod, name)
-                if _is_subclass(cls, base):
+                if is_subclass(cls, base):
                     odict[name.lower()] = cls()
 
         # Note: levmar does not support the rng option so this
@@ -5929,7 +5925,7 @@ class Session(NoNewAttributesAfterInit):
             cls = getattr(module, name)
 
             for base in baselist:
-                if _is_subclass(cls, base):
+                if is_subclass(cls, base):
                     break
             else:
                 continue
@@ -5992,7 +5988,7 @@ class Session(NoNewAttributesAfterInit):
         """
         name = modelclass.__name__.lower()
 
-        if not _is_subclass(modelclass, sherpa.models.ArithmeticModel):
+        if not is_subclass(modelclass, sherpa.models.ArithmeticModel):
             raise TypeError(f"model class '{name}' is not a derived class "
                             "from sherpa.models.ArithmeticModel")
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -95,6 +95,13 @@ dividing and multiplying the value by ``_guess_ampl_scale``.
 ###############################################################################
 
 
+# This logic was found in several modules so centralize it. Note that
+# this is not added to __all__.
+#
+def is_subclass(t1, t2):
+    """Is t2 a subclass of t1 but not the same as t1?"""
+    return inspect.isclass(t1) and issubclass(t1, t2) and (t1 is not t2)
+
 
 ###############################################################################
 


### PR DESCRIPTION
# Summary

Initial cleanup of the astro IO code in preparation for future changes. This fixes an issue when using the AstroPy IO backend (pyfits) which could cause Python to report an unclosed file on exit.

# Details

This is taken from #2017 which was itself taken from #1929. The idea is to reduce the size of that PR to make it easier to review. This PR concentrates on initial clean up of the I/O code, addressing one or two minor improvements, but basically setting the stage for later changes (hence I'd rather not spend time on improving the changes here as that may be wasted given the other changes in #2017, or can be better done after the later changes are made).

This is part of #1939.