### PR TITLE
model: avoid a compilation warning

### DIFF
--- a/sherpa/include/sherpa/model_extension.hh
+++ b/sherpa/include/sherpa/model_extension.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007, 2016, 2019, 2020, 2023
+//  Copyright (C) 2007, 2016, 2019, 2020, 2023, 2024
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -97,20 +97,6 @@ namespace sherpa { namespace models {
   
   }
 
-  static int py_integrated_1d(const double xlo, const double xhi, double &val,
-		       FunctionWithParams<DoubleArray> *funcAndPars,
-		       int errflag, double epsabs, double epsrel,
-		       unsigned int maxeval, std::ostringstream& err)
-  {
-    double abserr;
-    
-    return py_integrate_1d( (integrand_1d_vec)(integrand_1d_cb),
-			    (void*)funcAndPars, xlo, xhi,
-			    maxeval, epsabs, epsrel, val, abserr, errflag,
-			    err);
-    
-  }
-
   template <typename ArrayType>
   PyObject* py_modelfct1d_int( PyObject* self, PyObject* args, PyObject *kwds )
   {
@@ -166,12 +152,15 @@ namespace sherpa { namespace models {
     FunctionWithParams<ArrayType> *funcAndPars =		\
       new FunctionWithParams<ArrayType>(&pars, model_func);
     
+    double abserr;
     for ( npy_intp ii = 0; ii < nelem; ii++ )
-      if ( EXIT_SUCCESS != py_integrated_1d( xlo[ii], xhi[ii],
-					     result[ii], funcAndPars,
-					     errflag, epsabs, epsrel,
-					     (unsigned int)maxeval,
-					     err) ) {
+      if ( EXIT_SUCCESS != py_integrate_1d( (integrand_1d_vec)(integrand_1d_cb),
+					    (void*)funcAndPars,
+					    xlo[ii], xhi[ii],
+					    (unsigned int)maxeval,
+					    epsabs, epsrel,
+					    result[ii], abserr,
+					    errflag, err ) ) {
 	PyErr_SetString( PyExc_ValueError,
 			 (char*)"model evaluation failed" );
 	return NULL;


### PR DESCRIPTION
# Summary

Avoid a compilation warning about an apparently-unused 

# Details

There can be a complaint when compiling that the
py_integrated_1d symbol is unused. I assume this is actually an issue with the compiler - in this case g++ - since it is used, but maybe the fact it's used within a template leads to a false positive.

An example (from an old build but the line number is close to being correct):

```
In file included from sherpa/astro/models/src/_modelfcts.cc:23:0:
sherpa/include/sherpa/model_extension.hh:99:14: warning: ‘int sherpa::models::py_integrated_1d(double, double, double&, FunctionWithParams<sherpa::Array<double, 12> >*, int, double, double, unsigned int, std::ostringstream&)’ defined but not used [-Wunused-function]
   static int py_integrated_1d(const double xlo, const double xhi, double &val,
              ^~~~~~~~~~~~~~~~
```

A simple solution is to just inline the function, since - to be honest - moving it into a separate routine does not make a huge difference to the reader of the code.

There is some discussion in #774 but that is really about a different issue than this, although the warning message is mentioned there.