### PR TITLE
Add a name field to the IO backends

### DIFF
--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -32,10 +32,10 @@ When this module is first imported, Sherpa tries to import the
 backends installed with Sherpa in the order listed in the
 ``.sherpa.rc`` or ``.sherpa-standalone.rc`` file. The first module that imports
 successfully is set as the active backend. The following command prints the
-name and the location on disk of that module:
+name of the backend:
 
    >>> from sherpa.astro import io
-   >>> print(io.backend)
+   >>> print(io.backend.name)
 
 Change the backend
 ------------------

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -60,6 +60,10 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'set_arf_data', 'set_rmf_data', 'set_hdus')
 
 
+name: str = "crates"
+"""The name of the I/O backend."""
+
+
 CrateType = Union[TABLECrate, IMAGECrate]
 
 

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -48,6 +48,10 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'set_arf_data', 'set_rmf_data', 'set_hdus')
 
 
+name: str = "dummy"
+"""The name of the I/O backend."""
+
+
 warning = logging.getLogger(__name__).warning
 warning("""Cannot import usable I/O backend.
     If you are using CIAO, this is most likely an error and you should contact the CIAO helpdesk.

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -72,6 +72,10 @@ __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
            'set_arf_data', 'set_rmf_data', 'set_hdus')
 
 
+name: str = "pyfits"
+"""The name of the I/O backend."""
+
+
 DatasetType = Union[str, fits.HDUList]
 HDUType = Union[fits.PrimaryHDU, fits.BinTableHDU]
 

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -21,19 +21,12 @@
 """
 Read and write FITS [1]_ files using the ``astropy.io.fits`` module [2]_.
 
-Notes
------
-
-Support for PyFITS [3]_ was dropped in Sherpa 4.10.1.
-
 References
 ----------
 
 .. [1] https://en.wikipedia.org/wiki/FITS
 
 .. [2] http://astropy.readthedocs.org/en/latest/io/fits/
-
-.. [3] http://www.stsci.edu/institute/software_hardware/pyfits
 
 """
 

--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -624,17 +624,17 @@ def test_read_table_object(make_data_path):
     infile = make_data_path("1838_rprofile_rmid.fits")
     close = False
 
-    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    if io.backend.name == "crates":
         import pycrates  # type: ignore
         arg = pycrates.read_file(infile)
 
-    elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+    elif io.backend.name == "pyfits":
         from astropy.io import fits  # type: ignore
         arg = fits.open(infile)
         close = True
 
     else:
-        assert False, f"unknown backend: {io.backend.__name__}"
+        assert False, f"unknown backend: {io.backend}"
 
     try:
         # this implicitly checks case insensitivity on column names

--- a/sherpa/astro/io/tests/test_io_img.py
+++ b/sherpa/astro/io/tests/test_io_img.py
@@ -30,9 +30,9 @@ from sherpa.utils.testing import requires_data, requires_fits, \
     requires_region, requires_wcs
 
 
-def backend_is(name):
+def backend_is(name: str) -> bool:
     """Are we using the given backend?"""
-    return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
+    return io.backend.name == name
 
 
 @requires_fits
@@ -269,8 +269,8 @@ def test_axs_ordering_1880(tmp_path):
 def test_read_image():
     """Check we get a failure.
 
-    This is a regression test. The exact failure message depends
-    on the backend.
+    This is a regression test.
+
     """
 
     with pytest.raises(IOErr,
@@ -293,17 +293,17 @@ def test_read_image_object(make_data_path):
     infile = make_data_path("psf_0.0_00_bin1.img")
     close = False
 
-    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    if backend_is("crates"):
         import pycrates  # type: ignore
         arg = pycrates.read_file(infile)
 
-    elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+    elif backend_is("pyfits"):
         from astropy.io import fits  # type: ignore
         arg = fits.open(infile)
         close = True
 
     else:
-        assert False, f"unknown backend: {io.backend.__name__}"
+        assert False, f"unknown backend: {io.backend}"
 
     try:
         img = io.read_image(arg)

--- a/sherpa/astro/io/tests/test_io_response.py
+++ b/sherpa/astro/io/tests/test_io_response.py
@@ -39,9 +39,9 @@ from sherpa.utils.err import ArgumentErr, IOErr
 from sherpa.utils.testing import requires_data, requires_fits
 
 
-def backend_is(name):
+def backend_is(name: str) -> bool:
     """Are we using the specified backend?"""
-    return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
+    return io.backend.name == name
 
 
 @requires_data
@@ -1271,17 +1271,17 @@ def test_read_arf_object(make_data_path):
     infile = make_data_path("MNLup_2138_0670580101_EMOS1_S001_spec.arf")
     close = False
 
-    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    if backend_is("crates"):
         import pycrates  # type: ignore
         arg = pycrates.read_file(infile)
 
-    elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+    elif backend_is("pyfits"):
         from astropy.io import fits  # type: ignore
         arg = fits.open(infile)
         close = True
 
     else:
-        assert False, f"unknown backend: {io.backend.__name__}"
+        assert False, f"unknown backend: {io.backend}"
 
     try:
         with warnings.catch_warnings(record=True) as ws:
@@ -1320,17 +1320,17 @@ def test_read_rmf_object(make_data_path):
     infile = make_data_path("source.rmf")
     close = False
 
-    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
-        import pycrates
+    if backend_is("crates"):
+        import pycrates  # type: ignore
         arg = pycrates.RMFCrateDataset(infile, mode='r')
 
-    elif io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
-        from astropy.io import fits
+    elif backend_is("pyfits"):
+        from astropy.io import fits  # type: ignore
         arg = fits.open(infile)
         close = True
 
     else:
-        assert False, f"unknown backend: {io.backend.__name__}"
+        assert False, f"unknown backend: {io.backend}"
 
     try:
         rmf = io.read_rmf(arg)

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -41,7 +41,7 @@ except ImportError:
 
 try:
     from sherpa.astro.io import backend
-    is_crates_io = "sherpa.astro.io.crates_backend" == backend.__name__
+    is_crates_io = backend.name == "crates"
 except ImportError:
     is_crates_io = False
 

--- a/sherpa/astro/tests/test_astro_data_rosat_unit.py
+++ b/sherpa/astro/tests/test_astro_data_rosat_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2019, 2021
+#  Copyright (C) 2017, 2019, 2021, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -42,9 +42,9 @@ from sherpa.astro import io
 from sherpa.astro import ui
 
 
-def backend_is(name):
+def backend_is(name: str) -> bool:
     """Are we using the specified backend?"""
-    return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
+    return io.backend.name == name
 
 
 # The RMF includes the ARF (so is a "RSP" file).

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2021, 2023
+#  Copyright (C) 2017, 2018, 2021, 2023, 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -45,9 +45,9 @@ from sherpa.astro import io
 from sherpa.astro import ui
 
 
-def backend_is(name):
+def backend_is(name: str) -> bool:
     """Are we using the specified backend?"""
-    return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
+    return io.backend.name == name
 
 
 # PHA and ARF are stored uncompressed while RMF is gzip-compressed.

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -59,7 +59,7 @@ def skip_if_no_io(request):
     # If the I/O backend is not the dummy backend then we assume that
     # we can return.
     #
-    if io.backend.__name__ != "sherpa.astro.io.dummy_backend":
+    if io.backend.name != "dummy":
         return
 
     pytest.skip(reason="FITS backend required")
@@ -2602,7 +2602,7 @@ def check_save_ascii2d(session, expected, out, savefunc, idval, kwargs, check_st
 
     """
 
-    if session == AstroSession and io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    if session == AstroSession and io.backend.name == "crates":
         if idval is None:
             with pytest.raises(IOErr,
                                match="writing images in ASCII is not supported"):
@@ -3234,13 +3234,12 @@ def check_text_output(path, header, coldata):
     # Use the same logic as test_astro_ui_unit.py.
     #
     from sherpa.astro import io
-    name = io.backend.__name__
-    if name == "sherpa.astro.io.crates_backend":
+    if io.backend.name == "crates":
         expected = f"#TEXT/SIMPLE\n# {header}\n"
-    elif name == "sherpa.astro.io.pyfits_backend":
+    elif io.backend.name == "pyfits":
         expected = f"# {header}\n"
     else:
-        assert False, f"Unknown I/O backend: {name}"
+        assert False, f"Unknown I/O backend: {io.backend.name}"
 
     expected += coldata
     assert path.read_text() == expected

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -47,8 +47,8 @@ from sherpa.utils.testing import requires_data, requires_fits, \
     requires_region, requires_wcs, requires_xspec
 
 
-def backend_is(name):
-    return io.backend.__name__ == f"sherpa.astro.io.{name}_backend"
+def backend_is(name: str) -> bool:
+    return io.backend.name == name
 
 
 def check_table(hdu, colinfo):
@@ -731,7 +731,7 @@ def check_output(out, colnames, rows):
         assert lines[0] == f"# {cols}"
         lines = lines[1:]
     else:
-        raise RuntimeError(f"UNKNOWN I/O BACKEND: {io.backend.__name__}")
+        raise RuntimeError(f"UNKNOWN I/O BACKEND: {io.backend}")
 
     assert lines[-1] == ""
     lines = lines[:-1]
@@ -857,7 +857,7 @@ def test_save_data_data2d(tmp_path, clean_astro_ui):
     elif backend_is("pyfits"):
         expected = "\n".join([str(zz) for zz in z]) + "\n"
     else:
-        raise RuntimeError(f"UNKNOWN I/O BACKEND: {io.backend.__name__}")
+        raise RuntimeError(f"UNKNOWN I/O BACKEND: {io.backend}")
 
     assert cts == expected
 

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
@@ -67,10 +67,10 @@ def test_fake_pha_missing_rmf(idval, clean_astro_ui, tmp_path):
 
     # The error message depends on the backend.
     #
-    if io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+    if io.backend.name == "pyfits":
         emsg = f"file '{rmf}' not found"
 
-    elif io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    elif io.backend.name == "crates":
         emsg = f"File {rmf} does not exist"
 
     else:
@@ -101,10 +101,10 @@ def test_fake_pha_missing_arf(idval, clean_astro_ui, tmp_path):
 
     # The error message depends on the backend.
     #
-    if io.backend.__name__ == "sherpa.astro.io.pyfits_backend":
+    if io.backend.name == "pyfits":
         emsg = f"file '{arf}' not found"
 
-    elif io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    elif io.backend.name == "crates":
         emsg = f"File {arf} does not exist"
 
     else:

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -3400,7 +3400,7 @@ def test_load_data(make_data_path):
                        match="data set '1' does not specify systematic errors"):
         ui.get_syserror()
 
-    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
+    if io.backend.name == "crates":
         term = "@@/data1.dat"
         idx = _canonical_load_data.find(term)
         expected_output = _canonical_load_data[:idx] + term + \


### PR DESCRIPTION
# Summary

Add a name field to the I/O backends. This is mainly useful for testing and debugging.

# Details

Clean up the documentation (no need to link to PyFITS as it's old and hasn't been used by Sherpa for many years). This has been lying around in the I/O PRs I've been doing so may as well take it.

Add a name field to the backends and use it in our tests. It isn't technically necessary but we have a name field for the plot backends so it makes sense to add one here.

# Example

```
>>> from sherpa.astro import io
>>> io.backend.name
'pyfits'
>>> from sherpa.astro.io import crates_backend
>>> io.backend = crates_backend
>>> io.backend.name
'crates'
>>> from sherpa.astro.io import dummy_backend
WARNING: Cannot import usable I/O backend.
    If you are using CIAO, this is most likely an error and you should contact the CIAO helpdesk.
    If you are using Standalone Sherpa, please install astropy.
>>> io.backend = dummy_backend
>>> io.backend.name
'dummy'
```
