### PR TITLE
IO: ensure NUMELT/GRP are written out as integers for RMF header

### DIFF
--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -1803,8 +1803,9 @@ def _reconstruct_rmf(rmf: RMFType) -> DataType:
             "F_CHAN": f_chan_out,
             "N_CHAN": n_chan_out,
             "MATRIX": matrix_out,
-            "NUMGRP": numgrp,
-            "NUMELT": numelt}
+            # Ensure these are integer types
+            "NUMGRP": int(numgrp),
+            "NUMELT": int(numelt)}
 
 
 def _pack_rmf(dataset: RMFType) -> BlockList:


### PR DESCRIPTION
# Summary

Ensure the NUMELT and NUMGRP keywords for RMF files are written out as integers.

# Details

For some reason the NUMELT keyword was being treated as a floating-poiint value when it should/must be an integer, so fix this. Unfortunately this is tricky to identify in a test as we don't explicitly check the on-disk formats, as we are much-more concerned about being able to read back in the files we have written out, and in this case float<->int conversions can just happen automagically.

With the changes added in #1921 the logic is changed in the generic backend code (i.e. once) rather than in each backend.