### PR TITLE
CI: enforce NumPy does not use version 2.0 for the builds

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -43,7 +43,7 @@ fi
 # Figure out requested dependencies
 if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi
 if [ -n "${BOKEHVER}" ]; then BOKEH="bokeh=${BOKEHVER}"; fi
-if [ -n "${NUMPYVER}" ]; then NUMPY="numpy=${NUMPYVER}"; fi
+if [ -n "${NUMPYVER}" ]; then NUMPY="numpy=${NUMPYVER}"; else NUMPY="numpy<2.0"; fi
 # Xspec >=12.10.1n Conda package includes wcslib & CCfits and pulls in cfitsio & fftw
 if [ -n "${XSPECVER}" ];
  then export XSPEC="xspec-modelsonly=${XSPECVER}";

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -29,7 +29,7 @@ jobs:
           - name: Linux Build (w/o Xspec; Python 3.11)
             os: ubuntu-latest
             python-version: "3.11"
-            numpy-pkg: 'numpy'
+            numpy-pkg: 'numpy<2.0'
             install-type: install
             test-data: package
             fits-pkg: 'astropy'
@@ -39,7 +39,7 @@ jobs:
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
             python-version: "3.9"
-            numpy-pkg: 'numpy'
+            numpy-pkg: 'numpy<2.0'
             install-type: install
             test-data: package
             matplotlib-pkg: 'matplotlib>=3,<4'
@@ -48,7 +48,7 @@ jobs:
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest
             python-version: "3.10"
-            numpy-pkg: 'numpy'
+            numpy-pkg: 'numpy<2.0'
             install-type: develop
             fits-pkg: 'astropy'
             test-data: none
@@ -56,7 +56,7 @@ jobs:
           - name: Linux Build (submodule data w/o Matplotlib or Xspec)
             os: ubuntu-latest
             python-version: "3.9"
-            numpy-pkg: 'numpy'
+            numpy-pkg: 'numpy<2.0'
             install-type: develop
             fits-pkg: 'astropy'
             test-data: submodule


### PR DESCRIPTION
# Summary

Ensure the CI builds use numpy<2

# Details

At present the Sherpa tests will fail when NumPy 2.0 is selected, mainly because of "not critical" issues (e.g. how numeric values get converted to strings), so enforce a "numpy < 2.0" rule when installing NumPy.

See #1963 for a discussion of the test failures we get with NumPy 2.0.

A number of PRs use this commit.