### PR TITLE
minor cleanup of sherpa.optmethods

### DIFF
--- a/sherpa/optmethods/__init__.py
+++ b/sherpa/optmethods/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2018, 2020, 2021, 2023
+#  Copyright (C) 2007, 2015, 2018, 2020, 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -110,7 +110,7 @@ const1d
 
 import logging
 
-import numpy
+import numpy as np
 
 from sherpa.utils import NoNewAttributesAfterInit, \
     get_keyword_names, get_keyword_defaults, print_fields
@@ -247,7 +247,7 @@ class OptMethod(NoNewAttributesAfterInit):
         # Ensure that the best-fit parameters are in an array.  (If there's
         # only one, it might be returned as a bare float.)
         output = list(output)
-        output[1] = numpy.asarray(output[1]).ravel()
+        output[1] = np.asarray(output[1]).ravel()
         output = tuple(output)
 
         return output

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -162,9 +162,7 @@ class SimplexBase:
 
         def is_fct_stddev_small_enough():
             fval_std = np.std([col[-1] for col in self.simplex])
-            if fval_std < ftol:
-                return True
-            return False
+            return fval_std < ftol
 
         def is_max_length_small_enough():
             """

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -131,11 +131,6 @@ def _move_within_limits(x, xmin, xmax):
         x[above] = xmax[above]
 
 
-def _my_is_nan(x):
-    fubar = list(filter(lambda xx: xx != xx or xx is np.nan or np.isnan(xx) and np.isfinite(xx), x))
-    return len(fubar) > 0
-
-
 def _double_check_limits(myx: np.ndarray,
                          myxmin: np.ndarray,
                          myxmax: np.ndarray) -> None:
@@ -466,7 +461,7 @@ def minim(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, step=None,
     orig_fcn = stat_cb0
 
     def stat_cb0(x_new):
-        if _my_is_nan(x_new) or _outside_limits(x_new, xmin, xmax):
+        if np.isnan(x_new).any() or _outside_limits(x_new, xmin, xmax):
             return FUNC_MAX
         return orig_fcn(x_new)
 
@@ -953,7 +948,7 @@ def neldermead(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
     orig_fcn = stat_cb0
 
     def stat_cb0(x_new):
-        if _my_is_nan(x_new) or _outside_limits(x_new, xmin, xmax):
+        if np.isnan(x_new).any() or _outside_limits(x_new, xmin, xmax):
             return FUNC_MAX
         return orig_fcn(x_new)
 

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -380,7 +380,7 @@ def grid_search(fcn, x0, xmin, xmax, num=16, sequence=None, numcores=1,
                 raise TypeError(f"{seq} must be of length {npar}")
 
     answer = eval_stat_func(x)
-    sequence_results = list(parallel_map(eval_stat_func, sequence, numcores))
+    sequence_results = parallel_map(eval_stat_func, sequence, numcores)
     for xresult in sequence_results[1:]:
         if xresult[0] < answer[0]:
             answer = xresult
@@ -584,9 +584,10 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
         ############################# NelderMead #############################
         mymaxfev = min(maxfev_per_iter, maxfev)
         if all(x == 0.0):
-            mystep = list(map(lambda fubar: 1.2 + fubar, x))
+            mystep = 1.2 + x
         else:
-            mystep = list(map(lambda fubar: 1.2 * fubar, x))
+            mystep = 1.2 * x
+
         if 1 == numcores:
             result = neldermead(myfcn, x, xmin, xmax, maxfev=mymaxfev,
                                 ftol=ftol, finalsimplex=9, step=mystep)
@@ -664,9 +665,10 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
 
     if nfev < maxfev:
         if all(x == 0.0):
-            mystep = list(map(lambda fubar: 1.2 + fubar, x))
+            mystep = 1.2 + x
         else:
-            mystep = list(map(lambda fubar: 1.2 * fubar, x))
+            mystep = 1.2 * x
+
         if 1 == numcores:
             result = neldermead(fcn, x, xmin, xmax,
                                 maxfev=min(512*len(x), maxfev - nfev),

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -424,8 +424,7 @@ def minim(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, step=None,
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
     if step is None:
-        order = 'F' if np.isfortran(x) else 'C'
-        step = 0.4*np.ones(x.shape, np.float64, order)
+        step = np.full(x.shape, 0.4, dtype=np.float64)
     if simp is None:
         simp = 1.0e-2 * ftol
     if maxfev is None:
@@ -901,11 +900,10 @@ def neldermead(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
 
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
-    order = 'F' if np.isfortran(x) else 'C'
     if step is None or (np.iterable(step) and len(step) != len(x)):
-        step = 1.2 * np.ones(x.shape, np.float64, order)
+        step = np.full(x.shape, 1.2, dtype=np.float64)
     elif np.isscalar(step):
-        step = step * np.ones(x.shape, np.float64, order)
+        step = np.full(x.shape, step, dtype=np.float64)
 
     # A safeguard just in case the initial simplex is outside the bounds
     #

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -297,7 +297,7 @@ def difevo_nm(fcn, x0, xmin, xmax, ftol, maxfev, verbose, seed,
     weighting_factor = min(weighting_factor, 1.0)
 
     if population_size is None:
-        population_size = max(population_size, 16 * x.size)
+        population_size = 16 * x.size
 
     if maxfev is None:
         maxfev = 1024 * population_size

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -191,12 +191,10 @@ def difevo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
     # make sure that the cross over prob is within [0.1,1.0]
-    xprob = max(0.1, xprob)
-    xprob = min(xprob, 1.0)
+    xprob = float(np.clip(xprob, 0.1, 1.0))
 
     # make sure that weighting_factor is within [0.1,1.0]
-    weighting_factor = max(0.1, weighting_factor)
-    weighting_factor = min(weighting_factor, 1.0)
+    weighting_factor = float(np.clip(weighting_factor, 0.1, 1.0))
 
     if population_size is None:
         population_size = 16 * x.size
@@ -227,12 +225,10 @@ def difevo_lm(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
     # make sure that the cross over prob is within [0.1,1.0]
-    xprob = max(0.1, xprob)
-    xprob = min(xprob, 1.0)
+    xprob = float(np.clip(xprob, 0.1, 1.0))
 
     # make sure that weighting_factor is within [0.1,1.0]
-    weighting_factor = max(0.1, weighting_factor)
-    weighting_factor = min(weighting_factor, 1.0)
+    weighting_factor = float(np.clip(weighting_factor, 0.1, 1.0))
 
     if population_size is None:
         population_size = 16 * x.size
@@ -263,12 +259,10 @@ def difevo_nm(fcn, x0, xmin, xmax, ftol, maxfev, verbose, seed,
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
     # make sure that the cross over prob is within [0.1,1.0]
-    xprob = max(0.1, xprob)
-    xprob = min(xprob, 1.0)
+    xprob = float(np.clip(xprob, 0.1, 1.0))
 
     # make sure that weighting_factor is within [0.1,1.0]
-    weighting_factor = max(0.1, weighting_factor)
-    weighting_factor = min(weighting_factor, 1.0)
+    weighting_factor = float(np.clip(weighting_factor, 0.1, 1.0))
 
     if population_size is None:
         population_size = 16 * x.size
@@ -554,12 +548,10 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
     # make sure that the cross over prob is within [0.1,1.0]
-    xprob = max(0.1, xprob)
-    xprob = min(xprob, 1.0)
+    xprob = float(np.clip(xprob, 0.1, 1.0))
 
     # make sure that weighting_factor is within [0.1,1.0]
-    weighting_factor = max(0.1, weighting_factor)
-    weighting_factor = min(weighting_factor, 1.0)
+    weighting_factor = float(np.clip(weighting_factor, 0.1, 1.0))
 
     # Do we need to create a seed?
     #

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2016, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2007, 2016, 2018 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1226,8 +1226,6 @@ def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
     # TO DO: reduce 1 model eval by passing the resulting 'fvec' to cpp_lmdif
     m = numpy.asanyarray(stat_cb1(x)).size
 
-    error = []
-
     n = len(x)
     fjac = numpy.empty((m*n,))
 
@@ -1251,9 +1249,6 @@ def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
             nfev += nm_result[4]['nfev']
             x = nm_result[1]
             fval = nm_result[2]
-
-    if error:
-        raise error.pop()
 
     if 0 == info:
         info = 1

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -210,26 +210,6 @@ def _outside_limits(x, xmin, xmax):
     return (numpy.any(x < xmin) or numpy.any(x > xmax))
 
 
-def _same_par(a, b):
-    b = numpy.array(b, numpy.float64)
-    same = numpy.flatnonzero(a < b)
-    if same.size == 0:
-        return 1
-    return 0
-
-
-def _set_limits(x, xmin, xmax):
-    below = numpy.nonzero(x < xmin)
-    if below.size > 0:
-        return 1
-
-    above = numpy.nonzero(x > xmax)
-    if above.size > 0:
-        return 1
-
-    return 0
-
-
 def difevo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
            seed=2005815, population_size=None, xprob=0.9,
            weighting_factor=0.8):

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -421,11 +421,6 @@ def grid_search(fcn, x0, xmin, xmax, num=16, sequence=None, numcores=1,
 def minim(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, step=None,
           nloop=1, iquad=1, simp=None, verbose=-1, reflect=True):
 
-    # TODO: rework so do not have two stat_cb0 functions which
-    #       are both used
-    def stat_cb0(pars):
-        return fcn(pars)[0]
-
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
     if step is None:
@@ -436,12 +431,10 @@ def minim(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, step=None,
     if maxfev is None:
         maxfev = 512 * len(x)
 
-    orig_fcn = stat_cb0
-
     def stat_cb0(x_new):
         if np.isnan(x_new).any() or _outside_limits(x_new, xmin, xmax):
             return FUNC_MAX
-        return orig_fcn(x_new)
+        return fcn(x_new)[0]
 
     init = 0
     x, fval, neval, ifault = _saoopt.minim(reflect, verbose, maxfev, init, \
@@ -914,19 +907,12 @@ def neldermead(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
     elif np.isscalar(step):
         step = step * np.ones(x.shape, np.float64, order)
 
-    def stat_cb0(pars):
-        return fcn(pars)[0]
-
-    # TODO: should be able to avoid the redefinition
-    #
     # A safeguard just in case the initial simplex is outside the bounds
     #
-    orig_fcn = stat_cb0
-
     def stat_cb0(x_new):
         if np.isnan(x_new).any() or _outside_limits(x_new, xmin, xmax):
             return FUNC_MAX
-        return orig_fcn(x_new)
+        return fcn(x_new)[0]
 
     if np.isscalar(finalsimplex) and np.iterable(finalsimplex) == 0:
         finalsimplex = int(finalsimplex)
@@ -1138,9 +1124,6 @@ def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
 
     if maxfev is None:
         maxfev = 256 * len(x)
-
-    def stat_cb0(pars):
-        return fcn(pars)[0]
 
     def stat_cb1(pars):
         return fcn(pars)[1]

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -68,7 +68,7 @@ Best-fit value: 4.0
 
 """
 
-import numpy
+import numpy as np
 
 from sherpa.optmethods.ncoresde import ncoresDifEvo
 from sherpa.optmethods.ncoresnm import ncoresNelderMead
@@ -87,20 +87,20 @@ __all__ = ('difevo', 'difevo_lm', 'difevo_nm', 'grid_search', 'lmdif',
 #
 # Use FLT_EPSILON as default tolerance
 #
-EPSILON = numpy.float64(numpy.finfo(numpy.float32).eps)
+EPSILON = np.float64(np.finfo(np.float32).eps)
 
 #
 # Maximum callback function value, used to indicate that the optimizer
 # has exceeded parameter boundaries.  All the optimizers expect double
-# precision arguments, so we use numpy.float64 instead of SherpaFloat.
+# precision arguments, so we use np.float64 instead of SherpaFloat.
 #
-FUNC_MAX = numpy.finfo(numpy.float64).max
+FUNC_MAX = np.finfo(np.float64).max
 
 
 def _check_args(x0, xmin, xmax):
-    x = numpy.array(x0, numpy.float64)  # Make a copy
-    xmin = numpy.asarray(xmin, numpy.float64)
-    xmax = numpy.asarray(xmax, numpy.float64)
+    x = np.array(x0, np.float64)  # Make a copy
+    xmin = np.asarray(xmin, np.float64)
+    xmax = np.asarray(xmax, np.float64)
 
     if (x.shape != xmin.shape) or (x.shape != xmax.shape):
         raise TypeError('input array sizes do not match')
@@ -122,17 +122,17 @@ def _get_saofit_msg(maxfev, ierr):
 
 
 def _move_within_limits(x, xmin, xmax):
-    below = numpy.flatnonzero(x < xmin)
+    below = np.flatnonzero(x < xmin)
     if below.size > 0:
         x[below] = xmin[below]
 
-    above = numpy.flatnonzero(x > xmax)
+    above = np.flatnonzero(x > xmax)
     if above.size > 0:
         x[above] = xmax[above]
 
 
 def _my_is_nan(x):
-    fubar = list(filter(lambda xx: xx != xx or xx is numpy.nan or numpy.isnan(xx) and numpy.isfinite(xx), x))
+    fubar = list(filter(lambda xx: xx != xx or xx is np.nan or np.isnan(xx) and np.isfinite(xx), x))
     return len(fubar) > 0
 
 
@@ -146,12 +146,12 @@ def _narrow_limits(myrange, xxx, debug):
                 print('x = ', my_x, ' is > upper limit = ', my_h)
 
     def raise_min_limit(xrange, xmin, x, debug=False):
-        myxmin = numpy.asarray(list(map(lambda xx: xx - xrange * numpy.abs(xx), x)), numpy.float64)
+        myxmin = np.asarray(list(map(lambda xx: xx - xrange * np.abs(xx), x)), np.float64)
         if debug:
             print()
             print(f'raise_min_limit: myxmin={myxmin}')
             print(f'raise_min_limit: x={x}')
-        below = numpy.flatnonzero(myxmin < xmin)
+        below = np.flatnonzero(myxmin < xmin)
         if below.size > 0:
             myxmin[below] = xmin[below]
         if debug:
@@ -161,12 +161,12 @@ def _narrow_limits(myrange, xxx, debug):
         return myxmin
 
     def lower_max_limit(xrange, x, xmax, debug=False):
-        myxmax = numpy.asarray(list(map(lambda xx: xx + xrange * numpy.abs(xx), x)), numpy.float64)
+        myxmax = np.asarray(list(map(lambda xx: xx + xrange * np.abs(xx), x)), np.float64)
         if debug:
             print()
             print(f'lower_max_limit: x={x}')
             print(f'lower_max_limit: myxmax={myxmax}')
-        above = numpy.flatnonzero(myxmax > xmax)
+        above = np.flatnonzero(myxmax > xmax)
         if above.size > 0:
             myxmax[above] = xmax[above]
         if debug:
@@ -207,7 +207,7 @@ def _par_at_boundary(low, val, high, tol):
 
 
 def _outside_limits(x, xmin, xmax):
-    return (numpy.any(x < xmin) or numpy.any(x > xmax))
+    return (np.any(x < xmin) or np.any(x > xmax))
 
 
 def difevo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
@@ -268,7 +268,7 @@ def difevo_lm(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
 
     de = _saoopt.lm_difevo(verbose, maxfev, seed, population_size, ftol,
                            xprob, weighting_factor, xmin, xmax,
-                           x, fcn, numpy.asanyarray(fcn(x)).size)
+                           x, fcn, np.asanyarray(fcn(x)).size)
     fval = de[1]
     nfev = de[2]
     ierr = de[3]
@@ -384,9 +384,9 @@ def grid_search(fcn, x0, xmin, xmax, num=16, sequence=None, numcores=1,
             list_ranges[ii] = tuple(list_ranges[ii]) + (complex(N),)
             list_ranges[ii] = slice(*list_ranges[ii])
 
-        grid = numpy.mgrid[list_ranges]
+        grid = np.mgrid[list_ranges]
         mynfev = pow(N, npar)
-        grid = list(map(numpy.ravel, grid))
+        grid = list(map(np.ravel, grid))
         sequence = []
         for index in range(mynfev):
             tmp = []
@@ -396,7 +396,7 @@ def grid_search(fcn, x0, xmin, xmax, num=16, sequence=None, numcores=1,
         return sequence
 
     def eval_stat_func(xxx):
-        return numpy.append(func(xxx), xxx)
+        return np.append(func(xxx), xxx)
 
     if sequence is None:
         ranges = []
@@ -404,7 +404,7 @@ def grid_search(fcn, x0, xmin, xmax, num=16, sequence=None, numcores=1,
             ranges.append([xmin[index], xmax[index]])
         sequence = make_sequence(ranges, num)
     else:
-        if not numpy.iterable(sequence):
+        if not np.iterable(sequence):
             raise TypeError("sequence option must be iterable")
 
         for seq in sequence:
@@ -461,8 +461,8 @@ def minim(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, step=None,
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
     if step is None:
-        order = 'F' if numpy.isfortran(x) else 'C'
-        step = 0.4*numpy.ones(x.shape, numpy.float64, order)
+        order = 'F' if np.isfortran(x) else 'C'
+        step = 0.4*np.ones(x.shape, np.float64, order)
     if simp is None:
         simp = 1.0e-2 * ftol
     if maxfev is None:
@@ -613,7 +613,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
             xx = []
             for ii in range(len(xmin)):
                 xx.append(random.uniform(rng, xmin[ii], xmax[ii]))
-            return numpy.asarray(xx)
+            return np.asarray(xx)
 
         ############################# NelderMead #############################
         mymaxfev = min(maxfev_per_iter, maxfev)
@@ -624,7 +624,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
         if 1 == numcores:
             result = neldermead(myfcn, x, xmin, xmax, maxfev=mymaxfev,
                                 ftol=ftol, finalsimplex=9, step=mystep)
-            x = numpy.asarray(result[1], numpy.float64)
+            x = np.asarray(result[1], np.float64)
             nfval = result[2]
             nfev = result[4].get('nfev')
         else:
@@ -644,7 +644,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
             result = difevo_nm(myfcn, x, xmin, xmax, ftol, mymaxfev, verbose,
                                seed, pop, xprob, weight)
             nfev += result[4].get('nfev')
-            x = numpy.asarray(result[1], numpy.float64)
+            x = np.asarray(result[1], np.float64)
             nfval = result[2]
         else:
             ncores_de = ncoresDifEvo()
@@ -678,7 +678,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
                 nfev += result[4].get('nfev')
                 if result[2] < nfval:
                     nfval = result[2]
-                    x = numpy.asarray(result[1], numpy.float64)
+                    x = np.asarray(result[1], np.float64)
                 if verbose or debug:
                     print(f'f_de_nm{x}={result[2]:.14e} in {result[4].get("nfev")} nfev')
 
@@ -694,7 +694,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
 
         return x, nfval, nfev
 
-    x, fval, nfev = myopt(fcn, [x, xmin, xmax], numpy.sqrt(ftol), maxfev,
+    x, fval, nfev = myopt(fcn, [x, xmin, xmax], np.sqrt(ftol), maxfev,
                           seed, population_size, xprob, weighting_factor,
                           factor=2.0, debug=False)
 
@@ -708,7 +708,7 @@ def montecarlo(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None, verbose=0,
                                 maxfev=min(512*len(x), maxfev - nfev),
                                 ftol=ftol, finalsimplex=9, step=mystep)
 
-            x = numpy.asarray(result[1], numpy.float64)
+            x = np.asarray(result[1], np.float64)
             fval = result[2]
             nfev += result[4].get('nfev')
         else:
@@ -942,11 +942,11 @@ def neldermead(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
 
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
-    order = 'F' if numpy.isfortran(x) else 'C'
-    if step is None or (numpy.iterable(step) and len(step) != len(x)):
-        step = 1.2 * numpy.ones(x.shape, numpy.float64, order)
-    elif numpy.isscalar(step):
-        step = step * numpy.ones(x.shape, numpy.float64, order)
+    order = 'F' if np.isfortran(x) else 'C'
+    if step is None or (np.iterable(step) and len(step) != len(x)):
+        step = 1.2 * np.ones(x.shape, np.float64, order)
+    elif np.isscalar(step):
+        step = step * np.ones(x.shape, np.float64, order)
 
     def stat_cb0(pars):
         return fcn(pars)[0]
@@ -965,7 +965,7 @@ def neldermead(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
     # for internal use only
     debug = False
 
-    if numpy.isscalar(finalsimplex) and numpy.iterable(finalsimplex) == 0:
+    if np.isscalar(finalsimplex) and np.iterable(finalsimplex) == 0:
         finalsimplex = int(finalsimplex)
         if 0 == finalsimplex:
             finalsimplex = [1]
@@ -997,21 +997,21 @@ def neldermead(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
             finalsimplex = [2, 1, 1]
         else:
             finalsimplex = [2, 2, 2]
-    elif (not numpy.isscalar(finalsimplex) and
-          numpy.iterable(finalsimplex) == 1):
+    elif (not np.isscalar(finalsimplex) and
+          np.iterable(finalsimplex) == 1):
         pass
     else:
         finalsimplex = [2, 2, 2]
 
-    finalsimplex = numpy.asarray(finalsimplex, numpy.int_)
+    finalsimplex = np.asarray(finalsimplex, np.int_)
 
     if maxfev is None:
         maxfev = 1024 * len(x)
 
     if debug:
         print(f'opfcts.py neldermead() finalsimplex={finalsimplex}'
-              f'\tisscalar={numpy.isscalar(finalsimplex)}'
-              f'\titerable={numpy.iterable(finalsimplex)}')
+              f'\tisscalar={np.isscalar(finalsimplex)}'
+              f'\titerable={np.iterable(finalsimplex)}')
 
     def simplex(verbose, maxfev, init, final, tol, step, xmin, xmax, x,
                 myfcn, debug, ofval=FUNC_MAX):
@@ -1046,7 +1046,7 @@ def neldermead(fcn, x0, xmin, xmax, ftol=EPSILON, maxfev=None,
     if len(finalsimplex) >= 3 and 0 != iquad:
         nelmea = minim(fcn, x, xmin, xmax, ftol=10.0*ftol,
                        maxfev=maxfev - nfev - 12, iquad=1, reflect=reflect)
-        nelmea_x = numpy.asarray(nelmea[1], numpy.float64)
+        nelmea_x = np.asarray(nelmea[1], np.float64)
         nelmea_nfev = nelmea[4].get('nfev')
         info = nelmea[4].get('info')
         covarerr = nelmea[4].get('covarerr')
@@ -1155,10 +1155,10 @@ def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
         def __init__(self, func, fvec, pars):
             self.func = func
             self.fvec = fvec
-            epsmch = numpy.finfo(float).eps
-            self.eps = numpy.sqrt(max(epsmch, epsfcn))
+            epsmch = np.finfo(float).eps
+            self.eps = np.sqrt(max(epsmch, epsfcn))
             self.h = self.calc_h(pars)
-            self.pars = numpy.copy(pars)
+            self.pars = np.copy(pars)
 
         def __call__(self, param):
             wa = self.func(param[1:])
@@ -1166,7 +1166,7 @@ def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
 
         def calc_h(self, pars):
             nn = len(pars)
-            h = numpy.empty((nn,))
+            h = np.empty((nn,))
             for ii in range(nn):
                 h[ii] = self.eps * pars[ii]
                 if h[ii] == 0.0:
@@ -1178,9 +1178,9 @@ def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
         def calc_params(self):
             params = []
             for ii in range(len(self.h)):
-                tmp_pars = numpy.copy(self.pars)
+                tmp_pars = np.copy(self.pars)
                 tmp_pars[ii] += self.h[ii]
-                tmp_pars = numpy.append(ii, tmp_pars)
+                tmp_pars = np.append(ii, tmp_pars)
                 params.append(tmp_pars)
             return tuple(params)
 
@@ -1199,15 +1199,15 @@ def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
         fd_jac = fdJac(stat_cb1, fvec, pars)
         params = fd_jac.calc_params()
         fjac = parallel_map(fd_jac, params, numcores)
-        return numpy.concatenate(fjac)
+        return np.concatenate(fjac)
 
     fcn_parallel_counter = FuncCounter(fcn_parallel)
 
     # TO DO: reduce 1 model eval by passing the resulting 'fvec' to cpp_lmdif
-    m = numpy.asanyarray(stat_cb1(x)).size
+    m = np.asanyarray(stat_cb1(x)).size
 
     n = len(x)
-    fjac = numpy.empty((m*n,))
+    fjac = np.empty((m*n,))
 
     x, fval, nfev, info, fjac = \
         _saoopt.cpp_lmdif(stat_cb1, fcn_parallel_counter, numcores, m, x, ftol,
@@ -1215,7 +1215,7 @@ def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
                           xmax, fjac)
 
     if info > 0:
-        fjac = numpy.reshape(numpy.ravel(fjac, order='F'), (m, n), order='F')
+        fjac = np.reshape(np.ravel(fjac, order='F'), (m, n), order='F')
 
         if m != n:
             covar = fjac[:n, :n]
@@ -1223,7 +1223,7 @@ def lmdif(fcn, x0, xmin, xmax, ftol=EPSILON, xtol=EPSILON, gtol=EPSILON,
             covar = fjac
 
         if _par_at_boundary(xmin, x, xmax, xtol):
-            nm_result = neldermead(fcn, x, xmin, xmax, ftol=numpy.sqrt(ftol),
+            nm_result = neldermead(fcn, x, xmin, xmax, ftol=np.sqrt(ftol),
                                    maxfev=maxfev-nfev, finalsimplex=2, iquad=0,
                                    verbose=0)
             nfev += nm_result[4]['nfev']


### PR DESCRIPTION
# Summary

Internal clean up of the sherpa.optmethods code.

# Details

This is a subset of #2047 and comes about because I'm trying to address #2007 but the code in the `optmethods` directory hasn't been looked at in a while. So we (not in order)

- remove unused code (trying to only remove obviously-private routines to avoid issues noted after merging #2015)
- remove some debugging code that the user could never trigger (and we have better ways to log this info if we need to add such  logging)
- replace some code with more-modern numpy idioms (e.g. using `np.isnan`, taking advantage of 'x + y' being automatically "vectorized", and routines like `np.full` and `np.clip`)
- avoid creating multiple local functions when we can just write it once
- remove an attempt to support FORTRAN vs C array ordering for code which is only meant to be sent 1D arrays
- fix an array in an "internal" routine (`difevo_nm`) which would error out if called with `population_size=None` [which we never do but a user could]; in this case I don't think it's worth adding a test for this as we really should do this for all such routines and that's  a lot of noise and it's hard to validate the results of a successful run (other than "does not crash")
- try to avoid reusing the same variable to store different types (e.g. array vs scalar)
- try to clean up tuple handling, since type checkers don't really like "tuple_val += (x, y)" and I believe the code is actually clearer with the new version

The idea here is to make the code easier to review (and to identify regressions if things do change). I will note that some of these changes were found (or strongly hinted at) by type checkers, but adding significant type checker support is for a follow-on PR.