### PR TITLE
CM-887: Updating macos gitlab runner images to version 12 and update the MacOS SDK to version 11.0

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -3,13 +3,13 @@
 if [ "`uname -s`" == "Darwin" ] ; then
     compilers="clang_osx-64 clangxx_osx-64 gfortran_osx-64"
 
-    #Download the macOS 10.14 SDK to the CONDA_BUILD_SYSROOT location for the Conda Compilers to work
-    mkdir -p ${GITHUB_WORKSPACE}/10.14SDK
-    wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.14.sdk.tar.xz -O MacOSX10.14.sdk.tar.xz
+    #Download the macOS 11.0 SDK to the CONDA_BUILD_SYSROOT location for the Conda Compilers to work
+    mkdir -p ${GITHUB_WORKSPACE}/11.0SDK
+    wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.0.sdk.tar.xz -O MacOSX11.0.sdk.tar.xz
     if [[ $? -ne 0 ]]; then
-      echo "macOS 10.14 SDK download failed"
+      echo "macOS 11.0 SDK download failed"
     fi
-    tar -C ${GITHUB_WORKSPACE}/10.14SDK -xf MacOSX10.14.sdk.tar.xz
+    tar -C ${GITHUB_WORKSPACE}/11.0SDK -xf MacOSX11.0.sdk.tar.xz
     #End of Conda compilers section
 else
     compilers="gcc_linux-64 gxx_linux-64 gfortran_linux-64"

--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -125,12 +125,12 @@ jobs:
     runs-on: ${{ matrix.os-type }}
     strategy:
       matrix:
-        os-type: ["macos-11"]
+        os-type: ["macos-12"]
         conda-os: ["MacOSX-x86_64"]
         os-dir: ["osx-64"]
         python-version: ["3.9", "3.10", "3.11"]
     env:
-      CONDA_BUILD_SYSROOT: /opt/MacOSX10.14.sdk
+      CONDA_BUILD_SYSROOT: /opt/MacOSX11.0.sdk
 
     steps:
     - name: Conda Setup
@@ -142,16 +142,16 @@ jobs:
         source ${conda_loc}/etc/profile.d/conda.sh
         conda create -yq -n builder conda-build conda-verify
 
-    - name: macOS 10.14 SDK
+    - name: macOS 11.0 SDK
       if: ${{ matrix.conda-os == 'MacOSX-x86_64' }}
       run: |
-        #Download the MacOS 10.14 SDK to the CONDA_BUILD_SYSROOT location for the Conda Compilers to work
+        #Download the MacOS 11.0 SDK to the CONDA_BUILD_SYSROOT location for the Conda Compilers to work
         mkdir -p /opt
-        curl -L https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.14.sdk.tar.xz -o MacOSX10.14.sdk.tar.xz
+        curl -L https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.0.sdk.tar.xz -o MacOSX11.0.sdk.tar.xz
         if [[ $? -ne 0 ]]; then
-            echo "MacOS 10.14 SDK download failed"
+            echo "MacOS 11.0 SDK download failed"
         fi
-        sudo tar -C /opt -xf MacOSX10.14.sdk.tar.xz
+        sudo tar -C /opt -xf MacOSX11.0.sdk.tar.xz
 
     - name: Checkout Code
       uses: actions/checkout@v4.1.1

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -8,9 +8,15 @@ on:
     - '*'
   pull_request:
 
+#Reduces GH Action duplication:
+# Cancels the previous pipeline for this ref it is still running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   xspec_channel: "xspec/label/test"
-  CONDA_BUILD_SYSROOT: ${{ github.workspace }}/10.14SDK/MacOSX10.14.sdk
+  CONDA_BUILD_SYSROOT: ${{ github.workspace }}/11.0SDK/MacOSX11.0.sdk
 
 jobs:
   tests:

--- a/.github/workflows/ci-pip-arch.yml
+++ b/.github/workflows/ci-pip-arch.yml
@@ -9,6 +9,12 @@ on:
     # or present when PR is updated
     types: [synchronize, labeled]
 
+#Reduces GH Action duplication:
+# Cancels the previous pipeline for this ref it is still running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -8,6 +8,12 @@ on:
     - '*'
   pull_request:
 
+#Reduces GH Action duplication:
+# Cancels the previous pipeline for this ref it is still running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     defaults:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,2 +1,2 @@
 CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.14.sdk        # [osx]
+  - /opt/MacOSX11.0.sdk        # [osx]


### PR DESCRIPTION
This ups the actions macOS Intel version to 12, and updates the macOS SDK to version 11.0, which it consistent with CIAO.

I tested this on my fork, temporarily enabling the conda packaging tests to ensure they worked.

I also added concurrency checks to prevent duplicate actions, as I repeatedly pushed in a short time span, resulting in many duplicate actions being kicked off unnecessarily. 