### PR TITLE
Save the default identifier in save_all output

### DIFF
--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -1440,6 +1440,18 @@ def _save_dataset(out: OutType,
         _output(out, f"set_syserror({idstr}, {syserr.tolist()})")
 
 
+def _save_id(out: OutType, state: SessionType) -> None:
+    "Does the default id need changing?"
+
+    defid = state.get_default_id()
+    if defid == 1:
+        return
+
+    _output_banner(out, "Default identifier")
+    _output(out, f'set_default_id({repr(defid)})')
+    _output_nl(out)
+
+
 def save_all(state: SessionType, fh: Optional[TextIO] = None) -> None:
     """Save the information about the current session to a file handle.
 
@@ -1514,6 +1526,8 @@ def save_all(state: SessionType, fh: Optional[TextIO] = None) -> None:
     _save_models(out, state)
     if req_xspec:
         _save_xspec(out)
+
+    _save_id(out, state)
 
     if fh is None:
         fh = sys.stdout

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -3798,3 +3798,28 @@ def test_fake_image_wcs_coord():
     restore()
 
     check()
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize("defid", ["foo", 2])
+def test_store_default_id(defid):
+    "Do we record the default id when it's been changed?"
+
+    x = [3, 45]
+    y = [2, 19]
+
+    assert ui.get_default_id() == 1
+    ui.set_default_id(defid)
+    ui.load_arrays(defid, x, y)
+
+    restore()
+    assert ui.get_default_id() == defid
+    assert ui.list_data_ids() == [defid]
+    with pytest.raises(IdentifierErr,
+                       match="^data set 1 has not been set$"):
+        assert ui.get_data(1)
+
+    d = ui.get_data()
+    assert d.name == ""
+    assert d.x == pytest.approx(x)
+    assert d.y == pytest.approx(y)

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -3800,7 +3800,6 @@ def test_fake_image_wcs_coord():
     check()
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("defid", ["foo", 2])
 def test_store_default_id(defid):
     "Do we record the default id when it's been changed?"

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -398,6 +398,7 @@ class Session(sherpa.ui.utils.Session):
 
     # Add ability to save attributes specific to the astro package.
     # Save XSPEC module settings that need to be restored.
+    #
     def save(self, filename='sherpa.save', clobber=False):
         """Save the current Sherpa session to a file.
 
@@ -429,6 +430,14 @@ class Session(sherpa.ui.utils.Session):
         between versions of Sherpa, but is platform independent, and
         contains all the data. This means that files created by `save`
         can be sent to collaborators to share results.
+
+        The output of `save` is not guaranteed to work with different
+        versions of Sherpa, so it is not ideal as an archiving format.
+        The `save_all` command is better suited for long-term support,
+        but it unfortunately can not store ancillary variables, extra
+        modules, or all Sherpa settings. It is suggested that the
+        output of both should be checked when the output may be used
+        long term.
 
         Examples
         --------
@@ -15890,6 +15899,10 @@ class Session(sherpa.ui.utils.Session):
          3. some settings and values may not be recorded (such as
             header information).
 
+        .. versionchanged:: 4.17.0
+           The file will now contain a `set_default_id` call if the
+           default identifier has been changed.
+
         .. versionchanged:: 4.16.0
            Any set_psf calls are now included in the output file. The
            filter is no-longer included if it does not exclude any
@@ -15960,6 +15973,10 @@ class Session(sherpa.ui.utils.Session):
         >>> from io import StringIO
         >>> store = StringIO()
         >>> save_all(store)
+        >>> print(store.getvalue())
+        import numpy
+        from sherpa.astro.ui import *
+        ...
 
         """
 


### PR DESCRIPTION
# Summary

Record the default identifier in save_all output if the user has changed it. Fix #2077

# Details

Fortunately this is an easy fix. I have not added an explicit test of the output - i.e. no check of the actual text file that was create. Instead I rely on "implicit" tests where we load in the output of save_all and check that the default identifier has been changed.