### PR TITLE
Add a set_xsabundances call for XSPEC users

### DIFF
--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -32,6 +32,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
       :toctree: api
 
       get_xsabund
+      get_xsabundances
       get_xschatter
       get_xscosmo
       get_xspath_manager
@@ -42,6 +43,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
       get_xsxset
       read_xstable_model
       set_xsabund
+      set_xsabundances
       set_xschatter
       set_xscosmo
       set_xspath_manager

--- a/sherpa/astro/ui/__init__.py
+++ b/sherpa/astro/ui/__init__.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2018, 2020, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2018, 2020, 2021, 2024
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -54,11 +55,11 @@ if hasattr(sherpa.astro, 'xspec'):
 
     from sherpa.astro.xspec import get_xsabund, get_xscosmo, get_xsxsect, \
         set_xsabund, set_xscosmo, set_xsxsect, set_xsxset, get_xsxset, \
-        get_xschatter, set_xschatter
+        get_xschatter, set_xschatter, get_xsabundances, set_xsabundances
     __all__.extend(('get_xsabund', 'get_xschatter', 'get_xscosmo',
                     'get_xsxsect', 'set_xsabund', 'set_xschatter',
                     'set_xscosmo', 'set_xsxsect', 'set_xsxset',
-                    'get_xsxset'))
+                    'get_xsxset', 'get_xsabundances', 'set_xsabundances'))
 
 __all__.extend(_session._export_names(globals()))
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -15915,7 +15915,7 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        get_xsabund, set_xsabund
+        get_xsabund, get_xsabundances, set_xsabund, set_xsabundances
 
         Examples
         --------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -221,7 +221,7 @@ def get_xsabundances() -> dict[str, float]:
 
 # The current interface to the XSPEC model library makes this awkward
 # to write. Once the interface switches to using the FunctionUtility
-# interface this code will be a lot simpler iternally, without
+# interface this code will be a lot simpler internally, without
 # changing the API.
 #
 def set_xsabundances(abundances: dict[str, float]) -> None:

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -262,7 +262,7 @@ def set_xsabundances(abundances: dict[str, float]) -> None:
         try:
             z = elems[name]
         except KeyError:
-            raise ArgumentErr(f"Invalid element name: '{name}'")
+            raise ArgumentErr(f"Invalid element name: '{name}'") from None
 
         out[z - 1] = abund
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -116,7 +116,7 @@ from sherpa.models import ArithmeticModel, ArithmeticFunctionModel, \
     CompositeModel, Parameter, modelCacher1d, RegriddableModel1D
 from sherpa.models.parameter import hugeval
 from sherpa.utils import bool_cast
-from sherpa.utils.err import IOErr, ParameterErr
+from sherpa.utils.err import ArgumentErr, IOErr, ParameterErr
 from sherpa.utils.guess import param_apply_limits
 from sherpa.utils.numeric_types import SherpaFloat
 
@@ -252,15 +252,19 @@ def set_xsabundances(abundances: dict[str, float]) -> None:
 
     """
 
-    # Get the list of elemental values.
+    # Get the list of elemental values. We do not require that the
+    # dictionary contain all the elements, but it can not contain
+    # unknown elements.
     #
     elems = get_xselements()
     out = np.zeros(len(elems))
     for name, abund in abundances.items():
-        # Skip unknown names. Should this warn the user?
-        with suppress(KeyError):
+        try:
             z = elems[name]
-            out[z - 1] = abund
+        except KeyError:
+            raise ArgumentErr(f"Invalid element name: '{name}'")
+
+        out[z - 1] = abund
 
     # Write them to a file and then load them.
     #

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -378,7 +378,7 @@ def test_abund_set_dict():
 
     oval = xspec.get_xsabund()
 
-    # This is a pre-condition. It is't really needed, but it is a better
+    # This is a pre-condition. It isn't really needed, but it is a better
     # test if it holds.
     #
     #


### PR DESCRIPTION
# Summary

Add a set_xsabundances call to make it easier to change one or more elemental abundances for the XSPEC models and ensure that both the get and set calls are available from the sherpa.astro.ui module.

# Details

Taken from #1615 (where the internal code is nicer) but we can provide the same API to the user with the existing code, which makes it easier to review.

It follows from the get_xsabundances call added in #2017

We could add a more-complex API - such as getting or setting individual elements, or accessing the elements by name or atomic number, but 

- I'm not sure it's worth it
- those lower-level routines are better done when directly interacting with the C++ API, which needs 

  1. #1793 
  2. #1615
  
  and I'm not sure it's worth it **at this time** 

That is, this provides the most "bang" for our "buck"....

Unfortunately, the approach taken does lead to screen output when you call `set_xsabundances`, but that would require #1615 to address (since this is screen output from the XSPEC library and not from Python scope. It's something I can live with.

# Example

In 4.16.0/1 we have (for the ui layer):

```
sherpa-4.16.0> get_xsabund()
'angr'

sherpa-4.16.0> *abund*?
get_xsabund
set_xsabund
```

With this PR we get (note that `show_xsabund` was not added in this PR but is a 4.17.0 changhe):

```
In [1]: from sherpa.astro import ui

In [2]: ui.*abund*?
ui.get_xsabund
ui.get_xsabundances
ui.set_xsabund
ui.set_xsabundances
ui.show_xsabund
```

So, with

```
In [3]: ui.show_xsabund()
Solar Abundance Table:
angr
  H : 1.000e+00  He: 9.770e-02  Li: 1.450e-11  Be: 1.410e-11  B : 3.980e-10
  C : 3.630e-04  N : 1.120e-04  O : 8.510e-04  F : 3.630e-08  Ne: 1.230e-04
  Na: 2.140e-06  Mg: 3.800e-05  Al: 2.950e-06  Si: 3.550e-05  P : 2.820e-07
  S : 1.620e-05  Cl: 3.160e-07  Ar: 3.630e-06  K : 1.320e-07  Ca: 2.290e-06
  Sc: 1.260e-09  Ti: 9.770e-08  V : 1.000e-08  Cr: 4.680e-07  Mn: 2.450e-07
  Fe: 4.680e-05  Co: 8.320e-08  Ni: 1.780e-06  Cu: 1.620e-08  Zn: 3.980e-08
```

we now can

```
In [5]: avals = ui.get_xsabundances()

In [6]: type(avals)
Out[6]: dict

In [7]: print(avals)
{'H': 1.0, 'He': 0.09769999980926514, 'Li': 1.4500000158901294e-11, 'Be': 1.409999981355492e-11, 'B': 3.979999940728618e-10, 'C': 0.00036299999919719994, 'N': 0.00011200000153621659, 'O': 0.0008510000188834965, 'F': 3.630000122711863e-08, 'Ne': 0.0001230000052601099, 'Na': 2.1400001060101204e-06, 'Mg': 3.7999998312443495e-05, 'Al': 2.9499999527615728e-06, 'Si': 3.550000110408291e-05, 'P': 2.8200000201650255e-07, 'S': 1.6199999663513154e-05, 'Cl': 3.160000119351025e-07, 'Ar': 3.6300000374467345e-06, 'K': 1.3199999671087426e-07, 'Ca': 2.2900001113157487e-06, 'Sc': 1.259999993230565e-09, 'Ti': 9.770000275466373e-08, 'V': 9.99999993922529e-09, 'Cr': 4.679999960899295e-07, 'Mn': 2.4499999540239514e-07, 'Fe': 4.6799999836366624e-05, 'Co': 8.319999977857151e-08, 'Ni': 1.7800000478018774e-06, 'Cu': 1.619999956403717e-08, 'Zn': 3.979999974035309e-08}
```

and even

```
In [8]: avals['Li'] = 0; avals['Cu'] = 0

In [9]: ui.set_xsabundances(avals)
 Solar Abundance Vector set to file:  User defined abundance vector / no description specified

In [10]: ui.get_xsabund()
Out[10]: 'file'
```

after which we can see the changes in `show_xsabund`:

```
In [11]: ui.show_xsabund()
Solar Abundance Table:
file
  H : 1.000e+00  He: 9.770e-02  Li: 0.000e+00  Be: 1.410e-11  B : 3.980e-10
  C : 3.630e-04  N : 1.120e-04  O : 8.510e-04  F : 3.630e-08  Ne: 1.230e-04
  Na: 2.140e-06  Mg: 3.800e-05  Al: 2.950e-06  Si: 3.550e-05  P : 2.820e-07
  S : 1.620e-05  Cl: 3.160e-07  Ar: 3.630e-06  K : 1.320e-07  Ca: 2.290e-06
  Sc: 1.260e-09  Ti: 9.770e-08  V : 1.000e-08  Cr: 4.680e-07  Mn: 2.450e-07
  Fe: 4.680e-05  Co: 8.320e-08  Ni: 1.780e-06  Cu: 0.000e+00  Zn: 3.980e-08
```

