### PR TITLE
Improve support for PHA data starting at channel 0

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4714,12 +4714,16 @@ It is an integer or string.
                ) -> None:
         """Notice or ignore the given range.
 
+        Select or remove a range of channels when analyzing the data.
+        The units for the range, that is the values for the lo and hi
+        argument, is set by the analysis field.
+
         .. versionchanged:: 4.14.0
            PHA filtering has been improved to fix a number of corner
            cases which can result in the same filter now selecting one
            or two fewer channels that done in earlier versions of
-           Sherpa. The ``lo`` and ``hi`` arguments are now restricted based on
-           the units setting.
+           Sherpa. The ``lo`` and ``hi`` arguments are now restricted
+           based on the units setting.
 
         Parameters
         ----------

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -1469,7 +1469,7 @@ def test_roundtrip_channel0(tmp_path):
     pha = None
 
     pha2 = io.read_pha(outfile)
-    assert pha2.channel == pytest.approx([1, 2, 3])
+    assert pha2.channel == pytest.approx([0, 1, 2])
     assert pha2.counts == pytest.approx([2, 5, 9])
     assert pha2.exposure == pytest.approx(12)
     assert pha2.backscal == pytest.approx(1.2)

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -1450,3 +1450,27 @@ def test_read_pha_object(make_data_path):
     assert pha.get_rmf().matrix.max() == pytest.approx(0.1611403226852417)
 
     assert pha.get_background().counts[-1] == pytest.approx(59)
+
+
+@requires_fits
+def test_roundtrip_channel0(tmp_path):
+    """Check what happens if we write out and read back in channel 0.
+
+    This is a regression test.
+    """
+
+    pha = DataPHA("chan0", [0, 1, 2], [2, 5, 9])
+    pha.exposure = 12.0
+    pha.backscal = 1.2
+    pha.areascal = 0.4
+
+    outfile = str(tmp_path / "out.pha")
+    io.write_pha(outfile, pha, ascii=False)
+    pha = None
+
+    pha2 = io.read_pha(outfile)
+    assert pha2.channel == pytest.approx([1, 2, 3])
+    assert pha2.counts == pytest.approx([2, 5, 9])
+    assert pha2.exposure == pytest.approx(12)
+    assert pha2.backscal == pytest.approx(1.2)
+    assert pha2.areascal == pytest.approx(0.4)

--- a/sherpa/astro/io/tests/test_io_response.py
+++ b/sherpa/astro/io/tests/test_io_response.py
@@ -976,7 +976,7 @@ def test_write_fake_perfect_rmf(offset, tmp_path):
     assert new.energ_lo == pytest.approx(elo)
     assert new.energ_hi == pytest.approx(ehi)
     assert new.n_grp == pytest.approx([1] * 10)
-    assert new.f_chan == pytest.approx(np.arange(1, 11))
+    assert new.f_chan == pytest.approx(np.arange(1, 11) + offset - 1)
     assert new.n_chan == pytest.approx([1] * 10)
 
     assert new.matrix == pytest.approx([1] * 10)

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -465,12 +465,25 @@ def test_grouped_ciao4_5(parallel, run_thread, clean_astro_ui):
 
     def cmp_thread(fres, aa, covarerr):
         assert fres.numpoints == 46
-        assert fres.statval == approx(18.8316, rel=1e-4)
 
-        assert covarerr[0] == approx(0.104838, rel=1e-4)
-        assert covarerr[1] == approx(2.43937e-05, rel=1e-4)
-        assert aa.gamma.val == approx(1.83906, rel=1e-4)
-        assert aa.ampl.val == approx(0.000301258, rel=1e-4)
+        # Prior to 4.17.0 the selected channel range of 41 to 167
+        # mapped to 1.159:4.79661 keV and resulted in a best-fit
+        # statistic of 18.8316, gamma = 1.83906, and ampl of
+        # 3.01258e-4. In 4.17 the channels now start at 0 so
+        # the energy range has shifted. Ideally I'd change the
+        # test suite, but that is much harder to do than just
+        # change the fit results.
+        #
+        # The new energy range - as of 4.17 - os 1.18764:5.05439
+        # kev. There is not a huge lot of difference between these
+        # results (i.e between these two ranges).
+        #
+        assert fres.statval == approx(19.0311, rel=1e-4)
+
+        assert covarerr[0] == approx(0.104215, rel=1e-4)
+        assert covarerr[1] == approx(2.52228e-05, rel=1e-4)
+        assert aa.gamma.val == approx(1.83531, rel=1e-4)
+        assert aa.ampl.val == approx(0.000302545, rel=1e-4)
 
     check_thread(run_thread, 'grouped_ciao4.5', parallel, cmp_thread,
                  ['aa'])
@@ -641,7 +654,7 @@ def test_xmm2(run_thread, fix_xspec):
     wmsgs = set([str(w.message) for w in ws])
     assert wmsgs == emsgs
 
-    assert ui.get_data().channel[0] == approx(1.0, rel=1e-4)
+    assert ui.get_data().channel[0] == approx(0.0)
     rmf = ui.get_rmf()
     arf = ui.get_arf()
     assert rmf.detchans == 800

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -466,18 +466,6 @@ def test_grouped_ciao4_5(parallel, run_thread, clean_astro_ui):
     def cmp_thread(fres, aa, covarerr):
         assert fres.numpoints == 46
 
-        # Prior to 4.17.0 the selected channel range of 41 to 167
-        # mapped to 1.159:4.79661 keV and resulted in a best-fit
-        # statistic of 18.8316, gamma = 1.83906, and ampl of
-        # 3.01258e-4. In 4.17 the channels now start at 0 so
-        # the energy range has shifted. Ideally I'd change the
-        # test suite, but that is much harder to do than just
-        # change the fit results.
-        #
-        # The new energy range - as of 4.17 - os 1.18764:5.05439
-        # kev. There is not a huge lot of difference between these
-        # results (i.e between these two ranges).
-        #
         assert fres.statval == approx(19.0311, rel=1e-4)
 
         assert covarerr[0] == approx(0.104215, rel=1e-4)

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -3952,6 +3952,13 @@ def test_to_guess_when_all_ignored_dataimg():
         _ = data.to_guess()
 
 
+def test_get_x_when_empty_datapha():
+    """This is a regression test."""
+
+    data = DataPHA("empty", None, None)
+    assert data.get_x() is None
+
+
 def test_get_dims_when_empty_datapha():
     """This is a regression test."""
 

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -3674,7 +3674,7 @@ def test_1209_background(make_data_path):
 
     # We need to set up the channels array to match the background.
     #
-    d = DataPHA("dummy", np.arange(1, 801, dtype=np.int16), None)
+    d = DataPHA("dummy", np.arange(0, 800, dtype=np.int16), None)
     assert d.header["TELESCOP"] == "none"
     assert d.header["INSTRUME"] == "none"
     assert d.header["FILTER"] == "none"

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -185,49 +185,6 @@ def test_pha_get_filter_checks_ungrouped(chtype, expected, args):
     assert pha.get_filter(format='%.1f') == expected
 
 
-@pytest.mark.parametrize("chan", [0, -1, 4])
-def test_error_on_invalid_channel_ungrouped(chan):
-    """Does channel access fail when outside the bounds?
-
-    For ungrouped data it currently does not, but just
-    acts as an identity function.
-    """
-
-    pha = DataPHA('name', [1, 2, 3], [1, 1, 1])
-    assert pha._from_channel(chan) == chan
-
-
-@pytest.mark.parametrize("chan,exp1,exp2",
-                         [(0, 1, 3),
-                          (-1, 1, 1)])
-def test_error_on_invalid_channel_grouped(chan, exp1, exp2):
-    """Does channel access fail when outside the bounds?
-
-    It is not clear what _from_channel is doing here, so
-    just check the responses.
-    """
-
-    pha = DataPHA('name', [1, 2, 3], [1, 1, 1],
-                  grouping=[1, -1, 1])
-    assert pha.grouped
-    assert pha._from_channel(chan) == exp2
-
-
-@pytest.mark.parametrize("chan", [-2, 4])
-def test_error_on_invalid_channel_grouped2(chan):
-    """Does channel access fail when outside the bounds?
-
-    This one does error out in _from_channel.
-    """
-
-    pha = DataPHA('name', [1, 2, 3], [1, 1, 1],
-                  grouping=[1, -1, 1])
-    assert pha.grouped
-    with pytest.raises(DataErr,
-                       match=f"invalid group number: {chan - 1}"):
-        pha._from_channel(chan)
-
-
 def test_pha_get_xerr_all_bad_channel_no_group():
     """get_xerr handles all bad values [channel]
 

--- a/sherpa/astro/tests/test_astro_data_asca_unit.py
+++ b/sherpa/astro/tests/test_astro_data_asca_unit.py
@@ -61,7 +61,7 @@ def check_pha0(pha, errors=True, responses=True):
     assert pha.areascal == pytest.approx(1.0)
 
     nchan = 512
-    assert pha.channel == pytest.approx(np.arange(1, nchan + 1))
+    assert pha.channel == pytest.approx(np.arange(0, nchan))
 
     assert len(pha.counts) == nchan
     assert pha.counts.min() == pytest.approx(0.0)

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -650,7 +650,6 @@ def test_1209_background(make_data_path):
     assert d.header["FILTER"] == "NONE"
 
 
-@pytest.mark.xfail
 @requires_fits
 @requires_data
 def test_get_x_channel0(make_data_path):

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -78,7 +78,7 @@ def check_pha(pha):
     # between 1 and 1024 inclusive.
     #
     nchan = 1024
-    assert pha.channel == pytest.approx(np.arange(1, nchan + 1))
+    assert pha.channel == pytest.approx(np.arange(0, nchan))
 
     # Rather than check each element, use some simple summary
     # statistics.
@@ -634,7 +634,7 @@ def test_1209_background(make_data_path):
 
     # We need to set up the channels array to match the background.
     #
-    d = DataPHA("dummy", np.arange(1, 1025, dtype=np.int16), None)
+    d = DataPHA("dummy", np.arange(0, 1024, dtype=np.int16), None)
     assert d.header["TELESCOP"] == "none"
     assert d.header["INSTRUME"] == "none"
     assert d.header["FILTER"] == "none"

--- a/sherpa/astro/tests/test_astro_data_xmm_unit.py
+++ b/sherpa/astro/tests/test_astro_data_xmm_unit.py
@@ -61,7 +61,7 @@ def check_pha(pha, responses=True):
     assert pha.backscal == pytest.approx(1136000.)
 
     nchan = 800
-    assert pha.channel == pytest.approx(np.arange(1, nchan + 1))
+    assert pha.channel == pytest.approx(np.arange(0, nchan))
 
     # Rather than check each element, use some simple summary
     # statistics.

--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -1992,10 +1992,6 @@ def test_rmf_image_offset_0(make_data_path, tmp_path, recwarn):
                                      e_min=e_min, e_max=e_max,
                                      ethresh=1e-10)
 
-    # Hack the output as it's known to be wrong when offset != 1.
-    #
-    rmf_image.f_chan -= 1
-
     # A couple of simple checks. We can not directly compare
     # n_grp/n_chan/f_chan/matrix values. We can check some basic
     # matrix properties, such as the max value and the summation
@@ -2035,7 +2031,7 @@ def test_rmf_image_offset_0(make_data_path, tmp_path, recwarn):
     # It is not clear what these values should be, so treat as a
     # regression test.
     where, = np.where(selected_image)
-    expected = [146, 178, 183, 184, 185, 186, 187, 188, 189, 190]
+    expected = [146, 178, 184, 185, 186, 187, 188, 189, 190, 191]
     assert where[:10] == pytest.approx(expected)
 
     y_direct = rmf_direct.apply_rmf(mvals[selected_direct])

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -2042,11 +2042,7 @@ def test_pha_offset_via_file(offset, clean_astro_ui, tmp_path):
     # Have we read in the expected channels?
     expected_chans = np.arange(offset, offset + 9, dtype=np.int16)
     chans, = ui.get_indep()
-    if offset == 0:
-        # Test the current behaviour
-        assert chans == pytest.approx(expected_chans + 1)
-    else:
-        assert chans == pytest.approx(expected_chans)
+    assert chans == pytest.approx(expected_chans)
 
     # It is not clear what values lead to a loss in tolerance here.
     #

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -23,13 +23,13 @@ import os
 import re
 import logging
 
-import numpy
+import numpy as np
 from numpy.testing import assert_allclose
 
 import pytest
 
-from sherpa.astro.data import DataIMG, DataPHA
-from sherpa.astro.instrument import RMFModelPHA, create_arf
+from sherpa.astro.data import DataIMG, DataPHA, DataRMF
+from sherpa.astro.instrument import RMFModelPHA, create_arf, matrix_to_rmf
 from sherpa.astro import ui
 from sherpa.data import Data1D, Data2D, Data2DInt
 from sherpa.utils.err import ArgumentErr, DataErr, IdentifierErr, IOErr, StatErr
@@ -157,12 +157,12 @@ def test_dataspace1d_data1dint(clean_astro_ui):
     grid = ui.get_indep('x')
     assert len(grid) == 2
 
-    expected = numpy.asarray([20, 22.5, 25, 27.5, 30.0])
+    expected = np.asarray([20, 22.5, 25, 27.5, 30.0])
     assert grid[0] == pytest.approx(expected[:-1])
     assert grid[1] == pytest.approx(expected[1:])
 
     y = ui.get_dep('x')
-    assert y == pytest.approx(numpy.zeros(4))
+    assert y == pytest.approx(np.zeros(4))
 
 
 def test_dataspace1d_datapha(clean_astro_ui):
@@ -179,11 +179,11 @@ def test_dataspace1d_datapha(clean_astro_ui):
     grid = ui.get_indep('x')
     assert len(grid) == 1
 
-    expected = numpy.asarray([1, 2, 3, 4, 5])
+    expected = np.asarray([1, 2, 3, 4, 5])
     assert grid[0] == pytest.approx(expected)
 
     y = ui.get_dep('x')
-    assert y == pytest.approx(numpy.zeros(5))
+    assert y == pytest.approx(np.zeros(5))
 
     assert ui.get_exposure('x') is None
     assert ui.get_grouping('x') is None
@@ -234,11 +234,11 @@ def test_dataspace1d_datapha_bkg(clean_astro_ui):
     grid = ui.get_indep('x', bkg_id=2)
     assert len(grid) == 1
 
-    expected = numpy.asarray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    expected = np.asarray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     assert grid[0] == pytest.approx(expected)
 
     y = ui.get_dep('x', bkg_id=2)
-    assert y == pytest.approx(numpy.zeros(10))
+    assert y == pytest.approx(np.zeros(10))
 
     assert ui.get_exposure('x', bkg_id=2) is None
     assert ui.get_grouping('x', bkg_id=2) is None
@@ -426,7 +426,7 @@ def test_more_ui_bug38_pre_416(make_data_path, caplog):
     exact_record(caplog.records[1], "sherpa.ui.utils", "INFO",
                  "dataset 3c273: 0.2482:2.0294 -> 0.00146:2.0294 Energy (keV)")
 
-    ui.group_counts('3c273', 15, tabStops=numpy.zeros(1024))
+    ui.group_counts('3c273', 15, tabStops=np.zeros(1024))
 
     assert len(caplog.records) == 3
     exact_record(caplog.records[2], "sherpa.ui.utils", "INFO",
@@ -578,7 +578,7 @@ def test_group_reporting_case_pre_416(clean_astro_ui, caplog):
     current behaviour.
     """
 
-    x = numpy.arange(1, 22)
+    x = np.arange(1, 22)
     ui.load_arrays(1, x, x, ui.DataPHA)
     ui.notice(5, 7)
     ui.notice(9, 11)
@@ -596,7 +596,7 @@ def test_group_reporting_case_pre_416(clean_astro_ui, caplog):
 
     # Prior to 4.16.0 the group_xxx calls ignored the existing filter.
     #
-    ui.group_width(3, tabStops=numpy.zeros(21))
+    ui.group_width(3, tabStops=np.zeros(21))
 
     assert len(caplog.records) == 4
     exact_record(caplog.records[3], "sherpa.ui.utils", "INFO",
@@ -613,7 +613,7 @@ def test_group_reporting_case(clean_astro_ui, caplog):
     current behaviour.
     """
 
-    x = numpy.arange(1, 22)
+    x = np.arange(1, 22)
     ui.load_arrays(1, x, x, ui.DataPHA)
     ui.notice(5, 7)
     ui.notice(9, 11)
@@ -646,7 +646,7 @@ def test_group_bins_pre_416(idval, clean_astro_ui, caplog):
 
     idarg = 1 if idval is None else idval
 
-    x = numpy.arange(1, 22)
+    x = np.arange(1, 22)
     ui.load_arrays(idarg, x, x, ui.DataPHA)
     ui.notice(5, 7)
     ui.notice(9, 11)
@@ -695,7 +695,7 @@ def test_group_bins(idval, clean_astro_ui, caplog):
 
     idarg = 1 if idval is None else idval
 
-    x = numpy.arange(1, 22)
+    x = np.arange(1, 22)
     ui.load_arrays(idarg, x, x, ui.DataPHA)
     ui.notice(5, 7)
     ui.notice(9, 11)
@@ -917,8 +917,8 @@ def test_psf_model2d(model, clean_astro_ui):
     ui.load_psf('psf2d', model + '.mdl')
     ui.set_psf('psf2d')
     mdl = ui.get_model_component('mdl')
-    assert (numpy.array(mdl.get_center()) ==
-            numpy.array([108, 130])).all()
+    assert (np.array(mdl.get_center()) ==
+            np.array([108, 130])).all()
 
 
 def test_dataspace2d_default(clean_astro_ui):
@@ -931,7 +931,7 @@ def test_dataspace2d_default(clean_astro_ui):
     assert data.shape == (5, 3)
     assert data.x0 == pytest.approx([1, 2, 3] * 5)
     assert data.x1 == pytest.approx([1] * 3 + [2] * 3 + [3] * 3 + [4] * 3 + [5] * 3)
-    assert data.y == pytest.approx(numpy.zeros(15))
+    assert data.y == pytest.approx(np.zeros(15))
 
 
 def test_dataspace2d_data2d(clean_astro_ui):
@@ -944,7 +944,7 @@ def test_dataspace2d_data2d(clean_astro_ui):
     assert data.shape == (5, 3)
     assert data.x0 == pytest.approx([1, 2, 3] * 5)
     assert data.x1 == pytest.approx([1] * 3 + [2] * 3 + [3] * 3 + [4] * 3 + [5] * 3)
-    assert data.y == pytest.approx(numpy.zeros(15))
+    assert data.y == pytest.approx(np.zeros(15))
 
 
 def test_dataspace2d_data2dint(clean_astro_ui):
@@ -959,7 +959,7 @@ def test_dataspace2d_data2dint(clean_astro_ui):
     assert data.x0hi == pytest.approx([1.5, 2.5, 3.5] * 5)
     assert data.x1lo == pytest.approx([0.5] * 3 + [1.5] * 3 + [2.5] * 3 + [3.5] * 3 + [4.5] * 3)
     assert data.x1hi == pytest.approx([1.5] * 3 + [2.5] * 3 + [3.5] * 3 + [4.5] * 3 + [5.5] * 3)
-    assert data.y == pytest.approx(numpy.zeros(15))
+    assert data.y == pytest.approx(np.zeros(15))
 
     # These are presumably auto-generated
     assert data.x0 == pytest.approx([1, 2, 3] * 5)
@@ -1122,8 +1122,8 @@ def save_arrays(tmp_path, colnames, fits, read_func):
 
     # It looks like the input arrays to `write_arrays` should be numpy
     # arrays, so enforce that invariant.
-    a = numpy.asarray([1, 3, 9])
-    b = numpy.sqrt(numpy.asarray(a))
+    a = np.asarray([1, 3, 9])
+    b = np.sqrt(np.asarray(a))
     c = b * 0.1
 
     if colnames:
@@ -1180,8 +1180,8 @@ def test_save_arrays_colmismatch_errs(ascii_type, tmp_path):
 
     ofile = str(tmp_path / "should_not_get_created")
 
-    a = numpy.asarray([1, 3, 5])
-    b = numpy.asarray([4, 6, 8])
+    a = np.asarray([1, 3, 5])
+    b = np.asarray([4, 6, 8])
     c = a*b
     fields = ["odd", "even"]
 
@@ -1576,10 +1576,10 @@ def test_grouped_pha_all_bad_channel(clean_astro_ui):
     same test but with a response model.
 
     """
-    chans = numpy.arange(1, 6, dtype=numpy.int16)
-    counts = numpy.asarray([0, 1, 2, 0, 1], dtype=numpy.int16)
-    grouping = numpy.asarray([1, -1, -1, -1, -1], dtype=numpy.int16)
-    quality = numpy.asarray([2, 2, 2, 2, 2], dtype=numpy.int16)
+    chans = np.arange(1, 6, dtype=np.int16)
+    counts = np.asarray([0, 1, 2, 0, 1], dtype=np.int16)
+    grouping = np.asarray([1, -1, -1, -1, -1], dtype=np.int16)
+    quality = np.asarray([2, 2, 2, 2, 2], dtype=np.int16)
 
     dset = ui.DataPHA('low', chans, counts, grouping=grouping, quality=quality)
     ui.set_data(dset)
@@ -1608,15 +1608,15 @@ def test_grouped_pha_all_bad_response(arf, rmf, chantype, exp_counts, exp_xlo, e
 
     """
 
-    chans = numpy.arange(1, 6, dtype=numpy.int16)
-    counts = numpy.asarray([0, 1, 2, 0, 1], dtype=numpy.int16)
-    grouping = numpy.asarray([1, -1, -1, -1, -1], dtype=numpy.int16)
-    quality = numpy.asarray([2, 2, 2, 2, 2], dtype=numpy.int16)
+    chans = np.arange(1, 6, dtype=np.int16)
+    counts = np.asarray([0, 1, 2, 0, 1], dtype=np.int16)
+    grouping = np.asarray([1, -1, -1, -1, -1], dtype=np.int16)
+    quality = np.asarray([2, 2, 2, 2, 2], dtype=np.int16)
 
     dset = ui.DataPHA('low', chans, counts, grouping=grouping, quality=quality)
     ui.set_data(dset)
 
-    egrid = numpy.asarray([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+    egrid = np.asarray([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
     elo = egrid[:-1]
     ehi = egrid[1:]
 
@@ -1657,7 +1657,7 @@ def test_grouped_pha_all_bad_response_bg_warning(elo, ehi, nbins, fstr, bkg_id,
     with SherpaVerbosity("ERROR"):
         ui.load_pha('check', make_data_path('3c273.pi'))
 
-    ui.set_quality('check', 2 * numpy.ones(1024, dtype=numpy.int16), bkg_id=1)
+    ui.set_quality('check', 2 * np.ones(1024, dtype=np.int16), bkg_id=1)
 
     assert len(caplog.records) == 0
     ui.ignore_bad('check', bkg_id=1)
@@ -1760,8 +1760,8 @@ def test_unpack_arrays_datapha():
 def test_unpack_arrays_dataimg():
     """Can we call unpack_arrays? DataIMG"""
 
-    ivals = numpy.arange(12)
-    y, x = numpy.mgrid[0:3, 0:4]
+    ivals = np.arange(12)
+    y, x = np.mgrid[0:3, 0:4]
     x = x.flatten()
     y = y.flatten()
     ans = ui.unpack_arrays(x, y, ivals, (3, 4), ui.DataIMG)
@@ -1787,14 +1787,14 @@ def test_get_rate_bkg(idval, clean_astro_ui, make_data_path):
     r2 = ui.get_rate(idval, bkg_id=1)
 
     # All we do is check they are different
-    assert isinstance(r1, numpy.ndarray)
-    assert isinstance(r2, numpy.ndarray)
+    assert isinstance(r1, np.ndarray)
+    assert isinstance(r2, np.ndarray)
 
     # We can not say r1 > r2 as this is not true for all bins.
     # Technically two bins could be the same, but they are not for
     # this dataset.
     #
-    assert numpy.all(r1 != r2)
+    assert np.all(r1 != r2)
 
 
 @pytest.mark.parametrize("idval", [1, "x"])
@@ -1808,7 +1808,7 @@ def test_warn_about_bgnd_subtracted_with_model(idval, clean_astro_ui, caplog):
 
     ui.load_arrays(idval, [1, 2], [4, 3], ui.DataPHA)
 
-    egrid = numpy.asarray([1, 2, 3])
+    egrid = np.asarray([1, 2, 3])
     ui.set_arf(idval, create_arf(egrid[:-1], egrid[1:]))
 
     ui.set_bkg(idval, ui.DataPHA("b", [1, 2], [1, 1]))
@@ -1843,7 +1843,7 @@ def test_warn_about_bgnd_or_subtracted_no_model(idval, clean_astro_ui, caplog):
 
     ui.load_arrays(idval, [1, 2], [4, 3], ui.DataPHA)
 
-    egrid = numpy.asarray([1, 2, 3])
+    egrid = np.asarray([1, 2, 3])
     ui.set_arf(idval, create_arf(egrid[:-1], egrid[1:]))
 
     ui.set_bkg(idval, ui.DataPHA("b", [1, 2], [1, 1]))
@@ -1865,3 +1865,190 @@ def test_warn_about_bgnd_or_subtracted_no_model(idval, clean_astro_ui, caplog):
     assert sinfo[0].ids == [idval]
     assert sinfo[0].bkg_ids is None
     assert sinfo[0].statval == pytest.approx(13.0)
+
+
+def make_pha_offset(offset):
+    """Create the data files for this offset."""
+
+    delta = offset - 1
+    channels = np.arange(1, 10, dtype=np.int16) + delta
+    counts = np.zeros(9)
+
+    # The RMF is not "ideal".
+    #
+    energ = np.linspace(0.1, 1.1, 21)
+    energ_lo = energ[:-1]
+    energ_hi = energ[1:]
+
+    ebounds = np.asarray([0.05, 0.18, 0.32, 0.45, 0.55, 0.7, 0.85, 1.0,
+                          1.05, 1.2])
+    e_min = ebounds[:-1]
+    e_max = ebounds[1:]
+
+    pha = DataPHA("x", channels, counts)
+    pha.exposure = 100
+
+    # The RMF matrix is 20 by 9.
+    #
+    # We have several rows with multiple groups, in case there's odd
+    # behaviour with this.
+    #
+    mat = np.asarray([
+        [0.9, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.1, 0.8, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.1, 0.4, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.1, 0.8, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.8, 0.2, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.2, 0.8, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.1, 0.8, 0.1, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.2, 0.8, 0.2, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.6, 0.4, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.4, 0.6, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.3, 0.7, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.2, 0.8, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.1, 0.9, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.2, 0.0, 0.8, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.2, 0.7, 0.1, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.8, 0.1, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.8, 0.1],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.9]
+    ])
+    n_grp, f_chan, n_chan, matrix = matrix_to_rmf(mat)
+    f_chan += (offset - 1)
+    rmf = DataRMF("x", detchans=9, energ_lo=energ_lo,
+                  energ_hi=energ_hi, e_min=e_min, e_max=e_max,
+                  n_grp=n_grp, f_chan=f_chan, n_chan=n_chan,
+                  matrix=matrix, offset=offset)
+    specresp = np.linspace(100, 119, 20)
+    arf = create_arf(energ_lo, energ_hi, specresp)
+    return pha, arf, rmf, energ_lo, energ_hi, specresp, mat
+
+
+def check_pha_offset(specresp, matrix, energ_lo, energ_hi,
+                     tol=1e-6):
+    """Run the tests.
+
+    Evaluate the model for the full channel range and for
+    a subset.
+
+    """
+
+    ui.set_source(ui.polynom1d.mdl)
+    mdl.c0 = 50
+    mdl.c1 = 200
+
+    mvals = mdl(energ_lo, energ_hi)
+    assert np.all(mvals > 0)
+
+    # X is easy to calculate from first principles, but Y is
+    # harder to do.
+    #
+    expected_x0 = [0.115, 0.25, 0.385, 0.5, 0.625,
+                   0.775, 0.925, 1.025, 1.125]
+    expected_y0 = 100 * (specresp * mvals) @ matrix
+
+    # No filter
+    #
+    xvals0, yvals0 = ui.calc_model()
+
+    xmid0 = (xvals0[0] + xvals0[1]) / 2
+    assert xmid0 == pytest.approx(expected_x0)
+    assert yvals0 == pytest.approx(expected_y0, rel=tol)
+
+    # Subset the data: aim for channels 4,5,6.
+    #
+    ui.ignore()
+    ui.notice(0.5, 0.8)
+
+    data = ui.get_data()
+    assert data.mask == pytest.approx([False] * 3 + [True] * 3 + [False] * 3)
+
+    assert ui.get_filter(format="%.2f", delim="-") == "0.45-0.85"
+
+    # After filter
+    #
+    xvals1, yvals1 = ui.calc_model()
+
+    assert xvals1[0] == pytest.approx([0.45, 0.55, 0.70])
+    assert xvals1[1] == pytest.approx([0.55, 0.70, 0.85])
+
+    # I would have expected this to be
+    #   [False] * 3 + [True] * 15 + [False] * 2
+    # but it isn't.
+    #
+    mask = [False] + [True] * 17 + [False, False]
+    expected_y1 = 100 * (specresp[mask] * mvals[mask]) @ matrix[mask, :]
+    assert yvals1 == pytest.approx(expected_y1[data.mask], rel=tol)
+
+
+@pytest.mark.parametrize("offset", [0, 1, 2, 5])
+def test_pha_offset_direct(offset, clean_astro_ui):
+    """Do we get consistent behaviour with different offsets?
+
+    This creates the data structures in memory. See
+    test_pha_offset_via_file for reading from file.
+    """
+
+    # Given issue #2127 it is not clear what the intended behaviour
+    # is. For this test we assume that the channel values are as
+    # specified in the data file (although in this case the data is
+    # generated on-the-fly) and that the results are the same given an
+    # energy filter (if we chose a channel filter they they would not
+    # match).
+    #
+    pha, arf, rmf, energ_lo, energ_hi, specresp, matrix = make_pha_offset(offset)
+    ui.set_data(pha)
+    ui.set_rmf(rmf)
+    ui.set_arf(arf)
+
+    ui.set_analysis("energy")
+    check_pha_offset(specresp, matrix, energ_lo, energ_hi)
+
+
+@requires_fits
+@pytest.mark.parametrize("offset", [0, 1, 2, 5])
+def test_pha_offset_via_file(offset, clean_astro_ui, tmp_path):
+    """Do we get consistent behaviour with different offsets?
+
+    See test_pha_offset_direct for commentary - this version
+    writes the files out, reads them back in, and then checks it
+    still works.
+
+    """
+
+    from sherpa.astro import io
+
+    arfname = "src.arf"
+    rmfname = "src.rmf"
+    phaname = "src.pha"
+
+    pha, arf, rmf, energ_lo, energ_hi, specresp, matrix = make_pha_offset(offset)
+
+    pha.header["ANCRFILE"] = arfname
+    pha.header["RESPFILE"] = rmfname
+
+    phapath = tmp_path / phaname
+    io.write_pha(str(phapath), pha, ascii=False)
+    io.write_arf(str(tmp_path / arfname), arf, ascii=False)
+    io.write_rmf(str(tmp_path / rmfname), rmf)
+
+    ui.load_pha(str(phapath))
+
+    # Check we've read in the responses
+    assert ui.get_analysis() == "energy"
+
+    # Have we read in the expected channels?
+    expected_chans = np.arange(offset, offset + 9, dtype=np.int16)
+    chans, = ui.get_indep()
+    if offset == 0:
+        # Test the current behaviour
+        assert chans == pytest.approx(expected_chans + 1)
+    else:
+        assert chans == pytest.approx(expected_chans)
+
+    # It is not clear what values lead to a loss in tolerance here.
+    #
+    check_pha_offset(specresp, matrix, energ_lo, energ_hi,
+                     tol=1.5e-6)

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -1915,8 +1915,7 @@ def make_pha_offset(offset):
         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.8, 0.1],
         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.9]
     ])
-    n_grp, f_chan, n_chan, matrix = matrix_to_rmf(mat)
-    f_chan += (offset - 1)
+    n_grp, f_chan, n_chan, matrix = matrix_to_rmf(mat, startchan=offset)
     rmf = DataRMF("x", detchans=9, energ_lo=energ_lo,
                   energ_hi=energ_hi, e_min=e_min, e_max=e_max,
                   n_grp=n_grp, f_chan=f_chan, n_chan=n_chan,

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -2285,6 +2285,10 @@ class Session(sherpa.ui.utils.Session):
         multiple data sets can be loaded with this command, as
         described in the `sherpa.astro.datastack` module.
 
+        .. versionchanged:: 4.17.0
+           Channel numbers that start at 0 are now left as is rather
+           than be renumbered to start at 1.
+
         .. versionchanged:: 4.12.2
            The id argument is now used to define the first identifier
            when loading in a PHA2 file (previously they always used
@@ -2329,6 +2333,16 @@ class Session(sherpa.ui.utils.Session):
         they are interpreted as the `id` and `arg` parameters,
         respectively. The remaining parameters are expected to be
         given as named arguments.
+
+        Unlike XSPEC, Sherpa does not:
+
+        - use the error column in the file, prefering to re-calculate
+          them (so set use_errors=True to use the values from the
+          file);
+        - automatically subtract any background component;
+        - renumber channels so they start at 1;
+        - or use the group number rather than channel number when
+          filtering by channel.
 
         The `minimum_energy` setting of the `ogip` section of the
         Sherpa configuration file determines the behavior when an
@@ -5958,8 +5972,8 @@ class Session(sherpa.ui.utils.Session):
             by the ENERG_LO and ENERG_HI columns of the MATRIX block) of
             the OGIP standard.
         startchan : int, optional
-            The starting channel number: expected to be 0 or 1 but this is
-            not enforced.
+            The starting channel number: it should match the offset
+            value for the DataRMF class.
         e_min, e_max : None or array, optional
             The E_MIN and E_MAX columns of the EBOUNDS block of the
             RMF. If not set they are taken from rmflo and rmfhi

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -5955,6 +5955,10 @@ class Session(sherpa.ui.utils.Session):
         maps to a single energy bin), otherwise the RMF is taken from
         the image data stored in the file pointed to by `fname`.
 
+        .. versionchanged:: 4.17.0
+           Support for startchan values other than 1 has been
+           improved.
+
         .. versionchanged:: 4.16.0
            The e_min and e_max values will use the rmflo and rmfhi
            values if not set.

--- a/sherpa/astro/utils/tests/test_astro_utils_unit.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_unit.py
@@ -21,9 +21,11 @@
 import re
 
 import numpy as np
+
 import pytest
 
 from sherpa.astro.data import DataPHA, DataIMG, DataIMGInt
+from sherpa.astro.instrument import matrix_to_rmf
 from sherpa.astro import ui
 from sherpa.astro import utils
 from sherpa.astro.utils import do_group, expand_grouped_mask, filter_resp, \
@@ -66,6 +68,143 @@ def test_rmf_filter_no_chans(make_data_path):
     with pytest.raises(ValueError,
                        match="There are no noticed channels"):
         rmf.notice([])
+
+
+@pytest.mark.parametrize("offset", [0, 1, 2, 5])
+@pytest.mark.parametrize("selected,ng,fch,nch,mat,msk",
+                         [([1],
+                           [],
+                           [],
+                           [],
+                           [],
+                           [False] * 6),
+                          ([2],
+                           [1, 1],
+                           [2, 2],
+                           [1, 2],
+                           # There is an argument to say this should
+                           # just return [1, 1.2] as the 1.8 factor is
+                           # for channel 3. Do we just return all the
+                           # elements of a group if any element in the
+                           # group is needed?
+                           #
+                           [1, 1.2, 1.8],
+                           [False] + [True] * 2 + [False] * 3),
+                          ([3],
+                           [1, 1, 1, 1],
+                           [2, 2, 3, 3],
+                           [1, 2, 1, 2],
+                           [1, 1.2, 1.8, 2.0, 3.3, 3.7],
+                           [False] + [True] * 4 + [False]),
+                          ([4],
+                           [1, 1, 1, 1],
+                           [2, 3, 3, 4],
+                           [2, 1, 2, 1],
+                           [1.2, 1.8, 2.0, 3.3, 3.7, 4.0],
+                           [False] * 2 + [True] * 4),
+                          ([5],
+                           # Why is this not empty?
+                           [1, 1],
+                           [3, 4],
+                           [2, 1],
+                           [3.3, 3.7, 4.0],
+                           [False] * 4 + [True] * 2),
+                          ([1, 2],
+                           [1, 1],
+                           [2, 2],
+                           [1, 2],
+                           [1, 1.2, 1.8],
+                           [False] + [True] * 2 + [False] * 3),
+                          ([2, 3],
+                           [1, 1, 1, 1],
+                           [2, 2, 3, 3],
+                           [1, 2, 1, 2],
+                           [1, 1.2, 1.8, 2.0, 3.3, 3.7],
+                           [False] + [True] * 4 + [False]),
+                          ([1, 2, 3],
+                           [1, 1, 1, 1],
+                           [2, 2, 3, 3],
+                           [1, 2, 1, 2],
+                           [1, 1.2, 1.8, 2.0, 3.3, 3.7],
+                           [False] + [True] * 4 + [False]),
+                          ([3, 4],
+                           [1, 1, 1, 1, 1],
+                           [2, 2, 3, 3, 4],
+                           [1, 2, 1, 2, 1],
+                           [1, 1.2, 1.8, 2.0, 3.3, 3.7, 4.0],
+                           # Why does this include bin 2?
+                           [False] + [True] * 5),
+                          ([1, 5],
+                           # Assume this matches [5]
+                           [1, 1],
+                           [3, 4],
+                           [2, 1],
+                           [3.3, 3.7, 4.0],
+                           [False] * 4 + [True] * 2),
+                          ([2, 4],
+                           [1, 1, 1, 1, 1],
+                           [2, 2, 3, 3, 4],
+                           [1, 2, 1, 2, 1],
+                           [1, 1.2, 1.8, 2.0, 3.3, 3.7, 4.0],
+                           [False] + [True] * 5),
+                          ])
+def test_filter_resp_basics(offset, selected, ng, fch, nch, mat, msk):
+    """Check filter_resp behaves as expected.
+
+    There is no documentation in the code to say what the expected
+    behaviour is. The belief is that, given a list of channels we
+    are interested in we can
+
+    - restrict to just the subset of the matrix that can change
+      these fields
+    - provide a mask for the matrix ENERG_LO/HI columns so that model
+      evaluation can be restricted to just this range
+
+    See also
+    sherpa/astro/tests/test_astro_data2.py::test_rmf_offset_check_basics
+
+    """
+
+    # 6 energy grid values and 5 channels
+    #
+    # Note that the first row is empty and the rows do not sum to 1.0
+    # - this could represent a RSP, but it's actually just to
+    # make it obvious what values are being used.
+    #
+    fm = np.asarray([[0.0, 0.0, 0.0, 0.0, 0.0],
+                     [0.0, 1.0, 0.0, 0.0, 0.0],
+                     [0.0, 1.2, 1.8, 0.0, 0.0],
+                     [0.0, 0.0, 2.0, 0.0, 0.0],
+                     [0.0, 0.0, 3.3, 3.7, 0.0],
+                     [0.0, 0.0, 0.0, 4.0, 0.0]])
+
+    n_grp, f_chan, n_chan, matrix = matrix_to_rmf(fm)
+
+    # Correct for the offset, both for f_chan and for nchans
+    #
+    delta = offset - 1
+
+    f_chan += delta
+    nchans = np.asarray(selected) + delta
+
+    if offset == 0:
+        # PHA files with channel starting at 0 get reset to 1, so
+        # mimic that here.
+        #
+        nchans += 1
+
+    # The filter_resp command is sent the noticed channel numbers.
+    #
+    resp = filter_resp(nchans, n_grp, f_chan, n_chan, matrix, offset)
+    n_grp2, f_chan2, n_chan2, matrix2, mask2 = resp
+
+    # We have to correct for the offset here.
+    #
+    assert n_grp2 == pytest.approx(ng)
+    assert f_chan2 == pytest.approx(np.asarray(fch) + delta)
+    assert n_chan2 == pytest.approx(nch)
+    assert matrix2 == pytest.approx(mat)
+    assert mask2 == pytest.approx(msk)
 
 
 @pytest.mark.parametrize("lo, hi, expected",

--- a/sherpa/astro/utils/tests/test_astro_utils_unit.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_unit.py
@@ -178,28 +178,18 @@ def test_filter_resp_basics(offset, selected, ng, fch, nch, mat, msk):
                      [0.0, 0.0, 3.3, 3.7, 0.0],
                      [0.0, 0.0, 0.0, 4.0, 0.0]])
 
-    n_grp, f_chan, n_chan, matrix = matrix_to_rmf(fm)
+    n_grp, f_chan, n_chan, matrix = matrix_to_rmf(fm, startchan=offset)
 
-    # Correct for the offset, both for f_chan and for nchans
+    # Correct for the offset.
     #
     delta = offset - 1
-
-    f_chan += delta
     nchans = np.asarray(selected) + delta
-
-    if offset == 0:
-        # PHA files with channel starting at 0 get reset to 1, so
-        # mimic that here.
-        #
-        nchans += 1
 
     # The filter_resp command is sent the noticed channel numbers.
     #
     resp = filter_resp(nchans, n_grp, f_chan, n_chan, matrix, offset)
     n_grp2, f_chan2, n_chan2, matrix2, mask2 = resp
 
-    # We have to correct for the offset here.
-    #
     assert n_grp2 == pytest.approx(ng)
     assert f_chan2 == pytest.approx(np.asarray(fch) + delta)
     assert n_chan2 == pytest.approx(nch)

--- a/sherpa/include/sherpa/astro/utils.hh
+++ b/sherpa/include/sherpa/astro/utils.hh
@@ -1,5 +1,6 @@
 //
-//  Copyright (C) 2007, 2021  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2021, 2024
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -261,9 +262,6 @@ namespace sherpa { namespace astro { namespace utils {
 	  return EXIT_FAILURE;
 
 	lo = current_chan;
-	// if f_chan values are indices, convert to channels
-	if(!offset)
-	  lo++;
 	hi = lo + current_num_chans;
 
 	if( is_in( noticed_chans, len_not_chans, lo, hi ) ) {


### PR DESCRIPTION
# Summary

Improve the handling of PHA files that start at channel 0. PHA data that are read in from such a file no longer renumber the CHANNEL column to start at 0 rather than 1, which will mean that notice and ignore filter ranges that are given in channel units will need to be reduced by 1.

# Details

Fix #1267.
Fix #1979.
Fix #2146.

We have long had issues over handling "channel is not 1" cases, e.g.

- #1040
- #1267
- #1305
- #1979 
- ~#2127~ (I wrote this when working on this issue and I got confused, so I don't think the issue is technically a problem, although the code I pointed to is in fact strange and gets removed in this PR)

I have added a bunch of tests to check handling of offset=0, 1, 2, and 5, with the idea being that the results should be the same (this may require tweaking the input arguments based on the offset value), and I wanted to make sure we tested

- low level routines (mainly `sherpa.astro.utils._utils.filter_resp`)
- object routines - e.g. for users directly using `DataPHA`/`DataRMF`
- the UI layer - e.g. `load_pha`/`set_source`/`fit` [although I don't use `fit` but the recently-added `calc_model` routine to represent "evaluate model by the response" which we care about

These tests show that we actually seem to support channels starting at > 1 well. However, the channel=0 case appears bizarre because of the existing I/O code that if given CHANNEL=0, 1, ... in the file we auto-convert to CHANNEL=1, 2, .... This is **odd** but not in itself terrible **EXCEPT**

- we do not apply the same logic for DataPHA data we create manually, leading to uncertainty in using such data
- if you write out the data you have read in then it will have changed, which could be surprising

There are two fixes to change behaviour:

1. we no-longer re-number channel=0, 1, ... to channel=1, 2, ...

    This actually didn't change too many tests - those that did change are generally regression tests - e.g. we just want
    to ensure we get back the values we used to, so they need there checked values to be updated - but there is one
    test that had "real-world" implications: if you notice/ignore a dataset which starts at channel=0 then the selected
    channel range is now likely to be different.

2. remove the special-case offset=0 case we were having for RMF files

    This is primarily a fix to the filter_resp C++ code - and a **minimal** one at that, as we just need to remove the two
    problematic lines highlighted in #2127 - but there's some follow-on changes to some of the instrument handling to
    make sure we either allow offset/firstchan/startchan to be different from 1, or fixes for this code. 

I rely on the existing tests to catch problems (and I can confirm that they did).

In comparison/historical note, XSPEC basically 

a) forces the channels to start at 1
b) drops "bad" channels so you never see them
c) if there's grouping then the "channel" number actually refers to the group number, and not the PI/PHA channel value

I assume the existing (changed in this PR) behaviour of "adding 1 if the channels start at 0" was in part because of a).

# Example

In the following I use the SWIFT dataset we have, which starts at CHANNEL=0, and show that filtering/grouping gives the same result when using energy space. If you switch to channel space then the channel values now are 1 less than they were, as is the X axis of the data plot when displayed in channels.

## CIAO 4.16 behaviour

```
sherpa In [1]: load_pha("target_sr.pha")

sherpa In [2]: load_rmf("swxpc0to12s6_20130101v014.rmf.gz")
/home/dburke/micromamba/envs/ciao416/lib/python3.11/site-packages/sherpa/astro/data.py:859: UserWarning: The minimum ENERG_LO in the RMF 'swxpc0to12s6_20130101v014.rmf.gz' was 0 and has been replaced by 1e-10
  warnings.warn(wmsg)

sherpa In [3]: load_arf("target_sr.arf")
/home/dburke/micromamba/envs/ciao416/lib/python3.11/site-packages/sherpa/astro/data.py:859: UserWarning: The minimum ENERG_LO in the ARF 'target_sr.arf' was 0 and has been replaced by 1e-10
  warnings.warn(wmsg)

sherpa In [4]: notice(0.5, 6)
dataset 1: 0:10.24 -> 0.5:6 Energy (keV)

sherpa In [5]: group_counts(5)
dataset 1: 0.5:6 Energy (keV) (unchanged)

sherpa In [6]: dp = get_data_plot()

sherpa In [7]: print(dp.x)
[0.535      0.655      0.77500001 0.85499999 0.95999998 1.04500002
 1.11000001 1.39499998 1.76999998 2.45499998 4.505     ]

sherpa In [8]: print(dp.y)
[1.48430207e-02 7.33419700e-03 1.48430207e-02 1.15445738e-02
 8.65842752e-03 2.49362366e-02 1.29876542e-02 2.12043127e-03
 3.99619762e-03 9.36046243e-04 6.94990863e-05]

sherpa In [9]: notice()
dataset 1: 0.5:6 -> 0:10.24 Energy (keV)

sherpa In [10]: set_analysis("channel")
dataset 1: 1:1024 Channel

sherpa In [11]: set_analysis("energy")
dataset 1: 0:10.24 Energy (keV)

sherpa In [12]: notice(0.5, 6)
dataset 1: 0:10.24 -> 0.5:6 Energy (keV)

sherpa In [13]: set_analysis("channel")
dataset 1: 51:600 Channel

sherpa In [14]: notice(lo=41, hi=600)
dataset 1: 51:600 -> 41:600 Channel

sherpa In [15]: set_analysis("energy")
dataset 1: 0.4:6 Energy (keV)

sherpa In [16]: dp = get_data_plot()

sherpa In [17]: print(dp.x)
[0.405      0.41499999 0.425      0.435      0.44499999 0.455
 0.465      0.47499999 0.485      0.495      0.535      0.655
 0.77500001 0.85499999 0.95999998 1.04500002 1.11000001 1.39499998
 1.76999998 2.45499998 4.505     ]

sherpa In [18]: print(dp.y)
[0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00
 0.00000000e+00 0.00000000e+00 0.00000000e+00 4.15604934e-02
 0.00000000e+00 0.00000000e+00 1.48430207e-02 7.33419700e-03
 1.48430207e-02 1.15445738e-02 8.65842752e-03 2.49362366e-02
 1.29876542e-02 2.12043127e-03 3.99619762e-03 9.36046243e-04
 6.94990863e-05]

sherpa In [19]: set_analysis("channel")
dataset 1: 41:600 Channel

sherpa In [20]: dp = get_data_plot()

sherpa In [21]: print(dp.x)
[ 41.5  42.5  43.5  44.5  45.5  46.5  47.5  48.5  49.5  50.5  54.5  66.5
  78.5  86.5  97.  105.5 112.  140.5 178.  246.5 451.5]

sherpa In [22]: print(dp.y)
[0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00
 0.00000000e+00 0.00000000e+00 0.00000000e+00 4.15604537e-04
 0.00000000e+00 0.00000000e+00 1.48430192e-04 7.33419772e-05
 1.48430192e-04 1.15445705e-04 8.65842786e-05 2.49362722e-04
 1.29876418e-04 2.12043131e-05 3.99619748e-05 9.36046255e-06
 6.94990865e-07]
```

## This PR

```
In [2]: load_pha("sherpa-test-data/sherpatest/target_sr.pha")

In [3]: load_rmf("sherpa-test-data/sherpatest/swxpc0to12s6_20130101v014.rmf.gz")
/home/dburke/sherpa/sherpa-xspec/sherpa/astro/data.py:873: UserWarning: The minimum ENERG_LO in the RMF 'sherpa-test-data/sherpatest/swxpc0to12s6_20130101v014.rmf.gz' was 0 and has been replaced by 1e-10
  warnings.warn(wmsg)

In [4]: load_arf("sherpa-test-data/sherpatest/target_sr.arf")
/home/dburke/sherpa/sherpa-xspec/sherpa/astro/data.py:873: UserWarning: The minimum ENERG_LO in the ARF 'sherpa-test-data/sherpatest/target_sr.arf' was 0 and has been replaced by 1e-10
  warnings.warn(wmsg)

In [5]: plot_data()

In [6]: notice(0.5, 6)
dataset 1: 0:10.24 -> 0.5:6 Energy (keV)

In [7]: group_counts(5)
dataset 1: 0.5:6 Energy (keV) (unchanged)

In [8]: plot_data()

In [9]: dp = get_data_plot()

In [10]: print(dp.x)
[0.535      0.655      0.77500001 0.85499999 0.95999998 1.04500002
 1.11000001 1.39499998 1.76999998 2.45499998 4.505     ]

In [11]: print(dp.y)
[1.48430207e-02 7.33419700e-03 1.48430207e-02 1.15445738e-02
 8.65842752e-03 2.49362366e-02 1.29876542e-02 2.12043127e-03
 3.99619762e-03 9.36046243e-04 6.94990863e-05]

In [12]: notice()
dataset 1: 0.5:6 -> 0:10.24 Energy (keV)

In [13]: set_analysis("channel")
dataset 1: 0:1023 Channel

In [14]: set_analysis("energy")
dataset 1: 0:10.24 Energy (keV)

In [15]: notice(0.5, 6)
dataset 1: 0:10.24 -> 0.5:6 Energy (keV)

In [16]: set_analysis("channel")
dataset 1: 50:599 Channel

In [17]: notice(lo=40, hi=599)
dataset 1: 50:599 -> 40:599 Channel

In [18]: set_analysis("energy")
dataset 1: 0.4:6 Energy (keV)

In [19]: dp = get_data_plot()

In [20]: print(dp.x)
[0.405      0.41499999 0.425      0.435      0.44499999 0.455
 0.465      0.47499999 0.485      0.495      0.535      0.655
 0.77500001 0.85499999 0.95999998 1.04500002 1.11000001 1.39499998
 1.76999998 2.45499998 4.505     ]

In [21]: print(dp.y)
[0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00
 0.00000000e+00 0.00000000e+00 0.00000000e+00 4.15604934e-02
 0.00000000e+00 0.00000000e+00 1.48430207e-02 7.33419700e-03
 1.48430207e-02 1.15445738e-02 8.65842752e-03 2.49362366e-02
 1.29876542e-02 2.12043127e-03 3.99619762e-03 9.36046243e-04
 6.94990863e-05]

In [22]: set_analysis("channel")
dataset 1: 40:599 Channel

In [23]: dp = get_data_plot()

In [24]: print(dp.x)
[ 40.5  41.5  42.5  43.5  44.5  45.5  46.5  47.5  48.5  49.5  53.5  65.5
  77.5  85.5  96.  104.5 111.  139.5 177.  245.5 450.5]

In [25]: print(dp.y)
[0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00
 0.00000000e+00 0.00000000e+00 0.00000000e+00 4.15604537e-04
 0.00000000e+00 0.00000000e+00 1.48430192e-04 7.33419772e-05
 1.48430192e-04 1.15445705e-04 8.65842786e-05 2.49362722e-04
 1.29876418e-04 2.12043131e-05 3.99619748e-05 9.36046255e-06
 6.94990865e-07]
```