### PR TITLE
Allow the tests to pass with NumPy 2.0

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -43,7 +43,7 @@ fi
 # Figure out requested dependencies
 if [ -n "${MATPLOTLIBVER}" ]; then MATPLOTLIB="matplotlib=${MATPLOTLIBVER}"; fi
 if [ -n "${BOKEHVER}" ]; then BOKEH="bokeh=${BOKEHVER}"; fi
-if [ -n "${NUMPYVER}" ]; then NUMPY="numpy=${NUMPYVER}"; else NUMPY="numpy<2.0"; fi
+if [ -n "${NUMPYVER}" ]; then NUMPY="numpy=${NUMPYVER}"; fi
 # Xspec >=12.10.1n Conda package includes wcslib & CCfits and pulls in cfitsio & fftw
 if [ -n "${XSPECVER}" ];
  then export XSPEC="xspec-modelsonly=${XSPECVER}";

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -35,7 +35,7 @@ jobs:
           - name: Linux Build (w/o Xspec; Python 3.11)
             os: ubuntu-latest
             python-version: "3.11"
-            numpy-pkg: 'numpy<2.0'
+            numpy-pkg: 'numpy'
             install-type: install
             test-data: package
             fits-pkg: 'astropy'
@@ -45,7 +45,7 @@ jobs:
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
             python-version: "3.9"
-            numpy-pkg: 'numpy<2.0'
+            numpy-pkg: 'numpy'
             install-type: install
             test-data: package
             matplotlib-pkg: 'matplotlib>=3,<4'
@@ -54,7 +54,7 @@ jobs:
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest
             python-version: "3.10"
-            numpy-pkg: 'numpy<2.0'
+            numpy-pkg: 'numpy'
             install-type: develop
             fits-pkg: 'astropy'
             test-data: none
@@ -62,7 +62,7 @@ jobs:
           - name: Linux Build (submodule data w/o Matplotlib or Xspec)
             os: ubuntu-latest
             python-version: "3.9"
-            numpy-pkg: 'numpy<2.0'
+            numpy-pkg: 'numpy'
             install-type: develop
             fits-pkg: 'astropy'
             test-data: submodule

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -100,6 +100,17 @@ files and shows exactly which lines were executed while running the tests.
 
 Run doctests locally
 --------------------
+
+.. note::
+   The documentation tests are known to fail if NumPy 2.0 is installed
+   because the representation of NumPy types such as ``np.float64``
+   have changed, leading to errors like::
+
+       Expected:
+           2.5264364698914e-06
+       Got:
+           np.float64(2.5264364698914e-06)
+
 If `doctestplus <https://pypi.org/project/pytest-doctestplus/>` is installed
 (and it probably is because it's part of
 `sphinx-astropy <https://pypi.org/project/sphinx-astropy/>`,

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -34,17 +34,14 @@ Requirements
 Sherpa has the following requirements:
 
 * Python 3.9 to 3.11
-* NumPy (the exact lower limit has not been determined,
-  1.21.0 or later will work, earlier version may work)
+* NumPy (version 2.0 should work but there has been limited testing)
 * Linux or OS-X (patches to add Windows support are welcome)
 
 Sherpa can take advantage of the following Python packages
 if installed:
 
 * :term:`Astropy`: for reading and writing files in
-  :term:`FITS` format. The minimum required version of astropy
-  is version 1.3, although only versions 2 and higher are used in testing
-  (version 3.2 is known to cause problems, but version 3.2.1 is okay).
+  :term:`FITS` format.
 * :term:`matplotlib`: for visualisation of
   one-dimensional data or models, one- or two- dimensional
   error analysis, and the results of Monte-Carlo Markov Chain
@@ -331,7 +328,7 @@ module, but a quick check of an installed version can be made with
 the following command::
 
     % python -c 'from sherpa.astro import xspec; print(xspec.get_xsversion())'
-    12.14.0b
+    12.14.0i
 
 Other options
 ^^^^^^^^^^^^^

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -206,7 +206,7 @@ def test_sourceandbg(parallel, run_thread, fix_xspec):
         assert fit_results.numpoints == 1330
         assert fit_results.dof == 1325
 
-        assert covarerr[0] == approx(0.012097, rel=1e-3)
+        assert covarerr[0] == approx(0.012097, rel=1.05e-3)
         assert covarerr[1] == approx(0, rel=1e-3)
         assert covarerr[2] == approx(0.000280678, rel=1e-3)
         assert covarerr[3] == approx(0.00990783, rel=1e-3)

--- a/sherpa/estmethods/__init__.py
+++ b/sherpa/estmethods/__init__.py
@@ -380,6 +380,11 @@ def covariance(pars, parmins, parmaxes, parhardmins, parhardmaxes, sigma, eps,
         eflag = est_success
         ubound = diag[num]
         lbound = -diag[num]
+
+        # What happens when lbound or ubound is NaN? This is
+        # presumably why the code is written as it is below (e.g. a
+        # pass if the values can be added to pars[num]).
+        #
         if pars[num] + ubound < parhardmaxes[num]:
             pass
         else:
@@ -1092,6 +1097,7 @@ def confidence(pars, parmins, parmaxes, parhardmins, parhardmaxes, sigma, eps,
             print_status(myblog.blogger.info, verbose, status_prefix[dirn],
                          delta_zero, lock)
 
+        # This should really set the error flag appropriately.
         error_flags.append(est_success)
 
         #

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -276,7 +276,7 @@ class FitResults(NoNewAttributesAfterInit):
 
         self.succeeded = results[0]
         self.parnames = tuple(p.fullname for p in fit.model.get_thawed_pars())
-        self.parvals = tuple(results[1])
+        self.parvals = tuple(float(r) for r in results[1])
         self.istatval = init_stat
         self.statval = results[2]
         self.dstatval = np.abs(results[2] - init_stat)
@@ -439,29 +439,31 @@ class ErrorEstResults(NoNewAttributesAfterInit):
         self.sigma = fit.estmethod.sigma
         self.percent = erf(self.sigma / np.sqrt(2.0)) * 100.0
         self.parnames = tuple(p.fullname for p in parlist if not p.frozen)
-        self.parvals = tuple(p.val for p in parlist if not p.frozen)
-        self.nfits = 0
+        self.parvals = tuple(float(p.val) for p in parlist if not p.frozen)
 
         pmins = []
         pmaxes = []
         for i in range(len(parlist)):
             if (results[2][i] == est_hardmin or
-                    results[2][i] == est_hardminmax):
+                results[2][i] == est_hardminmax or
+                results[0][i] is None  # It looks like confidence does not set the flag
+                ):
                 pmins.append(None)
                 warning("hard minimum hit for parameter %s", self.parnames[i])
             else:
-                pmins.append(results[0][i])
+                pmins.append(float(results[0][i]))
 
             if (results[2][i] == est_hardmax or
-                    results[2][i] == est_hardminmax):
+                results[2][i] == est_hardminmax or
+                results[1][i] is None  # It looks like confidence does not set the flag
+                ):
                 pmaxes.append(None)
                 warning("hard maximum hit for parameter %s", self.parnames[i])
             else:
-                pmaxes.append(results[1][i])
+                pmaxes.append(float(results[1][i]))
 
         self.parmins = tuple(pmins)
         self.parmaxes = tuple(pmaxes)
-
         self.nfits = results[3]
         self.extra_output = results[4]
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1519,7 +1519,7 @@ def create_expr_integrated(lovals, hivals, mask=None,
     delim : str, optional
         The separator for a range.
     eps : number, optional
-        The tolerance for comparing two numbers with sao_fcmp.
+        This value is unused.
 
     Raises
     ------
@@ -4069,9 +4069,13 @@ def zeroin(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.0e-2):
             warning('%s: %s fa * fb < 0 is not met', __name__, fcn.__name__)
             return [[None, None], [[None, None], [None, None]], myfcn.nfev]
 
+        # With NumPy 2.0 the casting rules changed, leading to some
+        # behavioural changes in this code. The simplest fix was to
+        # make sure DBL_EPSILON did not remain a np.float32 value.
+        #
         xc = xa
         fc = fa
-        DBL_EPSILON = np.finfo(np.float32).eps
+        DBL_EPSILON = float(np.finfo(np.float32).eps)
         while myfcn.nfev < maxfev:
 
             prev_step = xb - xa

--- a/sherpa/utils/tests/test_root.py
+++ b/sherpa/utils/tests/test_root.py
@@ -99,6 +99,7 @@ def prob15(x, *args):
 
 
 def prob16(x, *args):
+    """See also prob35."""
     return (sqr(x) - 2.0) * x - 5.0
 
 
@@ -178,6 +179,10 @@ def prob34(x, *args):
 
 
 def prob35(x, *args):
+    """See also prob16.
+
+    It's not obvious this adds anything to prob16
+    """
     return (x*x - 2.0) * x - 5.0
 
 

--- a/sherpa/utils/tests/test_root.py
+++ b/sherpa/utils/tests/test_root.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2016, 2018, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2018, 2020, 2021, 2024
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -27,7 +28,7 @@ from sherpa.utils import demuller, bisection, new_muller, apache_muller, \
     zeroin
 
 
-def sqr(x, *args):
+def sqr(x):
     return x * x
 
 
@@ -99,7 +100,6 @@ def prob15(x, *args):
 
 
 def prob16(x, *args):
-    """See also prob35."""
     return (sqr(x) - 2.0) * x - 5.0
 
 
@@ -178,13 +178,7 @@ def prob34(x, *args):
     return 1.0 / x - numpy.sin(x) + 1.0
 
 
-def prob35(x, *args):
-    """See also prob16.
-
-    It's not obvious this adds anything to prob16
-    """
-    return (x*x - 2.0) * x - 5.0
-
+# prob35 was the same as prob16
 
 def prob36(x, *args):
     return 1.0 / x - 1.0
@@ -293,7 +287,6 @@ def demuller2(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
                           (prob32, 0.1, 0.9),
                           (prob33, 2.8, 3.1),
                           (prob34, -1.3, -0.5),
-                          (prob35, 2.0, 3.0),
                           (prob36, 0.5, 1.5),
                           (prob37, 0.5, 5.0),
                           (prob38, 1.0, 4.0),


### PR DESCRIPTION
# Summary

Allow the tests to pass when using NumPy 2.0, as long as pytest-doctestplus is not installed.

# Details

When NumPy 2.0 is installed we have three test failures and this commit addresses two of them

- [x] `test_root.py` failed with `zeroin` for two tests (which turned out to be a duplicate test)
- the representation of NumPy numbers has changed
  - [x] this affects the fit-related structures, which are checked for in our tests
  - [ ] it also affects `pytest-doctestplus` tests, but these are not used in our CI runs 


The root-finding code is not documented. I spent some time in trying to work out why `zeroin` failed for two tests and found that the two tests were actually the same (so one of the commits removes the second test). The issue is that the code relied on "loose" casting rules which were changed in NumPy 2.0

```
>>> import numpy as np
>>> np.__version__
'1.26.4'
>>> type(np.float32(2.0) + 1)
<class 'numpy.float64'>
```

versus

```
>>> import numpy as np
>>> np.__version__
'2.0.0'
>>> type(np.float32(2.0) + 1)
<class 'numpy.float32'>
```

The code made use of a `np.float32` value and previously this has been converted to `float64` but it now remained `float32`, which was a problem because it ended up being used in a statement where 1e120 was used, which is okay for `float64` but caused an overflow with `float32`, resulting in chaos (aka a failing test). The easiest change is to just convert the `float32` to a `float` to avoid this.

There may be other places where we are affected by this subtlety, but our tests don't show any obvious cases!

The second change is in the representation of numbers:

```
>>> import numpy as np
>>> np.__version__
'1.26.4'
>>> p = tuple(np.float64(x) for x in [2, 3])
>>> p
(2.0, 3.0)
>>> 
```

and

```
>>> import numpy as np
>>> np.__version__
'2.0.0'
>>> p = tuple(np.float64(x) for x in [2, 3])
>>> p
(np.float64(2.0), np.float64(3.0))
```

I have found the "obvious" cases - `fit` and `error` results and do an explicit `float(x)` cast, to remove the `numpy-ness` here. However, this is only found in a few test cases. There are plenty of other cases where we see this - as seen in the `doctestplux` output, and so we need to decide what to do (e.g. do we want to try and convert to `float` where we can?), but that is for a later PR. This is to allow NumPy 2 to be used in our CI runs.

For reference, here are some of the types of failures we see with `doctestplus`:

```
2395         >>> (clo == pha.channel).all()
Expected:
    True
Got:
    np.True_
```

```
3000         >>> pha.get_areascal()
Expected:
    1.0
Got:
    np.float64(1.0)
```

```
2959         >>> pha.get_backscal()
Expected:
    2.5264364698914e-06
Got:
    np.float64(2.5264364698914e-06)
```

```
061 The `val` attribute is used to retrieve or change the parameter value:
062 
063     >>> p.val
Expected:
    2.0
Got:
    np.float64(2.0)
```

```
2229         >>> d = Data1DInt('example', xlo, xhi, y)
2230         >>> d.xlo[0], d.xhi[-1]
Expected:
    (0.4, 2.400000000000001)
Got:
    (np.float64(0.4), np.float64(2.400000000000001))
```

```
537     >>> m1 = Gauss1D()
538     >>> m2 = NormGauss1D()
539     >>> m1.pos, m2.pos = 10, 10
540     >>> m1.ampl, m2.ampl = 10, 10
541     >>> m1.fwhm, m2.fwhm = 5, 5
542     >>> m1(10)
Expected:
    10.0
Got:
    np.float64(10.0)
```