### PR TITLE
Add explicit support for XSPEC 12.14.1

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -346,7 +346,8 @@ Update the XSPEC bindings?
 --------------------------
 
 The :py:mod:`sherpa.astro.xspec` module currently supports
-:term:`XSPEC` versions 12.14.0, 12.13.1, 12.13.0, 12.12.1, and 12.12.0.
+:term:`XSPEC` versions 12.14.1, 12.14.0, 12.13.1, 12.13.0, 12.12.1,
+and 12.12.0.
 It may build against newer versions, but if it does it will not provide
 access to any new models in the release. The following sections of the
 `XSPEC manual

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -148,5 +148,5 @@ Glossary
        `models from XSPEC
        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html>`_.
 
-       Sherpa can be built to use XSPEC versions 12.14.0, 12.13.1,
-       12.13.0, 12.12.1, and 12.12.0.
+       Sherpa can be built to use XSPEC versions 12.14.1, 12.14.0,
+       12.13.1, 12.13.0, 12.12.1, and 12.12.0.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -239,7 +239,20 @@ by the actual path to the HEADAS installation, and the versions of
 the libraries - such as ``CCfits_2.6`` - may need to be changed to
 match the contents of the XSPEC installation.
 
-1. If the full XSPEC 12.14.0 system has been built then use::
+1. If the full XSPEC 12.14.1 system has been built then use::
+
+       with-xspec = True
+       xspec_version = 12.14.1
+       xspec_lib_dirs = $HEADAS/lib
+       xspec_include_dirs = $HEADAS/include
+       xspec_libraries = XSFunctions XSUtil XS hdsp_6.34
+       ccfits_libraries = CCfits_2.6
+       wcslib_libraries = wcs-8.3
+
+   where the version numbers were taken from version 6.34 of HEASOFT and
+   may need updating with a newer release.
+
+2. If the full XSPEC 12.14.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.14.0
@@ -252,7 +265,7 @@ match the contents of the XSPEC installation.
    where the version numbers were taken from version 6.33.1 of HEASOFT and
    may need updating with a newer release.
 
-2. If the full XSPEC 12.13.1 system has been built then use::
+3. If the full XSPEC 12.13.1 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.13.1
@@ -265,7 +278,7 @@ match the contents of the XSPEC installation.
    where the version numbers were taken from version 6.32 of HEASOFT and
    may need updating with a newer release.
 
-3. If the full XSPEC 12.13.0 system has been built then use::
+4. If the full XSPEC 12.13.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.13.0
@@ -275,7 +288,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.6
        wcslib_libraries = wcs-7.7
 
-4. If the full XSPEC 12.12.1 system has been built then use::
+5. If the full XSPEC 12.12.1 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.12.1
@@ -285,7 +298,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.6
        wcslib_libraries = wcs-7.7
 
-5. If the full XSPEC 12.12.0 system has been built then use::
+6. If the full XSPEC 12.12.0 system has been built then use::
 
        with-xspec = True
        xspec_version = 12.12.0
@@ -295,7 +308,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.6
        wcslib_libraries = wcs-7.3.1
 
-6. If the model-only build of XSPEC - created with the
+7. If the model-only build of XSPEC - created with the
    ``--enable-xs-models-only`` flag when building HEASOFT - has been
    installed, then the configuration is similar, but the library names
    may not need version numbers and locations, depending on how the
@@ -320,7 +333,7 @@ module, but a quick check of an installed version can be made with
 the following command::
 
     % python -c 'from sherpa.astro import xspec; print(xspec.get_xsversion())'
-    12.14.0i
+    12.14.1
 
 Other options
 ^^^^^^^^^^^^^

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -30,7 +30,7 @@ from .extensions import build_ext
 #
 SUPPORTED_VERSIONS = [(12, 12, 0), (12, 12, 1),
                       (12, 13, 0), (12, 13, 1),
-                      (12, 14, 0)]
+                      (12, 14, 0), (12, 14, 1)]
 
 
 # We could use packaging.versions.Version here, but for our needs we

--- a/sherpa/astro/utils/xspec.py
+++ b/sherpa/astro/utils/xspec.py
@@ -1116,7 +1116,7 @@ def models_to_compiled(mdls: list[ModelDefinition],
     #
     SUPPORTED_VERSIONS = [(12, 12, 0), (12, 12, 1),
                           (12, 13, 0), (12, 13, 1),
-                          (12, 14, 0)]
+                          (12, 14, 0), (12, 14, 1)]
 
     xspec_version = (int(match[1]), int(match[2]), int(match[3]))
     for version in SUPPORTED_VERSIONS:

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -8173,7 +8173,7 @@ class XSgaussian(XSAdditiveModel):
 
     See Also
     --------
-    XSagauss, XSlorentz, XSvoigt, XSzagauss, XSzgauss
+    XSagauss, XSlorentz, XSvgaussian, XSvoigt, XSzagauss, XSzgauss
 
     References
     ----------
@@ -12003,6 +12003,49 @@ class XSvgadem(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, pars)
 
 
+@version_at_least("12.14.1")
+class XSvgaussian(XSAdditiveModel):
+    """The XSPEC vgaussian model: gaussian line profile with sigma in velocity
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.14.1 or later.
+
+    Attributes
+    ----------
+    LineE
+       The line energy, in keV.
+    Sigma
+       The line width, in km/s.
+    norm
+       The total flux in the line (photon/cm^2/s).
+
+    See Also
+    --------
+    XSgaussian, XSzvgaussian
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVgauss.html
+
+    """
+
+    __function__ = "C_vgaussianLine"
+
+    def __init__(self, name='vgaussian'):
+        self.LineE = XSParameter(name, 'LineE', 6.5, min=0.0,
+                                 max=1000000.0, hard_min=0.0,
+                                 hard_max=1000000.0, units='keV')
+        self.Sigma = XSParameter(name, 'Sigma', 100.0, min=0.0,
+                                 max=300000.0, hard_min=0.0,
+                                 hard_max=300000.0, units='km/s')
+
+        pars = (self.LineE, self.Sigma)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
 class XSvgnei(XSAdditiveModel):
     """The XSPEC vgnei model: collisional plasma, non-equilibrium, temperature evolution.
 
@@ -14271,6 +14314,52 @@ class XSzvagauss(XSAdditiveModel):
                                  max=300000.0, hard_min=0.0,
                                  hard_max=300000.0, units='km/s')
         self.Reshift = mkRedshift(name)
+
+        pars = (self.LineE, self.Sigma, self.Redshift)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
+@version_at_least("12.14.1")
+class XSzvgaussian(XSAdditiveModel):
+    """The XSPEC zvgaussian model: gaussian line profile with sigma in velocity
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.14.1 or later.
+
+    Attributes
+    ----------
+    LineE
+       The line energy, in keV.
+    Sigma
+       The line width, in km/s.
+    Redshift
+       The source redshift.
+    norm
+       The total flux in the line (photon/cm^2/s).
+
+    See Also
+    --------
+    XSvgaussian, XSzgauss
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVgauss.html
+
+    """
+
+    __function__ = "C_zvgaussianLine"
+
+    def __init__(self, name='zvgaussian'):
+        self.LineE = XSParameter(name, 'LineE', 6.5, min=0.0,
+                                 max=1000000.0, hard_min=0.0,
+                                 hard_max=1000000.0, units='keV')
+        self.Sigma = XSParameter(name, 'Sigma', 100.0, min=0.0,
+                                 max=300000.0, hard_min=0.0,
+                                 hard_max=300000.0, units='km/s')
+        self.Redshift = mkRedshift(name)
 
         pars = (self.LineE, self.Sigma, self.Redshift)
         XSAdditiveModel.__init__(self, name, pars)

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -20,7 +20,7 @@
 
 """Support for XSPEC models.
 
-Sherpa supports versions 12.14.0, 12.13.1, 12.13.0, 12.12.1, and
+Sherpa supports versions 12.14.1, 12.14.0, 12.13.1, 12.13.0, 12.12.1, and
 12.12.0 of XSPEC [1]_, and can be built against the model library or
 the full application.  There is no guarantee of support for older or
 newer versions of XSPEC.
@@ -31,7 +31,7 @@ XSPEC version - including patch level - the module is using::
 
    >>> from sherpa.astro import xspec
    >>> xspec.get_xsversion()
-   '12.14.0b'
+   '12.14.1d'
 
 Initializing XSPEC
 ------------------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -16014,6 +16014,53 @@ class XSvarabs(XSMultiplicativeModel):
         XSMultiplicativeModel.__init__(self, name, (self.H, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Cl, self.Ar, self.Ca, self.Cr, self.Fe, self.Co, self.Ni))
 
 
+@version_at_least("12.14.1")
+class XSvgabs(XSMultiplicativeModel):
+    """The XSPEC vgabs model: gaussian absorption line with sigma in km/s
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.14.1 or later.
+
+    Parameters
+    ----------
+    LineE
+       The line energy in keV.
+    Sigma
+       The line width in km/s.
+    Strength
+       The line depth in keV. The optical depth at the line center is
+       Strength / (Sigma / c) / sqrt(2 * pi).
+
+    See Also
+    --------
+    XSzvgabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVgabs.html
+
+    """
+
+    __function__ = "C_vgaussianAbsorptionLine"
+
+    def __init__(self, name='vgabs'):
+        self.LineE = XSParameter(name, 'LineE', 1.0, min=0.0,
+                                 max=1000000.0, hard_min=0.0,
+                                 hard_max=1000000.0, units='keV')
+        self.Sigma = XSParameter(name, 'Sigma', 100.0, min=0.0,
+                                 max=300000.0, hard_min=0.0,
+                                 hard_max=300000.0, units='km/s')
+        self.Strength = XSParameter(name, 'Strength', 1.0, min=0.0,
+                                    max=1000000.0, hard_min=0.0,
+                                    hard_max=1000000.0, units='keV')
+
+        pars = (self.LineE, self.Sigma, self.Strength)
+        XSMultiplicativeModel.__init__(self, name, pars)
+
+
 class XSvphabs(XSMultiplicativeModel):
     """The XSPEC vphabs model: photoelectric absorption.
 
@@ -16351,6 +16398,56 @@ class XSzedge(XSMultiplicativeModel):
         self.Redshift = mkRedshift(name)
 
         pars = (self.edgeE, self.MaxTau, self.Redshift)
+        XSMultiplicativeModel.__init__(self, name, pars)
+
+
+@version_at_least("12.14.1")
+class XSzvgabs(XSMultiplicativeModel):
+    """The XPEC zvgabs model: gaussian absorption line with sigma in km/s
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.14.1 or later.
+
+    Parameters
+    ----------
+    LineE
+       The line energy in keV.
+    Sigma
+       The line width in km/s.
+    Strength
+       The line depth in keV. The optical depth at the line center is
+       Strength / (Sigma / c) / sqrt(2 * pi).
+    Redshift
+       The redshift of the source.
+
+    See Also
+    --------
+    XSvgabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVgabs.html
+
+    """
+
+    __function__ = "C_zvgaussianAbsorptionLine"
+
+    def __init__(self, name='zvgabs'):
+        self.LineE = XSParameter(name, 'LineE', 1.0, min=0.0,
+                                 max=1000000.0, hard_min=0.0,
+                                 hard_max=1000000.0, units='keV')
+        self.Sigma = XSParameter(name, 'Sigma', 100.0, min=0.0,
+                                 max=300000.0, hard_min=0.0,
+                                 hard_max=300000.0, units='km/s')
+        self.Strength = XSParameter(name, 'Strength', 1.0, min=0.0,
+                                    max=1000000.0, hard_min=0.0,
+                                    hard_max=1000000.0, units='keV')
+        self.Redshift = mkRedshift(name)
+
+        pars = (self.LineE, self.Sigma, self.Strength, self.Redshift)
         XSMultiplicativeModel.__init__(self, name, pars)
 
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -14671,7 +14671,11 @@ class XSgabs(XSMultiplicativeModel):
         The line width (sigma), in keV.
     Strength
         The line depth, in keV. The optical depth at the line center is
-        Strength / (sqrt(2 pi) * Sigma).
+        Strength / Sigma / sqrt(2 pi).
+
+    See Also
+    --------
+    XSvgabs, XSzgabs
 
     References
     ----------
@@ -16402,8 +16406,58 @@ class XSzedge(XSMultiplicativeModel):
 
 
 @version_at_least("12.14.1")
+class XSzgabs(XSMultiplicativeModel):
+    """The XSPEC zgabs model: gaussian absorption line.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.14.1 or later.
+
+    Parameters
+    ----------
+    LineE
+       The line energy in keV.
+    Sigma
+       The line width in keV.
+    Strength
+       The line depth in keV. The optical depth at the line center is
+       Strength / Sigma / sqrt(2 * pi).
+    Redshift
+       The redshift of the source.
+
+    See Also
+    --------
+    XSgabs, XSzvgabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelGabs.html
+
+    """
+
+    __function__ = "C_zgaussianAbsorptionLine"
+
+    def __init__(self, name='zgabs'):
+        self.LineE = XSParameter(name, 'LineE', 1.0, min=0.0,
+                                 max=1000000.0, hard_min=0.0,
+                                 hard_max=1000000.0, units='keV')
+        self.Sigma = XSParameter(name, 'Sigma', 0.01, min=0.0,
+                                 max=10.0, hard_min=0.0,
+                                 hard_max=20.0, units='keV')
+        self.Strength = XSParameter(name, 'Strength', 1.0, min=0.0,
+                                    max=1000000.0, hard_min=0.0,
+                                    hard_max=1000000.0, units='keV')
+        self.Redshift = mkRedshift(name)
+
+        pars = (self.LineE, self.Sigma, self.Strength, self.Redshift)
+        XSMultiplicativeModel.__init__(self, name, pars)
+
+
+@version_at_least("12.14.1")
 class XSzvgabs(XSMultiplicativeModel):
-    """The XPEC zvgabs model: gaussian absorption line with sigma in km/s
+    """The XSPEC zvgabs model: gaussian absorption line with sigma in km/s
 
     The model is described at [1]_.
 
@@ -16424,7 +16478,7 @@ class XSzvgabs(XSMultiplicativeModel):
 
     See Also
     --------
-    XSvgabs
+    XSvgabs, XSzgabs
 
     References
     ----------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -2073,7 +2073,7 @@ class XSagauss(XSAdditiveModel):
 
     See Also
     --------
-    XSgaussian, XSzagauss, XSzgauss
+    XSgaussian, XSvagauss, XSzagauss, XSzgauss, XSzvagauss
 
     References
     ----------
@@ -11299,6 +11299,49 @@ class XStapec(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, pars)
 
 
+@version_at_least("12.14.1")
+class XSvagauss(XSAdditiveModel):
+    """The XSPEC vagauss model: gaussian line profile in wavelength space with sigma in velocity
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.14.1 or later.
+
+    Parameters
+    ----------
+    LineE
+       The line wavelength in Angstrom.
+    Sigma
+       The line width in km/s
+    norm
+       The total photon/cm^2/s in the line.
+
+    See Also
+    --------
+    XSagauss, XSzagauss, XSzvagauss
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVagauss.html
+
+    """
+
+    __function__ = "C_vagauss"
+
+    def __init__(self, name='vagauss'):
+        self.LineE = XSParameter(name, 'LineE', 10.0, min=0.0,
+                                 max=1000000.0, hard_min=0.0,
+                                 hard_max=1000000.0, units='A')
+        self.Sigma = XSParameter(name, 'Sigma', 100.0, min=0.0,
+                                 max=300000.0, hard_min=0.0,
+                                 hard_max=300000.0, units='km/s')
+
+        pars = (self.LineE, self.Sigma)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
 class XSvapec(XSAdditiveModel):
     """The XSPEC vapec model: APEC emission spectrum.
 
@@ -13810,7 +13853,7 @@ class XSzagauss(XSAdditiveModel):
 
     See Also
     --------
-    XSagauss, XSgaussian, XSzgauss
+    XSagauss, XSgaussian, XSvagauss, XSzgauss, XSzvagauss
 
     References
     ----------
@@ -14186,6 +14229,51 @@ class XSzpowerlw(XSAdditiveModel):
         self.Redshift = mkRedshift(name)
 
         XSAdditiveModel.__init__(self, name, (self.PhoIndex, self.Redshift))
+
+
+@version_at_least("12.14.1")
+class XSzvagauss(XSAdditiveModel):
+    """The XSPEC zvagauss model: gaussian line profile in wavelength space with sigma in velocity
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.14.1 or later.
+
+    Parameters
+    ----------
+    LineE
+       The line wavelength in Angstrom.
+    Sigma
+       The line width in km/s
+    Redshift
+    norm
+       The total photon/cm^2/s in the line.
+
+    See Also
+    --------
+    XSagauss, XSzagauss, XSzagauss
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVagauss.html
+
+    """
+
+    __function__ = "C_zvagauss"
+
+    def __init__(self, name='zvagauss'):
+        self.LineE = XSParameter(name, 'LineE', 10.0, min=0.0,
+                                 max=1000000.0, hard_min=0.0,
+                                 hard_max=1000000.0, units='A')
+        self.Sigma = XSParameter(name, 'Sigma', 100.0, min=0.0,
+                                 max=300000.0, hard_min=0.0,
+                                 hard_max=300000.0, units='km/s')
+        self.Reshift = mkRedshift(name)
+
+        pars = (self.LineE, self.Sigma, self.Redshift)
+        XSAdditiveModel.__init__(self, name, pars)
 
 
 class XSabsori(XSMultiplicativeModel):

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -2642,6 +2642,10 @@ class XSbcph(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. versionchanged:: 4.17.1
+       The default Redshift parameter has been changed from 0 to 0.1 to
+       match version 12.14.1 of XSPEC.
+
     .. versionadded:: 4.16.1
        This model requires XSPEC 12.14.0 or later.
 
@@ -2680,7 +2684,7 @@ class XSbcph(XSAdditiveModel):
     def __init__(self, name='bcph'):
         self.peakT = XSParameter(name, 'peakT', 2.2, min=0.1, max=100.0, hard_min=0.1, hard_max=100.0, units='keV')
         self.Abund = XSParameter(name, 'Abund', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
-        self.Redshift = mkRedshift(name, minval=0, maxval=50)
+        self.Redshift = mkRedshift(name, default=0.1, minval=0, maxval=50)
         self.Velocity = mkVelocity(name)
         self.switch = mkswitch(name)
 
@@ -4079,6 +4083,10 @@ class XSbvcph(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. versionchanged:: 4.17.1
+       The default Redshift parameter has been changed from 0 to 0.1 to
+       match version 12.14.1 of XSPEC.
+
     .. versionadded:: 4.16.1
        This model requires XSPEC 12.14.0 or later.
 
@@ -4130,7 +4138,7 @@ class XSbvcph(XSAdditiveModel):
         self.Ca = XSParameter(name, 'Ca', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
         self.Fe = XSParameter(name, 'Fe', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
         self.Ni = XSParameter(name, 'Ni', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
-        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=0.0, max=50.0, hard_min=0.0, hard_max=50.0, frozen=True)
+        self.Redshift = mkRedshift(name, default=0.1, minval=0, maxval=50)
         self.Velocity = mkVelocity(name)
         self.switch = mkswitch(name)
 
@@ -7177,6 +7185,10 @@ class XScph(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. versionchanged:: 4.17.1
+       The default Redshift parameter has gone back to 0.1 to match
+       version 12.14.1 of XSPEC.
+
     .. versionchanged:: 4.16.1
        The switch parameter default has changed from 1 to 2 to match
        XSPEC 12.14.0 and the maximum value is now 3.
@@ -7220,7 +7232,7 @@ class XScph(XSAdditiveModel):
                                  units='keV')
         self.Abund = XSParameter(name, 'Abund', 1, 0, 1000, 0, 1000,
                                  frozen=True)
-        self.Redshift = mkRedshift(name, minval=0, maxval=50)
+        self.Redshift = mkRedshift(name, default=0.1, minval=0, maxval=50)
         self.switch = mkswitch(name)
 
         pars = (self.peakT, self.Abund, self.Redshift, self.switch)
@@ -11544,6 +11556,10 @@ class XSvcph(XSAdditiveModel):
 
     The model is described at [1]_.
 
+    .. versionchanged:: 4.17.1
+       The default Redshift parameter has gone back to 0.1 to match
+       version 12.14.1 of XSPEC.
+
     .. versionchanged:: 4.16.1
        The switch parameter default has changed from 1 to 2 to match
        XSPEC 12.14.0 and the maximum value is now 3.
@@ -11614,7 +11630,7 @@ class XSvcph(XSAdditiveModel):
                               frozen=True)
         self.Ni = XSParameter(name, 'Ni', 1.0, 0., 1000., 0.0, 1000.0,
                               frozen=True)
-        self.Redshift = mkRedshift(name, minval=0, maxval=50)
+        self.Redshift = mkRedshift(name, default=0.1, minval=0, maxval=50)
         self.switch = mkswitch(name)
 
         pars = (self.peakT, self.He, self.C, self.N, self.O, self.Ne,

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -11088,6 +11088,125 @@ class XSssa(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.te, self.y))
 
 
+@version_at_least("12.14.1")
+class XSsssed(XSAdditiveModel):
+    """The XSPEC sssed model: Shakura & Sunyaev spectral energy distribution
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.14.1 or later.
+
+    Attributes
+    ----------
+    mass
+       The black hole mass in solar units.
+    dist
+       The comoving (proper) distance in kpc.
+    logmdot
+       The accretion rate, in eddington units.
+    Rin
+       The inner most radius of the accretion flow in r_g.
+    cosi
+       The inclination angle of the disc.
+    kTe_th
+       The electron temparatire the the thermal corona in keV. If
+       negative then it represents the innre hot Comptonisation
+       component.
+    kTe_nt
+       The apparent electron temperature for non-thermal corona (keV),
+       recommended to be fixed at 300 to mimic non-thermal electron
+       distribution. If negative then the model gives the
+       Comptonisation component in the passive disc corona region.
+    Gamma_th
+       The photon index of the inner hot corona. If negative then only
+       the inner Compton component is used.
+    Gamma_nt
+       The photon index of the disk-corona. If negative then the model
+       gives the outer disk.
+    frac_th
+       The fraction of the hot Comptonising component to the total
+       Comptonisation.
+    Rcor
+       The outer radius of the disc-corona region in r_g.
+    logrout
+       The outer radius if the accretion disc. If this parameter is -1
+       then the self-gravity radius, as calculated by Laor & Netzer
+       (1989) is used.
+    redshift
+       The redshift. This must be fixed.
+    color_cor
+       The switching parameter for colour correction: 0 no correction,
+       1 means use the approach as XSoptxagnf.
+    norm
+       This must be fixed to 1.
+
+    See Also
+    --------
+    XSoptxagnf
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelSssed.html
+
+    """
+
+    __function__ = "sssed"
+
+    def __init__(self, name='sssed'):
+        self.mass = XSParameter(name, 'mass', 10.0, min=1.0,
+                                max=10000000000.0, hard_min=1.0,
+                                hard_max=10000000000.0, frozen=True,
+                                units='solar')
+        self.dist = XSParameter(name, 'dist', 10.0, min=0.1,
+                                max=1000000000.0, hard_min=0.1,
+                                hard_max=1000000000.0, frozen=True,
+                                units='kpc')
+        self.logmdot = XSParameter(name, 'logmdot', 0.1, min=-3.0,
+                                   max=3.0, hard_min=-3.0,
+                                   hard_max=3.0, units='real')
+        self.Rin = XSParameter(name, 'Rin', 6.0, min=1.0, max=500.0,
+                               hard_min=1.0, hard_max=500.0, units='Rg')
+        self.cosi = XSParameter(name, 'cosi', 0.5, min=0.0, max=0.95,
+                                hard_min=0.0, hard_max=0.95, frozen=True)
+        self.kTe_th = XSParameter(name, 'kTe_th', 10.0, min=4.0,
+                                  max=300.0, hard_min=4.0,
+                                  hard_max=300.0, units='keV(-th)')
+        self.kTe_nt = XSParameter(name, 'kTe_nt', 300.0, min=10.0,
+                                  max=300.0, hard_min=10.0,
+                                  hard_max=300.0, frozen=True,
+                                  units='keV(-nt)')
+        self.Gamma_th = XSParameter(name, 'Gamma_th', 1.7, min=1.4,
+                                    max=4.0, hard_min=1.4,
+                                    hard_max=4.0)
+        self.Gamma_nt = XSParameter(name, 'Gamma_nt', 2.2, min=1.9,
+                                    max=4.0, hard_min=1.9,
+                                    hard_max=4.0, units='(-disk)')
+        # Over-ride the settings from 12.14.1 as they do not make sense
+        self.frac_th = XSParameter(name, 'frac_th', 0.2, min=0.0,
+                                   max=1.0, hard_min=0.0,
+                                   hard_max=1.0)
+        self.Rcor = XSParameter(name, 'Rcor', 10.0, min=1.0,
+                                max=5000.0, hard_min=1.0,
+                                hard_max=5000.0, units='Rg')
+        self.logrout = XSParameter(name, 'logrout', -1.0, min=-1.0,
+                                   max=7.0, hard_min=-1.0,
+                                   hard_max=7.0, frozen=True,
+                                   units='(-selfg)')
+        self.redshift = mkRedshift(name, minval=0, maxval=1, lc=True)
+        self.color_cor = XSParameter(name, 'color_cor', 1.0, min=0.0,
+                                     max=1.0, hard_min=0.0,
+                                     hard_max=1.0, frozen=True,
+                                     units='0off/1on')
+
+        pars = (self.mass, self.dist, self.logmdot, self.Rin,
+                self.cosi, self.kTe_th, self.kTe_nt, self.Gamma_th,
+                self.Gamma_nt, self.frac_th, self.Rcor, self.logrout,
+                self.redshift, self.color_cor)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
 class XSstep(XSAdditiveModel):
     """The XSPEC step model: step function convolved with gaussian.
 

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -582,8 +582,14 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_NORM(srcut, 3),                    // XSsrcut
   XSPECMODELFCT_NORM(sresc, 3),                    // XSsresc
   XSPECMODELFCT_NORM(ssa, 3),                      // XSssa
+#ifdef XSPEC_12_14_1
+  XSPECMODELFCT_NORM(sssed, 15),                   // XSsssed
+#endif
   XSPECMODELFCT_NORM(xsstep, 3),                   // XSstep
   XSPECMODELFCT_C_NORM(C_tapec, 5),                // XStapec
+#ifdef XSPEC_12_14_1
+  XSPECMODELFCT_C_NORM(C_vagauss, 3),              // XSvagauss
+#endif
   XSPECMODELFCT_C_NORM(C_vapec, 16),               // XSvapec
   XSPECMODELFCT_NORM(xsbrmv, 3),                   // XSvbremss
 #ifdef XSPEC_12_14_0
@@ -598,6 +604,9 @@ static PyMethodDef XSpecMethods[] = {
 #endif
   XSPECMODELFCT_C_NORM(C_vequil, 15),              // XSvequil
   XSPECMODELFCT_C_NORM(C_vgaussDem, 20),           // XSvgadem
+#ifdef XSPEC_12_14_1
+  XSPECMODELFCT_C_NORM(C_vgaussianLine, 3),        // XSvgaussian
+#endif
   XSPECMODELFCT_C_NORM(C_vgnei, 18),               // XSvgnei
   XSPECMODELFCT_C_NORM(C_vmeka, 18),               // XSvmeka
   XSPECMODELFCT_C_NORM(C_vmekal, 19),              // XSvmekal
@@ -683,6 +692,9 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C(C_tbrel, 42),                    // XSTBrel
   XSPECMODELFCT(xsred, 1),                         // XSuvred
   XSPECMODELFCT(xsabsv, 18),                       // XSvarabs
+#ifdef XSPEC_12_14_1
+  XSPECMODELFCT_C(C_vgaussianAbsorptionLine, 3),   // XSvgabs
+#endif
   XSPECMODELFCT(xsvphb, 18),                       // XSvphabs
   XSPECMODELFCT(xsabsw, 1),                        // XSwabs
   XSPECMODELFCT(xswnab, 2),                        // XSwndabs
@@ -691,6 +703,9 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C(xszbabs, 4),                     // XSzbabs
   XSPECMODELFCT(mszdst, 4),                        // XSzdust
   XSPECMODELFCT(xszedg, 3),                        // XSzedge
+#ifdef XSPEC_12_14_1
+  XSPECMODELFCT_C(C_zgaussianAbsorptionLine, 4),   // XSzgabs
+#endif
   XSPECMODELFCT(xszhcu, 3),                        // XSzhighect
   XSPECMODELFCT(zigm, 3),                          // XSzigm
   XSPECMODELFCT(xszabp, 3),                        // XSzpcfabs
@@ -700,8 +715,19 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT(xszcrd, 2),                        // XSzredden
   XSPECMODELFCT(msldst, 4),                        // XSzsmdust
   XSPECMODELFCT_C(C_ztbabs, 2),                    // XSzTBabs
+
+#ifdef XSPEC_12_14_1
+  XSPECMODELFCT_C_NORM(C_zvagauss, 4),             // XSzvagauss
+#endif
+
   XSPECMODELFCT(xszvab, 19),                       // XSzvarabs
   XSPECMODELFCT(xszvfe, 5),                        // XSzvfeabs
+#ifdef XSPEC_12_14_1
+  XSPECMODELFCT_C(C_zvgaussianAbsorptionLine, 4),  // XSzvgabs
+
+  XSPECMODELFCT_C_NORM(C_zvgaussianLine, 4),       // XSzvgaussian
+#endif
+
   XSPECMODELFCT(xszvph, 19),                       // XSzvphabs
   XSPECMODELFCT(xszabs, 2),                        // XSzwabs
   XSPECMODELFCT(xszwnb, 3),                        // XSzwndabs

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -37,7 +37,7 @@ from sherpa.utils.err import ParameterErr
 #    '(XSConvolutionKernel)'
 # in `xspec/__init__.py`
 #
-XSPEC_MODELS_COUNT = 282
+XSPEC_MODELS_COUNT = 284
 
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh
@@ -771,6 +771,17 @@ def test_evaluate_xspec_model_noncontiguous2(modelcls):
     write (due to numerical tolerances), as bins at the
     edges may not match well.
     """
+
+    # Release 12.14.1 adds the zagauss, zvagauss models, but the
+    # emission is very localized (1.235 to 1.245 keV) for the
+    # default parameters, and this falls within one of the ranges
+    # excluded in this test. So these two models only ever return
+    # all 0's, triggering the test to fail. We could tweak the
+    # test, but it doesn't seem worth it, so we just skip the
+    # model here.
+    #
+    if modelcls.__name__ in ['XSvagauss', 'XSzvagauss']:
+        return
 
     from sherpa.astro import xspec
 

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -37,7 +37,7 @@ from sherpa.utils.err import ParameterErr
 #    '(XSConvolutionKernel)'
 # in `xspec/__init__.py`
 #
-XSPEC_MODELS_COUNT = 281
+XSPEC_MODELS_COUNT = 282
 
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -37,7 +37,7 @@ from sherpa.utils.err import ParameterErr
 #    '(XSConvolutionKernel)'
 # in `xspec/__init__.py`
 #
-XSPEC_MODELS_COUNT = 286
+XSPEC_MODELS_COUNT = 288
 
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -210,15 +210,6 @@ def assert_is_finite(vals, modelcls, label):
     emsg = f"model {modelcls} is finite [{label}]"
     assert numpy.isfinite(vals).all(), emsg
 
-    # Some models seem to return 0's, so skip them for now:
-    # these models have a default redshift parameter of 0 but
-    # the code complains if z <= 0 and returns 0's.
-    #
-    if modelcls in [xs.XSbcph, xs.XSbvcph, xs.XScph, xs.XSvcph]:
-        assert (vals == 0.0).all(), \
-            f'Expected {modelcls} to evaluate to all zeros [{label}]'
-        return
-
     emsg = f"Expected model {modelcls} to have a value > 0 [{label}]"
     assert (vals > 0.0).any(), emsg
 

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -37,7 +37,7 @@ from sherpa.utils.err import ParameterErr
 #    '(XSConvolutionKernel)'
 # in `xspec/__init__.py`
 #
-XSPEC_MODELS_COUNT = 288
+XSPEC_MODELS_COUNT = 289
 
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -126,6 +126,11 @@ def get_xspec_models():
                    "12.14.0f", "12.14.0g", "12.14.0h"]:
         remove_item(model_names, 'XSbvvnei')
 
+    # Has been reported to XSPEC team.
+    #
+    if version == "12.14.1":
+        remove_item(model_names, 'XSismabs')
+
     models = [getattr(xs, model_name) for model_name in model_names]
     models = list(filter(lambda mod: mod.version_enabled, models))
 

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -37,7 +37,7 @@ from sherpa.utils.err import ParameterErr
 #    '(XSConvolutionKernel)'
 # in `xspec/__init__.py`
 #
-XSPEC_MODELS_COUNT = 284
+XSPEC_MODELS_COUNT = 286
 
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh


### PR DESCRIPTION
# Summary

Add models from XSPEC 12.14.1 and change the parameter settings to match those from 12.14.1, where necessary.

# Details

We do not need any changes to build against 12.14.1, which is nice, but there are new models we can provide.

I have reported two issues to the XSPEC  with 12.14.1 which have been fixed in 12.14.1b (the latest release at the time of writing, Sep 11 2024):

- `ismabs` seems to crash, so we skip this test if using 12.14.1; it has been fixed in 12.14.1b (it's not obvious there ever was a 12.14.1a as they were released at the same time from what I understand)
- the new `sssed` model has an invalid `frac_th` parameter settings in `model.dat`;  I have confirmed with XSPEC 12.14.1b that I got it right.

Adds models:

- additive: `sssed`, `vagauss`, `vgaussian`, `zvagauss`, `zvgaussian`
- multiplicative: `vgabs`, `zgabs`, `zvgabs`


I've run local tests built against XSPEC versions 12.14.1 and 12.14.1b and they pass.