### PR TITLE
Migrate to cxc xspec conda test channel

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  xspec_channel: "xspec/label/test"
+  xspec_channel: "https://cxc.cfa.harvard.edu/conda/xspec"
   CONDA_BUILD_SYSROOT: ${{ github.workspace }}/11.0SDK/MacOSX11.0.sdk
 
 jobs:


### PR DESCRIPTION
Summary
=======
Use the cxc xspec test channel for Sherpa test workflows.

Details
=====
Instead of using xspec packages from Anaconda Cloud for testing (not used in delivery of Sherpa releases), we are now pulling xspec from a test channel.
This channel may be periodically purged so as to only support testing the current release. Though, we can always re-upload them if we need to test an older workflow (as they are copies from CIAO).