### PR TITLE
Use the correct case for the symbol name in the parameter warning message

### DIFF
--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1055,7 +1055,7 @@ def test_ismabs_parameter_name_clashes():
 
         assert alias != name  # safety check
 
-        emsg = f"^Parameter name {alias.lower()} is deprecated for " + \
+        emsg = f"^Parameter name {alias} is deprecated for " + \
             f"model XSismabs, use {name} instead$"
         with pytest.warns(DeprecationWarning, match=emsg):
             par = getattr(mdl, alias)

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -660,7 +660,7 @@ class Model(NoNewAttributesAfterInit):
                 tp = 'thawed'
 
             s += f'\n   {p.fullname:<12s} {tp:<6s} {p.val:12g} '
-            if tp == 'linked':
+            if p.link is not None:
                 linkstr = f'expr: {p.link.fullname}'
                 s += f'{linkstr:>24s}'
             else:

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1118,10 +1118,14 @@ class CompositeModel(Model):
 
         Model.__init__(self, name, allpars)
 
+        # This check should probably be removed since it refers to
+        # loading a very-old session, and that is unlikely to work due
+        # to other changes in the code base.
+        #
         for part in self.parts:
             try:
                 self.is_discrete = self.is_discrete or part.is_discrete
-            except:
+            except AttributeError:
                 warning("Could not determine whether the model is discrete.\n" +
                         "This probably means that you have restored a session saved with a previous version of Sherpa.\n" +
                         "Falling back to assuming that the model is continuous.\n")

--- a/sherpa/models/regrid.py
+++ b/sherpa/models/regrid.py
@@ -308,7 +308,7 @@ class EvaluationSpace1D():
     @property
     def is_ascending(self):
         """Is the space ascending?"""
-        return self.x_axis.is_empty
+        return self.x_axis.is_ascending
 
     @property
     def grid(self):

--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -1542,7 +1542,7 @@ def test_evaluationspace_empty_is_integrated(cls):
     assert espace.is_integrated is False
 
 
-@pytest.mark.parametrize("cls", [pytest.param(EvaluationSpace1D, marks=pytest.mark.xfail), EvaluationSpace2D])
+@pytest.mark.parametrize("cls", [EvaluationSpace1D, EvaluationSpace2D])
 def test_evaluationspace_empty_is_ascending(cls):
     """Simple check"""
     espace = cls()

--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2017 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -37,6 +37,7 @@ from sherpa.astro import ui
 
 from sherpa.utils import linear_interp
 from sherpa.utils.err import DataErr, ModelErr
+from sherpa.utils.numeric_types import SherpaFloat
 
 from sherpa.models.regrid import ModelDomainRegridder1D, EvaluationSpace1D, \
     EvaluationSpace2D, PointAxis, IntegratedAxis
@@ -1525,3 +1526,78 @@ def test_non_integrated_model_on_integrated_axis_1d_true():
     #
     expected = [0.6, 0.6, 1, 4, 3.6, 2.2]
     assert got == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("cls", [EvaluationSpace1D, EvaluationSpace2D])
+def test_evaluationspace_empty_is_empty(cls):
+    """Simple check"""
+    espace = cls()
+    assert espace.is_empty is True
+
+
+@pytest.mark.parametrize("cls", [EvaluationSpace1D, EvaluationSpace2D])
+def test_evaluationspace_empty_is_integrated(cls):
+    """Simple check"""
+    espace = cls()
+    assert espace.is_integrated is False
+
+
+@pytest.mark.parametrize("cls", [pytest.param(EvaluationSpace1D, marks=pytest.mark.xfail), EvaluationSpace2D])
+def test_evaluationspace_empty_is_ascending(cls):
+    """Simple check"""
+    espace = cls()
+    with pytest.raises(DataErr, match="^Axis is empty or has a size of 0$"):
+        # This is a property
+        _ = espace.is_ascending
+
+
+@pytest.mark.parametrize("cls", [EvaluationSpace1D, EvaluationSpace2D])
+@pytest.mark.parametrize("meth", ["start", "end"])
+def test_evaluationspace_empty_range(cls, meth):
+    """Simple check"""
+    espace = cls()
+    with pytest.raises(DataErr, match="^Axis is empty or has a size of 0$"):
+        # These are properties, so accessing the field causes the error
+        _ = getattr(espace, meth)
+
+
+@pytest.mark.parametrize("cls,expected",
+                         [(EvaluationSpace1D, (None, )),
+                          (EvaluationSpace2D, ([None], [None]))
+                          ])
+def test_evaluationspace_empty_grid(cls, expected):
+    """Simple check.
+
+    EvaluationSpace1D has midpoint_grid but the 2D version does
+    not.
+    """
+    espace = cls()
+    assert espace.grid == expected
+
+
+@pytest.mark.parametrize("cls", [EvaluationSpace1D, EvaluationSpace2D])
+def test_evaluationspace_empty_zeroes(cls):
+    """Simple check"""
+    espace = cls()
+    assert espace.zeros_like().shape == (0, )
+
+
+@pytest.mark.parametrize("cls", [EvaluationSpace1D, EvaluationSpace2D])
+def test_evaluationspace_empty_overlaps(cls):
+    """Simple check"""
+    espace1 = cls()
+    espace2 = cls()
+    with pytest.raises(DataErr, match="^Axis is empty or has a size of 0$"):
+        espace1.overlaps(espace2)
+
+
+@pytest.mark.parametrize("cls", [EvaluationSpace1D])
+def test_evaluationspace_empty_contains(cls):
+    """This is a regression test.
+
+    EvaluationSpace2D does not have a __contains__ method.
+    """
+    espace1 = cls()
+    espace2 = cls()
+    with pytest.raises(DataErr, match="^Axis is empty or has a size of 0$"):
+        _ = espace1 in espace2


### PR DESCRIPTION
# Summary

Change how the warning message for deprecated parameter names for models is displayed (only seen when warning messages are turned on).

# Details

This has come out of the "try to add typing to the various bits of Sherpa" work. We have

- an error in `EvaluationSpace1D` where a property was returning the wrong thing
  - as this is an "internal" class, **and** the property is not used much / ever, then it has little downstream consequences
- when catching an exception, name the exception type
- an internal change that just makes the code a bit more obvious what is going on (and provides better information to type checkers)
- change how the parameter name access works, so that we report the actual case used by the user rather than always use the lower-case version, as it is a bit confusing. This is **only** relevant for those parameters that we have "alternative" names - we currently only have these for XSPEC models, but (as shown below) we can show this behavior without needing to have XSPEC installed. Most users will not see this message anyway as the warnings are hidden by default in interactive and script use.

None of these are earth shattering...

# Example

We use the `-Wa` option to always show the warnings. The setup is

```
% python -Wa
Python 3.11.9 (main, Apr 19 2024, 16:48:06) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from sherpa.models.model import Model
>>> from sherpa.models.parameter import Parameter
>>> class MyModel(Model):
...     ndim = 1
...     def __init__(self, name='mymodel'):
...         self.foo = Parameter(name, 'foo', 0, aliases=['bar'])
...         super().__init__(name, (self.foo, ))
... 
>>> m = MyModel()
>>> print(m)
mymodel
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   mymodel.foo  thawed            0 -3.40282e+38  3.40282e+38   
```

We expect to be aboe to use both `m.foo` and `m.bar` to access the value, in a case-insensitive manner, but that using `bar` will report a warning. The difference is in the case used when reporting the parameter name - previously we always use the lower-case version whereas we now report the case that the user entered.

## CIAO 4.16

```
>>> m.foo.val
0.0
>>> m.bar.val
/soft/ciao-4.16/lib/python3.11/site-packages/sherpa/models/model.py:583: DeprecationWarning: Parameter name bar is deprecated for model MyModel, use foo instead
  warnings.warn(wmsg, DeprecationWarning)
0.0
>>> m.BaR.val
/soft/ciao-4.16/lib/python3.11/site-packages/sherpa/models/model.py:583: DeprecationWarning: Parameter name bar is deprecated for model MyModel, use foo instead
  warnings.warn(wmsg, DeprecationWarning)
0.0
```

## this PR

``` 
>>> m.foo.val
0.0
>>> m.bar.val
/lagado.real/sherpa/sherpa-xspec/sherpa/models/model.py:707: DeprecationWarning: Parameter name bar is deprecated for model MyModel, use foo instead
  warnings.warn(wmsg, DeprecationWarning)
0.0
>>> m.BaR.val
/lagado.real/sherpa/sherpa-xspec/sherpa/models/model.py:707: DeprecationWarning: Parameter name BaR is deprecated for model MyModel, use foo instead
  warnings.warn(wmsg, DeprecationWarning)
0.0
```