### PR TITLE
Minor plot cleanup

### DIFF
--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -36,7 +36,7 @@ from sherpa.models.model import Model
 from sherpa import plot as shplot
 from sherpa.utils import parse_expr, dataspace1d, histogram1d, filter_bins, \
     sao_fcmp
-from sherpa.utils.err import IOErr, PlotErr, StatErr
+from sherpa.utils.err import IOErr, PlotErr
 
 warning = logging.getLogger(__name__).warning
 
@@ -695,7 +695,7 @@ class RMFPlot(shplot.HistogramPlot):
             # liable to change.
             #
             energies = [energy for energy in self.energies
-                        if energy >= elo[0] and energy < ehi[-1]]
+                        if elo[0] <= energy < ehi[-1]]
             if len(energies) == 0:
                 raise ValueError("energies must be "
                                  f">= {elo[0]} and < {ehi[-1]} keV")
@@ -906,7 +906,7 @@ class OrderPlot(ModelHistogram):
             self.xlo = []
             self.xhi = []
             self.y = []
-            (xlo, y, yerr, _,
+            (xlo, y, _, _,
              self.xlabel, self.ylabel) = data.to_plot(model)
             y = y[1]
 

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -446,6 +446,9 @@ class SourcePlot(shplot.SourceHistogramPlot):
         self.xlabel = f'{self.units.capitalize()} ({quant})'
         self.ylabel = f'{pre}  Photons{tlabel}/cm{sqr}{post}'
 
+        # Should self.mask be applied to self.xlo/hi/y here?
+        # If so, the plot method could be removed.
+
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         xlo = self.xlo
         xhi = self.xhi
@@ -456,6 +459,10 @@ class SourcePlot(shplot.SourceHistogramPlot):
             xhi = self.xhi[self.mask]
             y = self.y[self.mask]
 
+        # We could temporarily over-write self.xlo, self.xhi, self.y
+        # which would mean this could call super().plot(), or set up
+        # the data in prepare and avoid this method completely.
+        #
         shplot.Histogram.plot(self, xlo, xhi, y, title=self.title,
                               xlabel=self.xlabel, ylabel=self.ylabel,
                               overplot=overplot, clearwindow=clearwindow,
@@ -1108,7 +1115,6 @@ class DataIMGPlot(shplot.Image):
     def plot(self, overplot=False, clearwindow=True, **kwargs):
 
         super().plot(self.x0, self.x1, self.y, title=self.title,
-                        xlabel=self.xlabel, ylabel=self.ylabel,
-                        aspect=self.aspect,
-                        overplot=overplot, clearwindow=clearwindow,
-                        **kwargs)
+                     xlabel=self.xlabel, ylabel=self.ylabel,
+                     aspect=self.aspect, overplot=overplot,
+                     clearwindow=clearwindow, **kwargs)

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -439,8 +439,7 @@ class SourcePlot(shplot.SourceHistogramPlot):
                 post += pterm
 
         scale = (self.xhi + self.xlo) / 2
-        for _ in range(data.plot_fac):
-            self.y *= scale
+        self.y *= scale ** data.plot_fac
 
         sqr = shplot.backend.get_latex_for_string('^2')
         self.xlabel = f'{self.units.capitalize()} ({quant})'

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -974,34 +974,19 @@ class OrderPlot(ModelHistogram):
 class FluxHistogram(ModelHistogram):
     "Derived class for creating 1D flux distribution plots"
 
+    _fields: list[str] = ["modelvals", "clipped", "flux"] + \
+        ModelHistogram._fields
+    """The fields to include in the string output.
+
+    Names that end in ! are treated as scalars, otherwise they are
+    passed through NumPy's array2string.
+    """
+
     def __init__(self):
         self.modelvals = None
         self.clipped = None
         self.flux = None
         super().__init__()
-
-    def __str__(self):
-        vals = self.modelvals
-        if self.modelvals is not None:
-            vals = np.array2string(np.asarray(self.modelvals), separator=',',
-                                   precision=4, suppress_small=False)
-
-        clip = self.clipped
-        if self.clipped is not None:
-            # Could convert to boolean, but it is surprising for
-            # anyone trying to access the clipped field
-            clip = np.array2string(np.asarray(self.clipped), separator=',',
-                                   precision=4, suppress_small=False)
-
-        flux = self.flux
-        if self.flux is not None:
-            flux = np.array2string(np.asarray(self.flux), separator=',',
-                                   precision=4, suppress_small=False)
-
-        return '\n'.join([f'modelvals = {vals}',
-                          f'clipped = {clip}',
-                          f'flux = {flux}',
-                          ModelHistogram.__str__(self)])
 
     def prepare(self, fluxes, bins):
         """Define the histogram plot.

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -753,21 +753,21 @@ def test_str_flux_histogram_empty(energy, cls):
     out = str(obj).split('\n')
 
     assert out[0] == 'modelvals = None'
-    assert out[1] == 'clipped = None'
-    assert out[2] == 'flux = None'
-    assert out[3] == 'xlo    = None'
-    assert out[4] == 'xhi    = None'
-    assert out[5] == 'y      = None'
+    assert out[1] == 'clipped   = None'
+    assert out[2] == 'flux      = None'
+    assert out[3] == 'xlo       = None'
+    assert out[4] == 'xhi       = None'
+    assert out[5] == 'y         = None'
 
     # the exact text depends on the plot backend
     if energy:
-        assert out[6].startswith('xlabel = Energy flux ')
-        assert out[8] == 'title  = Energy flux distribution'
+        assert out[6].startswith('xlabel    = Energy flux ')
+        assert out[8] == 'title     = Energy flux distribution'
     else:
-        assert out[6].startswith('xlabel = Photon flux ')
-        assert out[8] == 'title  = Photon flux distribution'
+        assert out[6].startswith('xlabel    = Photon flux ')
+        assert out[8] == 'title     = Photon flux distribution'
 
-    assert out[7] == 'ylabel = Frequency'
+    assert out[7] == 'ylabel    = Frequency'
     assert out[9].startswith('histo_prefs = ')
 
     assert len(out) == 10
@@ -796,21 +796,21 @@ def test_str_flux_histogram_full(energy, cls, old_numpy_printing):
     # lines 1-4 are the modelvals array;assume they are
     # displayed correctly
     assert out[0] == 'modelvals = [[ 0.1, 1.1],'
-    assert out[4] == 'clipped = [ 1., 1., 0., 1.]'
-    assert out[5] == 'flux = [ 1. , 1.5, 2. , 0.5]'
-    assert out[6] == 'xlo    = [ 0.5  , 0.875, 1.25 , 1.625]'
-    assert out[7] == 'xhi    = [ 0.875, 1.25 , 1.625, 2.   ]'
-    assert out[8] == 'y      = [ 1., 1., 1., 1.]'
+    assert out[4] == 'clipped   = [ 1., 1., 0., 1.]'
+    assert out[5] == 'flux      = [ 1. , 1.5, 2. , 0.5]'
+    assert out[6] == 'xlo       = [ 0.5  , 0.875, 1.25 , 1.625]'
+    assert out[7] == 'xhi       = [ 0.875, 1.25 , 1.625, 2.   ]'
+    assert out[8] == 'y         = [ 1., 1., 1., 1.]'
 
     # the exact text depends on the plot backend
     if energy:
-        assert out[9].startswith('xlabel = Energy flux ')
-        assert out[11] == 'title  = Energy flux distribution'
+        assert out[9].startswith('xlabel    = Energy flux ')
+        assert out[11] == 'title     = Energy flux distribution'
     else:
-        assert out[9].startswith('xlabel = Photon flux ')
-        assert out[11] == 'title  = Photon flux distribution'
+        assert out[9].startswith('xlabel    = Photon flux ')
+        assert out[11] == 'title     = Photon flux distribution'
 
-    assert out[10] == 'ylabel = Frequency'
+    assert out[10] == 'ylabel    = Frequency'
     assert out[12].startswith('histo_prefs = ')
 
     assert len(out) == 13

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -407,6 +407,8 @@ def test_get_arf_plot_channel(idval, clean_astro_ui):
 
     # the y label depends on the backend (due to LaTeX)
     # assert ap.ylabel == 'cm$^2$'
+    assert 'cm' in ap.ylabel
+    assert '2' in ap.ylabel
 
 
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -39,7 +39,7 @@ from typing import Any, Literal, Optional, Sequence, Union
 import numpy as np
 
 from sherpa import get_config
-from sherpa.data import Data1D, Data1DInt, Data2D
+from sherpa.data import Data, Data1D, Data1DInt, Data2D
 from sherpa.estmethods import Covariance
 from sherpa.models.model import Model
 from sherpa.optmethods import LevMar, NelderMead
@@ -251,7 +251,7 @@ class TemporaryPlottingBackend(contextlib.AbstractContextManager):
         return False
 
 
-def _make_title(title, name=''):
+def _make_title(title: str, name: Optional[str] = '') -> str:
     """Return the plot title to use.
 
     Parameters
@@ -275,7 +275,7 @@ def _make_title(title, name=''):
     return f"{title} for {name}"
 
 
-def _errorbar_warning(stat):
+def _errorbar_warning(stat: Stat) -> str:
     """The warning message to display when error bars are being "faked".
 
     Parameters
@@ -294,7 +294,10 @@ def _errorbar_warning(stat):
         f"used in fits with {stat.name}"
 
 
-def calculate_errors(data, stat, yerrorbars=True):
+def calculate_errors(data: Data,
+                     stat: Stat,
+                     yerrorbars: bool = True
+                     ) -> Optional[np.ndarray]:
     """Calculate errors from the statistics object."""
 
     if stat is None:
@@ -666,7 +669,7 @@ class HistogramPlot(Histogram):
         self.title = None
         super().__init__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         xlo = self.xlo
         if self.xlo is not None:
             xlo = np.array2string(np.asarray(self.xlo), separator=',',
@@ -690,7 +693,7 @@ ylabel = {self.ylabel}
 title  = {self.title}
 histo_prefs = {self.histo_prefs}"""
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the histogram plot."""
         return backend.as_html_histogram(self)
 
@@ -926,7 +929,7 @@ class PDFPlot(HistogramPlot):
         self.points = None
         super().__init__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         points = self.points
         if self.points is not None:
             points = np.array2string(np.asarray(self.points),
@@ -935,7 +938,7 @@ class PDFPlot(HistogramPlot):
 
         return (f'points = {points}\n' + HistogramPlot.__str__(self))
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the PDF plot."""
         return backend.as_html_pdf(self)
 
@@ -1023,7 +1026,7 @@ class CDFPlot(Plot):
         self.title = None
         super().__init__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         x = self.x
         if self.x is not None:
             x = np.array2string(self.x, separator=',', precision=4,
@@ -1049,7 +1052,7 @@ ylabel = {self.ylabel}
 title  = {self.title}
 plot_prefs = {self.plot_prefs}"""
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the CDF plot."""
         return backend.as_html_cdf(self)
 
@@ -1127,7 +1130,7 @@ class LRHistogram(HistogramPlot):
         self.ppp = None
         super().__init__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         ratios = self.ratios
         if self.ratios is not None:
             ratios = np.array2string(np.asarray(self.ratios),
@@ -1138,7 +1141,7 @@ class LRHistogram(HistogramPlot):
                           f'lr = {self.lr}',
                           HistogramPlot.__str__(self)])
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the LRHistogram plot."""
         return backend.as_html_lr(self)
 
@@ -1213,7 +1216,7 @@ class SplitPlot(Plot, Contour):
         self.reset(rows, cols)
         super().__init__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (('rows   = %s\n' +
                  'cols   = %s\n' +
                  'plot_prefs = %s') %
@@ -1318,9 +1321,6 @@ class JointPlot(SplitPlot):
     tall as the bottom plot.
     """
 
-    def __init__(self):
-        super().__init__()
-
     def plottop(self, plot, *args, overplot=False, clearwindow=True,
                 **kwargs):
 
@@ -1414,7 +1414,7 @@ class DataPlot(Plot):
         self.title = None
         super().__init__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         x = self.x
         if self.x is not None:
             x = np.array2string(self.x, separator=',', precision=4,
@@ -1452,7 +1452,7 @@ class DataPlot(Plot):
                  self.title,
                  self.plot_prefs))
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the data plot."""
         return backend.as_html_data(self)
 
@@ -1622,7 +1622,7 @@ class DataContour(Contour):
         self.levels = None
         super().__init__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         x0 = self.x0
         if self.x0 is not None:
             x0 = np.array2string(self.x0, separator=',', precision=4,
@@ -1655,7 +1655,7 @@ class DataContour(Contour):
                  self.levels,
                  self.contour_prefs))
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the contour plot."""
         return backend.as_html_datacontour(self)
 
@@ -1740,7 +1740,7 @@ class ModelPlot(Plot):
         self.title = 'Model'
         super().__init__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         x = self.x
         if self.x is not None:
             x = np.array2string(self.x, separator=',', precision=4,
@@ -1778,7 +1778,7 @@ class ModelPlot(Plot):
                  self.title,
                  self.plot_prefs))
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the model plot."""
         return backend.as_html_model(self)
 
@@ -1999,7 +1999,7 @@ class ModelContour(Contour):
         self.levels = None
         super().__init__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         x0 = self.x0
         if self.x0 is not None:
             x0 = np.array2string(self.x0, separator=',', precision=4,
@@ -2032,7 +2032,7 @@ class ModelContour(Contour):
                  self.levels,
                  self.contour_prefs))
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the model contour plot."""
         return backend.as_html_modelcontour(self)
 
@@ -2125,7 +2125,7 @@ class FitPlot(Plot):
         self.modelplot = None
         super().__init__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         data_title = None
         if self.dataplot is not None:
             data_title = self.dataplot.title
@@ -2140,7 +2140,7 @@ class FitPlot(Plot):
                  model_title,
                  self.modelplot))
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the fit plot."""
         return backend.as_html_fit(self)
 
@@ -2209,7 +2209,7 @@ class FitContour(Contour):
         self.modelcontour = None
         super().__init__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         data_title = None
         if self.datacontour is not None:
             data_title = self.datacontour.title
@@ -2223,7 +2223,7 @@ class FitContour(Contour):
                  model_title,
                  self.modelcontour))
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the fit contour plot."""
         return backend.as_html_fitcontour(self)
 
@@ -2960,7 +2960,7 @@ class Confidence1D(DataPlot):
         if 'numcores' not in state:
             self.__dict__['numcores'] = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         x = self.x
         if self.x is not None:
             x = np.array2string(self.x, separator=',', precision=4,
@@ -2981,7 +2981,7 @@ class Confidence1D(DataPlot):
                 f'log    = {self.log}\n' +
                 f'parval = {self.parval}')
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the confidence 1D plot."""
         return backend.as_html_contour1d(self)
 
@@ -3207,7 +3207,7 @@ class Confidence2D(DataContour, Point):
         if 'numcores' not in state:
             self.__dict__['numcores'] = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         x0 = self.x0
         if self.x0 is not None:
             x0 = np.array2string(self.x0, separator=',', precision=4,
@@ -3237,7 +3237,7 @@ class Confidence2D(DataContour, Point):
                 f'parval1 = {self.parval1}\n' +
                 f'levels  = {self.levels}')
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the confidence 2D plot."""
         return backend.as_html_contour2d(self)
 
@@ -3536,7 +3536,7 @@ class Confidence2D(DataContour, Point):
             self.contour_prefs['ylog'] = False
 
 
-class IntervalProjectionWorker():
+class IntervalProjectionWorker:
     """Used to evaluate the model by IntervalProjection.
 
     .. versionchanged:: 4.16.1
@@ -3662,7 +3662,7 @@ class IntervalProjection(Confidence1D):
             fit.method = oldfitmethod
 
 
-class IntervalUncertaintyWorker():
+class IntervalUncertaintyWorker:
     """Used to evaluate the model by IntervalUncertainty.
 
     .. versionchanged:: 4.16.1
@@ -3727,7 +3727,7 @@ class IntervalUncertainty(Confidence1D):
             fit.model.thawedpars = oldpars
 
 
-class RegionProjectionWorker():
+class RegionProjectionWorker:
     """Used to evaluate the model by RegionProjection.
 
     .. versionchanged:: 4.16.1
@@ -3860,7 +3860,7 @@ class RegionProjection(Confidence2D):
             fit.method = oldfitmethod
 
 
-class RegionUncertaintyWorker():
+class RegionUncertaintyWorker:
     """Used to evaluate the model by RegionUncertainty.
 
     .. versionchanged:: 4.16.1

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -970,7 +970,6 @@ class ModelHistogramPlot(HistogramPlot):
         self.xlo = indep[0]
         self.xhi = indep[1]
         self.y = y[1]
-        assert self.y.size == self.xlo.size
 
 
 class SourceHistogramPlot(ModelHistogramPlot):
@@ -1910,7 +1909,6 @@ class ComponentSourceHistogramPlot(SourceHistogramPlot):
         self.xlo = indep[0]
         self.xhi = indep[1]
         self.y = y[1]
-        assert self.y.size == self.xlo.size
 
         self.title = f'Source model component: {model.name}'
 

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -802,9 +802,10 @@ class HistogramPlot(Histogram):
 
         """
 
-        Histogram.plot(self, self.xlo, self.xhi, self.y, title=self.title,
-                       xlabel=self.xlabel, ylabel=self.ylabel,
-                       overplot=overplot, clearwindow=clearwindow, **kwargs)
+        super().plot(self.xlo, self.xhi, self.y, title=self.title,
+                     xlabel=self.xlabel, ylabel=self.ylabel,
+                     overplot=overplot, clearwindow=clearwindow,
+                     **kwargs)
 
     @staticmethod
     def vline(x, ymin=0, ymax=1,
@@ -1154,18 +1155,19 @@ class CDFPlot(Plot):
 
         """
 
-        Plot.plot(self, self.x, self.y, title=self.title,
-                  xlabel=self.xlabel, ylabel=self.ylabel,
-                  overplot=overplot, clearwindow=clearwindow, **kwargs)
+        super().plot(self.x, self.y, title=self.title,
+                     xlabel=self.xlabel, ylabel=self.ylabel,
+                     overplot=overplot, clearwindow=clearwindow,
+                     **kwargs)
 
         # Note: the user arguments are not applied to the vertical lines
         #
-        Plot.vline(self.median, overplot=True, clearwindow=False,
-                   **self.median_defaults)
-        Plot.vline(self.lower, overplot=True, clearwindow=False,
-                   **self.lower_defaults)
-        Plot.vline(self.upper, overplot=True, clearwindow=False,
-                   **self.upper_defaults)
+        super().vline(self.median, overplot=True, clearwindow=False,
+                      **self.median_defaults)
+        super().vline(self.lower, overplot=True, clearwindow=False,
+                      **self.lower_defaults)
+        super().vline(self.upper, overplot=True, clearwindow=False,
+                      **self.upper_defaults)
 
 
 class LRHistogram(HistogramPlot):
@@ -1228,9 +1230,8 @@ class LRHistogram(HistogramPlot):
 
         """
 
-        Histogram.plot(self, self.xlo, self.xhi, self.y, title=self.title,
-                       xlabel=self.xlabel, ylabel=self.ylabel,
-                       overplot=overplot, clearwindow=clearwindow, **kwargs)
+        super().plot(overplot=overplot, clearwindow=clearwindow,
+                     **kwargs)
 
         if self.lr is None:
             return
@@ -1238,9 +1239,9 @@ class LRHistogram(HistogramPlot):
         # Note: the user arguments are not applied to the vertical line
         #
         if self.lr <= self.xhi.max() and self.lr >= self.xlo.min():
-            HistogramPlot.vline(self.lr, linecolor="orange",
-                                linestyle="solid", linewidth=1.5,
-                                overplot=True, clearwindow=False)
+            super().vline(self.lr, linecolor="orange",
+                          linestyle="solid", linewidth=1.5,
+                          overplot=True, clearwindow=False)
 
 
 class SplitPlot(Plot, Contour):
@@ -1525,9 +1526,10 @@ class DataPlot(Plot):
         prepare, overplot
 
         """
-        Plot.plot(self, self.x, self.y, yerr=self.yerr, xerr=self.xerr,
-                  title=self.title, xlabel=self.xlabel, ylabel=self.ylabel,
-                  overplot=overplot, clearwindow=clearwindow, **kwargs)
+        super().plot(self.x, self.y, yerr=self.yerr, xerr=self.xerr,
+                     title=self.title, xlabel=self.xlabel,
+                     ylabel=self.ylabel, overplot=overplot,
+                     clearwindow=clearwindow, **kwargs)
 
 
 class TracePlot(DataPlot):
@@ -1605,7 +1607,7 @@ class PSFKernelPlot(DataPlot):
         plot
         """
         psfdata = psf.get_kernel(data)
-        DataPlot.prepare(self, psfdata, stat)
+        super().prepare(data=psfdata, stat=stat)
         # self.ylabel = 'PSF value'
         # self.xlabel = 'PSF Kernel size'
         self.title = 'PSF Kernel'
@@ -1663,10 +1665,9 @@ class DataContour(Contour):
         self.title = data.name
 
     def contour(self, overcontour=False, clearwindow=True, **kwargs):
-        Contour.contour(self, self.x0, self.x1, self.y,
-                        levels=self.levels, title=self.title,
-                        xlabel=self.xlabel, ylabel=self.ylabel,
-                        overcontour=overcontour,
+        super().contour(self.x0, self.x1, self.y, levels=self.levels,
+                        title=self.title, xlabel=self.xlabel,
+                        ylabel=self.ylabel, overcontour=overcontour,
                         clearwindow=clearwindow, **kwargs)
 
 
@@ -1802,10 +1803,10 @@ class ModelPlot(Plot):
 
         """
         # This does not display yerr or xerr.
-        Plot.plot(self, self.x, self.y, title=self.title,
-                  xlabel=self.xlabel, ylabel=self.ylabel,
-                  overplot=overplot, clearwindow=clearwindow,
-                  **kwargs)
+        super().plot(self.x, self.y, title=self.title,
+                     xlabel=self.xlabel, ylabel=self.ylabel,
+                     overplot=overplot, clearwindow=clearwindow,
+                     **kwargs)
 
 
 class ComponentModelPlot(ModelPlot):
@@ -1951,7 +1952,7 @@ class PSFPlot(DataPlot):
         plot
         """
         psfdata = psf.get_kernel(data, False)
-        DataPlot.prepare(self, psfdata, stat)
+        super().prepare(data=psfdata, stat=stat)
         self.title = psf.kernel.name
 
 
@@ -3070,23 +3071,28 @@ class Confidence1D(DataPlot):
         if par not in fit.model.pars:
             raise ConfidenceErr('thawed', par.fullname, fit.model.name)
 
+        # Make sure xerr and yerr are cleared
+        self.xerr = None
+        self.yerr = None
+
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         if self.log:
             self.plot_prefs['xlog'] = True
 
-        Plot.plot(self, self.x, self.y, title=self.title, xlabel=self.xlabel,
-                  ylabel=self.ylabel, overplot=overplot,
-                  clearwindow=clearwindow, **kwargs)
+        super().plot(overplot=overplot, clearwindow=clearwindow,
+                     **kwargs)
 
         # Note: the user arguments are not applied to the lines
         #
         if self.stat is not None:
-            Plot.hline(self.stat, linecolor="green", linestyle="dash",
-                       linewidth=1.5, overplot=True, clearwindow=False)
+            super().hline(self.stat, linecolor="green",
+                          linestyle="dash", linewidth=1.5,
+                          overplot=True, clearwindow=False)
 
         if self.parval is not None:
-            Plot.vline(self.parval, linecolor="orange", linestyle="dash",
-                       linewidth=1.5, overplot=True, clearwindow=False)
+            super().vline(self.parval, linecolor="orange",
+                          linestyle="dash", linewidth=1.5,
+                          overplot=True, clearwindow=False)
 
         if self.log:
             self.plot_prefs['xlog'] = False
@@ -3424,9 +3430,7 @@ class Confidence2D(DataContour, Point):
         #
         overcontour = kwargs.pop('overcontour', False) or overplot
 
-        Contour.contour(self, self.x0, self.x1, self.y, levels=self.levels,
-                        title=self.title, xlabel=self.xlabel,
-                        ylabel=self.ylabel, overcontour=overcontour,
+        super().contour(overcontour=overcontour,
                         clearwindow=clearwindow, **kwargs)
 
         # Note: the user arguments are not applied to the point
@@ -3500,11 +3504,11 @@ class IntervalProjection(Confidence1D):
     def prepare(self, fast=True, min=None, max=None, nloop=20,
                 delv=None, fac=1, log=False, numcores=None):
         self.fast = fast
-        Confidence1D.prepare(self, min, max, nloop, delv, fac, log, numcores)
+        super().prepare(min, max, nloop, delv, fac, log, numcores)
 
     def calc(self, fit, par, methoddict=None, cache=True):
         self.title = 'Interval-Projection'
-        Confidence1D.calc(self, fit, par)
+        super().calc(fit=fit, par=par)
 
         # If "fast" option enabled, set fitting method to
         # lmdif if stat is chi-squared,
@@ -3609,7 +3613,7 @@ class IntervalUncertainty(Confidence1D):
 
     def calc(self, fit, par, methoddict=None, cache=True):
         self.title = 'Interval-Uncertainty'
-        Confidence1D.calc(self, fit, par)
+        super().calc(fit=fit, par=par)
 
         thawed = [p for p in fit.model.pars if not p.frozen]
         oldpars = fit.model.thawedpars
@@ -3697,12 +3701,12 @@ class RegionProjection(Confidence2D):
                 delv=None, fac=4, log=(False, False),
                 sigma=(1, 2, 3), levels=None, numcores=None):
         self.fast = fast
-        Confidence2D.prepare(self, min, max, nloop, delv, fac, log,
-                             sigma, levels, numcores)
+        super().prepare(min, max, nloop, delv, fac, log, sigma,
+                        levels=levels, numcores=numcores)
 
     def calc(self, fit, par0, par1, methoddict=None, cache=True):
         self.title = 'Region-Projection'
-        Confidence2D.calc(self, fit, par0, par1)
+        super().calc(fit=fit, par0=par0, par1=par1)
 
         # If "fast" option enabled, set fitting method to
         # lmdif if stat is chi-squared,
@@ -3808,7 +3812,7 @@ class RegionUncertainty(Confidence2D):
 
     def calc(self, fit, par0, par1, methoddict=None, cache=True):
         self.title = 'Region-Uncertainty'
-        Confidence2D.calc(self, fit, par0, par1)
+        super().calc(fit=fit, par0=par0, par1=par1)
 
         thawed = [i for i in fit.model.pars if not i.frozen]
         oldpars = fit.model.thawedpars

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -1802,9 +1802,11 @@ class ModelPlot(Plot):
         prepare, overplot
 
         """
-        Plot.plot(self, self.x, self.y, title=self.title, xlabel=self.xlabel,
-                  ylabel=self.ylabel, overplot=overplot,
-                  clearwindow=clearwindow, **kwargs)
+        # This does not display yerr or xerr.
+        Plot.plot(self, self.x, self.y, title=self.title,
+                  xlabel=self.xlabel, ylabel=self.ylabel,
+                  overplot=overplot, clearwindow=clearwindow,
+                  **kwargs)
 
 
 class ComponentModelPlot(ModelPlot):
@@ -2394,20 +2396,6 @@ class BaseResidualContour(ModelContour):
         self._calc_y(ys)
         self._title(data)
 
-    def contour(self,  # type: ignore[override]
-                overcontour: bool = False,
-                clearwindow: bool = True,
-                **kwargs) -> None:
-
-        x0 = self.x0
-        x1 = self.x1
-        y = self.y
-
-        Contour.contour(self, x0, x1, y, levels=self.levels,
-                        title=self.title, xlabel=self.xlabel,
-                        ylabel=self.ylabel, overcontour=overcontour,
-                        clearwindow=clearwindow, **kwargs)
-
 
 class DelchiPlot(BaseResidualPlot):
     """Create plots of the delta-chi value per point.
@@ -2524,15 +2512,10 @@ class ChisqrPlot(ModelPlot):
         self.y = self._calc_chisqr(y, staterr)
         # TODO: should this
         #   self.yerr = staterr * staterr
+        # but we currently do not display errors
         self.ylabel = backend.get_latex_for_string(r'\chi^2')
         self.title = _make_title(
             backend.get_latex_for_string(r'\chi^2'), data.name)
-
-    # TODO: should this draw x/y errors?
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
-        Plot.plot(self, self.x, self.y, title=self.title,
-                  xlabel=self.xlabel, ylabel=self.ylabel,
-                  overplot=overplot, clearwindow=clearwindow, **kwargs)
 
 
 class ChisqrHistogramPlot(ModelHistogramPlot):

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -1279,7 +1279,7 @@ def test_lrhist_str(check_str):
 
     check_str("\n".join(out),
               ["ratios = None",
-               "lr = None",
+               "lr     = None",
                "xlo    = None",
                "xhi    = None",
                "y      = None",
@@ -1299,7 +1299,7 @@ def test_lrhist_str(check_str):
 
     check_str("\n".join(out),
               ["ratios = [0. ,0.5,1. ,1.5,2. ,2.5,3. ,3.5,4. ,4.5]",
-               "lr = 0.1",
+               "lr     = 0.1",
                "xlo    = [0.  ,0.75,1.5 ,2.25,3.  ,3.75]",
                "xhi    = [0.75,1.5 ,2.25,3.  ,3.75,4.5 ]",
                "y      = [1. ,0.5,1. ,0.5,1. ,1. ]",


### PR DESCRIPTION
# Summary

Clean up some plot code to make better use of modern Python idioms. The string display of some of the objects has now changed so that the `name = value` lines are now aligned (except for the preference line).

# Details

This has been pulled out of #1988, concentrating on the "small clean up" stuff rather than the larger changes which were leading to #2076 - and I now believe that we don't have time to properly discuss them for 4.17.0, so we should just take the less controversial changes.

There is little behavioural change here: the only difference is that some of the string representation objects are now more consistent so that the `=` character lines up in the `xxx  = value\nyyy   = value\n...` output.

The other changes are to make more use of `super()` - which is a lot easier now after recent plot changes that have removed some of the interesting hierarchy we had - and to avoid defining methods which are the same as the superclass version.

One positive change, I think, is that it's a bit more obvious when we explicitly subvert the inheritance - since in those case we do not call methods via `super()` but explicitly call the class in question. This is needed because we have a hierarchy where the base classes have a `plot` method which takes the data to plot, but classes built on them change the API and require a call to `prepare` to set up fields in the object and the `plot` call just has `overplot`, `clearwindow`, and `**kwargs` as arguments. This is part of what #1988 and #2076 were about, but we can worry about cleaning that up in the future.

# Example

Note that the `name = value` lines now all line up on the `=` character **except** for the `histo_prefs` line (this was an intentional change as the preferences are slightly different and also generally would require adding even more spaces which just doesn't seem worth it).

## 4.16.0

```
>>> from sherpa.astro.plot import FluxHistogram
>>> p = FluxHistogram()
>>> print(p)
modelvals = None
clipped = None
flux = None
xlo    = None
xhi    = None
y      = None
xlabel = None
ylabel = None
title  = Model
histo_prefs = {'xlog': False, 'ylog': False, 'label': None, 'xerrorbars': False, 'yerrorbars': False, 'color': None, 'linestyle': 'solid', 'linewidth': None, 'marker': 'None', 'alpha': None, 'markerfacecolor': None, 'markersize': None, 'ecolor': None, 'capsize': None}
```

## Now

```
>>> from sherpa.astro.plot import FluxHistogram
>>> p = FluxHistogram()
>>> print(p)
modelvals = None
clipped   = None
flux      = None
xlo       = None
xhi       = None
y         = None
xlabel    = None
ylabel    = None
title     = Model
histo_prefs = {'xlog': False, 'ylog': False, 'label': None, 'xerrorbars': False, 'yerrorbars': False, 'color': None, 'linestyle': 'solid', 'linewidth': None, 'marker': 'None', 'alpha': None, 'markerfacecolor': None, 'markersize': None, 'ecolor': None, 'capsize': None}
```