### PR TITLE
XSPEC: add show_xsabund command

### DIFF
--- a/docs/ui/sherpa_astro_ui.rst
+++ b/docs/ui/sherpa_astro_ui.rst
@@ -135,6 +135,7 @@ burden...
       get_model_component
       get_model_component_image
       get_model_component_plot
+      get_model_components_plot
       get_model_contour
       get_model_contour_prefs
       get_model_image
@@ -174,6 +175,7 @@ burden...
       get_resid_plot
       get_response
       get_rmf
+      get_rmf_plot
       get_rng
       get_sampler
       get_sampler_name
@@ -182,6 +184,7 @@ burden...
       get_source
       get_source_component_image
       get_source_component_plot
+      get_source_components_plot
       get_source_contour
       get_source_image
       get_source_plot
@@ -303,6 +306,7 @@ burden...
       plot_kernel
       plot_model
       plot_model_component
+      plot_model_components
       plot_order
       plot_pdf
       plot_photon_flux
@@ -310,9 +314,11 @@ burden...
       plot_pvalue
       plot_ratio
       plot_resid
+      plot_rmf
       plot_scatter
       plot_source
       plot_source_component
+      plot_source_components
       plot_trace
       proj
       projection
@@ -403,6 +409,7 @@ burden...
       show_psf
       show_source
       show_stat
+      show_xsabund
       simulfit
       subtract
       t_sample

--- a/docs/ui/sherpa_ui.rst
+++ b/docs/ui/sherpa_ui.rst
@@ -91,6 +91,7 @@ hidden away. This needs better explanation...
       get_model_component
       get_model_component_image
       get_model_component_plot
+      get_model_components_plot
       get_model_contour
       get_model_contour_prefs
       get_model_image
@@ -131,6 +132,7 @@ hidden away. This needs better explanation...
       get_source
       get_source_component_image
       get_source_component_plot
+      get_source_components_plot
       get_source_contour
       get_source_image
       get_source_plot
@@ -203,6 +205,7 @@ hidden away. This needs better explanation...
       plot_kernel
       plot_model
       plot_model_component
+      plot_model_components
       plot_pdf
       plot_psf
       plot_pvalue
@@ -211,6 +214,7 @@ hidden away. This needs better explanation...
       plot_scatter
       plot_source
       plot_source_component
+      plot_source_components
       plot_trace
       proj
       projection

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -15887,6 +15887,80 @@ class Session(sherpa.ui.utils.Session):
         return sherpa.astro.utils.calc_kcorr(data, model, z, obslo, obshi,
                                              restlo, resthi)
 
+    def show_xsabund(self,
+                     outfile=None,  # str or file-like
+                     clobber: bool = False) -> None:
+        """Show the XSPEC abundance values.
+
+        .. versionadded:: 4.17.0
+
+        Parameters
+        ----------
+        outfile : str, file-like, or None, optional
+           If not given the results are displayed to the screen,
+           otherwise it is the file name (string) or file-like object
+           to write the results to.
+        clobber : bool, optional
+           If `outfile` is not ``None``, then this flag controls
+           whether an existing file can be overwritten (``True``)
+           or if it raises an exception (``False``, the default
+           setting).
+
+        See Also
+        --------
+        get_xsabund, set_xsabund
+
+        Examples
+        --------
+
+        Display the current abundance table and values:
+
+        >>> show_xsabund()
+        Solar Abundance Table:
+        angr
+          H : 1.000e+00  He: 9.770e-02  Li: 1.450e-11  Be: 1.410e-11  B : 3.980e-10
+          C : 3.630e-04  N : 1.120e-04  O : 8.510e-04  F : 3.630e-08  Ne: 1.230e-04
+          Na: 2.140e-06  Mg: 3.800e-05  Al: 2.950e-06  Si: 3.550e-05  P : 2.820e-07
+          S : 1.620e-05  Cl: 3.160e-07  Ar: 3.630e-06  K : 1.320e-07  Ca: 2.290e-06
+          Sc: 1.260e-09  Ti: 9.770e-08  V : 1.000e-08  Cr: 4.680e-07  Mn: 2.450e-07
+          Fe: 4.680e-05  Co: 8.320e-08  Ni: 1.780e-06  Cu: 1.620e-08  Zn: 3.980e-08
+
+        The output can be written to a file or a file-like instance,
+        such as a StringIO object:
+
+        >>> from io import StringIO
+        >>> buffer = StringIO()
+        >>> show_xsabund(buffer)
+        >>> txt = buffer.getvalue()
+
+        """
+
+        try:
+            xspec = sherpa.astro.xspec
+        except AttributeError:
+            warning("XSPEC support is not available")
+            return
+
+        # Very similar to the XSPEC "show abund" format, except that
+        # we do not have the "documentation" for the abundance table.
+        # This can be added but needs changes to the _xspec module.
+        #
+        lines = ["Solar Abundance Table:",
+                 f"{xspec.get_xsabund():4s}",
+                 ""]
+
+        # Rely on get_xsbundances to be in order of atomic number.
+        #
+        idx = 0
+        for name, abund in xspec.get_xsabundances().items():
+            lines[-1] += f"  {name:2s}: {abund:.3e}"
+            idx += 1
+            if idx == 5:
+                lines.append("")
+                idx = 0
+
+        send_to_pager("\n".join(lines), outfile, clobber)
+
     ###########################################################################
     # Session Text Save Function
     ###########################################################################

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -198,7 +198,7 @@ def get_xsabundances() -> dict[str, float]:
     Returns
     -------
     abundances : dict
-        The current set of abundances. The keys are the element name
+        The current set of abundances. The keys are the element names
         (e.g. 'Fe') and the values are the abundances.
 
     See Also
@@ -246,7 +246,7 @@ def get_xselements() -> dict[str, int]:
     # We just hard-code this since our interface to the XSPEC library
     # does not provide this information. We can add functions to
     # access this, which would replace this code, but at the moment it
-    # is very-unlikely that XSPEC will add more elements.
+    # is very unlikely that XSPEC will add more elements.
     #
     out = {}
     elems = ['H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne',

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -158,7 +158,7 @@ def get_xsabund(element: Optional[str] = None) -> Union[str, float]:
 
     See Also
     --------
-    set_xsabund
+    get_xsabundances, set_xsabund
 
     Examples
     --------
@@ -169,6 +169,11 @@ def get_xsabund(element: Optional[str] = None) -> Union[str, float]:
     >>> get_xsabund()
     'angr'
 
+    Return the abundance of Helium:
+
+    >>> get_xsabund('He')
+    0.09769999980926514
+
     The `set_xsabund` function has been used to read in the
     abundances from a file, so the routine now returns the
     string 'file':
@@ -177,15 +182,81 @@ def get_xsabund(element: Optional[str] = None) -> Union[str, float]:
     >>> get_xsabund()
     'file'
 
-    >>> get_xsabund('He')
-    0.09769999980926514
-
     """
 
     if element is None:
         return _xspec.get_xsabund()
 
     return _xspec.get_xsabund(element)
+
+
+def get_xsabundances() -> dict[str, float]:
+    """Return the abundance settings used by X-Spec.
+
+    .. versionadded:: 4.17.0
+
+    Returns
+    -------
+    abundances : dict
+        The current set of abundances. The keys are the element name
+        (e.g. 'Fe') and the values are the abundances.
+
+    See Also
+    --------
+    get_xsabund, set_xsabund
+
+    Examples
+    --------
+
+    >>> get_xsabundances()
+    {'H': 1.0, 'He': ...}
+
+    """
+
+    return {name: _xspec.get_xsabund(name)
+            for name in get_xselements().keys()}
+
+
+# This function is not added to __all__ as it is very specialized.
+#
+def get_xselements() -> dict[str, int]:
+    """Return the elements names and atomic numbers used by X-Spec.
+
+    .. versionadded:: 4.17.0
+
+    Returns
+    -------
+    elements : dict
+        The keys are the element names and the values the atomic
+        numbers.
+
+    Examples
+    --------
+
+    >>> els = get_xselements()
+    >>> len(els)
+    30
+    >>> els['H']
+    1
+    >>> els['Zn']
+    30
+
+    """
+
+    # We just hard-code this since our interface to the XSPEC library
+    # does not provide this information. We can add functions to
+    # access this, which would replace this code, but at the moment it
+    # is very-unlikely that XSPEC will add more elements.
+    #
+    out = {}
+    elems = ['H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne',
+             'Na', 'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca',
+             'Sc', 'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu',
+             'Zn']
+    for idx, elem in enumerate(elems, 1):
+        out[elem] = idx
+
+    return out
 
 
 def get_xschatter() -> int:
@@ -924,7 +995,7 @@ __all__ : tuple[str, ...]
 __all__ = ('get_xschatter', 'get_xsabund', 'get_xscosmo', 'get_xsxsect',
            'set_xschatter', 'set_xsabund', 'set_xscosmo', 'set_xsxsect',
            'get_xsversion', 'set_xsxset', 'get_xsxset', 'set_xsstate',
-           'get_xsstate')
+           'get_xsstate', 'get_xsabundances')
 
 
 class XSBaseParameter(Parameter):


### PR DESCRIPTION
# Summary

Add the show_xsabund command to the sherpa.astro.ui module and get_xsabundances to sherpa.astro.xspec.

# Details

This adds

 - sherpa.astro.ui.show_xsabund (and also to sherpa.astro.ui.utils.Session)

 - sherpa.astro.xspec.get_xsabundances() and, not exported, sherpa.astro.xspec.get_xselements()

The aim is to provide a "useful" show_xsabund() command for the UI user, but the get_xsabundances() command may be useful too.

Unfortunately, with the current interface, we can't get at the description/documenatation for each abundance table, so we can only label it as "`angr`" and not "`angr: Anders E. & Grevesse N. ...`". This could be done but would require adding functionality to the compiled code in `sherpa.astro.xspec._xspec`, and I claim the code here adds a useful capability as is, and we can extend it later.

This code is based on the larger "take advantage of the FunctionUtility interface" PR #1615, which is where a number of the tests are taken, that cover some functionality not actually changed here.

**EDITED TO ADD** When adding the routine (`set_xsabund`) to the read-the-docs documentation I realised that we could add some recently-added routines which had been missed from the PRs that added them (well, I first noted this in a different PR and thought I'd add them here). This does not add anything to sherpa itself, just the pages under https://sherpa.readthedocs.io/en/latest/ui/


# Example

This is the current behavior:

```
>>> from sherpa.astro import ui
>>> ui.get_xsabund()
'angr'
>>> ui.get_xsabund()
'angr'
```

The `show_xsabund` command is based on the XSPEC `show abund` command and returns:

```
>>> ui.show_xsabund()
Solar Abundance Table:
angr
  H : 1.000e+00  He: 9.770e-02  Li: 1.450e-11  Be: 1.410e-11  B : 3.980e-10
  C : 3.630e-04  N : 1.120e-04  O : 8.510e-04  F : 3.630e-08  Ne: 1.230e-04
  Na: 2.140e-06  Mg: 3.800e-05  Al: 2.950e-06  Si: 3.550e-05  P : 2.820e-07
  S : 1.620e-05  Cl: 3.160e-07  Ar: 3.630e-06  K : 1.320e-07  Ca: 2.290e-06
  Sc: 1.260e-09  Ti: 9.770e-08  V : 1.000e-08  Cr: 4.680e-07  Mn: 2.450e-07
  Fe: 4.680e-05  Co: 8.320e-08  Ni: 1.780e-06  Cu: 1.620e-08  Zn: 3.980e-08
```

(although this is the annoying show_xxx behaviour which displays it via a pager).

One thing to note that without changes to the C++ code we can't get the line to say `angr: Anders E. & Grevesse N. Geochimica et Cosmochimica Acta 53, 197 (1989)` in the output. This version is present in #1615 but I don't see that getting into the 4.17 release.

We have the lower-level command to get the individual elements (this information could have been got manually but this is just nicer):

```
>>> from sherpa.astro import xspec
>>> xspec.get_xsabundances()
{'H': 1.0, 'He': 0.09769999980926514, 'Li': 1.4500000158901294e-11, 'Be': 1.409999981355492e-11, 'B': 3.979999940728618e-10, 'C': 0.00036299999919719994, 'N': 0.00011200000153621659, 'O': 0.0008510000188834965, 'F': 3.630000122711863e-08, 'Ne': 0.0001230000052601099, 'Na': 2.1400001060101204e-06, 'Mg': 3.7999998312443495e-05, 'Al': 2.9499999527615728e-06, 'Si': 3.550000110408291e-05, 'P': 2.8200000201650255e-07, 'S': 1.6199999663513154e-05, 'Cl': 3.160000119351025e-07, 'Ar': 3.6300000374467345e-06, 'K': 1.3199999671087426e-07, 'Ca': 2.2900001113157487e-06, 'Sc': 1.259999993230565e-09, 'Ti': 9.770000275466373e-08, 'V': 9.99999993922529e-09, 'Cr': 4.679999960899295e-07, 'Mn': 2.4499999540239514e-07, 'Fe': 4.6799999836366624e-05, 'Co': 8.319999977857151e-08, 'Ni': 1.7800000478018774e-06, 'Cu': 1.619999956403717e-08, 'Zn': 3.979999974035309e-08}
>>> ui.set_xsabund("grsa")
 Solar Abundance Vector set to grsa:  Grevesse, N. & Sauval, A. J. Space Science Reviews 85, 161 (1998)
>>> xspec.get_xsabundances()
{'H': 1.0, 'He': 0.08510000258684158, 'Li': 1.2600000036389059e-11, 'Be': 2.5100000203281958e-11, 'B': 3.550000016172561e-10, 'C': 0.00033099998836405575, 'N': 8.320000051753595e-05, 'O': 0.0006760000251233578, 'F': 3.630000122711863e-08, 'Ne': 0.00011999999696854502, 'Na': 2.1400001060101204e-06, 'Mg': 3.7999998312443495e-05, 'Al': 2.9499999527615728e-06, 'Si': 3.550000110408291e-05, 'P': 2.8200000201650255e-07, 'S': 2.13999992411118e-05, 'Cl': 3.160000119351025e-07, 'Ar': 2.5100000584643567e-06, 'K': 1.3199999671087426e-07, 'Ca': 2.2900001113157487e-06, 'Sc': 1.4800000114334466e-09, 'Ti': 1.0499999802959792e-07, 'V': 9.99999993922529e-09, 'Cr': 4.679999960899295e-07, 'Mn': 2.4499999540239514e-07, 'Fe': 3.1600000511389226e-05, 'Co': 8.319999977857151e-08, 'Ni': 1.7800000478018774e-06, 'Cu': 1.619999956403717e-08, 'Zn': 3.979999974035309e-08}
```

The version in #1615 also allows access to the other tables without changing the loaded table, but that can be added at a later time (or when we take #1615) but this is useful as is.
