### PR TITLE
Initial support for XSPEC filtering keywords (XFLT)

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -508,7 +508,7 @@ noted as not being supported::
 
 
   class XSwdem(XSAdditiveModel):
-      """XSPEC AdditiveModel: wdem
+      """The XSPEC wdem model
 
       Parameters
       ----------
@@ -777,8 +777,10 @@ available.
       build Sherpa: the compiler should fail with an indication of
       what symbol names are missing.
 
-      .. note:: Ideally we would have a sensible ordering for the declarations in this
-		file, but at present it is ad-hoc.
+      .. note:: The idea is to match the ordering of the ``model.dat`` file,
+		to make it easier to spot additions and changes, but that
+		may be difficult to do once model definitons change in a
+	        new XSPEC version.
 
    b. ``sherpa/astro/xspec/__init__.py``
 
@@ -868,6 +870,9 @@ and abort the commit so that you can manually check before committing again.
 To use this opt-in functionality, simply copy the file to the appropriate location::
 
   cp scripts/pre-commit .git/hooks
+
+.. note:: The script has problems if dates are expressed as a range, rather
+          than per year.
 
 Notes
 =====

--- a/docs/model_classes/astro_xspec.rst
+++ b/docs/model_classes/astro_xspec.rst
@@ -190,6 +190,9 @@ The sherpa.astro.xspec module
       XSphabs
       XSplabs
       XSplcabs
+      XSpolconst
+      XSpollin
+      XSpolpow
       XSposm
       XSpowerlaw
       XSpshock
@@ -208,6 +211,7 @@ The sherpa.astro.xspec module
       XSsimpl
       XSsirf
       XSslimbh
+      XSsmaug
       XSsmedge
       XSsnapec
       XSspexpcut
@@ -296,10 +300,10 @@ The sherpa.astro.xspec module
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: XSagauss XSagnsed XSagnslim XSapec XSbapec XSbbody XSbbodyrad XSbcempow XSbcheb6 XSbcie XSbcoolflow XSbcph XSbequil XSbexpcheb6 XSbexrav XSbexriv XSbgadem XSbgnei XSbkn2pow XSbknpower XSbmc XSbnei XSbnpshock XSbpshock XSbremss XSbrnei XSbsedov XSbsnapec XSbtapec XSbvapec XSbvcempow XSbvcheb6 XSbvcie XSbvcoolflow XSbvcph XSbvequil XSbvexpcheb6 XSbvgadem XSbvgnei XSbvnei XSbvnpshock XSbvpshock XSbvrnei XSbvsedov XSbvtapec XSbvvapec XSbvvcie XSbvvgadem XSbvvgnei XSbvvnei XSbvvnpshock XSbvvpshock XSbvvrnei XSbvvsedov XSbvvtapec XSbvvwdem XSbvwdem XSbwcycl XSbwdem XSc6mekl XSc6pmekl XSc6pvmkl XSc6vmekl XScarbatm XScemekl XScempow XScevmkl XScflow XScheb6 XScie XScompLS XScompPS XScompST XScompTT XScompbb XScompmag XScomptb XScompth XScoolflow XScph XScplinear XScutoffpl XSdisk XSdiskbb XSdiskir XSdiskline XSdiskm XSdisko XSdiskpbb XSdiskpn XSeebremss XSeplogpar XSeqpair XSeqtherm XSequil XSexpcheb6 XSexpdec XSezdiskbb XSgadem XSgaussian XSgnei XSgrad XSgrbcomp XSgrbjet XSgrbm XShatm XSjet XSkerrbb XSkerrd XSkerrdisk XSkyrline XSlaor XSlaor2 XSlogpar XSlorentz XSmeka XSmekal XSmkcflow XSnei XSnlapec XSnpshock XSnsa XSnsagrav XSnsatmos XSnsmax XSnsmaxg XSnsx XSnteea XSnthComp XSoptxagn XSoptxagnf XSpegpwrlw XSpexmon XSpexrav XSpexriv XSplcabs XSposm XSpowerlaw XSpshock XSqsosed XSraymond XSredge XSrefsch XSrnei XSsedov XSsirf XSslimbh XSsnapec XSsrcut XSsresc XSssa XSstep XStapec XSvapec XSvbremss XSvcempow XSvcheb6 XSvcie XSvcoolflow XSvcph XSvequil XSvexpcheb6 XSvgadem XSvgnei XSvmcflow XSvmeka XSvmekal XSvnei XSvnpshock XSvoigt XSvpshock XSvraymond XSvrnei XSvsedov XSvtapec XSvvapec XSvvcie XSvvgadem XSvvgnei XSvvnei XSvvnpshock XSvvpshock XSvvrnei XSvvsedov XSvvtapec XSvvwdem XSvwdem XSwdem XSzagauss XSzbbody XSzbknpower XSzbremss XSzcutoffpl XSzgauss XSzkerrbb XSzlogpar XSzpowerlw
+.. inheritance-diagram:: XSagauss XSagnsed XSagnslim XSapec XSbapec XSbbody XSbbodyrad XSbcempow XSbcheb6 XSbcie XSbcoolflow XSbcph XSbequil XSbexpcheb6 XSbexrav XSbexriv XSbgadem XSbgnei XSbkn2pow XSbknpower XSbmc XSbnei XSbnpshock XSbpshock XSbremss XSbrnei XSbsedov XSbsnapec XSbtapec XSbvapec XSbvcempow XSbvcheb6 XSbvcie XSbvcoolflow XSbvcph XSbvequil XSbvexpcheb6 XSbvgadem XSbvgnei XSbvnei XSbvnpshock XSbvpshock XSbvrnei XSbvsedov XSbvtapec XSbvvapec XSbvvcie XSbvvgadem XSbvvgnei XSbvvnei XSbvvnpshock XSbvvpshock XSbvvrnei XSbvvsedov XSbvvtapec XSbvvwdem XSbvwdem XSbwcycl XSbwdem XSc6mekl XSc6pmekl XSc6pvmkl XSc6vmekl XScarbatm XScemekl XScempow XScevmkl XScflow XScheb6 XScie XScompLS XScompPS XScompST XScompTT XScompbb XScompmag XScomptb XScompth XScoolflow XScph XScplinear XScutoffpl XSdisk XSdiskbb XSdiskir XSdiskline XSdiskm XSdisko XSdiskpbb XSdiskpn XSeebremss XSeplogpar XSeqpair XSeqtherm XSequil XSexpcheb6 XSexpdec XSezdiskbb XSgadem XSgaussian XSgnei XSgrad XSgrbcomp XSgrbjet XSgrbm XShatm XSjet XSkerrbb XSkerrd XSkerrdisk XSkyrline XSlaor XSlaor2 XSlogpar XSlorentz XSmeka XSmekal XSmkcflow XSnei XSnlapec XSnpshock XSnsa XSnsagrav XSnsatmos XSnsmax XSnsmaxg XSnsx XSnteea XSnthComp XSoptxagn XSoptxagnf XSpegpwrlw XSpexmon XSpexrav XSpexriv XSplcabs XSposm XSpowerlaw XSpshock XSqsosed XSraymond XSredge XSrefsch XSrnei XSsedov XSsirf XSslimbh XSsmaug XSsnapec XSsrcut XSsresc XSssa XSstep XStapec XSvapec XSvbremss XSvcempow XSvcheb6 XSvcie XSvcoolflow XSvcph XSvequil XSvexpcheb6 XSvgadem XSvgnei XSvmcflow XSvmeka XSvmekal XSvnei XSvnpshock XSvoigt XSvpshock XSvraymond XSvrnei XSvsedov XSvtapec XSvvapec XSvvcie XSvvgadem XSvvgnei XSvvnei XSvvnpshock XSvvpshock XSvvrnei XSvvsedov XSvvtapec XSvvwdem XSvwdem XSwdem XSzagauss XSzbbody XSzbknpower XSzbremss XSzcutoffpl XSzgauss XSzkerrbb XSzlogpar XSzpowerlw
    :parts: 1
 
-.. inheritance-diagram:: XSSSS_ice XSTBabs XSTBfeo XSTBgas XSTBgrain XSTBpcf XSTBrel XSTBvarabs XSabsori XSacisabs XScabs XSconstant XScyclabs XSdust XSedge XSexpabs XSexpfac XSgabs XSheilin XShighecut XShrefl XSismabs XSismdust XSlog10con XSlogconst XSlyman XSnotch XSolivineabs XSpcfabs XSphabs XSplabs XSpwab XSredden XSsmedge XSspexpcut XSspline XSswind1 XSuvred XSvarabs XSvphabs XSwabs XSwndabs XSxion XSxscat XSzTBabs XSzbabs XSzdust XSzedge XSzhighect XSzigm XSzpcfabs XSzphabs XSzredden XSzsmdust XSzvarabs XSzvfeabs XSzvphabs XSzwabs XSzwndabs XSzxipab XSzxipcf
+.. inheritance-diagram:: XSSSS_ice XSTBabs XSTBfeo XSTBgas XSTBgrain XSTBpcf XSTBrel XSTBvarabs XSabsori XSacisabs XScabs XSconstant XScyclabs XSdust XSedge XSexpabs XSexpfac XSgabs XSheilin XShighecut XShrefl XSismabs XSismdust XSlog10con XSlogconst XSlyman XSnotch XSolivineabs XSpcfabs XSphabs XSplabs XSpolconst XSpollin XSpolpow XSpwab XSredden XSsmedge XSspexpcut XSspline XSswind1 XSuvred XSvarabs XSvphabs XSwabs XSwndabs XSxion XSxscat XSzTBabs XSzbabs XSzdust XSzedge XSzhighect XSzigm XSzpcfabs XSzphabs XSzredden XSzsmdust XSzvarabs XSzvfeabs XSzvphabs XSzwabs XSzwndabs XSzxipab XSzxipcf
    :parts: 1
 
 .. inheritance-diagram:: XScflux XScglumin XSclumin XScpflux XSgsmooth XSireflect XSkdblur XSkdblur2 XSkerrconv XSkyconv XSlsmooth XSpartcov XSrdblur XSreflect XSrfxconv XSrgsxsrc XSsimpl XSthcomp XSvashift XSvmshift XSxilconv XSzashift XSzmshift

--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -31,17 +31,21 @@ for a general description of the ``sherpa.astro.xspec`` module.
    .. autosummary::
       :toctree: api
 
+      clear_xsxflt
       get_xsabund
       get_xsabund_doc
       get_xsabundances
       get_xschatter
       get_xscosmo
+      get_xselements
       get_xspath_manager
       get_xspath_model
       get_xsstate
       get_xsversion
+      get_xsxflt
       get_xsxsect
       get_xsxset
+      load_xsxflt
       read_xstable_model
       set_xsabund
       set_xsabundances
@@ -49,6 +53,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
       set_xscosmo
       set_xspath_manager
       set_xsstate
+      set_xsxflt
       set_xsxsect
       set_xsxset
 

--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -4,8 +4,6 @@ The sherpa.astro.xspec module
 
 .. currentmodule:: sherpa.astro.xspec
 
-
-
 This document describes the base classes for XSPEC models, and
 the utility routines - such as querying and retrieving
 the abundance table information. The models provided by XSPEC

--- a/scripts/update_xspec_functions.py
+++ b/scripts/update_xspec_functions.py
@@ -72,19 +72,23 @@ def print_model(model: xspec.ModelDefinition,
         # sys.stderr.write(f"# Unsupported: {model.name} / {model.funcname}\n")
         return prev
 
-    # For the moment models that are calculated per-spectrum are unsupported.
+    # Identify, with a comment, the per-spectrum models.
+    #
     try:
-        if model.flags[1] == 1:
-            return prev
+        per_spectrum = model.flags[1] == 1
     except IndexError:
-        pass
+        per_spectrum = False
 
     # If we have changed "type" then print a new line
     if prev is not None and prev != model.modeltype:
         print("")
 
     # Add in the model name as a comment
-    print(f"{code[0]:50s} // XS{model.name}")
+    label = f"XS{model.name}"
+    if per_spectrum:
+        label += " [per spectrum]"
+
+    print(f"{code[0]:50s} // {label}")
     return model.modeltype
 
 

--- a/sherpa/astro/utils/tests/test_astro_utils_xspec.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_xspec.py
@@ -421,7 +421,7 @@ kT      keV     1.    0.008   0.008   64.0      64.0      .01
 
     expected = '''
 class XSapec(XSAdditiveModel):
-    """XSPEC AdditiveModel: apec
+    """The XSPEC apec model
 
     Parameters
     ----------
@@ -497,7 +497,7 @@ nH      cm^-3   1.0   1.e-6  1.e-5  1.e19  1.e20   -0.01
 
     expected = '''
 class XSabcd(XSMultiplicativeModel):
-    """XSPEC MultiplicativeModel: abcd
+    """The XSPEC abcd model
 
     Parameters
     ----------
@@ -565,7 +565,7 @@ order    " "  -1.   -3.    -3.      -1.       -1.       -1
 
     expected = '''
 class XSrgsxsrc(XSConvolutionKernel):
-    """XSPEC ConvolutionKernel: rgsxsrc
+    """The XSPEC rgsxsrc model
 
     Parameters
     ----------
@@ -631,7 +631,7 @@ xs   ""    10    1 2  20 30  0.01
     expected = '''import warnings
 
 class XSabcd(XSAdditiveModel):
-    """XSPEC AdditiveModel: abcd
+    """The XSPEC abcd model
 
     Parameters
     ----------
@@ -640,6 +640,8 @@ class XSabcd(XSAdditiveModel):
 
     """
     _calc = _models.foos
+
+    per_spectrum = True
 
     def __init__(self, name='abcd'):
         self.xs = XSParameter(name, 'xs', 10.0, min=2.0, max=20.0, hard_min=1.0, hard_max=30.0)
@@ -705,7 +707,7 @@ xs   ""    10    1 2  20 30  0.01
     expected = '''import warnings
 
 class XSabcd(XSAdditiveModel):
-    """XSPEC AdditiveModel: abcd
+    """The XSPEC abcd model
 
     Parameters
     ----------

--- a/sherpa/astro/utils/xspec.py
+++ b/sherpa/astro/utils/xspec.py
@@ -875,6 +875,10 @@ def simple_wrap(modelname: str, mdl: ModelDefinition) -> str:
     # caching. This needs to be done after the parent class has been
     # initialized.
     #
+    # Note that this may not be necessary anymore, but leave in for
+    # now. Users can manually change the attribute value to try out
+    # the cache support.
+    #
     if nflags > 1 and mdl.flags[1] == 1:
         out += f"{t2}self._use_caching = False\n"
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1681,10 +1681,10 @@ class XSModel(RegriddableModel1D, metaclass=ModelMeta):
         """What value is used for the ifl/spectrum argument?
 
         This is only relevant for models that use XFLT keywords (that
-        is, the model is marked as being evaluated for each spectrum
-        in the model.dat file). The value must be a positive integer,
-        and there is to see whether any XFLT keyords have been set up
-        for the spectrum number.
+        is, the model's per_spectrum flag is True).  The value must be
+        a positive integer, and it uses the data set up by the
+        set_xsxflt or load_xsxflt call with this identifier. There is
+        no check that XFLT data has been associated with this value.
 
         .. versionadded:: 4.17.0
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1433,10 +1433,16 @@ class XSModel(RegriddableModel1D, metaclass=ModelMeta):
             #   - model class
             #   - model name
             #   - parameter list
+            #   - any kwargs
             #
             msg = f"{ve}: {self.type}.{self.name}"
-            for par, val in zip(self.pars, args[0]):
+            for par, val in zip(self.pars, p):
                 msg += f" {par.name}={val}"
+
+            if kwargs:
+                msg += " KEYWORDS "
+                for k, v in kwargs.items():
+                    msg += f"{k}={v}"
 
             raise ValueError(msg) from None
 

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -358,6 +358,98 @@ static PyObject* get_xset( PyObject *self, PyObject *args  )
 
 }
 
+// XFLT functions
+//
+//      static int getNumberXFLT(int ifl);
+//      // This will throw a silent YellowAlert if map corresponding to ifl doesn't exist.
+//      static const std::map<string, Real>& getAllXFLT(int ifl);
+//      static bool inXFLT(int ifl, int i);
+//      static bool inXFLT(int ifl, string skey);
+//      static double getXFLT(int ifl, int i);
+//      static double getXFLT(int ifl, string skey);
+//      static void loadXFLT(int ifl, const std::map<string, Real>& values);
+//      static void clearXFLT();
+//
+// We use a dictionary interface - that is we set and get dictionaries
+// rather than have commands work on individual keys. That is,
+// checks like inXFLT have to be done by the user on the data returned
+// by these routines.
+//
+static PyObject* clearXFLT( PyObject *self )
+{
+  FunctionUtility::clearXFLT();
+  Py_RETURN_NONE;
+}
+
+static PyObject* getAllXFLT( PyObject *self, PyObject *args )
+{
+  int spectrumNumber = 1;
+
+  if ( !PyArg_ParseTuple( args, (char*)"i", &spectrumNumber ) )
+    return NULL;
+
+  PyObject *d = PyDict_New();
+
+  // Check that we have data, to avoid a YellowAlert when calling
+  // getAllXFLT.
+  //
+  if (FunctionUtility::getNumberXFLT(spectrumNumber) > 0) {
+    const std::map<string, Real> xflt = FunctionUtility::getAllXFLT(spectrumNumber);
+
+    // This would be nicer if we could assume C++11 (or C++17).
+    //
+    std::map<string, Real>::const_iterator item;
+    for (item = xflt.begin(); item != xflt.end(); ++item) {
+      PyObject *value = PyFloat_FromDouble(item->second);
+      PyDict_SetItemString(d, item->first.c_str(), value);
+      Py_DECREF(value);
+    }
+  }
+
+  return d;
+}
+
+static PyObject* loadXFLT( PyObject *self, PyObject *args )
+{
+  PyObject *xflt_dict = NULL;
+  int spectrumNumber = 1;
+
+  if ( !PyArg_ParseTuple( args, (char*)"iO!",
+			  &spectrumNumber,
+			  &PyDict_Type, &xflt_dict
+			  ) )
+    return NULL;
+
+  std::map<string, Real> xflt;
+
+  PyObject *key, *value;
+  Py_ssize_t pos = 0;
+
+  while (PyDict_Next(xflt_dict, &pos, &key, &value)) {
+
+    const char *k = PyUnicode_AsUTF8(key);
+    if (k == NULL) {
+	PyErr_SetString( PyExc_ValueError,
+			 (char*)"keys must be strings" );
+	return NULL;
+    }
+
+    double v = PyFloat_AsDouble(value);
+    if (v == -1 && PyErr_Occurred()) {
+	PyErr_SetString( PyExc_ValueError,
+			 (char*)"values must be numbers" );
+	return NULL;
+    }
+
+    xflt[k] = v;
+  }
+
+  // We do not check if xflt is empty.
+  FunctionUtility::loadXFLT(spectrumNumber, xflt);
+  Py_RETURN_NONE;
+}
+
+
 template <const std::string& get()>
 static PyObject* get_xspec_string( PyObject *self ) {
   return Py_BuildValue( (char*)"s", get().c_str() );
@@ -395,6 +487,12 @@ static PyMethodDef XSpecMethods[] = {
   FCTSPEC(set_xsxsect, set_cross),
   FCTSPEC(set_xsxset, set_xset),
   FCTSPEC(get_xsxset, get_xset),
+
+  // XFLT commands
+  NOARGSPEC(clear_xflt, clearXFLT),
+  FCTSPEC(get_xflt, getAllXFLT),
+  FCTSPEC(set_xflt, loadXFLT),
+
   NOARGSPEC(get_xspath_manager, get_xspec_string<FunctionUtility::managerPath>),
   NOARGSPEC(get_xspath_model, get_xspec_string<FunctionUtility::modelDataPath>),
   FCTSPEC(set_xspath_manager, set_manager_data_path),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -676,6 +676,7 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM(C_sedov, 6),                // XSsedov
   XSPECMODELFCT_C_NORM(C_sirf, 10),                // XSsirf
   XSPECMODELFCT_C_NORM(slimbbmodel, 10),           // XSslimbh
+  XSPECMODELFCT_C_NORM(xsmaug, 23),                // XSsmaug [per spectrum]
   XSPECMODELFCT_C_NORM(C_snapec, 7),               // XSsnapec
   XSPECMODELFCT_NORM(srcut, 3),                    // XSsrcut
   XSPECMODELFCT_NORM(sresc, 3),                    // XSsresc
@@ -765,6 +766,11 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT(xsabsp, 2),                        // XSpcfabs
   XSPECMODELFCT(xsphab, 1),                        // XSphabs
   XSPECMODELFCT(xsplab, 2),                        // XSplabs
+#ifdef XSPEC_12_12_1
+  XSPECMODELFCT_C(C_polconst, 2),                  // XSpolconst [per spectrum]
+  XSPECMODELFCT_C(C_pollin, 4),                    // XSpollin [per spectrum]
+  XSPECMODELFCT_C(C_polpow, 4),                    // XSpolpow [per spectrum]
+#endif
   XSPECMODELFCT_C(C_xspwab, 3),                    // XSpwab
   XSPECMODELFCT(xscred, 1),                        // XSredden
   XSPECMODELFCT(xssmdg, 4),                        // XSsmedge

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -37,7 +37,7 @@ from sherpa.utils.err import ParameterErr
 #    '(XSConvolutionKernel)'
 # in `xspec/__init__.py`
 #
-XSPEC_MODELS_COUNT = 281
+XSPEC_MODELS_COUNT = 285
 
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh
@@ -732,7 +732,7 @@ def test_evaluate_xspec_model(modelcls):
     which did not happen when they were all stuck in the same test function.
 
     Convolution models are skipped (easier to filter out here given the
-    current design).
+    current design), as are models which require XFLT keywords.
     """
 
     from sherpa.astro import xspec
@@ -740,6 +740,10 @@ def test_evaluate_xspec_model(modelcls):
     # use an identifier in case there is an error
     mdl = modelcls()
     if isinstance(mdl, xspec.XSConvolutionKernel):
+        return
+
+    # skip the models that need XFLT keywords
+    if mdl.per_spectrum:
         return
 
     elo, ehi, wlo, whi = make_grid()
@@ -768,6 +772,9 @@ def test_evaluate_xspec_model_noncontiguous2(modelcls):
     some models are implemented make this a tricky test to
     write (due to numerical tolerances), as bins at the
     edges may not match well.
+
+    Convolution models are skipped (easier to filter out here given the
+    current design), as are models which require XFLT keywords.
     """
 
     from sherpa.astro import xspec
@@ -775,6 +782,10 @@ def test_evaluate_xspec_model_noncontiguous2(modelcls):
     # use an identifier in case there is an error
     mdl = modelcls()
     if isinstance(mdl, xspec.XSConvolutionKernel):
+        return
+
+    # skip the models that need XFLT keywords
+    if mdl.per_spectrum:
         return
 
     elo, ehi, wlo, whi = make_grid_noncontig2()

--- a/sherpa/astro/xspec/tests/test_xspec_regrid.py
+++ b/sherpa/astro/xspec/tests/test_xspec_regrid.py
@@ -43,9 +43,11 @@ from sherpa.utils.testing import requires_data, requires_fits, \
 # way, when support is finally unlocked, we should find out from the
 # tests (rather that just going from xfail to xpass which is easy to
 # miss). It also lets us check why a test fails (in case the failure
-# mode changes due to other parts of Sherpa).
+# mode changes due to other parts of Sherpa). There are now two
+# variants.
 #
 IntegrateError = "'integrate' is an invalid keyword argument for this function"
+IntegrateError2 = r"function takes at most 4 arguments \(5 given\)"
 
 
 @requires_xspec
@@ -135,7 +137,7 @@ def test_regrid_identity(mname, xsmodel):
 
     # scale y values to make them closer to unity
     y1 = 100 * mdl(elo, ehi)
-    with pytest.raises(TypeError, match=IntegrateError):
+    with pytest.raises(TypeError, match=IntegrateError2):
         y2 = 100 * regrid(elo, ehi)
 
     # assert y2 == pytest.approx(y1)
@@ -163,7 +165,7 @@ def test_regrid_identity_combined():
 
     # scale y values to make them closer to unity
     y1 = mdl(elo, ehi)
-    with pytest.raises(TypeError, match=IntegrateError):
+    with pytest.raises(TypeError, match=IntegrateError2):
         y2 = regrid(elo, ehi)
 
     # assert y2 == pytest.approx(y1)
@@ -185,7 +187,7 @@ def test_additive():
     mdl.norm = 100
 
     y1 = mdl(egrid[:-1], egrid[1:])
-    with pytest.raises(TypeError, match=IntegrateError):
+    with pytest.raises(TypeError, match=IntegrateError2):
         y2 = regrid(egrid[:-1], egrid[1:])
 
     # assert y2 == pytest.approx(y1)
@@ -229,7 +231,7 @@ def test_additive_overlap(egrid, yexp):
 
     # will change regrid too
     mdl.norm = 100
-    with pytest.raises(TypeError, match=IntegrateError):
+    with pytest.raises(TypeError, match=IntegrateError2):
         y2 = regrid(egrid[:-1], egrid[1:])
 
     # assert y2 == pytest.approx(yexp)
@@ -265,7 +267,7 @@ def test_multiplicative():
     mdl.nh = 0.05
 
     y1 = mdl(egrid[:-1], egrid[1:])
-    with pytest.raises(TypeError, match=IntegrateError):
+    with pytest.raises(TypeError, match=IntegrateError2):
         y2 = regrid(egrid[:-1], egrid[1:])
 
     # assert y2 == pytest.approx(y1, rel=0.04)
@@ -304,7 +306,7 @@ def test_multiplicative_overlap(egrid, yexp):
     # will change regrid too
     mdl.nh = 0.05
 
-    with pytest.raises(TypeError, match=IntegrateError):
+    with pytest.raises(TypeError, match=IntegrateError2):
         y2 = regrid(egrid[:-1], egrid[1:])
 
     # assert y2 == pytest.approx(yexp)
@@ -337,7 +339,7 @@ def test_combined(name1, par1, val1, name2, par2, val2, xsmodel):
     regrid = mdl.regrid(ebase[:-1], ebase[1:])
 
     y1 = mdl(egrid[:-1], egrid[1:])
-    with pytest.raises(TypeError, match=IntegrateError):
+    with pytest.raises(TypeError, match=IntegrateError2):
         y2 = regrid(egrid[:-1], egrid[1:])
 
     # assert y2 == pytest.approx(y1, rel=0.04)
@@ -360,7 +362,7 @@ def test_combined_arithmetic_left(name, par, val, xsmodel):
     regrid = mdl.regrid(ebase[:-1], ebase[1:])
 
     yexp = 4 * com(egrid[:-1], egrid[1:])
-    with pytest.raises(TypeError, match=IntegrateError):
+    with pytest.raises(TypeError, match=IntegrateError2):
         y1 = regrid(egrid[:-1], egrid[1:])
 
     # assert y1 == pytest.approx(yexp, rel=0.04)
@@ -383,7 +385,7 @@ def test_combined_arithmetic_right(name, par, val, xsmodel):
     regrid = mdl.regrid(ebase[:-1], ebase[1:])
 
     yexp = 4 * com(egrid[:-1], egrid[1:])
-    with pytest.raises(TypeError, match=IntegrateError):
+    with pytest.raises(TypeError, match=IntegrateError2):
         y1 = regrid(egrid[:-1], egrid[1:])
 
     # assert y1 == pytest.approx(yexp, rel=0.04)
@@ -478,7 +480,7 @@ def test_sherpa_mul_xspec_add(sherpa_first):
 
     # Note the tolerance is different to test_sherpa_add_xspec_mul
     assert comb(eg1, eg2) == pytest.approx(yexp)
-    with pytest.raises(TypeError, match=IntegrateError):
+    with pytest.raises(TypeError, match=IntegrateError2):
         assert rcomb(eg1, eg2) == pytest.approx(yexp, rel=0.006)
 
 
@@ -514,7 +516,7 @@ def test_sherpa_add_xspec_mul(sherpa_first):
 
     # Note the tolerance is different to test_sherpa_mul_xspec_add
     assert comb(eg1, eg2) == pytest.approx(yexp)
-    with pytest.raises(TypeError, match=IntegrateError):
+    with pytest.raises(TypeError, match=IntegrateError2):
         assert rcomb(eg1, eg2) == pytest.approx(yexp, rel=0.07)
 
 

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -2309,3 +2309,124 @@ def test_table_mod_mul_escale_redshift(make_data_path):
     tbl.redshift = 0
     tbl.escale = 2
     assert tbl(elo, ehi) == pytest.approx(MUL_TABLE_E2, rel=2e-6)
+
+
+@pytest.fixture
+def clear_xflt():
+    """Clears XFLT database, runs test, then clears database.
+
+    The test using this fixture must be labelled as
+        @requires_xspec
+
+    """
+
+    from sherpa.astro import xspec
+    xspec.clear_xsxflt()
+    yield
+    xspec.clear_xsxflt()
+
+
+@requires_xspec
+def test_xflt_can_clear_all(clear_xflt):
+    """Check clear_xsxflt() does something."""
+
+    from sherpa.astro import xspec
+
+    xspec.set_xsxflt(1, {"a": 23})
+    xspec.set_xsxflt(3, {"b": 4.9})
+    assert len(xspec.get_xsxflt(1)) == 1
+    assert len(xspec.get_xsxflt(2)) == 0
+    assert len(xspec.get_xsxflt(3)) == 1
+
+    xspec.clear_xsxflt()
+
+    # We check spectrumNumber 1, 2, and 3 just to make sure.
+    for i in range(1, 4):
+        assert len(xspec.get_xsxflt(i)) == 0
+
+
+@requires_xspec
+def test_xflt_can_clear_single(clear_xflt):
+    """We can clear a single spectrumNumber with an empty dict."""
+
+    from sherpa.astro import xspec
+
+    xspec.set_xsxflt(1, {"a": 23, "b": 4.9})
+    xspec.set_xsxflt(2, {"a": 23, "b": 4.9})
+
+    assert len(xspec.get_xsxflt(1)) == 2
+    assert len(xspec.get_xsxflt(2)) == 2
+
+    xspec.set_xsxflt(2, {})
+
+    assert len(xspec.get_xsxflt(1)) == 2
+    assert len(xspec.get_xsxflt(2)) == 0
+
+
+@requires_xspec
+def test_xflt_can_get(clear_xflt):
+    """We can get the values we set.
+    It's not clear whether we should upper-case the keys, so check
+    that we do not change the case (this could be changed in the
+    future).
+    """
+
+    from sherpa.astro import xspec
+
+    xspec.set_xsxflt(1, {"CC": -1.2e-2, "aA": 23, "b": 4.9})
+
+    out = xspec.get_xsxflt(1)
+    assert len(out) == 3
+    assert out["aA"] == pytest.approx(23)
+    assert out["b"] == pytest.approx(4.9)
+    assert out["CC"] == pytest.approx(-1.2e-2)
+
+
+@requires_xspec
+def test_xflt_can_get_xsxstate(clear_xflt):
+    """Check we return the XFLT data as part of the state"""
+
+    from sherpa.astro import xspec
+
+    xspec.set_xsxflt(4, {"CC": -1.2e-2, "aA": 23, "b": 4.9})
+    xspec.set_xsxflt(2, {"FOO": 200})
+    xspec.set_xsxflt(1, {})  # this does not store any state data
+
+    state = xspec.get_xsstate()
+    assert "xflt" in state
+    xflt = state["xflt"]
+    assert len(xflt) == 2
+    assert sorted(xflt.keys()) == [2, 4]
+
+    assert sorted(xflt[2].keys()) == ["FOO"]
+    assert sorted(xflt[4].keys()) == ["CC", "aA", "b"]
+
+    assert xflt[2]["FOO"] == pytest.approx(200)
+    assert xflt[4]["aA"] == pytest.approx(23)
+    assert xflt[4]["b"] == pytest.approx(4.9)
+    assert xflt[4]["CC"] == pytest.approx(-1.2e-2)
+
+
+@requires_xspec
+def test_xflt_can_set_xsxstate(clear_xflt):
+    """Check we set the XFLT data via the state."""
+
+    from sherpa.astro import xspec
+
+    # Set the XSFLT state to see what happens
+    xspec.set_xsxflt(9, {"TMP": 2000})
+
+    xflt = {4: {"CC": -1.2e-2, "aA": 23, "b": 4.9},
+            2: {"FOO": 200},
+            1: {}}
+    xspec.set_xsstate({"xflt": xflt})
+
+    assert xspec.get_xsxflt(1) == {}
+    assert xspec.get_xsxflt(2) == {"FOO": 200}
+    assert xspec.get_xsxflt(4) == {"b": 4.9, "aA": 23, "CC": -1.2e-2}
+
+    # What about the previous setting?
+    assert xspec.get_xsxflt(9) == {}
+
+    # And this is an unknown record
+    assert xspec.get_xsxflt(3) == {}

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1818,7 +1818,7 @@ def test_model_can_send_spectrumnumber_combine():
         args.append((spectrumNumber, "con"))
         return fluxes + pars[1]
 
-    class TestSpectrumNumber(xspec.XSAdditiveModel):
+    class TestSpectrumNumber(xspec.XSPerSpectrum, xspec.XSAdditiveModel):
         _calc = test
 
         def __init__(self, name="test"):
@@ -1826,7 +1826,7 @@ def test_model_can_send_spectrumnumber_combine():
             self.norm = Parameter(name, "norm", 1, 0, 1)
             super().__init__(name, (self.index, self.norm))
 
-    class TestConvSpectrumNumber(xspec.XSConvolutionKernel):
+    class TestConvSpectrumNumber(xspec.XSPerSpectrum, xspec.XSConvolutionKernel):
         _calc = testcon
 
         def __init__(self, name="test"):
@@ -1927,7 +1927,7 @@ def test_model_can_send_spectrumnumber_combine_non_xspec():
         args.append((spectrumNumber, pars[0]))
         return pars[1] * np.ones_like(lo)
 
-    class TestSpectrumNumber2(xspec.XSAdditiveModel):
+    class TestSpectrumNumber2(xspec.XSPerSpectrum, xspec.XSAdditiveModel):
         _calc = test
 
         def __init__(self, name="test"):


### PR DESCRIPTION
- so the main UI should be something like `add_xflt` which takes a dataset (or an identifier for the UI layer) and returns a `SpectrumNumber`, there's some form of `show_xflt`, and `clear_xflt`; we don't really need much more (the lower-level code needs to have more)
- setting the `spectrum` attribute of a model can warn if there's no data, since the idea is that you've got a dataset
- the XSPEC model `startup` method can check whether the `spectrum` values have data for; it would also be nice to check that we don't "mix" `spectrum` values between different source models (or, perhaps more importantly, within the same source expression) but it's hard to get the balance right

I am likely going to do this in 

- #2224 

but I want to leave this available for now

# Summary

Add experimental support for XSPEC models that use filtering keywords (e.g. XFLT0001) and are marked as per-spectrum in the XSPEC model files. This adds the xssmaug, xspolconst, xspollin, and xspolpow XSPEC models and the load_xsxflt command.
 
# Details

To support the per-spectrum XSPEC models we need

- a way to set / get  the XFLT keyword database values - that is associate values with a given "spectrum number"
- a way to tell the XSPEC model to use the correct "spectrum number"

XSPEC can do this all automatically, but we

- do not require an integer value as a dataset identifier (in the UI layer)
- do not have the concept of an identifier when evaluating a model, as all we care about is the grid to evaluate the model on

So, matching these two systems is not simple and means the Sherpa user has to know about this all, unlike the XSPEC user. Which is why this is labelled experimental.

The XSPEC models provided in the model library are not particularly exciting for Sherpa (there is `smaug`, and then the other models require better handling of polarimetric errors than we currently provide). So it  may be more useful for user-weitten models.

However, I had been hoping to use this to then get mixing models - which also use the XFLT database - into Sherpa, but the current API for these models is not currently  designed for external use (i.e. outside XSPEC proper), as reported to me by an XSPEC developer [there are strong reasons for this]. Which perhaps limits the interest in this.

# Examples

## UI

Let's load in a PHA file three times, so we can see whether the model values change with the XFLT keywords:

```
In [1]: from sherpa.astro import ui

In [2]: ui.load_pha(1, "sherpa-test-data/sherpatest/3c273.pi")
...

In [3]: ui.load_pha(2, "sherpa-test-data/sherpatest/3c273.pi")
...

In [4]: ui.load_pha(3, "sherpa-test-data/sherpatest/3c273.pi")
...

In [5]: ui.notice(0.5, 6)
dataset 1: 0.00146:14.9504 -> 0.4672:6.57 Energy (keV)
dataset 2: 0.00146:14.9504 -> 0.4672:6.57 Energy (keV)
dataset 3: 0.00146:14.9504 -> 0.4672:6.57 Energy (keV)
```

Let's load in the XFLT keywords, normally this would be (ugly, and should be improved) - **BUT** the PHA file does not have any `XFLT0001`,... keywords, and I want to fake up 1 and 2 having the same values but 3 having a different set of values:

```
>>> ui.load_xsxflt(ui.get_data(1), 1)
>>> ui.load_xsxflt(ui.get_data(2), 2)
>>> ui.load_xsxflt(ui.get_data(3), 3)
```

So we manually create them. Now, we have to "magically" know what the values are - in this case the [smaug model page](https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelSmaug.html) we get

```
In [6]: from sherpa.astro import xspec  # need to check what needs to be imported

In [7]: xspec.set_xsxflt(1, {'inner': 1, 'outer': 2, 'width': 360})

In [8]: xspec.set_xsxflt(2, {'inner': 2, 'outer': 3, 'width': 360})
```

So, I've created "spectrum numbers" 1 and 2. 

Let's no create the models

```
In [9]: ui.set_source(1, ui.xsphabs.gal * ui.xssmaug.dragon1)

In [10]: ui.set_source(2, gal * dragon1)

In [12]: ui.set_source(3, gal * ui.xssmaug.dragon2)

In [13]: gal.nh.set(0.05, frozen=True)
```

Many parameters:

```
In [14]: print(dragon1)
xssmaug.dragon1
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   dragon1.kT_cc thawed            1         0.08          100        keV
   dragon1.kT_dt thawed            1            0          100        keV
   dragon1.kT_ix frozen            0            0           10           
   dragon1.kT_ir frozen          0.1       0.0001            1        Mpc
   dragon1.kT_cx thawed          0.5            0           10           
   dragon1.kT_cr thawed          0.1       0.0001           20        Mpc
   dragon1.kT_tx frozen            0            0           10           
   dragon1.kT_tr frozen          0.5       0.0001            3        Mpc
   dragon1.nH_cc frozen            1        1e-06            3     cm**-3
   dragon1.nH_ff frozen            1            0            1           
   dragon1.nH_cx thawed          0.5            0           10           
   dragon1.nH_cr thawed          0.1       0.0001            2        Mpc
   dragon1.nH_gx frozen            0            0           10           
   dragon1.nH_gr frozen        0.002       0.0001           20        Mpc
   dragon1.Ab_cc frozen            1            0            5      solar
   dragon1.Ab_xx frozen            0            0           10           
   dragon1.Ab_rr frozen          0.1       0.0001            1        Mpc
   dragon1.redshift frozen         0.01       0.0001           10           
   dragon1.meshpts frozen           10            1        10000           
   dragon1.rcutoff frozen            2            1            3        Mpc
   dragon1.mode frozen            1            0            2           
   dragon1.itype frozen            2            1            4           
   dragon1.norm thawed            1            0        1e+24           
```

Let's bump up the redshift:

```
In [15]: dragon2.redshift = dragon1.redshift

In [16]: dragon1.redshift = 0.15
```

Now we need to associate the model components to the spectrum numbers **BECAUSE** we don't have a way to do this (we could make the UI layer make it so that you need to use consecutive numbers when using these models, but that would likely be something we'd want to do after trying out how it works). These models start out defaulting to "1", so in this case we only need to change `dragon2`:

```
In [18]: dragon1.spectrum
Out[18]: 1

In [19]: dragon2.spectrum
Out[19]: 1

In [20]: dragon2.spectrum = 2
```

There's no check that this is a valid "spectrum number" - e.g. that `set_xsxflt/load_xsxflt` has been called. We perhaps could do this, but it's tricky to do well.

```
In [34]: ui.plot_model(1, alpha=0.5, label="1", xlog=True, ylog=True)

In [35]: ui.plot_model(2, alpha=0.5, label="2", overplot=True, linestyle="dotted")

In [36]: ui.plot_model(3, alpha=0.5, label="3", overplot=True, linestyle="dashed")
```

![sherpa-1](https://github.com/user-attachments/assets/23af5428-99bd-493e-901c-7cedbb72ff17)

Hmm, I expected 1 and 2 to be the same but 3 to be different because of the different XFLT keywords.

I think the third line is subtly different from the first two. We can check by removing the cache and bumping up the chatter level:

```
In [53]: dragon1.cache_clear()

In [54]: dragon2.cache_clear()

In [55]: dragon1._use_caching = False

In [56]: dragon2._use_caching = False

In [57]: xspec.set_xschatter(50)

In [58]: ui.plot_model(1, alpha=0.5, label="1", xlog=True, ylog=True)
calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4


 H0 = 70.000000  [km/s/Mpc]
q0   = 0.000000
L0   = 0.730000
DA   =  5.425e+02 [Mpc]

DSET 1
IN   =  1.578e-01 [Mpc] 
OUT  =  3.156e-01 [Mpc] 
WID  = 12.6 [rad]
EVOL (< 2.0 [Mpc] = 9.315e-01[Mpc**3]         
EINT (<2.0 [Mpc] = 

In [59]: ui.plot_model(2, alpha=0.5, label="1", xlog=True, ylog=True)
calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4


 H0 = 70.000000  [km/s/Mpc]
q0   = 0.000000
L0   = 0.730000
DA   =  5.425e+02 [Mpc]

DSET 1
IN   =  1.578e-01 [Mpc] 
OUT  =  3.156e-01 [Mpc] 
WID  = 12.6 [rad]
EVOL (< 2.0 [Mpc] = 9.315e-01[Mpc**3]         
EINT (<2.0 [Mpc] = 

In [60]: ui.plot_model(3, alpha=0.5, label="1", xlog=True, ylog=True)
calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4


DSET 2
IN   =  0.31561 [Mpc] 
OUT  =  0.473416 [Mpc] 
WID  = 12.6 [rad]
EVOL (< 2.0 [Mpc] = 1.533e+00[Mpc**3]         
EINT (<2.0 [Mpc] = 

```

```
In [67]: mp1 = ui.get_model_plot(1, recalc=True)
...

In [68]: mp2 = ui.get_model_plot(2, recalc=True)
...

In [69]: mp3 = ui.get_model_plot(3, recalc=True)
...

In [70]: (mp1.y == mp2.y).all()
Out[70]: True

In [71]: (mp1.y == mp3.y).all()
Out[71]: True
```

Darn it. I expected `mp3.y` to be different ...

Let's try rather different values:

```
In [73]: xspec.set_xsxflt(2, {'inner': 5, 'outer': 10, 'width': 20})

In [74]: mp3 = ui.get_model_plot(3, recalc=True)
calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4

calcMultiTempPlasma : plasmaType = 4


DSET 2
IN   =  0.789026 [Mpc] 
OUT  =  1.57805 [Mpc] 
WID  = 0.7 [rad]
EVOL (< 2.0 [Mpc] = 1.013e+00[Mpc**3]         
EINT (<2.0 [Mpc] = 

In [75]: (mp1.y == mp3.y).all()
Out[75]: True

```

So, I do not understand this model. You can see the XFLT keuwprds have changed the numbers printed to the screen, but not the evaluated model.
