### PR TITLE
Change the URL for XPA

### DIFF
--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -128,8 +128,7 @@ Glossary
        row on a spectrograph and the corresponding wavelength of light.
 
    XPA
-       The `XPA messaging system
-       <https://hea-www.harvard.edu/saord/xpa/>`_
+       The `XPA messaging system <https://github.com/ericmandel/xpa>`_
        is used by :term:`DS9` to communicate
        with external programs. Sherpa uses this functionality to
        control DS9 - by sending it images to display and retrieving

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -135,9 +135,7 @@ Glossary
        any regions a used may have created on the image data.
        The command-line tools used for this commiunication may be
        available via the package manager for a particular
-       operating system, such as
-       `xpa-tools for Ubuntu
-       <https://packages.ubuntu.com/xenial/xpa-tools>`_,
+       operating system, such as xpa-tools for Ubuntu,
        or they can be
        `built from source <https://github.com/ericmandel/xpa>`_.
 

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2016, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016, 2021, 2024
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -27,7 +28,7 @@ References
 
 ..  [DS9] SAOImageDS9, "An image display and visualization tool for astronomical data", https://ds9.si.edu/
 
-..  [XPA] "The XPA Messaging System", https://hea-www.harvard.edu/saord/xpa/
+..  [XPA] "The XPA Messaging System", https://github.com/ericmandel/xpa
 
 """
 


### PR DESCRIPTION
# Summary

Change the URL used for XPA. Fix #2100.

# Details

As XPA development has stopped, the old SAO page is no longer available, so change to use the GitHub URL (less information, but it is at least valid).