### PR TITLE
Ensure crates file reads are read-only

### DIFF
--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -66,14 +66,12 @@ CrateType = Union[TABLECrate, IMAGECrate]
 DatasetType = Union[str, CrateDataset]
 
 
-def open_crate(filename: str,
-               mode: str = "r") -> CrateType:
+def open_crate(filename: str) -> CrateType:
     """Get the "most interesting" block of the file.
 
     Parameters
     ----------
     filename : str
-    mode : str
 
     Returns
     -------
@@ -87,7 +85,7 @@ def open_crate(filename: str,
 
     """
     try:
-        dataset = CrateDataset(filename, mode=mode)
+        dataset = CrateDataset(filename, mode="r")
     except OSError as oe:
         raise IOErr('openfailed', str(oe)) from oe
 
@@ -309,7 +307,7 @@ def read_table_blocks(arg: Union[str, CrateDataset, TABLECrate],
     elif isinstance(arg, str):
         filename = arg
         try:
-            dataset = CrateDataset(arg)
+            dataset = CrateDataset(arg, mode="r")
         except OSError as oe:
             raise IOErr('openfailed', str(oe)) from oe
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -13822,7 +13822,7 @@ class Session(NoNewAttributesAfterInit):
 
     def plot_data(self, id=None, replot=False, overplot=False,
                   clearwindow=True, **kwargs):
-        """Plot the data values.
+        r"""Plot the data values.
 
         Parameters
         ----------


### PR DESCRIPTION
# Summary

Ensure that we read in table data as read-only when using the crates I/O backend.

# Details

I am not sure if this is a regression from #1921. It was found in a CIAO regression test but that was for a new test added in #1921.

There is also a small tweak for a docstring related to the #2086 change.