### PR TITLE
Rework plot classes

### DIFF
--- a/docs/plots/index.rst
+++ b/docs/plots/index.rst
@@ -106,11 +106,13 @@ to their ``prepare`` methods - normally data and model objects,
 but plot objects themselves can be passed around for "composite"
 plots - but there are several classes that accept the values to
 display directly:
-:py:class:`~sherpa.plot.Plot`,
-:py:class:`~sherpa.plot.Histogram`,
-:py:class:`~sherpa.plot.Point`,
+:py:class:`~sherpa.plot.PlotObject`,
+:py:class:`~sherpa.plot.HistogramOvject`,
+:py:class:`~sherpa.plot.PointObject`,
+:py:class:`~sherpa.plot.ContourObject`,
 and
-:py:class:`~sherpa.plot.Contour`. Here we use the Histogram
+:py:class:`~sherpa.plot.ImageObject`.
+Here we use the HistogramObject
 class directly to display the data directly, on top of the
 existing plot:
 
@@ -118,8 +120,8 @@ existing plot:
    :context: close-figs
    :include-source:
 
-   >>> from sherpa.plot import Histogram
-   >>> hplot = Histogram()
+   >>> from sherpa.plot import HistogramObject
+   >>> hplot = HistogramObject()
    >>> hplot.overplot(d.xlo, d.xhi, d.y)
 
 Creating a model
@@ -279,7 +281,7 @@ before we can replot the fit:
 .. plot::
    :context:
    :include-source:
-   
+
    >>> mplot.prepare(d, mdl)
    >>> fplot.plot()
 

--- a/docs/plots/plot.rst
+++ b/docs/plots/plot.rst
@@ -16,7 +16,9 @@ The sherpa.plot module
       Point
       Image
       Histogram
-      HistogramPlot
+      BasePlot
+      BaseHistogram
+      BaseContour
       DataHistogramPlot
       ModelHistogramPlot
       SourceHistogramPlot
@@ -77,5 +79,5 @@ The sherpa.plot module
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram::   Plot Contour Point Histogram HistogramPlot DataHistogramPlot ModelHistogramPlot SourceHistogramPlot PDFPlot CDFPlot LRHistogram SplitPlot JointPlot MultiPlot DataPlot TracePlot ScatterPlot PSFKernelPlot DataContour PSFKernelContour ModelPlot ComponentModelPlot ComponentModelHistogramPlot ComponentTemplateModelPlot SourcePlot ComponentSourcePlot ComponentSourceHistogramPlot ComponentTemplateSourcePlot PSFPlot ModelContour PSFContour SourceContour FitPlot FitContour BaseResidualPlot DelchiPlot ChisqrPlot RatioPlot ResidPlot BaseResidualHistogramPlot DelchiHistogramPlot ChisqrHistogramPlot RatioHistogramPlot ResidHistogramPlot BaseResidualContour ResidContour RatioContour Confidence1D Confidence2D IntervalProjectionWorker IntervalProjection IntervalUncertaintyWorker IntervalUncertainty RegionProjectionWorker RegionProjection RegionUncertaintyWorker RegionUncertainty
+.. inheritance-diagram::   Plot Contour Point Histogram BasePlot BaseHistogram BaseContour DataHistogramPlot ModelHistogramPlot SourceHistogramPlot PDFPlot CDFPlot LRHistogram SplitPlot JointPlot MultiPlot DataPlot TracePlot ScatterPlot PSFKernelPlot DataContour PSFKernelContour ModelPlot ComponentModelPlot ComponentModelHistogramPlot ComponentTemplateModelPlot SourcePlot ComponentSourcePlot ComponentSourceHistogramPlot ComponentTemplateSourcePlot PSFPlot ModelContour PSFContour SourceContour FitPlot FitContour BaseResidualPlot DelchiPlot ChisqrPlot RatioPlot ResidPlot BaseResidualHistogramPlot DelchiHistogramPlot ChisqrHistogramPlot RatioHistogramPlot ResidHistogramPlot BaseResidualContour ResidContour RatioContour Confidence1D Confidence2D IntervalProjectionWorker IntervalProjection IntervalUncertaintyWorker IntervalUncertainty RegionProjectionWorker RegionProjection RegionUncertaintyWorker RegionUncertainty
    :parts: 1

--- a/docs/plots/plot.rst
+++ b/docs/plots/plot.rst
@@ -11,11 +11,11 @@ The sherpa.plot module
    .. autosummary::
       :toctree: api
 
-      Plot
-      Contour
-      Point
-      Image
-      Histogram
+      PlotObject
+      HistogramObject
+      ContourObject
+      PointObject
+      ImageObject
       BasePlot
       BaseHistogram
       BaseContour
@@ -79,5 +79,5 @@ The sherpa.plot module
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram::   Plot Contour Point Histogram BasePlot BaseHistogram BaseContour DataHistogramPlot ModelHistogramPlot SourceHistogramPlot PDFPlot CDFPlot LRHistogram SplitPlot JointPlot MultiPlot DataPlot TracePlot ScatterPlot PSFKernelPlot DataContour PSFKernelContour ModelPlot ComponentModelPlot ComponentModelHistogramPlot ComponentTemplateModelPlot SourcePlot ComponentSourcePlot ComponentSourceHistogramPlot ComponentTemplateSourcePlot PSFPlot ModelContour PSFContour SourceContour FitPlot FitContour BaseResidualPlot DelchiPlot ChisqrPlot RatioPlot ResidPlot BaseResidualHistogramPlot DelchiHistogramPlot ChisqrHistogramPlot RatioHistogramPlot ResidHistogramPlot BaseResidualContour ResidContour RatioContour Confidence1D Confidence2D IntervalProjectionWorker IntervalProjection IntervalUncertaintyWorker IntervalUncertainty RegionProjectionWorker RegionProjection RegionUncertaintyWorker RegionUncertainty
+.. inheritance-diagram::   PlotObject HistogramObject ContourObject PointObject ImageObject BasePlot BaseHistogram BaseContour DataHistogramPlot ModelHistogramPlot SourceHistogramPlot PDFPlot CDFPlot LRHistogram SplitPlot JointPlot MultiPlot DataPlot TracePlot ScatterPlot PSFKernelPlot DataContour PSFKernelContour ModelPlot ComponentModelPlot ComponentModelHistogramPlot ComponentTemplateModelPlot SourcePlot ComponentSourcePlot ComponentSourceHistogramPlot ComponentTemplateSourcePlot PSFPlot ModelContour PSFContour SourceContour FitPlot FitContour BaseResidualPlot DelchiPlot ChisqrPlot RatioPlot ResidPlot BaseResidualHistogramPlot DelchiHistogramPlot ChisqrHistogramPlot RatioHistogramPlot ResidHistogramPlot BaseResidualContour ResidContour RatioContour Confidence1D Confidence2D IntervalProjectionWorker IntervalProjection IntervalUncertaintyWorker IntervalUncertainty RegionProjectionWorker RegionProjection RegionUncertaintyWorker RegionUncertainty
    :parts: 1

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -251,7 +251,7 @@ class ChisqrPHAPlot(shplot.ChisqrHistogramPlot):
         self.xlo, self.xhi = calc_x(data)
 
 
-class ModelPHAHistogram(shplot.HistogramPlot):
+class ModelPHAHistogram(shplot.BaseHistogram):
     """Plot a model for a PHA dataset.
 
     The filtering and grouping from the PHA dataset
@@ -504,7 +504,7 @@ class ComponentSourcePlot(SourcePlot):
         self.title = f'Source model component: {model.name}'
 
 
-class ARFPlot(shplot.HistogramPlot):
+class ARFPlot(shplot.BaseHistogram):
     """Create plots of the ancillary response file (ARF).
 
     Attributes
@@ -561,7 +561,7 @@ class ARFPlot(shplot.HistogramPlot):
             self.xhi = hc / arf.energ_lo
 
 
-class RMFPlot(shplot.HistogramPlot):
+class RMFPlot(shplot.BaseHistogram):
     """Create plots of the ancillary response file (RMF).
 
     A full RMF is a matrix that is hard to visualize.
@@ -728,7 +728,7 @@ class RMFPlot(shplot.HistogramPlot):
              **kwargs):
         """Plot the data.
 
-        This will plot the data sent to the prepare method.
+        This will plot the data created by the prepare method.
 
         Parameters
         ----------

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -1275,23 +1275,9 @@ def test_pha_model_checks_not_pha(cls):
         plotobj.prepare(d, m, stat=stats.LeastSq())
 
 
-@pytest.mark.parametrize("cls", [SourcePlot])
+
+@pytest.mark.parametrize("cls", [SourcePlot, OrderPlot])
 def test_pha_model_no_stat_checks_not_pha(cls):
-    """Check if error out with an invalid data message for Model classes
-
-    These classes do not take a stat argument for the prepare method.
-    """
-
-    d = Data1D("not-a-pha", [1, 2], [0, 2])
-    m = Const1D("mdl")
-    plotobj = cls()
-
-    with pytest.raises(IOErr, match="data set 'not-a-pha' does not contain a PHA spectrum"):
-        plotobj.prepare(d, m)
-
-
-@pytest.mark.parametrize("cls", [OrderPlot])
-def test_pha_model_no_stat_fails_not_pha(cls):
     """Check if error out with an invalid data message for Model classes
 
     These classes do not take a stat argument for the prepare method.
@@ -1326,7 +1312,7 @@ def test_arf_checks_data_is_pha():
         plotobj.prepare(arf=arf, data=d)
 
 
-def test_rmf_checks_arf():
+def test_rmf_checks_rmf():
     """Do we ensure it's an RMF?"""
 
     plotobj = RMFPlot()

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -1706,13 +1706,24 @@ class DataPlot(BasePlot):
              clearwindow=clearwindow, **opts)
 
 
-class TracePlot(DataPlot):
-    """Display a 1D array using an x axis starting at 1."""
+class TracePlot(BasePlot):
+    """Display a 1D array using an x axis starting at 1.
+
+    .. versionchanged:: 4.17.0
+       The base class has changed as part of the plot reorganization.
+
+    """
+
+    _fields: list[str] = ["x", "y", "yerr", "xlabel!", "ylabel!",
+                          "title!", "plot_prefs!"]
 
     def __init__(self):
+        self.yerr = None
         super().__init__()
         self.plot_prefs = basicbackend.get_model_plot_defaults()
+        del(self.plot_prefs["xerrorbars"])
 
+    # TODO: should we be able to send in yerr?
     def prepare(self, points, xlabel="x", name="x"):
         """The data to plot.
 
@@ -1736,11 +1747,52 @@ class TracePlot(DataPlot):
         self.ylabel = name
         self.title = f"Trace: {name}"
 
+    def plot(self, overplot=False, clearwindow=True, **kwargs):
+        """Plot the data.
 
-class ScatterPlot(DataPlot):
-    """Display x,y data as a scatter plot"""
+        This will plot the data sent to the prepare method.
+
+        Parameters
+        ----------
+        overplot : bool, optional
+           If `True` then add the data to an existing plot, otherwise
+           create a new plot.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
+        **kwargs
+           These values are passed on to the plot backend, and must
+           match the names of the keys of the object's
+           plot_prefs dictionary.
+
+        See Also
+        --------
+        prepare, overplot
+        """
+
+        x = check_not_none(self.x)
+        y = check_not_none(self.y)
+        opts = self._merge_settings(kwargs)
+        plot = self._object.plot
+        plot(x, y, yerr=self.yerr, title=self.title,
+             xlabel=self.xlabel, ylabel=self.ylabel,
+             overplot=overplot, clearwindow=clearwindow, **opts)
+
+
+class ScatterPlot(BasePlot):
+    """Display x,y data as a scatter plot
+
+    .. versionchanged:: 4.17.0
+       The base class has changed as part of the plot reorganization.
+
+    """
+
+    _fields: list[str] = ["x", "y", "yerr", "xerr", "xlabel!",
+                          "ylabel!", "title!", "plot_prefs!"]
 
     def __init__(self):
+        self.xerr = None
+        self.yerr = None
         super().__init__()
         self.plot_prefs = basicbackend.get_scatter_plot_defaults()
 
@@ -1764,6 +1816,37 @@ class ScatterPlot(DataPlot):
         self.xlabel = xlabel
         self.ylabel = ylabel
         self.title = f"Scatter: {name}"
+
+    def plot(self, overplot=False, clearwindow=True, **kwargs):
+        """Plot the data.
+
+        This will plot the data sent to the prepare method.
+
+        Parameters
+        ----------
+        overplot : bool, optional
+           If `True` then add the data to an existing plot, otherwise
+           create a new plot.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
+        **kwargs
+           These values are passed on to the plot backend, and must
+           match the names of the keys of the object's
+           plot_prefs dictionary.
+
+        See Also
+        --------
+        prepare, overplot
+        """
+
+        x = check_not_none(self.x)
+        y = check_not_none(self.y)
+        opts = self._merge_settings(kwargs)
+        plot = self._object.plot
+        plot(x, y, yerr=self.yerr, xerr=self.xerr, title=self.title,
+             xlabel=self.xlabel, ylabel=self.ylabel,
+             overplot=overplot, clearwindow=clearwindow, **opts)
 
 
 class PSFKernelPlot(DataPlot):

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -22,9 +22,30 @@
 
 Classes provide access to common plotting tasks, which is done by the
 plotting backend defined in the ``options.plot_pkg`` setting of the
-Sherpa configuration file. Note that plot objects can be created
-and used even when only the `sherpa.plot.backends.BasicBackend` is
-available.
+Sherpa configuration file.
+
+There are two types of classes here:
+
+- ones that accept the actual data to display in the `plot`, `contour`,
+  `overplot`, and `overcontour` methods;
+
+  - `Contour`, `Histogram`, `Image`, `Plot`, and `Point`
+
+- and the remaining classes, that are sent the data to plot in a
+  `prepare` method - often these take Sherpa objects, such as a
+  `sherpa.data.Data`, `sherpa.models.model.Model`, or
+  `sherpa.stats.Stat` instance, but some specialized types will be
+  sent the data as ndarray values.
+
+These objects can be created without a plotting backend, but they can
+not be displayed - e.g. call `plot` or `contour` on them - unless a
+working backend (that is, something other than
+`sherpa.plot.backends.BasicBackend`) is available.
+
+The plotting backend can be changed with the `set_backend` call, but
+this is only guaranteed to apply to classes created **after** the
+backend has been changed.
+
 """
 
 from __future__ import annotations
@@ -109,14 +130,14 @@ else:
             f"List of backends that have loaded and would be available: {[k for k in PLOT_BACKENDS]}")
 
 __all__ = ('Plot', 'Contour', 'Point', 'Histogram',
-           'MultiPlot',
+           'MultiPlot', 'BasePlot', 'BaseHistogram',
            'HistogramPlot', 'DataHistogramPlot',
            'ModelHistogramPlot', 'SourceHistogramPlot',
            'PDFPlot', 'CDFPlot', 'LRHistogram',
            'SplitPlot', 'JointPlot',
            'DataPlot', 'TracePlot', 'ScatterPlot',
            'PSFKernelPlot',
-           'DataContour', 'PSFKernelContour',
+           'BaseContour', 'DataContour', 'PSFKernelContour',
            'ModelPlot', 'ComponentModelPlot',
            'ComponentModelHistogramPlot', 'ComponentTemplateModelPlot',
            'SourcePlot', 'ComponentSourcePlot',
@@ -386,7 +407,7 @@ def arr2str(x: Optional[Sequence]) -> Optional[str]:
 # worth trying to share infrastructure between the plot classes and
 # the data classes to handle the similar __str__ handling.
 #
-def display_fields(obj,  # hard to provide an accurate type
+def display_fields(obj: Union[BasePlot, BaseHistogram, BaseContour],
                    fields: Sequence[str]) -> str:
     """Create the __str__ output for the object.
 
@@ -557,6 +578,31 @@ class Contour(NoNewAttributesAfterInit):
     def contour(self, x0, x1, y, title=None, xlabel=None,
                 ylabel=None, overcontour=False, clearwindow=True,
                 **kwargs):
+        """Display the contour data.
+
+        Parameters
+        ----------
+        x0, x1, y
+           The data values to plot. They should have the same length.
+        title, xlabel, ylabel : optional, string
+           The optional plot title and axis labels. These are ignored
+           if overplot is set to `True`.
+        overcontour : bool, optional
+           If `True` then add the data to an existing plot, otherwise
+           create a new plot.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
+        **kwargs
+           These values are passed on to the plot backend, and must
+           match the names of the keys of the object's
+           contour_prefs dictionary.
+
+        See Also
+        --------
+        overcontour
+
+        """
         opts = self._merge_settings(kwargs)
         backend.contour(x0, x1, y, title=title,
                         xlabel=xlabel, ylabel=ylabel,
@@ -734,8 +780,102 @@ class Histogram(NoNewAttributesAfterInit):
         self.plot(*args, **kwargs)
 
 
-class HistogramPlot(Histogram):
-    """Base class for histogram-style plots with a prepare method."""
+# The naming of this class is unfortunate, since for histograms we
+# have HistogramPlot for this case, but DataPlot has already been
+# used, hence the name BasePlot.
+#
+class BasePlot(Plot):
+    """Base class for data-style plots with a prepare method.
+
+    The data to plot is calculated by the prepare method, and stored
+    as fields in the object, so that the plot method can be called
+    with just plot options, not the actual data (unlike the Plot.plot
+    call).
+
+    .. versionadded:: 4.17.0
+
+    """
+
+    _fields: list[str] = ["x", "y", "xlabel!", "ylabel!", "title!",
+                          "plot_prefs!"]
+    """The fields to include in the string output.
+
+    Names that end in ! are treated as scalars, otherwise they are
+    passed through NumPy's array2string.
+
+    """
+
+    def __init__(self):
+        self.x = None
+        self.y = None
+        self.xlabel = None
+        self.ylabel = None
+        self.title = None
+        super().__init__()
+
+    def __str__(self) -> str:
+        return display_fields(self, self._fields)
+
+    def _repr_html_(self) -> str:
+        """Return a HTML (string) representation of the plot."""
+        return backend.as_html_plot(self)
+
+    def prepare(self, *args, **kwargs):
+        """Create the data to plot.
+
+        This sets the x, y and related fields so that plot will
+        display the data.
+
+        See Also
+        --------
+        plot
+
+        """
+        # would like to label this @abstractmethod but that would
+        # require significant changes to the class setup.
+        raise NotImplementedError()
+
+    def plot(self, overplot=False, clearwindow=True, **kwargs):
+        """Plot the data.
+
+        This will plot the data created by the prepare method.
+
+        Parameters
+        ----------
+        overplot : bool, optional
+           If `True` then add the data to an existing plot, otherwise
+           create a new plot.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
+        **kwargs
+           These values are passed on to the plot backend, and must
+           match the names of the keys of the object's
+           plot_prefs dictionary.
+
+        See Also
+        --------
+        prepare, overplot
+
+        """
+
+        super().plot(self.x, self.y, title=self.title,
+                     xlabel=self.xlabel, ylabel=self.ylabel,
+                     overplot=overplot, clearwindow=clearwindow,
+                     **kwargs)
+
+
+class BaseHistogram(Histogram):
+    """Base class for histogram-style plots with a prepare method.
+
+    The data to plot is calculated by the prepare method, and stored
+    as fields in the object, so that the plot method can be called
+    with just histogram options, not the actual data (unlike the
+    Histogram.plot call).
+
+    .. versionadded:: 4.17.0
+
+    """
 
     _fields: list[str] = ["xlo", "xhi", "y", "xlabel!", "ylabel!",
                           "title!", "histo_prefs!"]
@@ -743,6 +883,7 @@ class HistogramPlot(Histogram):
 
     Names that end in ! are treated as scalars, otherwise they are
     passed through NumPy's array2string.
+
     """
 
     def __init__(self):
@@ -778,10 +919,25 @@ class HistogramPlot(Histogram):
         xhi = np.asarray(self.xhi)
         return (xlo + xhi) / 2
 
+    def prepare(self, *args, **kwargs):
+        """Create the data to plot.
+
+        This sets the xlo, xhi, y and related fields so that plot will
+        display the data.
+
+        See Also
+        --------
+        plot
+
+        """
+        # would like to label this @abstractmethod but that would
+        # require significant changes to the class setup.
+        raise NotImplementedError()
+
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the data.
 
-        This will plot the data sent to the prepare method.
+        This will plot the data created by the prepare method.
 
         Parameters
         ----------
@@ -826,6 +982,12 @@ class HistogramPlot(Histogram):
                       overplot=overplot, clearwindow=clearwindow)
 
 
+# This class name was used well before BaseHistogram was created,
+# so keep it around as an alias.
+#
+HistogramPlot = BaseHistogram
+
+
 # I think we want slightly different histogram preferences
 # than most (mark by point rather than line).
 #
@@ -841,7 +1003,7 @@ def get_data_hist_prefs():
     return hprefs
 
 
-class DataHistogramPlot(HistogramPlot):
+class DataHistogramPlot(BaseHistogram):
     """Create 1D histogram plots of data values."""
 
     histo_prefs = get_data_hist_prefs()
@@ -907,7 +1069,7 @@ class DataHistogramPlot(HistogramPlot):
     # We have
     #
     # - the base class Histogram.plot can accept a yerr argument
-    # - the superclass (HistogramPlot.plot) does not know
+    # - the superclass (BaseHistogram.plot) does not know
     #   anything about yerr
     #
     # so the superclass is over-ridden here to basically call
@@ -916,7 +1078,7 @@ class DataHistogramPlot(HistogramPlot):
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the data.
 
-        This will plot the data sent to the prepare method.
+        This will plot the data created by the prepare method.
 
         Parameters
         ----------
@@ -943,7 +1105,7 @@ class DataHistogramPlot(HistogramPlot):
                        overplot=overplot, clearwindow=clearwindow, **kwargs)
 
 
-class ModelHistogramPlot(HistogramPlot):
+class ModelHistogramPlot(BaseHistogram):
     """Display a model as a histogram."""
 
     # TODO: should this include
@@ -957,7 +1119,7 @@ class ModelHistogramPlot(HistogramPlot):
                 data: Data1DInt,
                 model: Model,
                 stat: Optional[Stat] = None) -> None:
-        """Create the plot.
+        """Create the data to plot.
 
         The stat parameter is ignored.
         """
@@ -981,7 +1143,7 @@ class SourceHistogramPlot(ModelHistogramPlot):
         self.title = 'Source'
 
 
-class PDFPlot(HistogramPlot):
+class PDFPlot(BaseHistogram):
     """Display the probability density of an array.
 
     See Also
@@ -989,7 +1151,7 @@ class PDFPlot(HistogramPlot):
     CDFPlot
     """
 
-    _fields: list[str] = ["points"] + HistogramPlot._fields
+    _fields: list[str] = ["points"] + BaseHistogram._fields
     """The fields to include in the string output.
 
     Names that end in ! are treated as scalars, otherwise they are
@@ -1035,7 +1197,7 @@ class PDFPlot(HistogramPlot):
         self.title = f"PDF: {name}"
 
 
-class CDFPlot(Plot):
+class CDFPlot(BasePlot):
     """Display the cumulative distribution of an array.
 
     The cumulative distribution of the data is drawn along with
@@ -1086,19 +1248,11 @@ class CDFPlot(Plot):
     """The plot options (the CDF and axes)."""
 
     def __init__(self):
-        self.x = None
-        self.y = None
         self.points = None
         self.median = None
         self.lower = None
         self.upper = None
-        self.xlabel = None
-        self.ylabel = None
-        self.title = None
         super().__init__()
-
-    def __str__(self) -> str:
-        return display_fields(self, self._fields)
 
     def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the CDF plot."""
@@ -1134,7 +1288,7 @@ class CDFPlot(Plot):
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the data.
 
-        This will plot the data sent to the prepare method.
+        This will plot the data created by the prepare method.
 
         Parameters
         ----------
@@ -1155,9 +1309,7 @@ class CDFPlot(Plot):
 
         """
 
-        super().plot(self.x, self.y, title=self.title,
-                     xlabel=self.xlabel, ylabel=self.ylabel,
-                     overplot=overplot, clearwindow=clearwindow,
+        super().plot(overplot=overplot, clearwindow=clearwindow,
                      **kwargs)
 
         # Note: the user arguments are not applied to the vertical lines
@@ -1170,11 +1322,11 @@ class CDFPlot(Plot):
                       **self.upper_defaults)
 
 
-class LRHistogram(HistogramPlot):
+class LRHistogram(BaseHistogram):
     "Derived class for creating 1D likelihood ratio distribution plots"
 
 
-    _fields: list[str] = ["ratios", "lr!"] + HistogramPlot._fields
+    _fields: list[str] = ["ratios", "lr!"] + BaseHistogram._fields
     """The fields to include in the string output.
 
     Names that end in ! are treated as scalars, otherwise they are
@@ -1209,7 +1361,7 @@ class LRHistogram(HistogramPlot):
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the data.
 
-        This will plot the data sent to the prepare method.
+        This will plot the data created by the prepare method.
 
         Parameters
         ----------
@@ -1380,18 +1532,21 @@ class JointPlot(SplitPlot):
                               create=create)
 
         # The code used to check if the plot was an instance of
-        # FitPlot, which has been updated to check for the presence
-        # of attributes instead.
+        # FitPlot, which has been updated to check for the presence of
+        # attributes instead. The ordering is important, in case plot
+        # has both xlabel and data/modelplot attributes; in this case
+        # the assumption is that the data/modelplot attributes are the
+        # relevant ones to change.
         #
-        if hasattr(plot, 'xlabel'):
-            plot.xlabel = ''
-        elif hasattr(plot, 'dataplot') and hasattr(plot, 'modelplot'):
+        if hasattr(plot, 'dataplot') and hasattr(plot, 'modelplot'):
             dplot = plot.dataplot
             mplot = plot.modelplot
             if hasattr(dplot, 'xlabel'):
                 dplot.xlabel = ''
             if hasattr(mplot, 'xlabel'):
                 mplot.xlabel = ''
+        elif hasattr(plot, 'xlabel'):
+            plot.xlabel = ''
 
         kwargs['clearwindow'] = False
         plot.plot(*args, overplot=overplot, **kwargs)
@@ -1407,7 +1562,7 @@ class JointPlot(SplitPlot):
         plot.plot(*args, overplot=overplot, **kwargs)
 
 
-class DataPlot(Plot):
+class DataPlot(BasePlot):
     """Create 1D plots of data values.
 
     Attributes
@@ -1461,17 +1616,9 @@ class DataPlot(Plot):
     "The preferences for the plot."
 
     def __init__(self):
-        self.x = None
-        self.y = None
         self.yerr = None
         self.xerr = None
-        self.xlabel = None
-        self.ylabel = None
-        self.title = None
         super().__init__()
-
-    def __str__(self) -> str:
-        return display_fields(self, self._fields)
 
     def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the data plot."""
@@ -1506,7 +1653,7 @@ class DataPlot(Plot):
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the data.
 
-        This will plot the data sent to the prepare method.
+        This will plot the data created by the prepare method.
 
         Parameters
         ----------
@@ -1526,13 +1673,19 @@ class DataPlot(Plot):
         prepare, overplot
 
         """
-        super().plot(self.x, self.y, yerr=self.yerr, xerr=self.xerr,
-                     title=self.title, xlabel=self.xlabel,
-                     ylabel=self.ylabel, overplot=overplot,
-                     clearwindow=clearwindow, **kwargs)
+
+        # As we include the yerr and xerr fields we can not just call
+        # super().plot.
+        #
+        Plot.plot(self, self.x, self.y, yerr=self.yerr,
+                  xerr=self.xerr, title=self.title,
+                  xlabel=self.xlabel, ylabel=self.ylabel,
+                  overplot=overplot, clearwindow=clearwindow,
+                  **kwargs)
 
 
 class TracePlot(DataPlot):
+    """Display a 1D array using an x axis starting at 1."""
 
     plot_prefs = basicbackend.get_model_plot_defaults()
 
@@ -1561,6 +1714,7 @@ class TracePlot(DataPlot):
 
 
 class ScatterPlot(DataPlot):
+    """Display x,y data as a scatter plot"""
 
     plot_prefs = basicbackend.get_scatter_plot_defaults()
 
@@ -1613,7 +1767,94 @@ class PSFKernelPlot(DataPlot):
         self.title = 'PSF Kernel'
 
 
-class DataContour(Contour):
+class BaseContour(Contour):
+    """Base class for contour-style plots with a prepare method.
+
+    The data to plot is calculated by the prepare method, and stored
+    as fields in the object, so that the contour method can be called
+    with just contour options, not the actual data (unlike the
+    Contour.contour call).
+
+    .. versionadded:: 4.17.0
+
+    """
+
+    _fields: list[str] = ["x0", "x1", "y", "xlabel!", "ylabel!",
+                          "title!", "levels!", "contour_prefs!"]
+    """The fields to include in the string output.
+
+    Names that end in ! are treated as scalars, otherwise they are
+    passed through NumPy's array2string.
+
+    """
+
+    # To be over-ridden
+    contour_prefs = None
+
+    def __init__(self):
+        self.x0 = None
+        self.x1 = None
+        self.y = None
+        self.xlabel = None
+        self.ylabel = None
+        self.title = None
+        self.levels = None
+        super().__init__()
+
+    def __str__(self) -> str:
+        return display_fields(self, self._fields)
+
+    def _repr_html_(self) -> str:
+        """Return a HTML (string) representation of the model contour plot."""
+        raise NotImplementedError()
+
+    def prepare(self, *args, **kwargs):
+        """Create the data to plot.
+
+        This sets the x0, x1, y and related fields so that contour will
+        display the data.
+
+        See Also
+        --------
+        contour
+
+        """
+        # would like to label this @abstractmethod but that would
+        # require significant changes to the class setup.
+        raise NotImplementedError()
+
+    def contour(self, overcontour=False, clearwindow=True, **kwargs):
+        """Display the contour data.
+
+        This will display the data created by the prepare method.
+
+        Parameters
+        ----------
+        overcontour : bool, optional
+           If `True` then add the data to an existing plot, otherwise
+           create a new plot.
+        clearwindow : bool, optional
+           Should the existing plot area be cleared before creating this
+           new plot (e.g. for multi-panel plots)?
+        **kwargs
+           These values are passed on to the plot backend, and must
+           match the names of the keys of the object's
+           contour_prefs dictionary.
+
+        See Also
+        --------
+        overcontour
+
+        """
+
+        super().contour(self.x0, self.x1, self.y,
+                        levels=self.levels, title=self.title,
+                        xlabel=self.xlabel, ylabel=self.ylabel,
+                        overcontour=overcontour,
+                        clearwindow=clearwindow, **kwargs)
+
+
+class DataContour(BaseContour):
     """Create contours of 2D data.
 
     Attributes
@@ -1631,29 +1872,8 @@ class DataContour(Contour):
 
     """
 
-    _fields: list[str] = ["x0", "x1", "y", "xlabel!", "ylabel!",
-                          "title!", "levels!", "contour_prefs!"]
-    """The fields to include in the string output.
-
-    Names that end in ! are treated as scalars, otherwise they are
-    passed through NumPy's array2string.
-    """
-
     contour_prefs = basicbackend.get_data_contour_defaults()
     "The preferences for the plot."
-
-    def __init__(self):
-        self.x0 = None
-        self.x1 = None
-        self.y = None
-        self.xlabel = None
-        self.ylabel = None
-        self.title = None
-        self.levels = None
-        super().__init__()
-
-    def __str__(self) -> str:
-        return display_fields(self, self._fields)
 
     def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the contour plot."""
@@ -1663,12 +1883,6 @@ class DataContour(Contour):
         (self.x0, self.x1, self.y, self.xlabel,
          self.ylabel) = data.to_contour()
         self.title = data.name
-
-    def contour(self, overcontour=False, clearwindow=True, **kwargs):
-        super().contour(self.x0, self.x1, self.y, levels=self.levels,
-                        title=self.title, xlabel=self.xlabel,
-                        ylabel=self.ylabel, overcontour=overcontour,
-                        clearwindow=clearwindow, **kwargs)
 
 
 class PSFKernelContour(DataContour):
@@ -1682,7 +1896,7 @@ class PSFKernelContour(DataContour):
         self.title = 'PSF Kernel'
 
 
-class ModelPlot(Plot):
+class ModelPlot(BasePlot):
     """Create 1D plots of model values.
 
     Attributes
@@ -1738,17 +1952,10 @@ class ModelPlot(Plot):
     "The preferences for the plot."
 
     def __init__(self):
-        self.x = None
-        self.y = None
-        self.yerr = None
-        self.xerr = None
-        self.xlabel = None
-        self.ylabel = None
-        self.title = 'Model'
+        self.yerr = None  # may be used by subclasses
+        self.xerr = None  # may be used by subclasses
         super().__init__()
-
-    def __str__(self) -> str:
-        return display_fields(self, self._fields)
+        self.title = 'Model'
 
     def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the model plot."""
@@ -1778,35 +1985,6 @@ class ModelPlot(Plot):
         (self.x, self.y, self.yerr, self.xerr,
          self.xlabel, self.ylabel) = data.to_plot(yfunc=model)
         self.y = self.y[1]
-
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
-        """Plot the data.
-
-        This will plot the data sent to the prepare method.
-
-        Parameters
-        ----------
-        overplot : bool, optional
-           If `True` then add the data to an existing plot, otherwise
-           create a new plot.
-        clearwindow : bool, optional
-           Should the existing plot area be cleared before creating this
-           new plot (e.g. for multi-panel plots)?
-        **kwargs
-           These values are passed on to the plot backend, and must
-           match the names of the keys of the object's
-           plot_prefs dictionary.
-
-        See Also
-        --------
-        prepare, overplot
-
-        """
-        # This does not display yerr or xerr.
-        super().plot(self.x, self.y, title=self.title,
-                     xlabel=self.xlabel, ylabel=self.ylabel,
-                     overplot=overplot, clearwindow=clearwindow,
-                     **kwargs)
 
 
 class ComponentModelPlot(ModelPlot):
@@ -1956,32 +2134,15 @@ class PSFPlot(DataPlot):
         self.title = psf.kernel.name
 
 
-class ModelContour(Contour):
+class ModelContour(BaseContour):
     "Derived class for creating 2D model contours"
-
-    _fields: list[str] = ["x0", "x1", "y", "xlabel!", "ylabel!",
-                          "title!", "levels!", "contour_prefs!"]
-    """The fields to include in the string output.
-
-    Names that end in ! are treated as scalars, otherwise they are
-    passed through NumPy's array2string.
-    """
 
     contour_prefs = basicbackend.get_model_contour_defaults()
     "The preferences for the plot."
 
     def __init__(self):
-        self.x0 = None
-        self.x1 = None
-        self.y = None
-        self.xlabel = None
-        self.ylabel = None
-        self.title = 'Model'
-        self.levels = None
         super().__init__()
-
-    def __str__(self) -> str:
-        return display_fields(self, self._fields)
+        self.title = 'Model'
 
     def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the model contour plot."""
@@ -1999,12 +2160,6 @@ class ModelContour(Contour):
         (self.x0, self.x1, self.y, self.xlabel,
          self.ylabel) = data.to_contour(yfunc=model)
         self.y = self.y[1]
-
-    def contour(self, overcontour=False, clearwindow=True, **kwargs):
-        super().contour(self.x0, self.x1, self.y, levels=self.levels,
-                        title=self.title, xlabel=self.xlabel,
-                        ylabel=self.ylabel, overcontour=overcontour,
-                        clearwindow=clearwindow, **kwargs)
 
 
 class PSFContour(DataContour):
@@ -2024,7 +2179,7 @@ class SourceContour(ModelContour):
         self.title = 'Source'
 
 
-class FitPlot(Plot):
+class FitPlot(BasePlot):
     """Combine data and model plots for 1D data.
 
     Attributes
@@ -2117,7 +2272,7 @@ modelplot  = {model_title}
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the data.
 
-        This will plot the data sent to the prepare method.
+        This will plot the data created by the prepare method.
 
         Parameters
         ----------
@@ -2149,7 +2304,7 @@ modelplot  = {model_title}
         self.modelplot.overplot(**kwargs)
 
 
-class FitContour(Contour):
+class FitContour(BaseContour):
     "Derived class for creating 2D combination data and model contours"
 
     contour_prefs = basicbackend.get_fit_contour_defaults()
@@ -2879,6 +3034,15 @@ class Confidence1D(DataPlot):
     conf_type = "unknown"
     "The type of confidence analysis."
 
+    _fields = ["x", "y", "min!", "max!", "nloop!", "delv!",
+               "fac!", "log!", "parval!"]
+    """The fields to include in the string output.
+
+    Names that end in ! are treated as scalars, otherwise they are
+    passed through NumPy's array2string.
+
+    """
+
     def __init__(self):
         self.min = None
         self.max = None
@@ -2902,9 +3066,6 @@ class Confidence1D(DataPlot):
 
         if 'numcores' not in state:
             self.__dict__['numcores'] = None
-
-    def __str__(self) -> str:
-        return display_fields(self, self._fields)
 
     def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the confidence 1D plot."""
@@ -3123,6 +3284,16 @@ class Confidence2D(DataContour, Point):
     conf_type = "unknown"
     "The type of confidence analysis."
 
+    _fields = ["x0", "x1", "y", "min!", "max!", "nloop!", "fac!",
+               "delv!", "log!", "sigma!", "parval0!", "parval1!",
+               "levels!"]
+    """The fields to include in the string output.
+
+    Names that end in ! are treated as scalars, otherwise they are
+    passed through NumPy's array2string.
+
+    """
+
     def __init__(self):
         self.min = None
         self.max = None
@@ -3145,9 +3316,6 @@ class Confidence2D(DataContour, Point):
 
         if 'numcores' not in state:
             self.__dict__['numcores'] = None
-
-    def __str__(self) -> str:
-        return display_fields(self, self._fields)
 
     def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the confidence 2D plot."""
@@ -3850,15 +4018,10 @@ class MultiPlot:
     __slots__ = ("plots", "title")
 
     def __init__(self) -> None:
-        self.plots: list[Union[Plot, HistogramPlot]] = []
+        self.plots: list[Union[BasePlot, BaseHistogram]] = []
         self.title = ""
 
-    # The typing here says Plot but we actually want the sub-classes
-    # like DataPlot (i.e.  those that use the prepare method to set up
-    # the data to plot so that the plot method requires no data
-    # arguments) rather than the actual Plot class.
-    #
-    def add(self, plot: Union[Plot, HistogramPlot]) -> None:
+    def add(self, plot: Union[BasePlot, BaseHistogram]) -> None:
         """Add the plot to the list of data to plot.
 
         A copy of the plot object is stored, rather than the

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -414,8 +414,7 @@ def display_fields(obj: Union[BasePlot, BaseHistogram, BaseContour],
     Parameters
     ----------
     obj
-       The object to convert to a string. It is expected to be
-       derived from one of the plot classes.
+       The object to convert to a string.
     fields
        The fields to diplay. A field name ending in ! means display
        directly, otherwise the value is passed through arr2str.
@@ -3295,6 +3294,10 @@ class Confidence1D(DataPlot):
         if self.log:
             self.plot_prefs['xlog'] = True
 
+        # This repeats the check_not_none calls, but we know they
+        # will pass. It also will display xerr/yerr vlaues which is
+        # why they were cleared in the prepare call.
+        #
         super().plot(overplot=overplot, clearwindow=clearwindow,
                      **kwargs)
 

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -29,7 +29,8 @@ There are two types of classes here:
 - ones that accept the actual data to display in the `plot`, `contour`,
   `overplot`, and `overcontour` methods;
 
-  - `Contour`, `Histogram`, `Image`, `Plot`, and `Point`
+  - `ContourObject`, `HistogramObject`, `ImageObject`, `PlotObject`,
+    and `PointObject`
 
 - and the remaining classes, that are sent the data to plot in a
   `prepare` method - often these take Sherpa objects, such as a
@@ -129,8 +130,8 @@ else:
             "None of these imported correctly, so using the 'BasicBackend'.\n" +
             f"List of backends that have loaded and would be available: {[k for k in PLOT_BACKENDS]}")
 
-__all__ = ('Plot', 'Contour', 'Point', 'Histogram',
-           'MultiPlot', 'BasePlot', 'BaseHistogram',
+__all__ = ('PlotObject', 'ContourObject', 'PointObject', 'HistogramObject',
+           'ImageObject', 'MultiPlot', 'BasePlot', 'BaseHistogram',
            'HistogramPlot', 'DataHistogramPlot',
            'ModelHistogramPlot', 'SourceHistogramPlot',
            'PDFPlot', 'CDFPlot', 'LRHistogram',
@@ -490,24 +491,14 @@ def check_not_none(arg: Optional[T], method: str = "prepare") -> T:
     raise PlotErr(f"{method} has not been called")
 
 
-class Plot(NoNewAttributesAfterInit):
-    "Base class for line plots"
+class PlotObject:
+    """Draw a set of point (x, y) data
 
-    plot_prefs = basicbackend.get_plot_defaults()
-    "The preferences for the plot."
+    The preferences are set in the plot_prefs dictionary.
+    """
 
     def __init__(self):
-        """
-        Initialize a Plot object.  All 1D line plot
-        instances utilize Plot, which provides a generic
-        interface to a backend.
-
-        Once an instance of Plot is initialized no new
-        attributes of the class can be made. (To eliminate
-        the accidental creation of erroneous attributes)
-        """
-        self.plot_prefs = self.plot_prefs.copy()
-        super().__init__()
+        self.plot_prefs = basicbackend.get_plot_defaults().copy()
 
     @staticmethod
     def vline(x, ymin=0, ymax=1,
@@ -585,29 +576,20 @@ class Plot(NoNewAttributesAfterInit):
         self.plot(*args, **kwargs)
 
 
-class Contour(NoNewAttributesAfterInit):
-    "Base class for contour plots"
+class ContourObject:
+    """Draw contours on a set of (x0, x1, y) data.
 
-    contour_prefs = basicbackend.get_contour_defaults()
-    "The preferences for the plot."
+    The preferences are set in the contour_prefs dictionary.
+    """
 
     def __init__(self):
-        """
-        Initialize a Contour object.  All 2D contour plot
-        instances utilize Contour, which provides a generic
-        interface to a backend.
-
-        Once an instance of Contour is initialized no new
-        attributes of the class can be made. (To eliminate
-        the accidental creation of erroneous attributes)
-        """
-        self.contour_prefs = self.contour_prefs.copy()
-        super().__init__()
+        self.contour_prefs = basicbackend.get_contour_defaults().copy()
 
     def _merge_settings(self, kwargs):
-        """Return the plot preferences merged with user settings."""
+        """Return the contour preferences merged with user settings."""
         return {**self.contour_prefs, **kwargs}
 
+    # The levels argument should really be included here
     def contour(self, x0, x1, y, title=None, xlabel=None,
                 ylabel=None, overcontour=False, clearwindow=True,
                 **kwargs):
@@ -648,27 +630,17 @@ class Contour(NoNewAttributesAfterInit):
         self.contour(*args, **kwargs)
 
 
-class Point(NoNewAttributesAfterInit):
-    "Base class for point plots"
+class PointObject:
+    """Draw a point (x, y).
 
-    point_prefs = basicbackend.get_point_defaults()
-    "The preferences for the plot."
+    The preferences are set in the point_prefs dictionary.
+    """
 
     def __init__(self):
-        """
-        Initialize a Point object.  All 1D point plot
-        instances utilize Point, which provides a generic
-        interface to a backend.
-
-        Once an instance of Point is initialized no new
-        attributes of the class can be made. (To eliminate
-        the accidental creation of erroneous attributes)
-        """
-        self.point_prefs = self.point_prefs.copy()
-        super().__init__()
+        self.point_prefs = basicbackend.get_point_defaults().copy()
 
     def _merge_settings(self, kwargs):
-        """Return the plot preferences merged with user settings."""
+        """Return the point preferences merged with user settings."""
         return {**self.point_prefs, **kwargs}
 
     def point(self, x, y, overplot=True, clearwindow=False, **kwargs):
@@ -696,30 +668,21 @@ class Point(NoNewAttributesAfterInit):
                      **opts)
 
 
-class Image(NoNewAttributesAfterInit):
-    """Base class for image plots
+class ImageObject:
+    """Draw an image from a set of (x0, x1, y) data.
+
+    The preferences are set in the image_prefs dictionary.
 
     .. warning::
         This class is experimental and subject to change in the future.
         Currently, is is only used within _repr_html_ methods.
     """
 
-    image_prefs = basicbackend.get_image_defaults()
-    "The preferences for the plot."
-
     def __init__(self):
-        """
-        Initialize a Image object.
-
-        Once an instance of Image is initialized no new
-        attributes of the class can be made. (To eliminate
-        the accidental creation of erroneous attributes.)
-        """
-        self.image_prefs = self.image_prefs.copy()
-        super().__init__()
+        self.image_prefs = basicbackend.get_image_defaults().copy()
 
     def _merge_settings(self, kwargs):
-        """Return the plot preferences merged with user settings."""
+        """Return the image preferences merged with user settings."""
         return {**self.image_prefs, **kwargs}
 
     def plot(self, x0, x1, y, overplot=True, clearwindow=False, **kwargs):
@@ -749,27 +712,17 @@ class Image(NoNewAttributesAfterInit):
                      **opts)
 
 
-class Histogram(NoNewAttributesAfterInit):
-    "Base class for histogram plots"
+class HistogramObject:
+    """Draw a set of binned (xlo, xhi, y) data
 
-    histo_prefs = basicbackend.get_histo_defaults()
-    "The preferences for the plot."
+    The preferences are set in the histo_prefs dictionary.
+    """
 
     def __init__(self):
-        """
-        Initialize a Histogram object.  All 1D histogram plot
-        instances utilize Histogram, which provides a generic
-        interface to a backend.
-
-        Once an instance of Histogram is initialized no new
-        attributes of the class can be made. (To eliminate
-        the accidental creation of erroneous attributes)
-        """
-        self.histo_prefs = self.histo_prefs.copy()
-        super().__init__()
+        self.histo_prefs = basicbackend.get_histo_defaults().copy()
 
     def _merge_settings(self, kwargs):
-        """Return the plot preferences merged with user settings."""
+        """Return the histogram preferences merged with user settings."""
         return {**self.histo_prefs, **kwargs}
 
     def plot(self, xlo, xhi, y, yerr=None, title=None, xlabel=None,
@@ -811,6 +764,16 @@ class Histogram(NoNewAttributesAfterInit):
                       clearwindow=clearwindow, **opts)
 
     def overplot(self, *args, **kwargs):
+        """Add the data to an existing plot.
+
+        This is the same as calling the plot method with
+        overplot set to True.
+
+        See Also
+        --------
+        plot
+
+        """
         kwargs['overplot'] = True
         self.plot(*args, **kwargs)
 
@@ -819,7 +782,7 @@ class Histogram(NoNewAttributesAfterInit):
 # have HistogramPlot for this case, but DataPlot has already been
 # used, hence the name BasePlot.
 #
-class BasePlot(Plot):
+class BasePlot(NoNewAttributesAfterInit):
     """Base class for data-style plots with a prepare method.
 
     The data to plot is calculated by the prepare method, and stored
@@ -846,6 +809,8 @@ class BasePlot(Plot):
         self.xlabel = None
         self.ylabel = None
         self.title = None
+        self._object = PlotObject()
+        self.plot_prefs = self._object.plot_prefs.copy()
         super().__init__()
 
     def __str__(self) -> str:
@@ -869,6 +834,10 @@ class BasePlot(Plot):
         # would like to label this @abstractmethod but that would
         # require significant changes to the class setup.
         raise NotImplementedError()
+
+    def _merge_settings(self, kwargs):
+        """Return the plot preferences merged with user settings."""
+        return {**self.plot_prefs, **kwargs}
 
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the data.
@@ -896,12 +865,27 @@ class BasePlot(Plot):
 
         x = check_not_none(self.x)
         y = check_not_none(self.y)
-        super().plot(x, y, title=self.title, xlabel=self.xlabel,
-                     ylabel=self.ylabel, overplot=overplot,
-                     clearwindow=clearwindow, **kwargs)
+        opts = self._merge_settings(kwargs)
+        plot = self._object.plot
+        plot(x, y, title=self.title, xlabel=self.xlabel,
+             ylabel=self.ylabel, overplot=overplot,
+             clearwindow=clearwindow, **opts)
+
+    def overplot(self, **kwargs):
+        """Add the data to an existing plot.
+
+        This is the same as calling the plot method with
+        overplot set to True.
+
+        See Also
+        --------
+        plot
+        """
+        kwargs['overplot'] = True
+        self.plot(**kwargs)
 
 
-class BaseHistogram(Histogram):
+class BaseHistogram(NoNewAttributesAfterInit):
     """Base class for histogram-style plots with a prepare method.
 
     The data to plot is calculated by the prepare method, and stored
@@ -929,6 +913,8 @@ class BaseHistogram(Histogram):
         self.xlabel = None
         self.ylabel = None
         self.title = None
+        self._object = HistogramObject()
+        self.histo_prefs = self._object.histo_prefs.copy()
         super().__init__()
 
     def __str__(self) -> str:
@@ -970,6 +956,10 @@ class BaseHistogram(Histogram):
         # require significant changes to the class setup.
         raise NotImplementedError()
 
+    def _merge_settings(self, kwargs):
+        """Return the histogram preferences merged with user settings."""
+        return {**self.histo_prefs, **kwargs}
+
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the data.
 
@@ -997,28 +987,24 @@ class BaseHistogram(Histogram):
         xlo = check_not_none(self.xlo)
         xhi = check_not_none(self.xhi)
         y = check_not_none(self.y)
-        super().plot(xlo, xhi, y, title=self.title,
-                     xlabel=self.xlabel, ylabel=self.ylabel,
-                     overplot=overplot, clearwindow=clearwindow,
-                     **kwargs)
+        opts = self._merge_settings(kwargs)
+        plot = self._object.plot
+        plot(xlo, xhi, y, title=self.title, xlabel=self.xlabel,
+             ylabel=self.ylabel, overplot=overplot,
+             clearwindow=clearwindow, **opts)
 
-    @staticmethod
-    def vline(x, ymin=0, ymax=1,
-              linecolor=None, linestyle=None, linewidth=None,
-              overplot=False, clearwindow=True):
-        "Draw a line at constant x, extending over the plot."
-        backend.vline(x, ymin=ymin, ymax=ymax, linecolor=linecolor,
-                      linestyle=linestyle, linewidth=linewidth,
-                      overplot=overplot, clearwindow=clearwindow)
+    def overplot(self, **kwargs):
+        """Add the data to an existing plot.
 
-    @staticmethod
-    def hline(y, xmin=0, xmax=1,
-              linecolor=None, linestyle=None, linewidth=None,
-              overplot=False, clearwindow=True):
-        "Draw a line at constant y, extending over the plot."
-        backend.hline(y, xmin=xmin, xmax=xmax, linecolor=linecolor,
-                      linestyle=linestyle, linewidth=linewidth,
-                      overplot=overplot, clearwindow=clearwindow)
+        This is the same as calling the plot method with
+        overplot set to True.
+
+        See Also
+        --------
+        plot
+        """
+        kwargs['overplot'] = True
+        self.plot(**kwargs)
 
 
 # This class name was used well before BaseHistogram was created,
@@ -1045,12 +1031,10 @@ def get_data_hist_prefs():
 class DataHistogramPlot(BaseHistogram):
     """Create 1D histogram plots of data values."""
 
-    histo_prefs = get_data_hist_prefs()
-    "The preferences for the plot."
-
     def __init__(self):
         self.yerr = None
         super().__init__()
+        self.histo_prefs = get_data_hist_prefs()
 
     @property
     def xerr(self):
@@ -1105,15 +1089,6 @@ class DataHistogramPlot(BaseHistogram):
 
         self.title = data.name
 
-    # We have
-    #
-    # - the base class Histogram.plot can accept a yerr argument
-    # - the superclass (BaseHistogram.plot) does not know
-    #   anything about yerr
-    #
-    # so the superclass is over-ridden here to basically call
-    # the base class.
-    #
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the data.
 
@@ -1141,12 +1116,12 @@ class DataHistogramPlot(BaseHistogram):
         xlo = check_not_none(self.xlo)
         xhi = check_not_none(self.xhi)
         y = check_not_none(self.y)
-        Histogram.plot(self, xlo, xhi, y,
-                       # Note: the superclass does not recognize yerr
-                       yerr=self.yerr,
-                       title=self.title, xlabel=self.xlabel,
-                       ylabel=self.ylabel, overplot=overplot,
-                       clearwindow=clearwindow, **kwargs)
+        opts = self._merge_settings(kwargs)
+        plot = self._object.plot
+        # This adds in the yerr field
+        plot(xlo, xhi, y, yerr=self.yerr, title=self.title,
+             xlabel=self.xlabel, ylabel=self.ylabel,
+             overplot=overplot, clearwindow=clearwindow, **opts)
 
 
 class ModelHistogramPlot(BaseHistogram):
@@ -1288,15 +1263,13 @@ class CDFPlot(BasePlot):
                       "linewidth": 1.5}
     """The options used to draw the 84.13% line."""
 
-    plot_prefs = basicbackend.get_cdf_plot_defaults()
-    """The plot options (the CDF and axes)."""
-
     def __init__(self):
         self.points = None
         self.median = None
         self.lower = None
         self.upper = None
         super().__init__()
+        self.plot_prefs = basicbackend.get_cdf_plot_defaults()
 
     def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the CDF plot."""
@@ -1358,12 +1331,12 @@ class CDFPlot(BasePlot):
 
         # Note: the user arguments are not applied to the vertical lines
         #
-        super().vline(self.median, overplot=True, clearwindow=False,
-                      **self.median_defaults)
-        super().vline(self.lower, overplot=True, clearwindow=False,
-                      **self.lower_defaults)
-        super().vline(self.upper, overplot=True, clearwindow=False,
-                      **self.upper_defaults)
+        PlotObject.vline(self.median, overplot=True,
+                         clearwindow=False, **self.median_defaults)
+        PlotObject.vline(self.lower, overplot=True, clearwindow=False,
+                         **self.lower_defaults)
+        PlotObject.vline(self.upper, overplot=True, clearwindow=False,
+                         **self.upper_defaults)
 
 
 class LRHistogram(BaseHistogram):
@@ -1435,13 +1408,16 @@ class LRHistogram(BaseHistogram):
         # Note: the user arguments are not applied to the vertical line
         #
         if self.lr <= self.xhi.max() and self.lr >= self.xlo.min():
-            super().vline(self.lr, linecolor="orange",
-                          linestyle="solid", linewidth=1.5,
-                          overplot=True, clearwindow=False)
+            PlotObject.vline(self.lr, linecolor="orange",
+                             linestyle="solid", linewidth=1.5,
+                             overplot=True, clearwindow=False)
 
 
-class SplitPlot(Plot, Contour):
+class SplitPlot:
     """Create multiple plots.
+
+    .. versionchanged:: 4.17.1
+       The class no-longer derives from `Plot` or `Contour`.
 
     Attributes
     ----------
@@ -1464,6 +1440,7 @@ class SplitPlot(Plot, Contour):
     def __init__(self, rows=2, cols=1):
         self.reset(rows, cols)
         super().__init__()
+        self.plot_prefs = basicbackend.get_split_plot_defaults()
 
     def __str__(self) -> str:
         return display_fields(self, self._fields)
@@ -1656,13 +1633,11 @@ class DataPlot(BasePlot):
     passed through NumPy's array2string.
     """
 
-    plot_prefs = basicbackend.get_data_plot_defaults()
-    "The preferences for the plot."
-
     def __init__(self):
         self.yerr = None
         self.xerr = None
         super().__init__()
+        self.plot_prefs = basicbackend.get_data_plot_defaults().copy()
 
     def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the data plot."""
@@ -1723,16 +1698,20 @@ class DataPlot(BasePlot):
         #
         x = check_not_none(self.x)
         y = check_not_none(self.y)
-        Plot.plot(self, x, y, yerr=self.yerr, xerr=self.xerr,
-                  title=self.title, xlabel=self.xlabel,
-                  ylabel=self.ylabel, overplot=overplot,
-                  clearwindow=clearwindow, **kwargs)
+        opts = self._merge_settings(kwargs)
+        plot = self._object.plot
+        plot(x, y, yerr=self.yerr, xerr=self.xerr,
+             title=self.title, xlabel=self.xlabel,
+             ylabel=self.ylabel, overplot=overplot,
+             clearwindow=clearwindow, **opts)
 
 
 class TracePlot(DataPlot):
     """Display a 1D array using an x axis starting at 1."""
 
-    plot_prefs = basicbackend.get_model_plot_defaults()
+    def __init__(self):
+        super().__init__()
+        self.plot_prefs = basicbackend.get_model_plot_defaults()
 
     def prepare(self, points, xlabel="x", name="x"):
         """The data to plot.
@@ -1761,7 +1740,9 @@ class TracePlot(DataPlot):
 class ScatterPlot(DataPlot):
     """Display x,y data as a scatter plot"""
 
-    plot_prefs = basicbackend.get_scatter_plot_defaults()
+    def __init__(self):
+        super().__init__()
+        self.plot_prefs = basicbackend.get_scatter_plot_defaults()
 
     def prepare(self, x, y, xlabel="x", ylabel="y", name="(x,y)"):
         """The data to plot.
@@ -1812,7 +1793,7 @@ class PSFKernelPlot(DataPlot):
         self.title = 'PSF Kernel'
 
 
-class BaseContour(Contour):
+class BaseContour(NoNewAttributesAfterInit):
     """Base class for contour-style plots with a prepare method.
 
     The data to plot is calculated by the prepare method, and stored
@@ -1844,6 +1825,7 @@ class BaseContour(Contour):
         self.ylabel = None
         self.title = None
         self.levels = None
+        self._object = ContourObject()
         super().__init__()
 
     def __str__(self) -> str:
@@ -1867,6 +1849,10 @@ class BaseContour(Contour):
         # would like to label this @abstractmethod but that would
         # require significant changes to the class setup.
         raise NotImplementedError()
+
+    def _merge_settings(self, kwargs):
+        """Return the contour preferences merged with user settings."""
+        return {**self.contour_prefs, **kwargs}
 
     def contour(self, overcontour=False, clearwindow=True, **kwargs):
         """Display the contour data.
@@ -1895,10 +1881,28 @@ class BaseContour(Contour):
         x0 = check_not_none(self.x0)
         x1 = check_not_none(self.x1)
         y = check_not_none(self.y)
-        super().contour(x0, x1, y, levels=self.levels,
-                        title=self.title, xlabel=self.xlabel,
-                        ylabel=self.ylabel, overcontour=overcontour,
-                        clearwindow=clearwindow, **kwargs)
+        opts = self._merge_settings(kwargs)
+
+        # The levels are currently assumed to be a preference setting.
+        opts["levels"] = self.levels
+
+        contour = self._object.contour
+        contour(x0, x1, y, title=self.title, xlabel=self.xlabel,
+                ylabel=self.ylabel, overcontour=overcontour,
+                clearwindow=clearwindow, **opts)
+
+    def overcontour(self, **kwargs):
+        """Add the contour to an existing visualization.
+
+        This is the same as calling the contour method with
+        overcontour set to True.
+
+        See Also
+        --------
+        contour
+        """
+        kwargs['overcontour'] = True
+        self.contour(**kwargs)
 
 
 class DataContour(BaseContour):
@@ -1919,8 +1923,9 @@ class DataContour(BaseContour):
 
     """
 
-    contour_prefs = basicbackend.get_data_contour_defaults()
-    "The preferences for the plot."
+    def __init__(self):
+        super().__init__()
+        self.contour_prefs = basicbackend.get_data_contour_defaults()
 
     def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the contour plot."""
@@ -1995,14 +2000,13 @@ class ModelPlot(BasePlot):
     passed through NumPy's array2string.
     """
 
-    plot_prefs = basicbackend.get_model_plot_defaults()
-    "The preferences for the plot."
 
     def __init__(self):
         self.yerr = None  # may be used by subclasses
         self.xerr = None  # may be used by subclasses
         super().__init__()
         self.title = 'Model'
+        self.plot_prefs = basicbackend.get_model_plot_defaults()
 
     def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the model plot."""
@@ -2057,8 +2061,9 @@ class ComponentModelHistogramPlot(ModelHistogramPlot):
 
     """
 
-    histo_prefs = basicbackend.get_component_histo_defaults()
-    "The preferences for the plot."
+    def __init__(self):
+        super().__init__()
+        self.histo_prefs = basicbackend.get_component_histo_defaults()
 
     # TODO: ComponentSourceHistogramPlot calls data.to_component_plot
     # but this just uses data.to_plot. Does it matter?
@@ -2104,7 +2109,9 @@ class SourcePlot(ModelPlot):
 class ComponentSourcePlot(SourcePlot):
     """Component source plots."""
 
-    plot_prefs = basicbackend.get_component_plot_defaults()
+    def __init__(self):
+        super().__init__()
+        self.plot_prefs = basicbackend.get_component_plot_defaults()
 
     def prepare(self, data, model, stat=None):
         (self.x, self.y, self.yerr, self.xerr,
@@ -2122,7 +2129,9 @@ class ComponentSourceHistogramPlot(SourceHistogramPlot):
 
     """
 
-    histo_prefs = basicbackend.get_component_histo_defaults()
+    def __init__(self):
+        super().__init__()
+        self.histo_prefs = basicbackend.get_component_histo_defaults()
 
     def prepare(self, data, model, stat=None):
 
@@ -2184,12 +2193,10 @@ class PSFPlot(DataPlot):
 class ModelContour(BaseContour):
     "Derived class for creating 2D model contours"
 
-    contour_prefs = basicbackend.get_model_contour_defaults()
-    "The preferences for the plot."
-
     def __init__(self):
         super().__init__()
         self.title = 'Model'
+        self.contour_prefs = basicbackend.get_model_contour_defaults()
 
     def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the model contour plot."""
@@ -2266,17 +2273,12 @@ class FitPlot(BasePlot):
 
     """
 
-    plot_prefs = basicbackend.get_fit_plot_defaults()
-    """The preferences for the plot. Note that the display for the
-    data and model plots are controlled by the preferences for
-    the dataplot and modelplot objects, so this is currently
-    unused.
-    """
-
     def __init__(self):
         self.dataplot = None
         self.modelplot = None
         super().__init__()
+        # The plot_prefs field is currently ignored
+        self.plot_prefs = basicbackend.get_fit_plot_defaults()
 
     def __str__(self) -> str:
         data_title = None
@@ -2354,13 +2356,11 @@ modelplot  = {model_title}
 class FitContour(BaseContour):
     "Derived class for creating 2D combination data and model contours"
 
-    contour_prefs = basicbackend.get_fit_contour_defaults()
-    "The preferences for the plot."
-
     def __init__(self):
         self.datacontour = None
         self.modelcontour = None
         super().__init__()
+        self.contour_prefs = basicbackend.get_fit_contour_defaults()
 
     def __str__(self) -> str:
         data_title = None
@@ -2460,17 +2460,18 @@ class BaseResidualPlot(ModelPlot):
         self.plot_prefs['ylog'] = False
         kwargs.pop('ylog', True)
 
+        opts = self._merge_settings(kwargs)
+
         # The superclass is not called since the y errors are
         # potentially included in the plot.
         #
-        Plot.plot(self, x, y, yerr=self.yerr, xerr=self.xerr,
-                  title=self.title, xlabel=self.xlabel,
-                  ylabel=self.ylabel, overplot=overplot,
-                  clearwindow=clearwindow, **kwargs)
-        super().hline(y=self.residual_axis, xmin=0, xmax=1,
-                      linecolor=self.residual_color,
-                      linewidth=self.residual_lw,
-                      overplot=True)
+        plot = self._object.plot
+        plot(x, y, yerr=self.yerr, xerr=self.xerr,
+             title=self.title, xlabel=self.xlabel, ylabel=self.ylabel,
+             overplot=overplot, clearwindow=clearwindow, **opts)
+        PlotObject.hline(y=self.residual_axis, xmin=0, xmax=1,
+                         linecolor=self.residual_color,
+                         linewidth=self.residual_lw, overplot=True)
 
 
 class BaseResidualHistogramPlot(ModelHistogramPlot):
@@ -2555,17 +2556,20 @@ class BaseResidualHistogramPlot(ModelHistogramPlot):
         self.histo_prefs['ylog'] = False
         kwargs.pop('ylog', True)
 
+        opts = self._merge_settings(kwargs)
+
         # The superclass is not called since the y errors are
         # potentially included in the plot.
         #
-        Histogram.plot(self, xlo, xhi, y, yerr=self.yerr,
-                       title=self.title, xlabel=self.xlabel,
-                       ylabel=self.ylabel, overplot=overplot,
-                       clearwindow=clearwindow, **kwargs)
-        super().hline(y=self.residual_axis, xmin=0, xmax=1,
-                      linecolor=self.residual_color,
-                      linewidth=self.residual_lw,
-                      overplot=True)
+        plot = self._object.plot
+        plot(xlo, xhi, y, yerr=self.yerr, title=self.title,
+             xlabel=self.xlabel, ylabel=self.ylabel,
+             overplot=overplot, clearwindow=clearwindow,
+             **opts)
+        PlotObject.hline(y=self.residual_axis, xmin=0, xmax=1,
+                         linecolor=self.residual_color,
+                         linewidth=self.residual_lw,
+                         overplot=True)
 
 
 class BaseResidualContour(ModelContour):
@@ -2623,8 +2627,9 @@ class DelchiPlot(BaseResidualPlot):
     linear scale.
     """
 
-    plot_prefs = basicbackend.get_resid_plot_defaults()
-    "The preferences for the plot."
+    def __init__(self):
+        super().__init__()
+        self.plot_prefs = basicbackend.get_resid_plot_defaults()
 
     def _calc_y(self,
                 data: Data1D,
@@ -2651,8 +2656,9 @@ class DelchiPlot(BaseResidualPlot):
 class DelchiHistogramPlot(BaseResidualHistogramPlot):
     """Create plots of the delta-chi value per point."""
 
-    histo_prefs = basicbackend.get_resid_histo_defaults()
-    "The preferences for the delchi plot."
+    def __init__(self):
+        super().__init__()
+        self.histo_prefs = basicbackend.get_resid_histo_defaults()
 
     def _calc_y(self,
                 data: Data1DInt,
@@ -2695,8 +2701,9 @@ class ChisqrPlot(ModelPlot):
        Plot labels.
     """
 
-    plot_prefs = basicbackend.get_model_plot_defaults()
-    "The preferences for the plot."
+    def __init__(self):
+        super().__init__()
+        self.plot_prefs = basicbackend.get_model_plot_defaults()
 
     def _calc_chisqr(self, ylist, staterr):
         dy = ylist[0] - ylist[1]
@@ -2722,8 +2729,9 @@ class ChisqrPlot(ModelPlot):
 class ChisqrHistogramPlot(ModelHistogramPlot):
     """Create plot of the ChiSq residuals per point."""
 
-    histo_prefs = basicbackend.get_resid_histo_defaults()
-    "The preferences for the residual plot."
+    def __init__(self):
+        super().__init__()
+        self.histo_prefs = basicbackend.get_resid_histo_defaults()
 
     def _calc_x(self, data: Data1DInt, model: Model) -> None:
         """Define the xlo and xhi fields"""
@@ -2785,8 +2793,9 @@ class ResidPlot(BaseResidualPlot):
     linear scale.
     """
 
-    plot_prefs = basicbackend.get_resid_plot_defaults()
-    "The preferences for the plot."
+    def __init__(self):
+        super().__init__()
+        self.plot_prefs = basicbackend.get_resid_plot_defaults()
 
     def _calc_y(self,
                 data: Data1D,
@@ -2816,8 +2825,9 @@ class ResidPlot(BaseResidualPlot):
 class ResidHistogramPlot(BaseResidualHistogramPlot):
     """Create plots of the residual value per point."""
 
-    histo_prefs = basicbackend.get_resid_histo_defaults()
-    "The preferences for the residual plot."
+    def __init__(self):
+        super().__init__()
+        self.histo_prefs = basicbackend.get_resid_histo_defaults()
 
     def _calc_y(self,
                 data: Data1DInt,
@@ -2852,8 +2862,9 @@ class ResidHistogramPlot(BaseResidualHistogramPlot):
 class ResidContour(BaseResidualContour):
     "Derived class for creating 2D residual contours (data-model)"
 
-    contour_prefs = basicbackend.get_resid_contour_defaults()
-    "The preferences for the plot."
+    def __init__(self):
+        super().__init__()
+        self.contour_prefs = basicbackend.get_resid_contour_defaults()
 
     def _calc_y(self,
                 ylist: tuple[np.ndarray, np.ndarray]) -> None:
@@ -2888,8 +2899,9 @@ class RatioPlot(BaseResidualPlot):
     linear scale.
     """
 
-    plot_prefs = basicbackend.get_ratio_plot_defaults()
-    "The preferences for the plot."
+    def __init__(self):
+        super().__init__()
+        self.plot_prefs = basicbackend.get_ratio_plot_defaults()
 
     residual_axis = 1
     """At what point on the y axis is the residual line drawn."""
@@ -2930,8 +2942,9 @@ class RatioHistogramPlot(BaseResidualHistogramPlot):
 
     # Turn on yerrorbars by default. What is the best way to do this?
     #
-    histo_prefs = basicbackend.get_resid_histo_defaults() | {"yerrorbars": True}
-    "The preferences for the ratio plot."
+    def __init__(self):
+        super().__init__()
+        self.histo_prefs = basicbackend.get_resid_histo_defaults() | {"yerrorbars": True}
 
     residual_axis = 1
 
@@ -2974,8 +2987,9 @@ class RatioHistogramPlot(BaseResidualHistogramPlot):
 class RatioContour(BaseResidualContour):
     "Derived class for creating 2D ratio contours (data divided by model)"
 
-    contour_prefs = basicbackend.get_ratio_contour_defaults()
-    "The preferences for the plot."
+    def __init__(self):
+        super().__init__()
+        self.contour_prefs = basicbackend.get_ratio_contour_defaults()
 
     def _calc_y(self,
                 ylist: tuple[np.ndarray, np.ndarray]) -> None:
@@ -3054,8 +3068,11 @@ def calc_par_range(minval: float,
     return x
 
 
-class Confidence1D(DataPlot):
+class Confidence1D(BasePlot):
     """The base class for 1D confidence plots.
+
+    .. versionchanged:: 4.17.0
+       The class now derives from `BasePlot` rather than `DataPlot`.
 
     .. versionchanged:: 4.16.1
        Handling of log-scaled axes and use of the delv argument has
@@ -3063,8 +3080,6 @@ class Confidence1D(DataPlot):
        value (if available).
 
     """
-
-
 
     _fields: list[str] = ["x", "y", "min!", "max!", "nloop!", "delv!",
                           "fac!", "log!", "parval!"]
@@ -3074,21 +3089,9 @@ class Confidence1D(DataPlot):
     passed through NumPy's array2string.
     """
 
-    plot_prefs = basicbackend.get_confid_plot_defaults()
-    "The preferences for the plot."
-
     # This is only used for an error message
     conf_type = "unknown"
     "The type of confidence analysis."
-
-    _fields = ["x", "y", "min!", "max!", "nloop!", "delv!",
-               "fac!", "log!", "parval!"]
-    """The fields to include in the string output.
-
-    Names that end in ! are treated as scalars, otherwise they are
-    passed through NumPy's array2string.
-
-    """
 
     def __init__(self):
         self.min = None
@@ -3101,6 +3104,7 @@ class Confidence1D(DataPlot):
         self.stat = None
         self.numcores = None
         super().__init__()
+        self.plot_prefs = basicbackend.get_confid_plot_defaults()
 
     def __setstate__(self, state):
         self.__dict__.update(state)
@@ -3279,10 +3283,6 @@ class Confidence1D(DataPlot):
         if par not in fit.model.pars:
             raise ConfidenceErr('thawed', par.fullname, fit.model.name)
 
-        # Make sure xerr and yerr are cleared
-        self.xerr = None
-        self.yerr = None
-
     def plot(self, overplot=False, clearwindow=True, **kwargs):
 
         # This is to be done before the same checks are made in
@@ -3294,31 +3294,31 @@ class Confidence1D(DataPlot):
         if self.log:
             self.plot_prefs['xlog'] = True
 
-        # This repeats the check_not_none calls, but we know they
-        # will pass. It also will display xerr/yerr vlaues which is
-        # why they were cleared in the prepare call.
-        #
         super().plot(overplot=overplot, clearwindow=clearwindow,
                      **kwargs)
 
         # Note: the user arguments are not applied to the lines
         #
         if self.stat is not None:
-            super().hline(self.stat, linecolor="green",
-                          linestyle="dash", linewidth=1.5,
-                          overplot=True, clearwindow=False)
+            PlotObject.hline(self.stat, linecolor="green",
+                             linestyle="dash", linewidth=1.5,
+                             overplot=True, clearwindow=False)
 
         if self.parval is not None:
-            super().vline(self.parval, linecolor="orange",
-                          linestyle="dash", linewidth=1.5,
-                          overplot=True, clearwindow=False)
+            PlotObject.vline(self.parval, linecolor="orange",
+                             linestyle="dash", linewidth=1.5,
+                             overplot=True, clearwindow=False)
 
         if self.log:
             self.plot_prefs['xlog'] = False
 
 
-class Confidence2D(DataContour, Point):
+class Confidence2D(BaseContour):
     """The base class for 2D confidence contours.
+
+    .. versionchanged:: 4.17.0
+       The class now derives from `BaseContour` rather than
+       `DataContour` and `Point`.
 
     .. versionchanged:: 4.16.1
        Handling of log-scaled axes and use of the delv argument has
@@ -3326,25 +3326,13 @@ class Confidence2D(DataContour, Point):
 
     """
 
-    _fields: list[str] = ["x0", "x1", "y", "min!", "max!", "nloop!",
-                          "fac!", "delv!", "log!", "sigma!", "parval0!",
-                          "parval1!", "levels!"]
-    """The fields to include in the string output.
-
-    Names that end in ! are treated as scalars, otherwise they are
-    passed through NumPy's array2string.
-    """
-
-    contour_prefs = basicbackend.get_confid_contour_defaults()
-    point_prefs = basicbackend.get_confid_point_defaults()
-
     # This is only used for an error message
     conf_type = "unknown"
     "The type of confidence analysis."
 
-    _fields = ["x0", "x1", "y", "min!", "max!", "nloop!", "fac!",
-               "delv!", "log!", "sigma!", "parval0!", "parval1!",
-               "levels!"]
+    _fields: list[str] = ["x0", "x1", "y", "min!", "max!", "nloop!",
+                          "fac!", "delv!", "log!", "sigma!",
+                          "parval0!", "parval1!", "levels!"]
     """The fields to include in the string output.
 
     Names that end in ! are treated as scalars, otherwise they are
@@ -3364,7 +3352,12 @@ class Confidence2D(DataContour, Point):
         self.parval1 = None
         self.stat = None
         self.numcores = None
+
+        self.point_prefs = basicbackend.get_confid_point_defaults()
+
         super().__init__()
+
+        self.contour_prefs = basicbackend.get_confid_contour_defaults()
 
     def __setstate__(self, state):
         self.__dict__.update(state)
@@ -3668,7 +3661,7 @@ class Confidence2D(DataContour, Point):
 
         # Note: the user arguments are not applied to the point
         #
-        point = Point()
+        point = PointObject()
         point.point_prefs = self.point_prefs
         point.point(self.parval0, self.parval1,
                     overplot=True, clearwindow=False)
@@ -4145,3 +4138,12 @@ class MultiPlot:
 
             overplot = True
             clearwindow = False
+
+
+# Set up some aliases for old code. Is this useful?
+#
+## Plot = PlotObject
+## Histogram = HistogramObject
+## Contour = ContourObject
+## Image = ImageObject
+## Point = PointObject

--- a/sherpa/plot/testing.py
+++ b/sherpa/plot/testing.py
@@ -101,6 +101,7 @@ def check_full(r, summary, label='', title='', nsummary=0, test_other=None):
             assert "<svg " in r
         elif (HAS_BOKEH and isinstance(plot.backend, BokehBackend)):
             assert "BokehJS library" in r
+
         return
 
     assert '<svg ' not in r

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1311,8 +1311,7 @@ def test_lrhist_str(check_str):
     assert last.startswith("histo_prefs = {")
 
 
-@pytest.mark.parametrize("cls", [sherpaplot.Histogram,
-                                 sherpaplot.HistogramPlot,
+@pytest.mark.parametrize("cls", [sherpaplot.HistogramPlot,
                                  sherpaplot.DataHistogramPlot,
                                  sherpaplot.ModelHistogramPlot,
                                  sherpaplot.SourceHistogramPlot,
@@ -1390,6 +1389,9 @@ def test_does_fitplot_have_labels():
         aval = getattr(fp, attr)
         assert not callable(aval), attr
 
-    for attr in ["hline", "overplot", "plot", "prepare", "vline"]:
+    for attr in ["overplot", "plot", "prepare"]:
         aval = getattr(fp, attr)
         assert callable(aval), attr
+
+    for attr in ["hline", "vline"]:
+        assert not hasattr(fp, attr)

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1367,3 +1367,31 @@ def test_badstat_data1ding(pcls, scls):
     with pytest.raises(StatErr,
                        match=f"^{pcls.__name__} not applicable using current statistic: {s.name}$"):
         p.prepare(data=d, model=m, stat=s)
+
+
+def test_does_fitplot_have_labels():
+    """This is a regression test to see if xlabel/ylabel exists.
+
+    This is relevant because JointPlot uses the presence of xlabel vs
+    dataplot/modelplot to determine how to hide the x-axis label of
+    the top plot (written during 4.17.0 development). So we want to
+    check what the current status is here.
+
+    This can be thought of checking the plot hierarchy: i.e. how much
+    does FitPlot share with other classes?.
+
+    """
+
+    fp = sherpa.FitPlot()
+
+    for attr in ["xlabel", "ylabel", "title"]:
+        assert not hasattr(fp, attr), attr
+
+    # add these in for good measure
+    for attr in ["dataplot", "modelplot", "plot_prefs"]:
+        aval = getattr(fp, attr)
+        assert not callable(aval), attr
+
+    for attr in ["hline", "overplot", "plot", "prepare", "vline"]:
+        aval = getattr(fp, attr)
+        assert callable(aval), attr

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1375,7 +1375,8 @@ def test_does_fitplot_have_labels():
     This is relevant because JointPlot uses the presence of xlabel vs
     dataplot/modelplot to determine how to hide the x-axis label of
     the top plot (written during 4.17.0 development). So we want to
-    check what the current status is here.
+    check what the current status is here. The JointPlot code has
+    now been changed, but leave this test in
 
     This can be thought of checking the plot hierarchy: i.e. how much
     does FitPlot share with other classes?.
@@ -1384,11 +1385,8 @@ def test_does_fitplot_have_labels():
 
     fp = sherpa.FitPlot()
 
-    for attr in ["xlabel", "ylabel", "title"]:
-        assert not hasattr(fp, attr), attr
-
-    # add these in for good measure
-    for attr in ["dataplot", "modelplot", "plot_prefs"]:
+    # Should FitPlot really have x/ylabel and title fields?
+    for attr in ["xlabel", "ylabel", "title", "dataplot", "modelplot", "plot_prefs"]:
         aval = getattr(fp, attr)
         assert not callable(aval), attr
 

--- a/sherpa/plot/tests/test_plot_notebook.py
+++ b/sherpa/plot/tests/test_plot_notebook.py
@@ -92,7 +92,7 @@ def test_lrhist(all_plot_backends):
 def test_data(all_plot_backends):
     p = plot.DataPlot()
     r = p._repr_html_()
-    check_full(r, 'DataPlot', 'None', 'None', nsummary=7)  # NOT empty
+    check_empty(r, 'DataPlot', nsummary=7)
 
     x = np.arange(5, 8, 0.5)
     y = np.ones(x.size)

--- a/sherpa/plot/tests/test_plot_notebook.py
+++ b/sherpa/plot/tests/test_plot_notebook.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2022, 2023
+#  Copyright (C) 2020 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -37,9 +37,9 @@ from sherpa.plot.testing import check_empty, check_full
 
 
 def test_histogram(all_plot_backends):
-    p = plot.HistogramPlot()
+    p = plot.BaseHistogram()
     r = p._repr_html_()
-    check_empty(r, 'HistogramPlot', nsummary=6)
+    check_empty(r, 'BaseHistogram', nsummary=6)
 
     p.xlo = np.asarray([1, 2, 3])
     p.xhi = np.asarray([2, 2.5, 4])
@@ -48,7 +48,7 @@ def test_histogram(all_plot_backends):
     p.ylabel = 'Y'
     p.title = 'Title String'
     r = p._repr_html_()
-    check_full(r, 'HistogramPlot', 'X <sup>2</sup>',
+    check_full(r, 'BaseHistogram', 'X <sup>2</sup>',
                'Title String', nsummary=6)
 
 

--- a/sherpa/plot/tests/test_plot_notebook.py
+++ b/sherpa/plot/tests/test_plot_notebook.py
@@ -37,9 +37,9 @@ from sherpa.plot.testing import check_empty, check_full
 
 
 def test_histogram(all_plot_backends):
-    p = plot.BaseHistogram()
+    p = plot.DataHistogramPlot()
     r = p._repr_html_()
-    check_empty(r, 'BaseHistogram', nsummary=6)
+    check_empty(r, 'DataHistogramPlot', nsummary=6)
 
     p.xlo = np.asarray([1, 2, 3])
     p.xhi = np.asarray([2, 2.5, 4])
@@ -48,7 +48,7 @@ def test_histogram(all_plot_backends):
     p.ylabel = 'Y'
     p.title = 'Title String'
     r = p._repr_html_()
-    check_full(r, 'BaseHistogram', 'X <sup>2</sup>',
+    check_full(r, 'DataHistogramPlot', 'X <sup>2</sup>',
                'Title String', nsummary=6)
 
 

--- a/sherpa/plot/tests/test_plot_warnings.py
+++ b/sherpa/plot/tests/test_plot_warnings.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2019 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -290,8 +290,10 @@ def test_fit_plot_see_errorbar_warnings(caplog, statClass, flag):
     # I am skipping model plot here, since it is assumed that there
     # are no errors on the model.
     #
+    # Prior to 4.17.0 this included checking the FitPlot class.
+    #
     prefname = 'yerrorbars'
-    for plot in [dplot, fplot]:
+    for plot in [dplot]:
         prefs = plot.plot_prefs
         assert (prefname not in prefs) or prefs[prefname]
 
@@ -358,10 +360,12 @@ def test_fit_residstyle_plot_see_errorbar_warnings(caplog, plotClass,
     # I am skipping model plot here, since it is assumed that there
     # are no errors on the model.
     #
+    # Prior to 4.17.0 this included checking the FitPlot class.
+    #
     prefname = 'yerrorbars'
-    for plot in [dplot, fplot, rplot]:
+    for plot in [dplot, rplot]:
         prefs = plot.plot_prefs
-        assert (prefname not in prefs) or prefs[prefname]
+        assert (prefname not in prefs) or prefs[prefname], (type(plot), prefname)
 
     stat = statClass()
 

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -1544,7 +1544,7 @@ def test_get_trace_plot_empty(session):
     s = session()
     p = s.get_trace_plot()
     assert isinstance(p, sherpa.plot.TracePlot)
-    for f in ['x', 'y', 'xerr', 'yerr', 'xlabel', 'ylabel', 'title']:
+    for f in ['x', 'y', 'yerr', 'xlabel', 'ylabel', 'title']:
         assert getattr(p, f) is None
 
 
@@ -1565,7 +1565,6 @@ def test_get_trace_plot(session):
 
     assert p.x == pytest.approx([0, 1, 2])
     assert p.y == pytest.approx(y)
-    assert p.xerr is None
     assert p.yerr is None
     assert p.xlabel == 'iteration'
     assert p.ylabel == 'x'
@@ -1591,7 +1590,6 @@ def test_get_trace_plot_labels_noname(session):
 
     assert p.x == pytest.approx([0, 1, 2])
     assert p.y == pytest.approx(y)
-    assert p.xerr is None
     assert p.yerr is None
     assert p.xlabel == 'iteration'
     assert p.ylabel == 'x'
@@ -1618,7 +1616,6 @@ def test_get_trace_plot_labels(session):
 
     assert p.x == pytest.approx([0, 1, 2])
     assert p.y == pytest.approx(y)
-    assert p.xerr is None
     assert p.yerr is None
     assert p.xlabel == 'iteration'
     assert p.ylabel == 'Awesome sauce'

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -40,7 +40,8 @@ from sherpa.data import Data1D, Data1DInt, Data2D
 from sherpa.models import basic
 import sherpa.plot
 from sherpa.stats import Chi2Gehrels
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, IdentifierErr, PlotErr
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, IdentifierErr, \
+    PlotErr
 
 
 _data_x = [10, 20, 40, 90]
@@ -1635,7 +1636,7 @@ def test_get_cdf_plot_empty(session):
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_plot_cdf_replot_no_data(session, requires_pylab):
+def test_plot_cdf_replot_no_data(session):
     """what does replot=True do for plot_cdf?
 
     The code doesn't check for this evantuality,
@@ -1646,8 +1647,7 @@ def test_plot_cdf_replot_no_data(session, requires_pylab):
 
     x = np.asarray([2, 8, 4, 6])
 
-    # error can depend on matplotlib version
-    with pytest.raises(ValueError):
+    with pytest.raises(PlotErr, match="prepare has not been called"):
         s.plot_cdf(x, replot=True)
 
 
@@ -1835,7 +1835,7 @@ def test_plot_pdf(session):
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_plot_pdf_replot_no_data(session, requires_pylab):
+def test_plot_pdf_replot_no_data(session):
     """what does replot=True do for plot_pdf?
 
     The code doesn't check for this evantuality,
@@ -1847,10 +1847,8 @@ def test_plot_pdf_replot_no_data(session, requires_pylab):
     x = np.asarray([2, 8, 4, 6])
 
     # check on the error so we know when the code has changed
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(PlotErr, match="prepare has not been called"):
         s.plot_pdf(x, replot=True)
-
-    assert "'NoneType' has no len" in str(exc.value)
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
@@ -2365,36 +2363,18 @@ def test_get_model_component_plot_model(session):
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
-def test_pylab_plot_scatter_empty_replot(session, requires_pylab):
+def test_pylab_plot_scatter_empty_replot(session):
     """plot_scatter with replot=False and no data
 
     Just check the current behavior
     """
 
-    from matplotlib import pyplot as plt
-
     s = session()
 
     x = np.arange(3)
     y = x + 5
-    s.plot_scatter(x, y, replot=True)
-
-    fig = plt.gcf()
-
-    assert len(fig.axes) == 1
-
-    ax = fig.axes[0]
-
-    assert ax.xaxis.get_label().get_text() == ''
-    assert ax.yaxis.get_label().get_text() == ''
-
-    assert len(ax.lines) == 1
-    line = ax.lines[0]
-
-    assert line.get_xdata() == [None]
-    assert line.get_ydata() == [None]
-
-    plt.close()
+    with pytest.raises(PlotErr, match="prepare has not been called"):
+        s.plot_scatter(x, y, replot=True)
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
@@ -2444,8 +2424,7 @@ def test_pylab_plot_trace_empty_replot(session, requires_pylab):
 
     y = np.arange(100, 104)
 
-    # error can depend on matplotlib version
-    with pytest.raises(ValueError):
+    with pytest.raises(PlotErr, match="prepare has not been called"):
         s.plot_trace(y, replot=True)
 
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -40,7 +40,7 @@ from sherpa.models.basic import TableModel
 from sherpa.models.model import Model, SimulFitModel
 from sherpa.models.template import add_interpolator, create_template_model, \
     reset_interpolators
-from sherpa.plot import Plot, MultiPlot, set_backend
+from sherpa.plot import BasePlot, BaseHistogram, MultiPlot, set_backend
 from sherpa.utils import NoNewAttributesAfterInit, is_subclass, \
     export_method, send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \
@@ -715,7 +715,8 @@ class FitStore:
     model : Model
 
 
-def get_components_helper(getfunc: Callable[..., Plot],
+def get_components_helper(getfunc: Callable[...,
+                                            Union[BasePlot, BaseHistogram]],
                           model: Model,
                           idval: Union[int, str]) -> MultiPlot:
     """Handle get_source/model_components_plot.
@@ -942,6 +943,7 @@ class Session(NoNewAttributesAfterInit):
         # as a single-element list, but it was felt that having a
         # consistent access pattern was cleaner.
         #
+        self._plot_types: dict[str, list[Union[BasePlot, BaseHistogram]]]
         self._plot_types = {
             'data': [sherpa.plot.DataPlot(), sherpa.plot.DataHistogramPlot()],
             'model': [sherpa.plot.ModelPlot(), sherpa.plot.ModelHistogramPlot()],


### PR DESCRIPTION
Follow on to 
- #1988

This had been crazier, as it used to also include

- using slots rather than NoNewAttributesAfterInit
- using protocol-like classes to determine how to create the string representation and whether something was plottable or contourable

The idea here is to see if breaking the plot hierarchy - so that the class that does the plotting/contouring is separate from the class that has a `prepare` method - is helpful.