### PR TITLE
Improve messages about invalid file types (PHA)

### DIFF
--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -524,7 +524,7 @@ def _read_ancillary(data: dict[str, str],
 
     except Exception as exc:
         if output_once:
-            warning(str(exc))
+            warning("unable to read %s: %s", label, str(exc))
 
     return out
 
@@ -653,7 +653,7 @@ def read_pha(arg,
 
             except Exception as exc:
                 if output_once:
-                    warning(str(exc))
+                    warning("unable to read background: %s", str(exc))
 
         for bkg_type, bscal_type in zip(('background_up', 'background_down'),
                                         ('backscup', 'backscdn')):

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -90,7 +90,7 @@ def open_crate(filename: str,
     try:
         dataset = CrateDataset(filename, mode=mode)
     except OSError as oe:
-        raise IOErr('openfailed', f"unable to open {filename}: {oe}") from oe
+        raise IOErr('openfailed', str(oe)) from oe
 
     current = dataset.get_current_crate()
     try:
@@ -505,7 +505,7 @@ def read_table_blocks(arg: Union[str, CrateDataset, TABLECrate],
         try:
             dataset = CrateDataset(arg)
         except OSError as oe:
-            raise IOErr('openfailed', f"unable to open {arg}: {oe}") from oe
+            raise IOErr('openfailed', str(oe)) from oe
 
     else:
         raise IOErr('badfile', arg, "CrateDataset obj")
@@ -843,7 +843,7 @@ def get_rmf_data(arg: Union[str, pycrates.RMFCrateDataset],
         try:
             rmfdataset = pycrates.RMFCrateDataset(arg, mode="r")
         except OSError as oe:
-            raise IOErr('openfailed', f"unable to open {arg}: {oe}") from oe
+            raise IOErr('openfailed', str(oe)) from oe
 
         if pycrates.is_rmf(rmfdataset) != 1:
             raise IOErr('badfile', arg, "RMFCrateDataset obj")
@@ -977,7 +977,7 @@ def get_pha_data(arg: Union[str, pycrates.PHACrateDataset],
         try:
             phadataset = pycrates.PHACrateDataset(arg, mode="r")
         except OSError as oe:
-            raise IOErr('openfailed', f"unable to open {arg}: {oe}") from oe
+            raise IOErr('openfailed', str(oe)) from oe
 
         if pycrates.is_pha(phadataset) != 1:
             raise IOErr('badfile', arg, "PHACrateDataset obj")

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -337,7 +337,7 @@ def open_fits(filename: str) -> fits.HDUList:
         try:
             return fits.open(fname)
         except OSError as oe:
-            raise IOErr('openfailed', f"unable to open {fname}: {oe}") from oe
+            raise IOErr('openfailed', str(oe)) from oe
 
 
 def read_table_blocks(arg: DatasetType,

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -822,10 +822,12 @@ def test_write_pha_fits_with_extras_roundtrip(tmp_path, caplog):
     assert lvl == logging.WARNING
 
     # message depends on the backend.
+    start = "unable to read ARF: "
     if backend_is("crates"):
-        assert msg.startswith("unable to open ")
+        assert msg.startswith(f"{start}File")
+        assert msg.endswith("/made-up-ancrfile.fits does not exist.")
     elif backend_is("pyfits"):
-        assert msg.startswith("file '")
+        assert msg.startswith(f"{start}file '")
         assert msg.endswith("/made-up-ancrfile.fits' not found")
     else:
         raise RuntimeError(f"Unknown io backend: {io.backend}")
@@ -904,10 +906,12 @@ def test_pha_missing_backfile(tmp_path, caplog):
     assert lvl == logging.WARNING
 
     # message depends on the backend.
+    start = "unable to read background: "
     if backend_is("crates"):
-        assert msg.startswith("unable to open ")
+        assert msg.startswith(f"{start}File")
+        assert msg.endswith("/made-up-backfile.fits does not exist.")
     elif backend_is("pyfits"):
-        assert msg.startswith("file '")
+        assert msg.startswith(f"{start}file '")
         assert msg.endswith("/made-up-backfile.fits' not found")
     else:
         raise RuntimeError(f"Unknown io backend: {io.backend}")

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -85,7 +85,7 @@ def test_load_xstable_model_fails_with_dir(tmp_path):
     ui.clean()
     assert ui.list_model_components() == []
     with pytest.raises(IOErr,
-                       match="^unable to open "):
+                       match="^Unable to read XSPEC table model: "):
         ui.load_xstable_model('tmpdir', str(tmpdir))
 
     assert ui.list_model_components() == []
@@ -132,7 +132,7 @@ def test_load_xstable_model_fails_with_empty_file(tmp_path):
     assert ui.list_model_components() == []
 
     with pytest.raises(IOErr,
-                       match="^unable to open "):
+                       match="^Unable to read XSPEC table model: "):
         ui.load_xstable_model('devnull', str(empty))
 
     assert ui.list_model_components() == []

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -852,7 +852,13 @@ def read_xstable_model(modelname, filename, etable=False):
     # Not all keywords are going to be present, so check what are.
     #
     blkname = 'PRIMARY'
-    hdr = read_hdr(filename, blockname=blkname, hdrkeys=None)
+    try:
+        hdr = read_hdr(filename, blockname=blkname, hdrkeys=None)
+    except IOErr as ie:
+        # The error message will be generic, so add some more
+        # information.
+        #
+        raise IOErr(f"Unable to read XSPEC table model: {ie}") from ie
 
     try:
         hduclas1 = hdr["HDUCLAS1"].upper()


### PR DESCRIPTION
# Summary

Tweak the warning messages when files can not be read to better indicate the type of file being loaded (for PHA related files).

# Details

So, in recent work I've been trying to standardize the error messages we get from the I/O backends. We can never do it completely, since different backends provide different error messages and we want to retain some of this information, but we can try to normalize it. One change I made was to change a `IOErr(str(exc))` call to something like `IOErr(f"some text including filename: {exc}")`, at least for the crates backend - see 

- #2017
- https://github.com/sherpa/sherpa/commit/4bf833423abda3d6b29a24a9049b621e46e942df

In reviewing changes seen in the CIAO regression testing, I realized that it would make more sense to add context at the caller, rather than in the low-level I/O code. So, have the backend raise `IOErr(str(exc))` and then the caller can catch this and either add context - as we do in the `sherpa.astro.xspec.read_xstable_model` call - or the warning message we create after catching the error when reading in response/background files for PHA data.

It turns out that great minds think alike, and I'd already made some of these changes in #2085.

I don't think there's a "single obviously true" approach for these calls, so we may decide to make more clean ups down the road.

# Example

So, if we copy a PHA file to a new location but do not also copy the `ANCRFILE`, `RESPFILE`, and `BACKFILE` files, we get the following warnings when we try to load the file in. For CIAO 4.16 you can guess what it is trying to load in because the files have sensible names, but with the new code we have a label (ARF, RMF, background) to go along with the error message.

I included both backends here to show that the low-level messages are different, even for the case of "file not found".

The main branch has, for crates, the odd output of 'unable to open xxx.y: File xxx.y does not exist.`, which while true, doesn't really help. I think the proposed version is better and more consistent between the two backends.

## CIAO 4.16 + crates

```
sherpa In [2]: io.backend.__name__
Out[2]: 'sherpa.astro.io.crates_backend'

sherpa In [3]: load_pha("foo.pi")
WARNING: File aciss_1_src7.arf does not exist.
WARNING: File aciss_1_src7.rmf does not exist.
WARNING: File aciss_1_bkg7.pi does not exist.
```

## CIAO 4.16 + pyfits

```
sherpa In [6]: io.backend.__name__
Out[6]: 'sherpa.astro.io.pyfits_backend'

sherpa In [7]: load_pha("foo.pi")
WARNING: file 'aciss_1_src7.arf' not found
WARNING: file 'aciss_1_src7.rmf' not found
WARNING: file 'aciss_1_bkg7.pi' not found
```

## Main branch + crates

```
>>> io.backend.name
'crates'
>>> ui.load_pha("foo.pi")
WARNING: unable to open aciss_1_src7.arf: File aciss_1_src7.arf does not exist.
WARNING: unable to open aciss_1_src7.rmf: File aciss_1_src7.rmf does not exist.
WARNING: unable to open aciss_1_bkg7.pi: File aciss_1_bkg7.pi does not exist.
```

## Main branch + pyfits

```
>>> io.backend.name
'pyfits'
>>> ui.load_pha("foo.pi")
WARNING: file 'aciss_1_src7.arf' not found
WARNING: file 'aciss_1_src7.rmf' not found
WARNING: file 'aciss_1_bkg7.pi' not found
```

## This PR + crates

```
>>> from sherpa.astro import io
>>> from sherpa.astro.io import crates_backend, pyfits_backend
>>> from sherpa.astro import ui
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
>>> io.backend.name
'pyfits'
>>> io.backend = crates_backend
>>> io.backend.name
'crates'
>>> ui.load_pha("foo.pi")
WARNING: unable to read ARF: File aciss_1_src7.arf does not exist.
WARNING: unable to read RMF: File aciss_1_src7.rmf does not exist.
WARNING: unable to read background: File aciss_1_bkg7.pi does not exist.
```

## This PR + pyfits

```
>>> io.backend = pyfits_backend
>>> io.backend.name
'pyfits'
>>> ui.load_pha("foo.pi")
WARNING: unable to read ARF: file 'aciss_1_src7.arf' not found
WARNING: unable to read RMF: file 'aciss_1_src7.rmf' not found
WARNING: unable to read background: file 'aciss_1_bkg7.pi' not found
```