### PR TITLE
data: allow axis labels to be changed

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -5607,18 +5607,18 @@ class DataIMGInt(DataIMG):
     edges (``x0edges[:-1]`` or ``x0edges[1:]``) and then repeat them to match
     the number of bins in the flattened data array::
 
-    >>> import numpy as np
-    >>> x = np.random.normal(size=1000, loc=1.2)
-    >>> y = np.random.normal(size=1000)
-    >>> xrange = np.arange(-2, 4.1, 0.5)
-    >>> yrange = np.arange(-2, 2.1, 0.5)
-    >>> hist, x0edges, x1edges = np.histogram2d(y, x, bins=(yrange, xrange))
-    >>> x0lo, x1lo = np.meshgrid(x0edges[:-1], x1edges[:-1])
-    >>> x0hi, x1hi = np.meshgrid(x0edges[1:], x1edges[1:])
-    >>> image = DataIMGInt("binned_image",
-    ...                    x0lo=x0lo.flatten(), x1lo=x1lo.flatten(),
-    ...                    x0hi=x0hi.flatten(), x1hi=x1hi.flatten(),
-    ...                    y=hist.flatten(), shape=hist.shape)
+      >>> import numpy as np
+      >>> x = np.random.normal(size=1000, loc=1.2)
+      >>> y = np.random.normal(size=1000)
+      >>> xrange = np.arange(-2, 4.1, 0.5)
+      >>> yrange = np.arange(-2, 2.1, 0.5)
+      >>> hist, x0edges, x1edges = np.histogram2d(y, x, bins=(yrange, xrange))
+      >>> x0lo, x1lo = np.meshgrid(x0edges[:-1], x1edges[:-1])
+      >>> x0hi, x1hi = np.meshgrid(x0edges[1:], x1edges[1:])
+      >>> image = DataIMGInt("binned_image",
+      ...                    x0lo=x0lo.flatten(), x1lo=x1lo.flatten(),
+      ...                    x0hi=x0hi.flatten(), x1hi=x1hi.flatten(),
+      ...                    y=hist.flatten(), shape=hist.shape)
 
     Note that in this example, we end up with a "logical" coordinate system
     in ``image`` and no WCS system to convert it to anything else. On the other hand,

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -4000,3 +4000,217 @@ def test_get_filter_when_empty_2d(data_class, args):
 
     data = data_class("empty", *args)
     assert data.get_filter() == ''
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("analysis,label",
+                         [("energy", "Energy (keV)"),
+                          ("wavelength", "Wavelength (Angstrom)"),
+                          ("channel", "Channel")])
+def test_get_xlabel_pha(make_data_path, analysis, label):
+    """get_xlabel for PHA file"""
+
+    import sherpa.astro.io
+    infile = make_data_path("3c273.pi")
+    data = sherpa.astro.io.read_pha(infile)
+    data.set_analysis(analysis)
+    assert data.get_xlabel() == label
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("analysis", ["energy", "wavelength", "channel"])
+@pytest.mark.parametrize("label", ["not a label", "", "Energy (keV)"])
+def test_set_xlabel_pha(make_data_path, analysis, label):
+    """set_xlabel for PHA file"""
+
+    import sherpa.astro.io
+    infile = make_data_path("3c273.pi")
+    data = sherpa.astro.io.read_pha(infile)
+    data.set_xlabel(label)
+    data.set_analysis(analysis)
+    assert data.get_xlabel() == label
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("analysis,units",
+                         [("energy", "keV"),
+                          ("wavelength", "Angstrom"),
+                          ("channel", "channel")])
+def test_get_ylabel_pha(make_data_path, analysis, units):
+    """get_ylabel for PHA file
+
+    This does not check all the options for the label.
+    """
+
+    import sherpa.astro.io
+    infile = make_data_path("3c273.pi")
+    data = sherpa.astro.io.read_pha(infile)
+    data.set_analysis(analysis)
+    assert data.get_ylabel() == f"Counts/sec/{units}"
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("analysis", ["energy", "wavelength", "channel"])
+@pytest.mark.parametrize("label", ["not a label", "", "Energy (keV)"])
+def test_set_ylabel_pha(make_data_path, analysis, label):
+    """set_ylabel for PHA file
+
+    This does not check all the options for the label.
+    """
+
+    import sherpa.astro.io
+    infile = make_data_path("3c273.pi")
+    data = sherpa.astro.io.read_pha(infile)
+    data.set_ylabel(label)
+    data.set_analysis(analysis)
+    assert data.get_ylabel() == label
+
+
+@requires_data
+@requires_fits
+def test_get_xlabel_arf(make_data_path):
+    """get_xlabel for ARF"""
+
+    import sherpa.astro.io
+    infile = make_data_path("3c273.arf")
+
+    data = sherpa.astro.io.read_arf(infile)
+    assert data.get_xlabel() == 'Energy (keV)'
+
+
+@requires_data
+@requires_fits
+def test_get_ylabel_arf(make_data_path):
+    """get_ylabel for ARF"""
+
+    import sherpa.astro.io
+    infile = make_data_path("3c273.arf")
+
+    data = sherpa.astro.io.read_arf(infile)
+    # The label depends on the backend
+    ylabel = data.get_ylabel()
+    assert 'cm' in ylabel
+    assert '2' in ylabel
+
+
+@requires_data
+@requires_fits
+def test_get_xlabel_rmf(make_data_path):
+    """get_xlabel for RMF"""
+
+    import sherpa.astro.io
+    infile = make_data_path("3c273.rmf")
+
+    data = sherpa.astro.io.read_rmf(infile)
+    assert data.get_xlabel() == 'Energy (keV)'
+
+
+@requires_data
+@requires_fits
+def test_get_ylabel_rmf(make_data_path):
+    """get_ylabel for RMF"""
+
+    import sherpa.astro.io
+    infile = make_data_path("3c273.rmf")
+
+    data = sherpa.astro.io.read_rmf(infile)
+    assert data.get_ylabel() == 'Counts'
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("label", ["not a label", "", "Energy (keV)"])
+@pytest.mark.parametrize("resp", ["arf", "rmf"])
+def test_set_xlabel_pha_response(make_data_path, label, resp):
+    """set_xlabel for PHA related"""
+
+    import sherpa.astro.io
+    infile = make_data_path(f"3c273.{resp}")
+
+    getfunc = getattr(sherpa.astro.io, f"read_{resp}")
+    data = getfunc(infile)
+    data.set_xlabel(label)
+    assert data.get_xlabel() == label
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("label", ["not a label", "", "Energy (keV)"])
+@pytest.mark.parametrize("resp", ["arf", "rmf"])
+def test_set_ylabel_pha_response(make_data_path, label, resp):
+    """set_xlabel for PHA related"""
+
+    import sherpa.astro.io
+    infile = make_data_path(f"3c273.{resp}")
+
+    getfunc = getattr(sherpa.astro.io, f"read_{resp}")
+    data = getfunc(infile)
+    data.set_ylabel(label)
+    assert data.get_ylabel() == label
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("coord", ["logical", "physical", "world"])
+@pytest.mark.parametrize("axis", ["x0", "x1"])
+def test_get_xlabel_img(make_data_path, coord, axis):
+    """get_xlabel for DataIMG"""
+
+    import sherpa.astro.io
+    infile = make_data_path("acisf08478_000N001_r0043_regevt3_srcimg.fits")
+
+    data = sherpa.astro.io.read_image(infile)
+    getfunc = getattr(data, f"get_{axis}label")
+    assert getfunc() == axis
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("coord", ["logical", "physical", "world"])
+@pytest.mark.parametrize("axis", ["x0", "x1"])
+@pytest.mark.parametrize("label", ["not a label", "", "Energy (keV)"])
+def test_set_xlabel_img(make_data_path, coord, axis, label):
+    """get_xlabel for DataIMG"""
+
+    import sherpa.astro.io
+    infile = make_data_path("acisf08478_000N001_r0043_regevt3_srcimg.fits")
+
+    data = sherpa.astro.io.read_image(infile)
+    getfunc = getattr(data, f"get_{axis}label")
+    setfunc = getattr(data, f"set_{axis}label")
+
+    setfunc(label)
+    assert getfunc() == label
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("coord", ["logical", "physical", "world"])
+@pytest.mark.parametrize("axis", ["x0", "x1"])
+def test_get_ylabel_img(make_data_path, coord, axis):
+    """get_ylabel for DataIMG"""
+
+    import sherpa.astro.io
+    infile = make_data_path("acisf08478_000N001_r0043_regevt3_srcimg.fits")
+
+    data = sherpa.astro.io.read_image(infile)
+    assert data.get_ylabel() == 'y'
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("coord", ["logical", "physical", "world"])
+@pytest.mark.parametrize("label", ["not a label", "", "Energy (keV)"])
+def test_set_xlabel_img(make_data_path, coord, label):
+    """get_xlabel for DataIMG"""
+
+    import sherpa.astro.io
+    infile = make_data_path("acisf08478_000N001_r0043_regevt3_srcimg.fits")
+
+    data = sherpa.astro.io.read_image(infile)
+    data.set_ylabel(label)
+    assert data.get_ylabel() == label

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1167,11 +1167,24 @@ def test_img_file_get_axes_world(coord, read_test_image):
                           ('physical', 'x0 (pixels)'),
                           ('world', 'RA (deg)'),
                           ('wcs', 'RA (deg)')])
-def test_img_file_get_xlabel(coord, expected, read_test_image):
+def test_img_file_get_x0label(coord, expected, read_test_image):
     """get_x0label"""
     d = read_test_image
     d.set_coord(coord)
     assert d.get_x0label() == expected
+
+
+@requires_fits
+@requires_data
+@requires_wcs
+@pytest.mark.parametrize('coord', ['logical', 'physical', 'world'])
+@pytest.mark.parametrize('label', ['', 'not a label', 'x0'])
+def test_img_file_set_x0label(coord, label, read_test_image):
+    """set_x0label"""
+    d = read_test_image
+    d.set_coord(coord)
+    d.set_x0label(label)
+    assert d.get_x0label() == label
 
 
 @requires_fits
@@ -1183,11 +1196,48 @@ def test_img_file_get_xlabel(coord, expected, read_test_image):
                           ('physical', 'x1 (pixels)'),
                           ('world', 'DEC (deg)'),
                           ('wcs', 'DEC (deg)')])
-def test_img_file_get_ylabel(coord, expected, read_test_image):
+def test_img_file_get_x1label(coord, expected, read_test_image):
     """get_x1label"""
     d = read_test_image
     d.set_coord(coord)
     assert d.get_x1label() == expected
+
+
+@requires_fits
+@requires_data
+@requires_wcs
+@pytest.mark.parametrize('coord', ['logical', 'physical', 'world'])
+@pytest.mark.parametrize('label', ['', 'not a label', 'x0'])
+def test_img_file_set_x1label(coord, label, read_test_image):
+    """set_x1label"""
+    d = read_test_image
+    d.set_coord(coord)
+    d.set_x1label(label)
+    assert d.get_x1label() == label
+
+
+@requires_fits
+@requires_data
+@requires_wcs
+@pytest.mark.parametrize('coord', ['logical', 'physical', 'world'])
+def test_img_file_get_ylabel(coord, read_test_image):
+    """get_ylabel"""
+    d = read_test_image
+    d.set_coord(coord)
+    assert d.get_ylabel() == 'y'
+
+
+@requires_fits
+@requires_data
+@requires_wcs
+@pytest.mark.parametrize('coord', ['logical', 'physical', 'world'])
+@pytest.mark.parametrize('label', ['', 'not a label', 'y'])
+def test_img_file_set_ylabel(coord, label, read_test_image):
+    """set_ylabel"""
+    d = read_test_image
+    d.set_coord(coord)
+    d.set_ylabel(label)
+    assert d.get_ylabel() == label
 
 
 def test_img_get_bounding_mask_nofilter(make_test_image):

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -878,6 +878,8 @@ class Data(NoNewAttributesAfterInit, BaseData):
         self.y, self.mask = _check_dep(y)
         self.staterror = staterror
         self.syserror = syserror
+
+        self._ylabel = 'y'
         NoNewAttributesAfterInit.__init__(self)
 
     def _check_data_space(self, dataspace):
@@ -1399,7 +1401,10 @@ class Data(NoNewAttributesAfterInit, BaseData):
         """
         return self.get_error(filter, staterrfunc)
 
-    def get_ylabel(self, yfunc=None):
+    # It looks like we never set yfunc when calling this method so we
+    # could remove it.
+    #
+    def get_ylabel(self, yfunc=None) -> str:
         """Return label for dependent axis in N-D view of dependent variable.
 
         Parameters
@@ -1408,9 +1413,32 @@ class Data(NoNewAttributesAfterInit, BaseData):
 
         Returns
         -------
+        label: str
+           The label.
+
+        See Also
+        --------
+        set_ylabel
 
         """
-        return 'y'
+        return self._ylabel
+
+    def set_ylabel(self, label: str) -> None:
+        """Set the label for the dependent axis.
+
+        .. versionadded:: 4.17.0
+
+        Parameters
+        ----------
+        label: str
+            The new label.
+
+        See Also
+        --------
+        get_ylabel
+
+        """
+        self._ylabel = label
 
     @overload
     def apply_filter(self, data: None) -> None:
@@ -1660,6 +1688,7 @@ class Data1D(Data):
                  staterror: Optional[ArrayType] = None,
                  syserror: Optional[ArrayType] = None
                  ) -> None:
+        self._xlabel = 'x'
         super().__init__(name, (x, ), y, staterror, syserror)
 
     def _repr_html_(self) -> str:
@@ -1717,8 +1746,29 @@ class Data1D(Data):
         -------
         label : str
 
+        See Also
+        --------
+        set_xlabel
+
         """
-        return 'x'
+        return self._xlabel
+
+    def set_xlabel(self, label: str) -> None:
+        """Set the label for the independent axis.
+
+        .. versionadded:: 4.17.0
+
+        Parameters
+        -------
+        label : str
+           The new label.
+
+        See Also
+        --------
+        set_xlabel
+
+        """
+        self._xlabel = label
 
     # The superclass suggests returning both the independent and
     # dependent axis sizes.
@@ -2051,6 +2101,9 @@ class Data1DInt(Data1D):
                  staterror: Optional[ArrayType] = None,
                  syserror: Optional[ArrayType] = None
                  ) -> None:
+
+        # Note: we do not call the superclass here.
+        self._xlabel = 'x'
         Data.__init__(self, name, (xlo, xhi), y, staterror, syserror)
 
     def _repr_html_(self) -> str:
@@ -2339,6 +2392,10 @@ class Data2D(Data):
                  syserror: Optional[ArrayType] = None
                  ) -> None:
         self.shape = shape
+
+        self._x0label = 'x0'
+        self._x1label = 'x1'
+
         super().__init__(name, (x0, x1), y, staterror, syserror)
 
     def _repr_html_(self) -> str:
@@ -2369,14 +2426,59 @@ class Data2D(Data):
 
         Returns
         -------
+        label: str
+
+        See Also
+        --------
+        get_x1label, set_x0label
 
         """
-        return 'x0'
+        return self._x0label
 
     def get_x1label(self) -> str:
         """Return label for second dimension in 2-D view of independent axis/axes.
+        Returns
+        -------
+        label: str
+
+        See Also
+        --------
+        get_x0label, set_x1label
+
         """
-        return 'x1'
+        return self._x1label
+
+    def set_x0label(self, label: str) -> None:
+        """Set the label for the first independent axis.
+
+        .. versionadded:: 4.17.0
+
+        Parameters
+        -------
+        label: str
+
+        See Also
+        --------
+        get_x0label, set_x1label
+
+        """
+        self._x0label = label
+
+    def set_x1label(self, label: str) -> None:
+        """Set the label for the second independent axis.
+
+        .. versionadded:: 4.17.0
+
+        Parameters
+        -------
+        label: str
+
+        See Also
+        --------
+        get_x1label, set_x0label
+
+        """
+        self._x1label = label
 
     def get_axes(self) -> tuple[np.ndarray, np.ndarray]:
         self._check_shape()
@@ -2593,7 +2695,12 @@ class Data2DInt(Data2D):
                  staterror: Optional[ArrayType] = None,
                  syserror: Optional[ArrayType] = None
                  ) -> None:
+
+        # Note: we do not call the superclass here.
         self.shape = shape
+        self._x0label = 'x0'
+        self._x1label = 'x1'
+        self._ylabel = 'y'
         Data.__init__(self, name, (x0lo, x1lo, x0hi, x1hi), y, staterror, syserror)
 
     def _init_data_space(self,

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -266,9 +266,23 @@ def test_data_get_xlabel(data):
     assert data.get_xlabel() == "x"
 
 
+@pytest.mark.parametrize("data", DATA_1D_CLASSES, indirect=True)
+@pytest.mark.parametrize("label", ["not a label", "", "x"])
+def test_data_change_xlabel(data, label):
+    data.set_xlabel(label)
+    assert data.get_xlabel() == label
+
+
 @pytest.mark.parametrize("data", DATA_2D_CLASSES, indirect=True)
 def test_data_get_x0label(data):
     assert data.get_x0label() == "x0"
+
+
+@pytest.mark.parametrize("data", DATA_2D_CLASSES, indirect=True)
+@pytest.mark.parametrize("label", ["not a label", "", "x0"])
+def test_data_change_x0label(data, label):
+    data.set_x0label(label)
+    assert data.get_x0label() == label
 
 
 @pytest.mark.parametrize("data", DATA_2D_CLASSES, indirect=True)
@@ -276,9 +290,23 @@ def test_data_get_x1label(data):
     assert data.get_x1label() == "x1"
 
 
+@pytest.mark.parametrize("data", DATA_2D_CLASSES, indirect=True)
+@pytest.mark.parametrize("label", ["not a label", "", "x1"])
+def test_data_change_x1label(data, label):
+    data.set_x1label(label)
+    assert data.get_x1label() == label
+
+
 @pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
 def test_data_get_ylabel(data):
     assert data.get_ylabel() == "y"
+
+
+@pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
+@pytest.mark.parametrize("label", ["not a label", "", "y"])
+def test_data_change_ylabel(data, label):
+    data.set_ylabel(label)
+    assert data.get_ylabel() == label
 
 
 @pytest.mark.parametrize("data", (Data, ), indirect=True)

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -13912,6 +13912,18 @@ class Session(NoNewAttributesAfterInit):
         >>> plot_data(2, overplot=True, alpha=0.7, color='brown')
         >>> plot_data(3, overplot=True, alpha=0.7, color='purple')
 
+        Set the labels used for the X and Y axes for the data. In this
+        example the matplotlib backend is used and so the LaTeX
+        support is used to display an Angstrom symbol as part of the X
+        axis label. Note that the labels will be retained for other
+        plots, including other plot types such as plot_model() or
+        plot_fit_resid().
+
+        >>> d = get_data()
+        >>> d.set_xlabel(r"x axis [$\AA$]")
+        >>> d.set_ylabel("y axis")
+        >>> plot_data()
+
         """
 
         plotobj = self.get_data_plot(id, recalc=not replot)


### PR DESCRIPTION
# Summary

Allow the independent and dependent axis labels to be changed. Address #2083

# Details

To complement

  get_xlabel, get_x0label, get_x1label, get_ylabel

add

  set_xlabel, set_x0label, set_x1label, set_ylabel

for the data types. This is trickier than at first thought, since

a) we introduce _xlabel, _ylabel, ... fields to store the labels
   so we can set up the defaults (in the __init__ call) and then
   over-ride them by the user

b) since we have some interesting hierarchies, with __init__ calls
   that can not be just passed to a superclass, we have to either
   create these attributes in more places than we'd want

c) some classes have labels that depend on the object setting
   (DataPHA and DataIMG), so we need to decide how to handle this.
   The assumption taken is that if a user has not called set_*label
   then the get_*label call returns the expected value, but as soon
   as set_xlabel is used then the requested label is always returned.

I thought about adding in UI routines to provide easy access to the user, but for now we rely on the user manually having to call the get_data routine for us.

# Examples

## generic data set

This uses a SDSS spectrum, but the data doesn't really matter (I just used this because it has units on both axes and so we want to label them).

First, the default behaviour

```python
plot_fit_delchi()
plt.ylabel(r"Residual [$\sigma$]")
plt.savefig("no-labels.png")
```

![no-labels](https://github.com/user-attachments/assets/9a8177d8-0855-4d58-b2a6-4bf9191a9d68)

With this PR

```python
get_data().set_xlabel("Wavelength [$\AA$]")
get_data().set_ylabel("Flux [10$^{-17}$ erg/cm$^2$/s/$\AA$]")

plot_fit_delchi()
plt.ylabel(r"Residual [$\sigma$]")
plt.savefig("with-labels.png")
```

![with-labels](https://github.com/user-attachments/assets/e282c30d-96ed-4690-9657-c86f70c4e786)

## PHA

The PHA case is special. Here are some default plots

```python
notice(0.3, 6)
plot_data()
```

![pha-energy](https://github.com/user-attachments/assets/1e1f32cb-0e51-4d33-be73-d8c85b1af558)

```python
set_analysis("wave", type="counts", factor=2)
plot_data()
```

![pha-wave](https://github.com/user-attachments/assets/8a6380c6-7f69-4773-b09e-5e69ef53590d)

Now re-load the data and call

```
notice(0.3, 6)
get_data().set_xlabel("Foo Bar")
get_data().set_ylabel("Bar Foo")
plot_data()
```

![pha-energy-2](https://github.com/user-attachments/assets/cf0f7031-4aef-42cf-a74b-a417b7832c42)


```python
set_analysis("wave", type="counts", factor=2)
plot_data()
```

![pha-wave-2](https://github.com/user-attachments/assets/2c47dd6a-42be-4d9f-9718-9f080c7097ab)


# Notes

- the `set_*label` call will remain - so a call to `plot_data` or `plot_model` ... will use the new labels.
- there's no way to change the y label for things like `plot_resid`/`plot_delchi`,`plot_ratio` since this is determined by the plot rather than the data, so you still may have to do post-processing work for your visualzation (e.g. the messing around with `plot.ylabel` call here)
- PHA data change the labels depending on choices (e.g. analysis setting, plot as a rate or counts, the factor setting) but once `set_*label` is called then that logic is "lost" (well, you can call `set_*label(None)` to restore it but that is currently not documented/tested).
