### PR TITLE
Minor typing cleanups

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -986,8 +986,13 @@ class DataARF(DataOgipResponse):
     def get_dep(self, filter=False):
         return self._rsp
 
-    def get_ylabel(self) -> str:
+    def get_ylabel(self, yfunc=None) -> str:
         """The label for the dependent axis.
+
+        Parameters
+        ----------
+        yfunc
+           Unused.
 
         See Also
         --------
@@ -4150,7 +4155,7 @@ It is an integer or string.
         #
         return self._from_channel(self.channel, group=False, response_id=response_id)
 
-    def get_xlabel(self) -> None:
+    def get_xlabel(self) -> str:
         """The label for the independent axis.
 
         If set_xlabel has been called then the label used in that call
@@ -4347,8 +4352,13 @@ It is an integer or string.
         dlam = hc / elo - hc / ehi
         return dlam / 2
 
-    def get_ylabel(self):
+    def get_ylabel(self, yfunc=None) -> str:
         """The label for the dependent axis.
+
+        Parameters
+        ----------
+        yfunc
+           Unused.
 
         See Also
         --------
@@ -5468,7 +5478,7 @@ class DataIMG(Data2D):
 
         return (axis0, axis1)
 
-    def get_x0label(self) -> None:
+    def get_x0label(self) -> str:
         """Return the label for the first independent axis.
 
         If set_x0label has been called then the label used in that call

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10999,7 +10999,7 @@ class Session(sherpa.ui.utils.Session):
             id: Optional[IdType] = None,
             *otherids: IdType,
             **kwargs
-            ) -> FitResults:
+            ) -> None:
         # pylint: disable=W1113
         """Fit a model to one or more data sets.
 
@@ -11108,7 +11108,7 @@ class Session(sherpa.ui.utils.Session):
                 id: Optional[IdType] = None,
                 *otherids: IdType,
                 **kwargs
-                ) -> FitResults:
+                ) -> None:
         # pylint: disable=W1113
         """Fit a model to one or more background PHA data sets.
 
@@ -11188,7 +11188,7 @@ class Session(sherpa.ui.utils.Session):
         kwargs['bkg_only'] = True
         self._fit(id, *otherids, **kwargs)
 
-    def _fit(self, id=None, *otherids, **kwargs):
+    def _fit(self, id=None, *otherids, **kwargs) -> None:
         # pylint: disable=W1113
 
         # validate the kwds to f.fit() so user typos do not

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1410,6 +1410,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
         Parameters
         ----------
         yfunc
+           Unused.
 
         Returns
         -------

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -9291,7 +9291,7 @@ class Session(NoNewAttributesAfterInit):
             id: Optional[IdType] = None,
             *otherids: IdType,
             **kwargs
-            ) -> FitResults:
+            ) -> None:
         """Fit a model to one or more data sets.
 
         Use forward fitting to find the best-fit model to one or more

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -47,6 +47,7 @@ from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \
     DataErr, IdentifierErr, IOErr, ModelErr, ParameterErr, PlotErr, \
     SessionErr
 from sherpa.utils.numeric_types import SherpaFloat
+from sherpa.utils.random import RandomType
 from sherpa.utils.types import IdType
 
 info = logging.getLogger(__name__).info
@@ -916,7 +917,11 @@ class Session(NoNewAttributesAfterInit):
         self._set_contour_types()
         self._set_image_types()
 
-    def _set_plot_types(self):
+        # Reset the generator.
+        #
+        self.set_rng(None)
+
+    def _set_plot_types(self) -> None:
         """Set up the plot types."""
 
         # The keys of _plot_types are used to define:
@@ -969,7 +974,7 @@ class Session(NoNewAttributesAfterInit):
             "compmodel": "model_component"
         }
 
-    def _set_contour_types(self):
+    def _set_contour_types(self) -> None:
         """Set up the contour types."""
 
         # This is used by the get_<key>_contour calls to access the
@@ -988,7 +993,7 @@ class Session(NoNewAttributesAfterInit):
             "kernel": sherpa.plot.PSFKernelContour()
         }
 
-    def _set_image_types(self):
+    def _set_image_types(self) -> None:
         """Set up the image types."""
 
         # This is used by the get_<key>_image calls to access the
@@ -1011,11 +1016,7 @@ class Session(NoNewAttributesAfterInit):
             'source_component': sherpa.image.ComponentSourceImage()
         }
 
-        # Reset the generator.
-        #
-        self.set_rng(None)
-
-    def get_rng(self):
+    def get_rng(self) -> Optional[RandomType]:
         """Return the RNG generator in use.
 
         The return can be None, which means that the routines in
@@ -1035,7 +1036,7 @@ class Session(NoNewAttributesAfterInit):
 
         return self._rng
 
-    def set_rng(self, rng):
+    def set_rng(self, rng: Optional[RandomType]) -> None:
         """Set the RNG generator.
 
         .. versionadded:: 4.16.0


### PR DESCRIPTION
# Summary

Clean up some of the recently-added typing rules.

# Details

This fixes a few minor issues that are

- errors I've made with the typing rules, such as labelling a method as returning `None` when it should have been `str` from its superclass
- the `set_ylabel` call has a `yfunc` argument in the parent class but we forgot to propogate it to the child classes; this argument is optional *and* unused, but fixing it up makes tools like mypy or pyright a little-bit happier (we could also remove this argument but I worry that that could cause more issues)
- a minor code improvement for the location to cal `set_rng(None)` during a reset; my guess is that this got moved during a rebase

These are all really minor but I noticed them recently and, rather than wait for them to be fixed in the respective PRs, let's just make an easy-to-review PR for them.