### PR TITLE
Asymmetric settings

### DIFF
--- a/sherpa/sim/__init__.py
+++ b/sherpa/sim/__init__.py
@@ -194,7 +194,7 @@ parameter::
 
 import logging
 
-import numpy
+import numpy as np
 
 from sherpa.data import Data1D, Data1DAsymmetricErrs
 from sherpa.fit import Fit
@@ -217,7 +217,7 @@ from sherpa.utils import random
 
 info = logging.getLogger("sherpa").info
 
-_tol = numpy.finfo(float).eps
+_tol = np.finfo(float).eps
 
 string_types = (str, )
 
@@ -714,7 +714,7 @@ class MCMC(NoNewAttributesAfterInit):
         sampler_kwargs = self._sampler_opt.copy()
         sampler_kwargs['priors'] = priors
 
-        oldthawedpars = numpy.array(mu)
+        oldthawedpars = np.array(mu)
         thawedparmins = fit.model.thawedparhardmins
         thawedparmaxes = fit.model.thawedparhardmaxes
 
@@ -888,7 +888,7 @@ class ReSampleData(NoNewAttributesAfterInit):
 
             name = par.fullname
             pars_index.append(name)
-            pars[name] = numpy.zeros(niter)
+            pars[name] = np.zeros(niter)
 
         data = self.data
         x = data.x
@@ -903,13 +903,13 @@ class ReSampleData(NoNewAttributesAfterInit):
         ny = len(y)
 
         # TODO: we do not properly handle Data1DInt here
-        fake_data = Data1D('tmp', x, numpy.zeros(ny))
+        fake_data = Data1D('tmp', x, np.zeros(ny))
 
         if rng is None:
-            numpy.random.seed(seed)
+            np.random.seed(seed)
 
-        ry_all = numpy.zeros((niter, ny), dtype=y_l.dtype)
-        stats = numpy.zeros(niter)
+        ry_all = np.zeros((niter, ny), dtype=y_l.dtype)
+        stats = np.zeros(niter)
         for j in range(niter):
             ry = ry_all[j]
             for i in range(ny):
@@ -972,8 +972,8 @@ class ReSampleData(NoNewAttributesAfterInit):
 
         result = {'samples': ry_all, 'statistic': stats}
         for name in pars_index:
-            avg = numpy.average(pars[name])
-            std = numpy.std(pars[name])
+            avg = np.average(pars[name])
+            std = np.std(pars[name])
             info('%s : avg = %s , std = %s', name, avg, std)
             result[name] = pars[name]
 

--- a/sherpa/sim/__init__.py
+++ b/sherpa/sim/__init__.py
@@ -833,7 +833,7 @@ class ReSampleData(NoNewAttributesAfterInit):
 
         self.data = data
         self.model = model
-        NoNewAttributesAfterInit.__init__(self)
+        super().__init__()
 
     def __call__(self, niter=1000, seed=None, rng=None):
         return self.call(niter, seed, rng=rng)

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -97,6 +97,8 @@ def _check_str_type(arg: str, argname: str) -> None:
     raise ArgumentTypeErr('badarg', argname, "a string")
 
 
+# With Python 3.10 these can return TypeGuard annotations.
+#
 def _is_integer(val):
     return isinstance(val, (int, np.integer))
 
@@ -2344,7 +2346,10 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-TODO: remove the list of supported methods once the
     # relevant documentation has been updated.
-    def set_method(self, meth: str) -> None:
+    #
+    def set_method(self,
+                   meth: Union[OptMethod, str]
+                   ) -> None:
         """Set the optimization method.
 
         The primary task of Sherpa is to fit a model M(p) to a set of
@@ -2417,7 +2422,7 @@ class Session(NoNewAttributesAfterInit):
         if _is_str(meth):
             method = self._get_method_by_name(meth)
         else:
-            _check_type(meth, sherpa.optmethods.OptMethod, 'meth',
+            _check_type(meth, OptMethod, 'meth',
                         'a method name or object')
             method = meth
 
@@ -2442,7 +2447,9 @@ class Session(NoNewAttributesAfterInit):
         if optname not in self._current_method.config:
             raise ArgumentErr('badopt', optname, self.get_method_name())
 
-    def get_method_opt(self, optname=None):
+    def get_method_opt(self,
+                       optname: Optional[str] = None
+                       ) -> Any:
         """Return one or all of the options for the current optimization
         method.
 
@@ -2486,7 +2493,7 @@ class Session(NoNewAttributesAfterInit):
         self._check_method_opt(optname)
         return self._current_method.config[optname]
 
-    def set_method_opt(self, optname, val) -> None:
+    def set_method_opt(self, optname: str, val: Any) -> None:
         """Set an option for the current optimization method.
 
         This is a helper function since the optimization options can also
@@ -2546,7 +2553,9 @@ class Session(NoNewAttributesAfterInit):
         """
         return self._current_itermethod['name']
 
-    def get_iter_method_opt(self, optname=None):
+    def get_iter_method_opt(self,
+                            optname: Optional[str] = None
+                            ) -> Any:
         """Return one or all options for the iterative-fitting scheme.
 
         The options available for the iterative-fitting methods are
@@ -2725,7 +2734,7 @@ class Session(NoNewAttributesAfterInit):
 
         self._current_itermethod = self._itermethods[meth]
 
-    def set_iter_method_opt(self, optname, val) -> None:
+    def set_iter_method_opt(self, optname: str, val: Any) -> None:
         """Set an option for the iterative-fitting scheme.
 
         Parameters


### PR DESCRIPTION
# Summary

Allow the statistic and optimizer to be changed when re-sampling data with asymmetric errors. Fix #2093.

# Details

The fix for #2093 turns out to be pretty easy. I decided that the UI layer would see no user-visible change here, but that it would now use the stat/optimiser objects. We could make the `resample_data` take optional `stat` and `method` arguments to allow the user to over-ride this, but I'm not sure it's worth it (although it would make it easier to replicate the previous behavior). Users of the OO code have direct access to this setting.

There are also some code clean ups (which shouldn't change behaviour) and both new and fixes made to the UI typing rules.