### PR TITLE
docs: typo fixes and remove some references.

### DIFF
--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -7089,7 +7089,7 @@ class Session(NoNewAttributesAfterInit):
         >>> get_model_pars(mdl)
         ['fwhm', 'xpos', 'ypos', 'ellip', 'theta', 'ampl', 'c0']
 
-        If a model expression contaoins linked parameters that are not
+        If a model expression contains linked parameters that are not
         part of the model expression then they will also be included
         (in this case both the const2d and scale1d parameters are
         named 'c0', hence the duplication):

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1800,10 +1800,10 @@ def get_error_estimates(x, sorted=False):
 
 
 def multinormal_pdf(x, mu, sigma):
-    """The PDF of a multivariate-normal.
+    """The PDF of a multivariate-normal distribution.
 
     Returns the probability density function (PDF) of a
-    multivariate normal [1]_.
+    multivariate normal [1]_ distribution.
 
     Parameters
     ----------
@@ -1821,7 +1821,7 @@ def multinormal_pdf(x, mu, sigma):
     References
     ----------
 
-    .. [1] http://en.wikipedia.org/wiki/Multivariate_normal_distribution
+    .. [1] https://en.wikipedia.org/wiki/Multivariate_normal_distribution
 
     """
     x = np.asarray(x)
@@ -1853,10 +1853,10 @@ def multinormal_pdf(x, mu, sigma):
 
 
 def multit_pdf(x, mu, sigma, dof):
-    """The PDF of a multivariate student-t.
+    """The PDF of a multivariate student-t distribution.
 
     Returns the probability density function (PDF) of a
-    multivariate student-t distribution [1]_.
+    multivariate student-t [1]_ distribution.
 
     Parameters
     ----------
@@ -1875,7 +1875,7 @@ def multit_pdf(x, mu, sigma, dof):
     References
     ----------
 
-    .. [1] http://en.wikipedia.org/wiki/Multivariate_Student_distribution
+    .. [1] https://en.wikipedia.org/wiki/Multivariate_Student_distribution
 
     """
     n = float(dof)


### PR DESCRIPTION
# Summary

Fix a typo in a docstring and change how two references are included in the text.

# Details

Reported by @wmclaugh when reviewing the Sherpa ahelp files, which are created from the docstring content. There were 4 problems and this should fix 3 of them; the other one is a typo in the code used to create the ahelp files.

Fix up a typo and remove two reference links which were causing an issue for the ahelp files we generated for CIAO (it's a big discussion revolving around the on-disk file conversion to RST to the format used by sphinx to the ahelp XML format, which leads to a line-break being added between "[1]" and ".", which is surprisingly hard to fix so it's easier to just avoid this in the first place by making sure we don't end a sentence on "[1]".