### PR TITLE
Add delete_bkg command - fix #891

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -2160,6 +2160,7 @@ will be removed. The identifiers can be integers or strings.
 
         """
         if (arf is None) and (rmf is None):
+            # TODO: this does not clear out any existing setting
             return
 
         resp_id = self._fix_response_id(id)
@@ -4863,6 +4864,10 @@ It is an integer or string.
         #
         for bid in bkg_ids:
             bkg = self.get_background(bid)
+            if bkg is None:
+                # Skip any missing identifier
+                continue
+
             old_bkg_units = bkg.units
             try:
                 bkg.units = self.units
@@ -4976,6 +4981,9 @@ It is an integer or string.
         #
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
+            if bkg is None:
+                raise DataErr(f"Internal error: unknown background id {bkg_id}")
+
             try:
                 bkg.grouped = True
             except DataErr as exc:
@@ -5003,6 +5011,9 @@ It is an integer or string.
             # Unlike the group case we do not need to worry about this
             # failing.
             bkg = self.get_background(bkg_id)
+            if bkg is None:
+                raise DataErr(f"Internal error: unknown background id {bkg_id}")
+
             bkg.grouped = False
 
     def subtract(self):

--- a/sherpa/astro/fake.py
+++ b/sherpa/astro/fake.py
@@ -228,8 +228,8 @@ def fake_pha(data, model,
         # exposure time (as units=counts), scaling factors, and the number
         # of background components.
         #
-        for bkg_id in data.background_ids:
-            cts = data.get_background(bkg_id).counts
+        for bkg_id, bkg in data.get_backgrounds():
+            cts = bkg.counts
             scale = data.get_background_scale(bkg_id, units="counts")
             model_prediction += scale * cts
 

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1992,6 +1992,78 @@ def test_get_background_scale_missing_option(is_bkg, option, expected):
     assert scale == pytest.approx(expected)
 
 
+def test_pha_get_backgrounds_is_empty():
+    """Check we get the empty list when there's no background"""
+
+    d = DataPHA('x', [1, 2], [1, 2])
+    assert d.get_backgrounds() == []
+
+
+def test_pha_get_backgrounds_default():
+    """Check we get the default id"""
+
+    d = DataPHA('x', [1, 2], [1, 2])
+    b = DataPHA('y', [1, 2], [0, 1])
+    d.set_background(b)
+
+    bkgs = d.get_backgrounds()
+    assert len(bkgs) == 1
+    assert len(bkgs[0]) == 2
+    assert bkgs[0][0] == 1
+    assert bkgs[0][1] == b
+
+
+def test_pha_get_backgrounds_explicit():
+    """Check we get the given id"""
+
+    d = DataPHA('x', [1, 2], [1, 2])
+    b = DataPHA('y', [1, 2], [0, 1])
+    d.set_background(b, id="up")
+
+    bkgs = d.get_backgrounds()
+    assert len(bkgs) == 1
+    assert len(bkgs[0]) == 2
+    assert bkgs[0][0] == "up"
+    assert bkgs[0][1] == b
+
+
+def test_pha_get_backgrounds_multiple():
+    """Check we get the given id"""
+
+    d = DataPHA('x', [1, 2], [1, 2])
+    b1 = DataPHA('y1', [1, 2], [0, 1])
+    b2 = DataPHA('y2', [1, 2], [1, 0])
+    d.set_background(b1, id="up")
+    d.set_background(b2, id="down")
+
+    bkgs = d.get_backgrounds()
+    assert len(bkgs) == 2
+    assert len(bkgs[0]) == 2
+    assert bkgs[0][0] == "up"
+    assert bkgs[0][1] == b1
+    assert len(bkgs[1]) == 2
+    assert bkgs[1][0] == "down"
+    assert bkgs[1][1] == b2
+
+
+def test_pha_get_backgrounds_after_deletion():
+    """Check we do not get the deleted background"""
+
+    d = DataPHA('x', [1, 2], [1, 2])
+    b1 = DataPHA('y1', [1, 2], [0, 1])
+    b2 = DataPHA('y2', [1, 2], [1, 0])
+    d.set_background(b1, id="up")
+    d.set_background(b2, id="down")
+
+    d.delete_background("up")
+
+    bkgs = d.get_backgrounds()
+    assert len(bkgs) == 1
+    assert len(bkgs[0]) == 2
+    assert bkgs[0][0] == "down"
+    assert bkgs[0][1] == b2
+
+
 @pytest.mark.parametrize("lo,hi,emsg", [("1:20", None, 'lower'), (None, "2", 'upper'), ("0.5", "7", 'lower')])
 @pytest.mark.parametrize("ignore", [False, True])
 def test_pha_notice_errors_out_on_string_range(lo, hi, emsg, ignore):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -9978,8 +9978,8 @@ class Session(sherpa.ui.utils.Session):
             # an argument to say they should be kept, but it's not
             # clear what is best.
             #
-            for bkg_id in pha.background_ids:
-                restore[bkg_id] = {"data": pha.get_background(bkg_id)}
+            for bkg_id, bkg in pha.get_backgrounds():
+                restore[bkg_id] = {"data": bkg}
                 try:
                     restore[bkg_id]["model"] = self.get_bkg_source(idval,
                                                                    bkg_id)
@@ -11231,8 +11231,7 @@ class Session(sherpa.ui.utils.Session):
 
                 continue
 
-            for bkg_id in s.data.background_ids:
-                bkg_data = s.data.get_background(bkg_id)
+            for bkg_id, bkg_data in s.data.get_backgrounds():
                 bkg_model = self.get_bkg_model(s.idval, bkg_id)
                 # At this point we know bkg_data is not None
                 out.append(BkgFitStore(s.idval, bkg_data, bkg_model, bkg_id))
@@ -11285,8 +11284,7 @@ class Session(sherpa.ui.utils.Session):
             if not isinstance(data, DataPHA):
                 continue
 
-            for bkg_id in data.background_ids:
-                bkg_data = self.get_bkg(idval, bkg_id)
+            for bkg_id, bkg_data in data.get_backgrounds():
                 try:
                     bkg_model = self.get_bkg_model(idval, bkg_id)
                 except ModelErr:
@@ -11304,7 +11302,8 @@ class Session(sherpa.ui.utils.Session):
     def _get_bkg_fit(self,
                      id: Optional[IdType],
                      otherids: Sequence[IdType] = (),
-                     estmethod=None, numcores=1
+                     estmethod=None,
+                     numcores=1
                      ) -> tuple[tuple[IdType, ...], Fit]:
         """Create the fit object for the given identifiers.
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -8753,7 +8753,8 @@ class Session(NoNewAttributesAfterInit):
 
     def _get_fit_obj(self,
                      store: Sequence[FitStore],
-                     estmethod, numcores=1
+                     estmethod,
+                     numcores=1
                      ) -> tuple[tuple[IdType, ...], Fit]:
         """Create the fit object given the data and models.
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -4156,6 +4156,8 @@ class Session(NoNewAttributesAfterInit):
         -----
         The source expression is not removed by this function.
 
+        The routine does nothing if the given dataset does not exist.
+
         Examples
         --------
 


### PR DESCRIPTION
# Summary

Add the delete_bkg call. Fix #891.

# Details

This originally had a lot of clean-up documention/typing work which got moved into #2124, hence some of the dicsussion below in the comments does not match the current code.

We add

- `delete_bkg` call to the UI layer
- `get_backgrounds` to the `DataPHA` object, in an attempt to "better type" the code (e.g. to avoid some cases where we know a value is not None because the identifier exists but the code does not)

One question that came up from this work was
- #2113

which I do not plan to address here.

# Issues to resolve

- this code follows the existing `delete_data` behavior and does not error out if a dataset has no backgrounds (it's a little more complicated than this, but this is the main issue) and the question is should it error out
- our code essentially mimics a dictionary (since it does) so maybe we should make this the primary API rather than existing calls
- the current code actually lets you (I **think**) temporarily remove a background but leave it still associated with the parent `DataPHA` whereas the new code does not; this strikes me as a subtle disaster waiting to strike

# Example

```
>>> from sherpa.astro import ui
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
WARNING: failed to import sherpa.astro.xspec; XSPEC models will not be available
>>> ui.load_pha("sherpa-test-data/sherpatest/3c273.pi")
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273.pi'
but not used; to use them, re-read with use_errors=True
read ARF file sherpa-test-data/sherpatest/3c273.arf
read RMF file sherpa-test-data/sherpatest/3c273.rmf
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273_bg.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273_bg.pi'
but not used; to use them, re-read with use_errors=True
read background file sherpa-test-data/sherpatest/3c273_bg.pi
>>> ui.subtract()
```

So, what happens if we delete the background?

```
>>> ui.delete_bkg()
dataset 1: background subtraction has been removed
```

And we can no-longer get it:

```
>>> ui.get_bkg()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in get_bkg
  File "/home/dburke/sherpa/sherpa-conda/sherpa/astro/ui/utils.py", line 7010, in get_bkg
    raise IdentifierErr('getitem', 'background data set',
sherpa.utils.err.IdentifierErr: background data set 1 in PHA data set 1 has not been set
```
