### PR TITLE
Improve handling of STAT/SYS_ERR PHA columns

### DIFF
--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -1803,8 +1803,9 @@ def _reconstruct_rmf(rmf: RMFType) -> DataType:
             "F_CHAN": f_chan_out,
             "N_CHAN": n_chan_out,
             "MATRIX": matrix_out,
-            "NUMGRP": numgrp,
-            "NUMELT": numelt}
+            # Ensure these are integer types
+            "NUMGRP": int(numgrp),
+            "NUMELT": int(numelt)}
 
 
 def _pack_rmf(dataset: RMFType) -> BlockList:

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -793,7 +793,7 @@ def _process_pha_block(filename: str,
     #
     # However, we can have values of 0, which is not useful for
     # Sherpa, so we remove them (this is likely pointing at the
-    # handling of the POISERR keyword being sub-optimal).
+    # handling of the POISERR keyword being suboptimal).
     #
     staterr = get("STAT_ERR", expand=True)
     syserr = get("SYS_ERR", expand=True)

--- a/sherpa/astro/tests/test_astro_data_asca_unit.py
+++ b/sherpa/astro/tests/test_astro_data_asca_unit.py
@@ -282,7 +282,7 @@ def check_rmf0(rmf):
 
     # Expect the upper edge of bin j to equal the lower
     # edge of bin j + 1. Note that we check that the low
-    # bin has been relpaced (i.e. is not 0.0).
+    # bin has been replaced (i.e. is not 0.0).
     #
     assert rmf.energ_lo[1:] == pytest.approx(rmf.energ_hi[:-1])
     assert rmf.energ_lo[0] == pytest.approx(0.20000000298023)
@@ -343,7 +343,7 @@ def check_rmf1(rmf):
 
     # Expect the upper edge of bin j to equal the lower
     # edge of bin j + 1. Note that we check that the low
-    # bin has been relpaced (i.e. is not 0.0).
+    # bin has been replaced (i.e. is not 0.0).
     #
     assert rmf.energ_lo[1:] == pytest.approx(rmf.energ_hi[:-1])
     assert rmf.energ_lo[0] == pytest.approx(0.20000000298023)

--- a/sherpa/astro/tests/test_astro_data_asca_unit.py
+++ b/sherpa/astro/tests/test_astro_data_asca_unit.py
@@ -1,0 +1,869 @@
+#
+#  Copyright (C) 2024
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Test handling of ASCA data.
+
+This has the advantage of having, in our test data
+
+- CHANNEL=0 and CHANNEL=1
+- different DETCHAN values
+
+"""
+
+import numpy as np
+
+import pytest
+
+from sherpa.astro.data import DataARF, DataPHA, DataRMF
+from sherpa.astro import io
+from sherpa.astro import ui
+from sherpa.utils.err import IdentifierErr, IOErr
+from sherpa.utils.logging import SherpaVerbosity
+from sherpa.utils.testing import requires_data, requires_fits, requires_xspec
+
+
+# We have an ASCA SIS file which uses offset=0 and another with
+# offset=1, so check both.
+#
+PHA0FILE = "s0_mar24_bin.pha"
+ARF0FILE = "s0_mar24.arf"
+RMF0FILE = "s0_mar24.rmf"
+
+PHA1FILE = "sis0.pha"
+ARF1FILE = "sis0.arf"
+RMF1FILE = "sis0.rmf"
+
+
+def check_pha0(pha, errors=True, responses=True):
+    """Does the data match expectation?"""
+
+    assert isinstance(pha, DataPHA)
+
+    assert pha.exposure == pytest.approx(33483.25)
+    assert pha.backscal == pytest.approx(4.4189453125e-2)
+    assert pha.areascal == pytest.approx(1.0)
+
+    nchan = 512
+    assert pha.channel == pytest.approx(np.arange(1, nchan + 1))
+
+    assert len(pha.counts) == nchan
+    assert pha.counts.min() == pytest.approx(0.0)
+    assert pha.counts.max() == pytest.approx(35.0)
+    assert pha.counts.sum() == pytest.approx(1688.0)
+    assert np.argmax(pha.counts) == 36
+
+    for field in ['staterror', 'bin_lo', 'bin_hi']:
+        assert getattr(pha, field) is None
+
+    # Note this file has systematic, not statistical, errors.
+    # Even if they are all 0.0.
+    #
+    if errors:
+        assert len(pha.syserror) == nchan
+        assert pha.syserror.min() == pytest.approx(0.0)
+        assert np.ptp(pha.syserror) == 0.0
+
+    else:
+        assert pha.syserror is None
+
+    assert len(pha.grouping) == nchan
+    assert len(pha.quality) == nchan
+
+    assert sum(pha.grouping == 1) == 79
+    assert sum(pha.grouping == -1) == (nchan - 79)
+
+    assert sum(pha.quality == 0) == 496
+    assert pha.quality[0] == 0
+    assert pha.quality[17] == 0
+    vals = pha.quality[np.arange(1, 17)]
+    assert vals[0] == 5
+    assert np.ptp(vals) == 0
+
+    assert pha.grouped
+    assert pha.subtracted is False
+    assert pha.rate
+    assert pha.plot_fac == 0
+    assert pha.background_ids == []
+    assert pha.get_background() is None
+
+    if responses:
+        assert pha.units == 'energy'
+        assert pha.response_ids == [1]
+
+        barf, brmf = pha.get_response()
+        assert barf.name.endswith("/s0_mar24.arf")
+        assert brmf.name.endswith("/s0_mar24.rmf")
+
+    else:
+        assert pha.units == 'channel'
+        assert pha.response_ids == []
+
+    # Select a few header keywords. Some are OGIP related,
+    # some are "we expect them", and some are there just to
+    # check we encode the type / value correctly.
+    #
+    assert pha.header["HDUCLASS"] == "OGIP"
+    assert pha.header["HDUCLAS1"] == "SPECTRUM"
+    assert pha.header["HDUCLAS2"] == ""
+    assert pha.header["HDUCLAS3"] == "COUNT"
+    assert pha.header["DETCHANS"] == nchan
+    assert pha.header["CHANTYPE"] == "PI"
+
+    # This keyword is removed from the header.
+    assert "POISERR" not in pha.header
+
+    assert pha.header["TELESCOP"] == "ASCA"
+    assert pha.header["INSTRUME"] == "SIS0"
+    assert pha.header["FILTER"] == "NONE"
+    assert pha.header["OBJECT"] == "HE_1104-1805"
+
+
+def check_pha1(pha, errors=True, responses=True):
+    """Does the data match expectation?
+
+    For this file neither option does anything,
+    """
+
+    assert isinstance(pha, DataPHA)
+
+    assert pha.exposure == pytest.approx(28677.96586243063)
+    assert pha.backscal == pytest.approx(2.550781332e-2)
+    assert pha.areascal == pytest.approx(1.0)
+
+    nchan = 1024
+    assert pha.channel == pytest.approx(np.arange(1, nchan + 1))
+
+    assert len(pha.counts) == nchan
+    assert pha.counts.min() == pytest.approx(0.0)
+    assert pha.counts.max() == pytest.approx(487.0)
+    assert pha.counts.sum() == pytest.approx(50389.0)
+    assert np.argmax(pha.counts) == 85
+
+    for field in ['staterror', 'syserror',
+                  'bin_lo', 'bin_hi',
+                  'grouping', 'quality'
+                  ]:
+        assert getattr(pha, field) is None
+
+    assert pha.grouped is False
+    assert pha.subtracted is False
+    assert pha.units == 'channel'
+    assert pha.rate
+    assert pha.plot_fac == 0
+    assert pha.background_ids == []
+    assert pha.response_ids == []
+    assert pha.get_background() is None
+
+    # Select a few header keywords. Some are OGIP related,
+    # some are "we expect them", and some are there just to
+    # check we encode the type / value correctly.
+    #
+    assert pha.header["HDUCLASS"] == "OGIP"
+    assert pha.header["HDUCLAS1"] == "SPECTRUM"
+    assert pha.header["HDUCLAS2"] == ""
+    assert pha.header["HDUCLAS3"] == "COUNT"
+    assert pha.header["DETCHANS"] == nchan
+    assert pha.header["CHANTYPE"] == "PI"
+
+    # This keyword is removed from the header.
+    assert "POISERR" not in pha.header
+
+    assert pha.header["TELESCOP"] == "ASCA"
+    assert pha.header["INSTRUME"] == "SIS0"
+    assert pha.header["FILTER"] == "none"
+    assert pha.header["OBJECT"] == "A2029"
+
+
+def check_arf0(arf):
+    """Does the ARF contain the expected values?"""
+
+    assert isinstance(arf, DataARF)
+
+    nbins = 1180
+
+    # Expect the upper edge of bin j to equal the lower
+    # edge of bin j + 1.
+    #
+    assert len(arf.energ_lo) == nbins
+    assert (arf.energ_lo[1:] == arf.energ_hi[:-1]).all()
+    assert arf.energ_lo[0] == pytest.approx(0.20000000298023)
+    assert arf.energ_hi[0] == pytest.approx(0.21000000834465)
+    assert arf.energ_lo[-1] == pytest.approx(11.9901790619)
+    assert arf.energ_hi[-1] == pytest.approx(12.0)
+
+    # Rather than check each element, use some simple summary
+    # statistics.
+    #
+    assert len(arf.specresp) == nbins
+    assert arf.specresp.min() == pytest.approx(5.23834753036499)
+    assert arf.specresp.max() == pytest.approx(221.3942108154297)
+    assert arf.specresp.sum() == pytest.approx(115339.06293487549)
+    assert np.argmax(arf.specresp) == 193
+
+    for field in ['bin_lo', 'bin_hi', 'exposure']:
+        assert getattr(arf, field) is None
+
+
+def check_arf1(arf):
+    """Does the ARF contain the expected values?"""
+
+    assert isinstance(arf, DataARF)
+
+    nbins = 1180
+
+    # Expect the upper edge of bin j to equal the lower
+    # edge of bin j + 1.
+    #
+    assert len(arf.energ_lo) == nbins
+    assert (arf.energ_lo[1:] == arf.energ_hi[:-1]).all()
+    assert arf.energ_lo[0] == pytest.approx(0.20000000298023)
+    assert arf.energ_hi[0] == pytest.approx(0.21000000834465)
+    assert arf.energ_lo[-1] == pytest.approx(11.9901790619)
+    assert arf.energ_hi[-1] == pytest.approx(12.0)
+
+    # Rather than check each element, use some simple summary
+    # statistics.
+    #
+    assert len(arf.specresp) == nbins
+    assert arf.specresp.min() == pytest.approx(5.3960146904)
+    assert arf.specresp.max() == pytest.approx(235.13063049)
+    assert arf.specresp.sum() == pytest.approx(125779.58236)
+    assert np.argmax(arf.specresp) == 194
+
+    for field in ['bin_lo', 'bin_hi', 'exposure']:
+        assert getattr(arf, field) is None
+
+
+def check_rmf0(rmf):
+    """Does the RMF contain the expected values?"""
+
+    assert isinstance(rmf, DataRMF)
+
+    nchans = 512
+    nbins = 1180
+    nsize1 = 1189
+    nsize2 = 260775
+
+    assert rmf.detchans == nchans
+    assert rmf.offset == 0
+
+    for field in ['energ_lo', 'energ_hi']:
+        assert getattr(rmf, field).size == nbins
+
+    assert rmf.n_grp.size == nbins
+    assert rmf.n_grp.min() == 0
+    assert rmf.n_grp.max() == 2
+    assert rmf.n_grp.sum() == nsize1
+
+    assert rmf.f_chan.size == nsize1
+    assert rmf.f_chan.min() == 14
+    assert rmf.f_chan.max() == 19
+    assert rmf.f_chan.sum() == 16711
+
+    assert rmf.n_chan.size == nsize1
+    assert rmf.n_chan.min() == 1
+    assert rmf.n_chan.max() == 426
+    assert rmf.n_chan.sum() == nsize2
+
+    assert rmf.matrix.size == nsize2
+    assert rmf.matrix.min() == pytest.approx(1.0003149952808599e-07)
+    assert rmf.matrix.max() == pytest.approx(0.11968599259853363)
+    assert rmf.matrix.sum() == pytest.approx(544.8837793875416)
+    assert np.argmax(rmf.matrix) == 4307
+
+    for field in ['e_min', 'e_max']:
+        assert getattr(rmf, field).size == nchans
+
+    # Expect the upper edge of bin j to equal the lower
+    # edge of bin j + 1. Note that we check that the low
+    # bin has been relpaced (i.e. is not 0.0).
+    #
+    assert rmf.energ_lo[1:] == pytest.approx(rmf.energ_hi[:-1])
+    assert rmf.energ_lo[0] == pytest.approx(0.20000000298023)
+    assert rmf.energ_hi[0] == pytest.approx(0.21000000834465)
+    assert rmf.energ_lo[-1] == pytest.approx(11.9901790619)
+    assert rmf.energ_hi[-1] == pytest.approx(12.0)
+
+    assert rmf.e_min[1:] == pytest.approx(rmf.e_max[:-1])
+    assert rmf.e_min[0] == pytest.approx(0.013292968273162842)
+    assert rmf.e_max[0] == pytest.approx(0.04193559288978577)
+    assert rmf.e_min[-1] == pytest.approx(14.649674415588379)
+    assert rmf.e_max[-1] == pytest.approx(14.678317070007324)
+
+
+def check_rmf1(rmf):
+
+    assert isinstance(rmf, DataRMF)
+
+    nchans = 1024
+    nbins = 1180
+    nsize1 = 1171
+    nsize2 = 505483
+
+    assert rmf.detchans == nchans
+    assert rmf.offset == 1
+
+    for field in ['energ_lo', 'energ_hi']:
+        assert getattr(rmf, field).size == nbins
+
+    assert rmf.n_grp.size == nbins
+    assert rmf.n_grp.min() == 0
+    assert rmf.n_grp.max() == 1
+    assert rmf.n_grp.sum() == nsize1
+
+    assert rmf.f_chan.size == nsize1
+    assert rmf.f_chan.min() == 26
+    assert rmf.f_chan.max() == 26
+    assert rmf.f_chan.sum() == 30446
+
+    assert rmf.n_chan.size == nsize1
+    assert rmf.n_chan.min() == 1
+    assert rmf.n_chan.max() == 851
+    assert rmf.n_chan.sum() == nsize2
+
+    assert rmf.matrix.size == nsize2
+    # TODO: asking for the min value causes this test to hang on my
+    # machine. I can read in the file outside of the test and get
+    # the minimum value. Why is it just here?
+    #
+    # assert rmf.matrix.min() == pytest.approx(1.0003149952808599e-7)
+    assert (rmf.matrix > 1e-7).all()  # approximate the above
+    assert rmf.matrix.max() == pytest.approx(0.11497905850410461)
+    assert rmf.matrix.sum() == pytest.approx(552.932040504181)
+    assert np.argmax(rmf.matrix) == 7324
+
+    for field in ['e_min', 'e_max']:
+        assert getattr(rmf, field).size == nchans
+
+    # Expect the upper edge of bin j to equal the lower
+    # edge of bin j + 1. Note that we check that the low
+    # bin has been relpaced (i.e. is not 0.0).
+    #
+    assert rmf.energ_lo[1:] == pytest.approx(rmf.energ_hi[:-1])
+    assert rmf.energ_lo[0] == pytest.approx(0.20000000298023)
+    assert rmf.energ_hi[0] == pytest.approx(0.21000000834465)
+    assert rmf.energ_lo[-1] == pytest.approx(11.9901790619)
+    assert rmf.energ_hi[-1] == pytest.approx(12.0)
+
+    assert rmf.e_min[1:] == pytest.approx(rmf.e_max[:-1])
+    assert rmf.e_min[0] == pytest.approx(0.0)
+    assert rmf.e_max[0] == pytest.approx(0.013666952028870583)
+    assert rmf.e_min[-1] == pytest.approx(14.228230476379395)
+    assert rmf.e_max[-1] == pytest.approx(14.240230560302734)
+
+
+def record_starts_with(r, start, level="INFO"):
+    """This only checks the start of the message, as it contains
+    test-specific information (the location of the file name).
+    """
+
+    assert r.name == "sherpa.astro.io"
+    assert r.levelname == level
+
+    # We use this, rather than msg.startswith(start), as the error
+    # message is more useful if there is a difference.
+    #
+    nchar = len(start)
+    msg = r.getMessage()
+    assert msg[:nchar] == start
+
+
+# Since the log messages we get for the PHA0 and PHA1 cases are
+# different, it's easiest just to repeat the tests rather than to try
+# and write a single test.
+#
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("errors", [False, pytest.param(True, marks=pytest.mark.xfail)])  # issue #2117
+def test_read_pha0(errors, make_data_path, caplog):
+    """Can we read in an ASCS PHA file."""
+
+    with SherpaVerbosity("INFO"):
+        infile = make_data_path(PHA0FILE)
+
+    pha = io.read_pha(infile, use_errors=errors)
+    check_pha0(pha, errors=errors, responses=True)
+
+    # What messages were created?
+    if errors:
+        assert len(caplog.records) == 3
+        idx = 0
+    else:
+        assert len(caplog.records) == 4
+
+        rec = caplog.records[0]
+        record_starts_with(rec,
+                           "statistical and systematic errors were found in file '/")
+
+        idx = 1
+
+    rec = caplog.records[idx]
+    record_starts_with(rec, "read ARF file /")
+
+    idx +=1
+    rec = caplog.records[idx]
+    record_starts_with(rec, "read RMF file /")
+
+    idx +=1
+    rec = caplog.records[idx]
+
+    # The end of the message comes from the I/O backend and we do not
+    # bother testing that here.
+    #
+    record_starts_with(rec, "unable to read background: ",
+                       level="WARNING")
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("errors", [False, pytest.param(True, marks=pytest.mark.xfail)])  # issue #2117
+def test_read_pha1(errors, make_data_path, caplog):
+    """Can we read in an ASCS PHA file."""
+
+    with SherpaVerbosity("INFO"):
+        infile = make_data_path(PHA1FILE)
+
+    pha = io.read_pha(infile, use_errors=errors)
+    check_pha1(pha, errors=errors, responses=True)
+
+    # What messages were created?
+    if errors:
+        assert len(caplog.records) == 0
+        return
+
+    assert len(caplog.records) == 2
+
+    rec = caplog.records[0]
+    record_starts_with(rec, "systematic errors were not found in file '/",
+                       level="WARNING")
+
+    rec = caplog.records[1]
+    record_starts_with(rec, "statistical errors were found in file '/")
+
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("errors", [False, pytest.param(True, marks=pytest.mark.xfail)])  # issue #2117
+def test_roundtrip_pha0(errors, make_data_path, tmp_path, caplog):
+    """Can we write out an ASCA PHA file and then read it back in?"""
+
+    infile = make_data_path(PHA0FILE)
+    with SherpaVerbosity("ERROR"):
+        pha1 = io.read_pha(infile, use_errors=errors)
+
+    assert len(caplog.records) == 0
+
+    outpath = tmp_path / "test.pha"
+    outfile = str(outpath)
+    io.write_pha(outfile, pha1, ascii=False, clobber=True)
+
+    with SherpaVerbosity("INFO"):
+        pha2 = io.read_pha(outfile, use_errors=errors)
+
+    check_pha0(pha2, responses=False, errors=errors)
+
+    # What messages were created?
+    if errors:
+        assert len(caplog.records) == 2
+        idx = 0
+    else:
+        assert len(caplog.records) == 4
+
+        rec = caplog.records[0]
+        record_starts_with(rec,
+                           "systematic errors were not found in file '/",
+                           level="WARNING")
+
+        rec = caplog.records[1]
+        record_starts_with(rec,
+                           "statistical errors were found in file '/")
+
+        idx = 2
+
+    # The end of the message comes from the I/O backend and we do not
+    # bother testing that here.
+    #
+    rec = caplog.records[idx]
+    record_starts_with(rec, "unable to read ARF: ",
+                       level="WARNING")
+
+    idx += 1
+    rec = caplog.records[idx]
+    record_starts_with(rec, "unable to read RMF: ",
+                       level="WARNING")
+
+    # TODO: why does this no-longer mention being unable to read in
+    # the background?
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("errors", [False, pytest.param(True, marks=pytest.mark.xfail)])  # issue #2117
+def test_roundtrip_pha1(errors, make_data_path, tmp_path, caplog):
+    """Can we write out an ASCA PHA file and then read it back in?"""
+
+    infile = make_data_path(PHA1FILE)
+    with SherpaVerbosity("ERROR"):
+        pha1 = io.read_pha(infile, use_errors=errors)
+
+    assert len(caplog.records) == 0
+
+    outpath = tmp_path / "test.pha"
+    outfile = str(outpath)
+    io.write_pha(outfile, pha1, ascii=False, clobber=True)
+
+    with SherpaVerbosity("INFO"):
+        pha2 = io.read_pha(outfile, use_errors=errors)
+
+    check_pha1(pha2, responses=False, errors=errors)
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("filename,check",
+                         [(ARF0FILE, check_arf0),
+                          (ARF1FILE, check_arf1)])
+def test_read_arf(filename, check, make_data_path):
+    """Can we read in an ASCA ARF."""
+
+    infile = make_data_path(filename)
+    arf = io.read_arf(infile)
+    check(arf)
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("filename,check",
+                         [(ARF0FILE, check_arf0),
+                          (ARF1FILE, check_arf1)])
+def test_roundtrip_arf(filename, check, make_data_path, tmp_path):
+    """Can we write out an ASCA ARF file and then read it back in?"""
+
+    infile = make_data_path(filename)
+    arf1 = io.read_arf(infile)
+
+    outpath = tmp_path / "test.arf"
+    outfile = str(outpath)
+    io.write_arf(outfile, arf1, ascii=False, clobber=True)
+
+    arf2 = io.read_arf(outfile)
+    check(arf2)
+
+
+def validate_record(r):
+    """Check it represents the expected log output."""
+
+    assert r.name == "sherpa.astro.io"
+    assert r.levelname == "ERROR"
+    msg = r.getMessage()
+
+    # Can use startswith/endswith, but then the error message when the
+    # test fails is less useful. This way pytest reports the location
+    # of the difference.
+    #
+    assert msg[:62] == "Failed to locate TLMIN keyword for F_CHAN column in RMF file '"
+    assert msg[-102:] == "sis0.rmf'; Update the offset value in the RMF data set to the appropriate TLMIN value prior to fitting"
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("filename,check,tlmin",
+                         [(RMF0FILE, check_rmf0, False),
+                          (RMF1FILE, check_rmf1, True)])
+def test_read_rmf(filename, check, tlmin, make_data_path, caplog):
+    """Can we read in an ASCA RMF."""
+
+    infile = make_data_path(filename)
+    with SherpaVerbosity("INFO"):
+        rmf = io.read_rmf(infile)
+
+    if tlmin:
+        assert len(caplog.records) == 1
+        validate_record(caplog.records[0])
+    else:
+        assert len(caplog.records) == 0
+
+    check(rmf)
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("filename,check,tlmin",
+                         [(RMF0FILE, check_rmf0, False),
+                          (RMF1FILE, check_rmf1, True)])
+def test_roundtrip_rmf(filename, check, tlmin, make_data_path, tmp_path, caplog):
+    """Can we write out an ASCA RMF file and then read it back in?"""
+
+    infile = make_data_path(filename)
+    with SherpaVerbosity("INFO"):
+        rmf1 = io.read_rmf(infile)
+
+    if tlmin:
+        assert len(caplog.records) == 1
+        validate_record(caplog.records[0])
+        ntot = 1
+    else:
+        assert len(caplog.records) == 0
+        ntot = 0
+
+    outpath = tmp_path / "test.rmf"
+    outfile = str(outpath)
+    with SherpaVerbosity("INFO"):
+        io.write_rmf(outfile, rmf1, clobber=True)
+
+    # Note that the TLMIN value is written out so there is no more
+    # message about the value being missing.
+    #
+    with SherpaVerbosity("INFO"):
+        rmf2 = io.read_rmf(outfile)
+
+    check(rmf2)
+    assert len(caplog.records) == ntot
+
+
+@pytest.mark.xfail  # issue #2117
+@requires_xspec
+@requires_data
+@requires_fits
+def test_can_use_pha0(make_data_path, clean_astro_ui):
+    """A basic check that we can use the ASCA data.
+
+    Unlike the previous tests, that directly access the io module,
+    this uses the ui interface.
+    """
+
+    ui.set_stat("chi2xspecvar")
+
+    # Load the errors to match XSPEC.
+    #
+    ui.load_pha(make_data_path(PHA0FILE), use_errors=True)
+    assert ui.get_analysis() == 'energy'
+
+    assert ui.get_arf().name.endswith("/s0_mar24.arf")
+    assert ui.get_rmf().name.endswith("/s0_mar24.rmf")
+    with pytest.raises(IdentifierErr):
+        assert ui.get_bkg()
+
+    # As noted below, this drops the first bin that XSPEC uses. XSPEC
+    # reports mid-energy values for its first 5 groups as:
+    #
+    #    2.76142806E-2
+    #    0.27107656
+    #    0.514538884
+    #    0.557502866
+    #    0.614788055
+    #
+    # In CIAO 4.16 we have "collapsed" the first three groups as our
+    # first couple of bins are
+    #
+    #        mid     |     lo      |      hi
+    #    0.27107659    0.01329297     0.52886021
+    #    0.55750284    0.52886021     0.58614546
+    #    0.61478809    0.58614546     0.64343071
+    #
+    # This is because some of the channels are labelled "bad"
+    #
+    # % dmlist s0_mar24_bin.pha"[cols -sys_err][#row=:24]" data,clean
+    # #  CHANNEL COUNTS     QUALITY    GROUPING
+    #       0          0          0          1
+    #       1          0          5         -1
+    #       2          0          5         -1
+    #       3          0          5         -1
+    #       4          0          5         -1
+    #       5          0          5         -1
+    #       6          0          5         -1
+    #       7          0          5         -1
+    #       8          0          5         -1
+    #       9          0          5         -1
+    #      10          0          5         -1
+    #      11          0          5         -1
+    #      12          0          5         -1
+    #      13          0          5         -1
+    #      14         13          5         -1
+    #      15         15          5         -1
+    #      16          8          5         -1
+    #      17         17          0         -1
+    #      18         12          0          1
+    #      19          9          0         -1
+    #      20          7          0          1
+    #      21         12          0         -1
+    #      22         18          0          1
+    #      23         15          0          1
+    #
+    # So, does XSPEC ignore the QUALITY=5 rows so it treats the
+    # first group as channels 0 and 17,
+    # second group as channels 18 and 19 ?
+    #
+    ui.ignore(hi=0.5)
+    ui.ignore(lo=7.0)
+
+    ui.set_source(ui.xsphabs.gal * ui.powlaw1d.pl)
+    ui.set_par('gal.nh', 0.05)
+    ui.set_par('pl.gamma', 1.7)
+    ui.set_par('pl.ampl', 2.7e-4)
+
+    # Value obtained from XSPEC 12.14.1
+    #
+    #    XSPEC12> data s0_mar24_bin.pha
+    #    - complains about FILTER none/NONE mis-match
+    #    - complains about missing background
+    #    XSPEC12> setplot energy
+    #    XSPEC12> ignore **-0.5,7.0-**
+    #    - reports ignores "channels" 1-2 and 74-81
+    #    XSPEC12> mo phabs * powerlaw
+    #    XSPEC12> newpar 1 0.05
+    #    XSPEC12> newpar 2 1.7
+    #    XSPEC12> newpar 3 2.7e-4
+    #    - reports a statistic of 69.34
+    #
+
+    # XSPEC reports 71, we get 70 (CIAO 4.16)
+    #
+    NBINS = 70
+
+    # XSPEC reports 69.34
+    #
+    STATVAL = 65.06460092188946
+
+    s = ui.get_stat_info()[0]
+    assert s.numpoints == NBINS
+    assert s.dof == (NBINS - 3)
+
+    assert s.statval == pytest.approx(STATVAL, rel=0, abs=0.005)
+
+    # The plot data starts
+    #
+    #   0.514538884 1.43213272E-2 1.77258905E-2 4.29915963E-3 8.83223955E-3
+    #   0.557502866 2.86426246E-2 1.09483553E-2 2.38912692E-3 7.78075447E-3
+    #
+    # and ends with
+    #
+    #  5.79910278 0.229140997 9.77531774E-4 2.52397615E-4 8.68383213E-4
+    #  6.35763454 0.329390287 6.80021825E-4 1.75580892E-4 5.45510848E-4
+    #
+    fp = ui.get_fit_plot()
+    dp = fp.dataplot
+    mp = fp.modelplot
+
+    assert len(dp.x) == NBINS
+
+    assert dp.xlo[0] == pytest.approx(0.52886021)
+    assert dp.xhi[0] == pytest.approx(0.58614546)
+    assert dp.x[0] == pytest.approx(0.55750284)
+
+    assert dp.xlo[-1] == pytest.approx(6.02824402)
+    assert dp.xhi[-1] == pytest.approx(6.68702459)
+    assert dp.x[-1] == pytest.approx(6.35763431)
+
+    # Check the model values, as they get convolved through the
+    # response, and then filtered and grouped (since using the
+    # modelplot from a fit rather than from get_model_plot, which is
+    # ungrouped).
+    #
+    assert len(mp.y) == NBINS
+
+    # Values from XSPEC:
+    #
+    assert mp.y[0] == pytest.approx(7.78075447E-3)
+    assert mp.y[-1] == pytest.approx(5.45510848e-4)
+
+
+@pytest.mark.xfail  # issue #2117
+@requires_xspec
+@requires_data
+@requires_fits
+def test_can_use_pha1(make_data_path, clean_astro_ui):
+    """A basic check that we can use the ASCA data.
+
+    Unlike the previous tests, that directly access the io module,
+    this uses the ui interface.
+    """
+
+    ui.set_stat("chi2xspecvar")
+
+    # Load the errors to match XSPEC.
+    #
+    ui.load_pha(make_data_path(PHA1FILE), use_errors=True)
+    assert ui.get_analysis() == 'channel'
+
+    ui.load_rmf(make_data_path("sis0.rmf"))
+    ui.load_arf(make_data_path("sis0.arf"))
+
+    assert ui.get_analysis() == 'energy'
+
+    with pytest.raises(IdentifierErr):
+        assert ui.get_bkg()
+
+    ui.ignore(hi=0.4)
+    ui.ignore(lo=7.0)
+
+    # This is not a great fit. Use mekal rather than apec in the
+    # assumption it isn't going to change significantly over time.
+    #
+    ui.set_source(ui.xsphabs.gal * ui.xsmekal.clus)
+    ui.set_par('gal.nh', 0.09)
+    ui.set_par('clus.kt', 5.9)
+    ui.set_par('clus.abundanc', 0.3)
+    ui.set_par('clus.redshift', 0.0767)
+    ui.set_par('clus.norm', 4.65e-2)
+
+    # Value obtained from XSPEC 12.14.1
+    #
+    #    XSPEC12> data s0_mar24_bin.pha
+    #    - complains about FILTER none/NONE mis-match
+    #    - complains about missing background
+    #    XSPEC12> setplot energy
+    #    XSPEC12> ignore **-0.5,7.0-**
+    #    - reports ignores "channels" 1-2 and 74-81
+    #    XSPEC12> mo phabs * mekal
+    #    XSPEC12> newpar 1 9e-2
+    #    XSPEC12> newpar 2 5.9
+    #    XSPEC12> newpar 4 0.3
+    #    XSPEC12> newpar 7 4.65e-2
+    #    - reports a statistic of 544.23
+    #
+
+    NBINS = 450
+    STATVAL = 544.23
+
+    s = ui.get_stat_info()[0]
+    assert s.numpoints == NBINS
+    assert s.dof == (NBINS - 3)
+
+    assert s.statval == pytest.approx(STATVAL, rel=0, abs=0.005)
+
+    fp = ui.get_fit_plot()
+    dp = fp.dataplot
+    mp = fp.modelplot
+
+    assert len(dp.x) == NBINS
+    assert len(mp.y) == NBINS
+
+    # Values taken from
+    #
+    #   XSPEC12> iplot
+    #   PLT> wdata foo.txt
+    #
+    assert dp.x[0] == pytest.approx(0.416999876)
+    assert dp.x[-1] == pytest.approx(6.98360157)
+
+    assert mp.y[0] == pytest.approx(0.153414682)
+    assert mp.y[-1] == pytest.approx(1.06004886e-2)

--- a/sherpa/astro/tests/test_astro_data_chandra_unit.py
+++ b/sherpa/astro/tests/test_astro_data_chandra_unit.py
@@ -1,0 +1,675 @@
+#
+#  Copyright (C) 2024
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Test handling of Chandra data.
+
+Most of the Chandra testing is done in other files.
+
+"""
+
+import numpy as np
+
+import pytest
+
+from sherpa.astro.data import DataARF, DataPHA, DataRMF
+from sherpa.astro import io
+from sherpa.astro import ui
+from sherpa.utils.err import IOErr
+from sherpa.utils.logging import SherpaVerbosity
+from sherpa.utils.testing import requires_data, requires_fits
+
+
+# We potentially have different instruments to test.
+#
+PHAFILE = "obs3.pi"
+ARFFILE = "obs3.arf"
+RMFFILE = "obs3.rmf"
+PHA_EXPOSURE = 68936.36552833
+
+PHAFILE_GRATING = "3c120_heg_-1.pha.gz"
+ARFFILE_GRATING = "3c120_heg_-1.arf.gz"
+RMFFILE_GRATING = "3c120_heg_-1.rmf.gz"
+PHA_GRATING_EXPOSURE = 77716.294300039
+ARF_GRATING_EXPOSURE = 77717.297715256
+
+
+def check_pha(pha, responses=True):
+    """Does the data match expectation?"""
+
+    assert isinstance(pha, DataPHA)
+
+    assert pha.exposure == pytest.approx(PHA_EXPOSURE)
+    assert pha.areascal == pytest.approx(1.0)
+    assert pha.backscal == pytest.approx(1.63383e-7)
+
+    nchan = 1024
+    assert pha.channel == pytest.approx(np.arange(1, nchan + 1))
+
+    # Rather than check each element, use some simple summary
+    # statistics.
+    #
+    assert len(pha.counts) == nchan
+    assert pha.counts.min() == pytest.approx(0.0)
+    assert pha.counts.max() == pytest.approx(2.0)
+    assert pha.counts.sum() == pytest.approx(77)
+    assert np.argmax(pha.counts) == 10
+
+    for field in ['staterror', 'syserror', 'quality', 'grouping',
+                  'bin_lo', 'bin_hi']:
+        assert getattr(pha, field) is None
+
+    assert pha.grouped is False
+    assert pha.subtracted is False
+    assert pha.rate
+    assert pha.plot_fac == 0
+
+    if responses:
+        assert pha.units == 'energy'
+        assert pha.response_ids == [1]
+        assert pha.background_ids == [1]
+
+        barf, brmf = pha.get_response()
+        assert barf.name.endswith("/obs3.arf")
+        assert brmf.name.endswith("/obs3.rmf")
+
+        b1 = pha.get_background(1)
+        assert b1.name.endswith("obs3_bg.pi")
+        assert b1.areascal == pytest.approx(1.0)
+        assert b1.backscal == pytest.approx(3.26767e-7)
+        assert b1.exposure == pytest.approx(PHA_EXPOSURE)
+
+        assert b1.counts.min() == pytest.approx(0.0)
+        assert b1.counts.max() == pytest.approx(4.0)
+        assert b1.counts.sum() == pytest.approx(76.0)
+
+    else:
+        assert pha.units == 'channel'
+        assert pha.response_ids == []
+        assert pha.background_ids == []
+
+        assert pha.get_background() is None
+
+    # Select a few header keywords. Some are OGIP related,
+    # some are "we expect them", and some are there just to
+    # check we encode the type / value correctly.
+    #
+    assert pha.header["HDUCLASS"] == "OGIP"
+    assert pha.header["HDUCLAS1"] == "SPECTRUM"
+    assert pha.header["HDUCLAS2"] == "TOTAL"
+    assert pha.header["HDUCLAS3"] == "TYPE:I"
+    assert pha.header["HDUCLAS4"] == "COUNT"
+    assert pha.header["DETCHANS"] == nchan
+    assert pha.header["CHANTYPE"] == "PI"
+
+    # This keyword is removed from the header.
+    assert "POISERR" not in pha.header
+
+    assert pha.header["TELESCOP"] == "CHANDRA"
+    assert pha.header["INSTRUME"] == "ACIS"
+    assert pha.header["GRATING"] == "NONE"
+    assert "FILTER" not in pha.header["FILTER"]
+    assert pha.header["OBJECT"] == "4C19.44"
+
+    assert pha.header["RA_TARG"] == pytest.approx(209.26875)
+    assert pha.header["DEC_TARG"] == pytest.approx(19.316944)
+    assert "RA_OBJ" not in pha.header
+    assert "DEC_OBJ" not in pha.header
+
+
+def check_arf(arf):
+    """Does the ARF contain the expected values?"""
+
+    assert isinstance(arf, DataARF)
+
+    nbins = 1078
+
+    # Expect the upper edge of bin j to equal the lower
+    # edge of bin j + 1.
+    #
+    assert len(arf.energ_lo) == nbins
+    assert (arf.energ_lo[1:] == arf.energ_hi[:-1]).all()
+    assert arf.energ_lo[0] == pytest.approx(0.22)
+    assert arf.energ_hi[0] == pytest.approx(0.23)
+    assert arf.energ_lo[-1] == pytest.approx(10.99)
+    assert arf.energ_hi[-1] == pytest.approx(11.0)
+
+    assert arf.bin_lo is None
+    assert arf.bin_hi is None
+
+    # Rather than check each element, use some simple summary
+    # statistics.
+    #
+    assert len(arf.specresp) == nbins
+    assert arf.specresp.min() == pytest.approx(0.5785124898)
+    assert arf.specresp.max() == pytest.approx(686.1730957)
+    assert arf.specresp.sum() == pytest.approx(254262.18811)
+    assert np.argmax(arf.specresp) == 132
+
+    assert arf.exposure == pytest.approx(PHA_EXPOSURE)
+
+
+def check_rmf(rmf):
+    """Does the RMF contain the expected values?"""
+
+    assert isinstance(rmf, DataRMF)
+
+    nchans = 1024
+    nbins = 1078
+    nsize1 = 1484
+    nsize2 = 429463
+
+    assert rmf.detchans == nchans
+    assert rmf.offset == 1
+
+    for field in ['energ_lo', 'energ_hi']:
+        assert getattr(rmf, field).size == nbins
+
+    assert rmf.n_grp.size == nbins
+    assert rmf.n_grp.min() == 1
+    assert rmf.n_grp.max() == 3
+    assert rmf.n_grp.sum() == nsize1
+
+    assert rmf.f_chan.size == nsize1
+    assert rmf.f_chan.min() == 1
+    assert rmf.f_chan.max() == 728
+    assert rmf.f_chan.sum() == 267802
+
+    assert rmf.n_chan.size == nsize1
+    assert rmf.n_chan.min() == 6
+    assert rmf.n_chan.max() == 1023
+    assert rmf.n_chan.sum() == nsize2
+
+    assert rmf.matrix.size == nsize2
+    assert rmf.matrix.min() == pytest.approx(8.832556908089373e-09)
+    assert rmf.matrix.max() == pytest.approx(0.13701042532920837)
+    assert rmf.matrix.sum() == pytest.approx(1078)
+    assert np.argmax(rmf.matrix) == 5086
+
+    for field in ['e_min', 'e_max']:
+        assert getattr(rmf, field).size == nchans
+
+    # Expect the upper edge of bin j to equal the lower
+    # edge of bin j + 1.
+    #
+    assert rmf.energ_lo[1:] == pytest.approx(rmf.energ_hi[:-1])
+
+    assert rmf.energ_lo[0] == pytest.approx(0.22)
+    assert rmf.energ_hi[0] == pytest.approx(0.23)
+    assert rmf.energ_lo[-1] == pytest.approx(10.99)
+    assert rmf.energ_hi[-1] == pytest.approx(11.0)
+
+    assert len(rmf.e_min) == 1024
+    assert rmf.e_min[1:] == pytest.approx(rmf.e_max[:-1])
+
+    assert rmf.e_min[0] == pytest.approx(0.0014600000577047467)
+    assert rmf.e_max[0] == pytest.approx(0.014600000344216824)
+    assert rmf.e_min[-1] == pytest.approx(14.935799598693848)
+    assert rmf.e_max[-1] == pytest.approx(14.950400352478027)
+
+
+def check_pha_grating(pha, errors=False, responses=True):
+    """Does the data match expectation?"""
+
+    assert isinstance(pha, DataPHA)
+
+    assert pha.exposure == pytest.approx(PHA_GRATING_EXPOSURE)
+    assert pha.areascal == pytest.approx(1.0)
+    assert pha.backscal == pytest.approx(1.0)
+
+    nchan = 8192
+    assert pha.channel == pytest.approx(np.arange(1, nchan + 1))
+
+    # Rather than check each element, use some simple summary
+    # statistics.
+    #
+    assert len(pha.counts) == nchan
+    assert pha.counts.min() == pytest.approx(0.0)
+    assert pha.counts.max() == pytest.approx(15.0)
+    assert pha.counts.sum() == pytest.approx(16298.0)
+    assert np.argmax(pha.counts) == 5871
+
+    assert len(pha.bin_lo) == nchan
+    assert len(pha.bin_hi) == nchan
+    assert pha.bin_hi[1:] == pytest.approx(pha.bin_lo[:-1])
+    assert pha.bin_lo[0] == pytest.approx(21.4775)
+    assert pha.bin_hi[0] == pytest.approx(21.48)
+    assert pha.bin_lo[-1] == pytest.approx(1.0)
+    assert pha.bin_hi[-1] == pytest.approx(1.0025)
+
+    for field in ['syserror', 'quality', 'grouping']:
+        assert getattr(pha, field) is None
+
+    if errors:
+        assert len(pha.staterror) == nchan
+        assert pha.staterror.min() == pytest.approx(1.8660254)
+        assert pha.staterror.max() == pytest.approx(4.968627)
+        assert pha.staterror.sum() == pytest.approx(20342.717)
+    else:
+        assert pha.staterror is None
+
+    assert pha.grouped is False
+    assert pha.subtracted is False
+    assert pha.rate
+    assert pha.plot_fac == 0
+
+    if responses:
+        assert pha.units == 'energy'
+        assert pha.response_ids == [1]
+        assert pha.background_ids == [1, 2]
+
+        barf, brmf = pha.get_response()
+        assert barf.name.endswith("/3c120_heg_-1.arf")
+        assert brmf.name.endswith("/3c120_heg_-1.rmf")
+
+        b1 = pha.get_background(1)
+        b2 = pha.get_background(2)
+        assert b1.name.endswith("3c120_heg_-1.pha.gz")
+        assert b2.name.endswith("3c120_heg_-1.pha.gz")
+
+        for b in [b1, b2]:
+            assert getattr(b, "backscal") == pytest.approx(4.0188284)
+            assert getattr(b, "exposure") == pytest.approx(PHA_GRATING_EXPOSURE)
+            assert getattr(b, "staterror") is None
+
+        assert b1.counts.min() == pytest.approx(0.0)
+        assert b1.counts.max() == pytest.approx(3.0)
+        assert b1.counts.sum() == pytest.approx(513.0)
+
+        assert b2.counts.min() == pytest.approx(0.0)
+        assert b2.counts.max() == pytest.approx(2.0)
+        assert b2.counts.sum() == pytest.approx(405.0)
+
+    else:
+        assert pha.units == 'channel'
+        assert pha.response_ids == []
+        assert pha.background_ids == []
+
+        assert pha.get_background() is None
+
+    # Select a few header keywords. Some are OGIP related,
+    # some are "we expect them", and some are there just to
+    # check we encode the type / value correctly.
+    #
+    assert pha.header["HDUCLASS"] == "OGIP"
+    assert pha.header["HDUCLAS1"] == "SPECTRUM"
+    assert pha.header["HDUCLAS2"] == "TOTAL"
+    assert pha.header["HDUCLAS3"] == "COUNT"
+    assert pha.header["HDUCLAS4"] == "TYPE:I"
+    assert pha.header["DETCHANS"] == nchan
+    assert pha.header["CHANTYPE"] == "PI"
+
+    # This keyword is removed from the header.
+    assert "POISERR" not in pha.header
+
+    assert pha.header["TELESCOP"] == "CHANDRA"
+    assert pha.header["INSTRUME"] == "ACIS"
+    assert pha.header["GRATING"] == "HETG"
+    assert pha.header["FILTER"] == ""
+    assert pha.header["OBJECT"] == "3C 120"
+
+    assert pha.header["RA_TARG"] == pytest.approx(68.29625)
+    assert pha.header["DEC_TARG"] == pytest.approx(5.354333)
+    assert "RA_OBJ" not in pha.header
+    assert "DEC_OBJ" not in pha.header
+
+    assert pha.header["SPEC_NUM"] == 3
+    assert pha.header["TG_M"] == -1
+    assert pha.header["TG_PART"] == 1
+    assert pha.header["TG_SRCID"] == 1
+
+
+def check_arf_grating(arf):
+    """Does the ARF contain the expected values?"""
+
+    assert isinstance(arf, DataARF)
+
+    nbins = 8192
+
+    # Expect the upper edge of bin j to equal the lower
+    # edge of bin j + 1.
+    #
+    assert len(arf.energ_lo) == nbins
+    assert (arf.energ_lo[1:] == arf.energ_hi[:-1]).all()
+    assert arf.energ_lo[0] == pytest.approx(0.57720757)
+    assert arf.energ_hi[0] == pytest.approx(0.57727474)
+    assert arf.energ_lo[-1] == pytest.approx(12.36749935)
+    assert arf.energ_hi[-1] == pytest.approx(12.39841843)
+
+    assert len(arf.bin_lo) == nbins
+    assert len(arf.bin_hi) == nbins
+    assert arf.bin_hi[1:] == pytest.approx(arf.bin_lo[:-1])
+    assert arf.bin_lo[0] == pytest.approx(21.4775)
+    assert arf.bin_hi[0] == pytest.approx(21.48)
+    assert arf.bin_lo[-1] == pytest.approx(1.0)
+    assert arf.bin_hi[-1] == pytest.approx(1.0025)
+
+    # Rather than check each element, use some simple summary
+    # statistics.
+    #
+    assert len(arf.specresp) == nbins
+    assert arf.specresp.min() == pytest.approx(0.0)
+    assert arf.specresp.max() == pytest.approx(28.142807006835938)
+    assert arf.specresp.sum() == pytest.approx(61266.833162411756)
+    assert np.argmax(arf.specresp) == 5849
+
+    assert arf.exposure == pytest.approx(ARF_GRATING_EXPOSURE)
+
+
+def check_rmf_grating(rmf):
+    """Does the RMF contain the expected values?"""
+
+    assert isinstance(rmf, DataRMF)
+
+    nchans = 8192
+    nbins = 8192
+    nsize1 = 8192
+    nsize2 = 841124
+
+    assert rmf.detchans == nchans
+    assert rmf.offset == 1
+
+    for field in ['energ_lo', 'energ_hi']:
+        assert getattr(rmf, field).size == nbins
+
+    assert rmf.n_grp.size == nbins
+    assert rmf.n_grp.min() == 1
+    assert rmf.n_grp.max() == 1
+    assert rmf.n_grp.sum() == nsize1
+
+    assert rmf.f_chan.size == nsize1
+    assert rmf.f_chan.min() == 1
+    assert rmf.f_chan.max() == 8141
+    assert rmf.f_chan.sum() == 33142062
+
+    assert rmf.n_chan.size == nsize1
+    assert rmf.n_chan.min() == 52
+    assert rmf.n_chan.max() == 103
+    assert rmf.n_chan.sum() == nsize2
+
+    assert rmf.matrix.size == nsize2
+    assert rmf.matrix.min() == pytest.approx(1.1740531890333088e-06)
+    assert rmf.matrix.max() == pytest.approx(0.31429963429969676)
+    assert rmf.matrix.sum() == pytest.approx(7860.054242052272)
+    assert np.argmax(rmf.matrix) == 0
+
+    for field in ['e_min', 'e_max']:
+        assert getattr(rmf, field).size == nchans
+
+    # Expect the upper edge of bin j to equal the lower
+    # edge of bin j + 1.
+    #
+    assert rmf.energ_lo[1:] == pytest.approx(rmf.energ_hi[:-1])
+
+    assert rmf.energ_lo[0] == pytest.approx(0.57720757)
+    assert rmf.energ_hi[0] == pytest.approx(0.57727474)
+    assert rmf.energ_lo[-1] == pytest.approx(12.36749935)
+    assert rmf.energ_hi[-1] == pytest.approx(12.39841843)
+
+    assert rmf.e_min == pytest.approx(rmf.energ_lo)
+    assert rmf.e_max == pytest.approx(rmf.energ_hi)
+
+
+def record_starts_with(r, start, level="INFO"):
+    """This only checks the start of the message, as it contains
+    test-specific information (the location of the file name).
+    """
+
+    assert r.name == "sherpa.astro.io"
+    assert r.levelname == level
+
+    # We use this, rather than msg.startswith(start), as the error
+    # message is more useful if there is a difference.
+    #
+    nchar = len(start)
+    msg = r.getMessage()
+    assert msg[:nchar] == start
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("errors", [False, True])
+def test_read_pha(errors, make_data_path, caplog):
+    """Can we read in a Chandra PHA file."""
+
+    infile = make_data_path(PHAFILE)
+    with SherpaVerbosity("INFO"):
+        pha = io.read_pha(infile, use_errors=errors)
+
+    check_pha(pha, responses=True)
+
+    assert len(caplog.records) == 3
+
+    record_starts_with(caplog.records[0],
+                       "read ARF file /")
+    record_starts_with(caplog.records[1],
+                       "read RMF file /")
+    record_starts_with(caplog.records[2],
+                       "read background file /")
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("errors", [False, True])
+def test_roundtrip_pha(errors, make_data_path, tmp_path, caplog):
+    """Can we write out a Chandra PHA file and then read it back in?"""
+
+    infile = make_data_path(PHAFILE)
+    with SherpaVerbosity("ERROR"):
+        pha1 = io.read_pha(infile, use_errors=errors)
+
+    assert len(caplog.records) == 0
+
+    outpath = tmp_path / "test.pha"
+    outfile = str(outpath)
+    io.write_pha(outfile, pha1, ascii=False, clobber=True)
+
+    with SherpaVerbosity("INFO"):
+        pha2 = io.read_pha(outfile, use_errors=errors)
+
+    check_pha(pha2, responses=False)
+
+    assert len(caplog.records) == 3
+
+    record_starts_with(caplog.records[0],
+                       "unable to read ARF: ",
+                       level="WARNING")
+    record_starts_with(caplog.records[1],
+                       "unable to read RMF: ",
+                       level="WARNING")
+    record_starts_with(caplog.records[2],
+                       "unable to read background: ",
+                       level="WARNING")
+
+
+@requires_data
+@requires_fits
+def test_read_arf(make_data_path):
+    """Can we read in a Chandra ARF."""
+
+    infile = make_data_path(ARFFILE)
+    arf = io.read_arf(infile)
+    check_arf(arf)
+
+
+@requires_data
+@requires_fits
+def test_roundtrip_arf(make_data_path, tmp_path):
+    """Can we write out a Chandra ARF file and then read it back in?"""
+
+    infile = make_data_path(ARFFILE)
+    arf1 = io.read_arf(infile)
+
+    outpath = tmp_path / "test.arf"
+    outfile = str(outpath)
+    io.write_arf(outfile, arf1, ascii=False, clobber=True)
+
+    arf2 = io.read_arf(outfile)
+    check_arf(arf2)
+
+
+@requires_data
+@requires_fits
+def test_read_rmf(make_data_path):
+    """Can we read in a Chandra RMF."""
+
+    infile = make_data_path(RMFFILE)
+    rmf = io.read_rmf(infile)
+    check_rmf(rmf)
+
+
+@requires_data
+@requires_fits
+def test_roundtrip_rmf(make_data_path, tmp_path):
+    """Can we write out a Chandra RMF file and then read it back in?"""
+
+    infile = make_data_path(RMFFILE)
+    rmf1 = io.read_rmf(infile)
+
+    outpath = tmp_path / "test.rmf"
+    outfile = str(outpath)
+    io.write_rmf(outfile, rmf1, clobber=True)
+
+    rmf2 = io.read_rmf(outfile)
+    check_rmf(rmf2)
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("errors", [False, True])
+def test_read_pha_grating(errors, make_data_path, caplog):
+    """Can we read in a Chandra grating PHA file."""
+
+    infile = make_data_path(PHAFILE_GRATING)
+    with SherpaVerbosity("INFO"):
+        pha = io.read_pha(infile, use_errors=errors)
+
+    check_pha_grating(pha, errors=errors, responses=True)
+
+    if errors:
+        assert len(caplog.records) == 4
+        idx = 0
+    else:
+        assert len(caplog.records) == 6
+
+        record_starts_with(caplog.records[0],
+                           "systematic errors were not found in file '/",
+                           level="WARNING")
+        record_starts_with(caplog.records[1],
+                           "statistical errors were found in file '/")
+
+        idx = 2
+
+    record_starts_with(caplog.records[idx],
+                       "read ARF file /")
+    idx += 1
+    record_starts_with(caplog.records[idx],
+                       "read RMF file /")
+    idx += 1
+    record_starts_with(caplog.records[idx],
+                       "read background_up into a dataset from file /")
+    idx += 1
+    record_starts_with(caplog.records[idx],
+                       "read background_down into a dataset from file /")
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("errors", [False, True])
+def test_roundtrip_pha_grating(errors, make_data_path, tmp_path, caplog):
+    """Can we write out a Chandra grating PHA file and then read it back in?"""
+
+    infile = make_data_path(PHAFILE_GRATING)
+    with SherpaVerbosity("ERROR"):
+        pha1 = io.read_pha(infile, use_errors=errors)
+
+    assert len(caplog.records) == 0
+
+    outpath = tmp_path / "test.pha"
+    outfile = str(outpath)
+    io.write_pha(outfile, pha1, ascii=False, clobber=True)
+
+    with SherpaVerbosity("INFO"):
+        pha2 = io.read_pha(outfile, use_errors=errors)
+
+    check_pha_grating(pha2, errors=errors, responses=False)
+
+    assert len(caplog.records) == 3
+
+    record_starts_with(caplog.records[0],
+                       "unable to read ARF: ",
+                       level="WARNING")
+    record_starts_with(caplog.records[1],
+                       "unable to read RMF: ",
+                       level="WARNING")
+    record_starts_with(caplog.records[2],
+                       "unable to read background: ",
+                       level="WARNING")
+
+
+@requires_data
+@requires_fits
+def test_read_arf_grating(make_data_path):
+    """Can we read in a Chandra grating ARF."""
+
+    infile = make_data_path(ARFFILE_GRATING)
+    arf = io.read_arf(infile)
+    check_arf_grating(arf)
+
+
+@requires_data
+@requires_fits
+def test_roundtrip_arf_grating(make_data_path, tmp_path):
+    """Can we write out a Chandra grating ARF file and then read it back in?"""
+
+    infile = make_data_path(ARFFILE_GRATING)
+    arf1 = io.read_arf(infile)
+
+    outpath = tmp_path / "test.arf"
+    outfile = str(outpath)
+    io.write_arf(outfile, arf1, ascii=False, clobber=True)
+
+    arf2 = io.read_arf(outfile)
+    check_arf_grating(arf2)
+
+
+@requires_data
+@requires_fits
+def test_read_rmf_grating(make_data_path):
+    """Can we read in a Chandra grating RMF."""
+
+    infile = make_data_path(RMFFILE_GRATING)
+    rmf = io.read_rmf(infile)
+    check_rmf_grating(rmf)
+
+
+@requires_data
+@requires_fits
+def test_roundtrip_rmf_grating(make_data_path, tmp_path):
+    """Can we write out a Chandra grating RMF file and then read it back in?"""
+
+    infile = make_data_path(RMFFILE_GRATING)
+    rmf1 = io.read_rmf(infile)
+
+    outpath = tmp_path / "test.rmf"
+    outfile = str(outpath)
+    io.write_rmf(outfile, rmf1, clobber=True)
+
+    rmf2 = io.read_rmf(outfile)
+    check_rmf_grating(rmf2)

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -34,15 +34,14 @@ References
 import warnings
 
 import numpy as np
-from numpy.testing import assert_allclose
 
 import pytest
 
-from sherpa.utils.testing import requires_data, requires_fits
-from sherpa.utils.err import IOErr
 from sherpa.astro.data import DataARF, DataPHA, DataRMF
 from sherpa.astro import io
 from sherpa.astro import ui
+from sherpa.utils.err import IOErr
+from sherpa.utils.testing import requires_data, requires_fits
 
 
 def backend_is(name: str) -> bool:
@@ -63,37 +62,30 @@ RMFFILE = 'swxpc0to12s6_20130101v014.rmf'
 EMIN = 1.0e-10
 
 
-@requires_data
-@requires_fits
-def test_read_pha(make_data_path):
-    """Can we read in a Swift PHA file."""
+def check_pha(pha):
+    """Does the data match expectation?"""
 
-    infile = make_data_path(PHAFILE)
-    pha = io.read_pha(infile)
     assert isinstance(pha, DataPHA)
 
-    # assert_allclose defaults to a tolerance of 1e-7
-    # which is close to the precision these values are stored
-    # in the file.
-    assert_allclose(pha.exposure, 4812.26699895)
-    assert_allclose(pha.backscal, 1.148e-3)
-    assert_allclose(pha.areascal, 1.0)
+    assert pha.exposure == pytest.approx(4812.26699895)
+    assert pha.backscal == pytest.approx(1.148e-3)
+    assert pha.areascal == pytest.approx(1.0)
 
     # Although channel is an integer, it's treated as a
     # float. Note that the channels start at 0 in the file,
-    # but they are promoted to 1 by the crates backend.
+    # but they are promoted to 1 by the generic backend.
     # XSPEC 12.9.1b, on reading this file, reports channel numbers
     # between 1 and 1024 inclusive.
     #
     nchan = 1024
-    assert_allclose(pha.channel, np.arange(1, nchan + 1))
+    assert pha.channel == pytest.approx(np.arange(1, nchan + 1))
 
     # Rather than check each element, use some simple summary
     # statistics.
     assert len(pha.counts) == nchan
-    assert_allclose(pha.counts.min(), 0.0)
-    assert_allclose(pha.counts.max(), 3.0)
-    assert_allclose(pha.counts.sum(), 58.0)
+    assert pha.counts.min() == pytest.approx(0.0)
+    assert pha.counts.max() == pytest.approx(3.0)
+    assert pha.counts.sum() == pytest.approx(58.0)
     assert np.argmax(pha.counts) == 110
 
     for field in ['staterror', 'syserror', 'bin_lo', 'bin_hi',
@@ -108,6 +100,137 @@ def test_read_pha(make_data_path):
     assert pha.response_ids == []
     assert pha.background_ids == []
     assert pha.get_background() is None
+
+    # Select a few header keywords. Some are OGIP related,
+    # some are "we expect them", and some are there just to
+    # check we encode the type / value correctly.
+    #
+    assert pha.header["HDUCLASS"] == "OGIP"
+    assert pha.header["HDUCLAS1"] == "SPECTRUM"
+    assert pha.header["HDUCLAS2"] == "TOTAL"
+    assert pha.header["HDUCLAS3"] == "COUNT"
+    assert pha.header["DETCHANS"] == 1024
+    assert pha.header["CHANTYPE"] == "PI"
+
+    # This keyword is removed from the header.
+    assert "POISERR" not in pha.header
+
+    assert pha.header["TELESCOP"] == "SWIFT"
+    assert pha.header["INSTRUME"] == "XRT"
+    assert pha.header["FILTER"] == "NONE"
+    assert pha.header["OBJECT"] == "2M02594633+3855363"
+
+    assert pha.header["RA_OBJ"] == pytest.approx(44.9445)
+    assert pha.header["DEC_OBJ"] == pytest.approx(38.9263)
+    assert pha.header["UTCFINIT"] == pytest.approx(-15.64118)
+
+    assert not pha.header["XBADFRAM"]
+
+
+def check_arf(arf):
+    """Does the ARF contain the expected values?"""
+
+    assert isinstance(arf, DataARF)
+
+    nbins = 2400
+
+    # Expect the upper edge of bin j to equal the lower
+    # edge of bin j + 1. Note that we check that the low
+    # bin has been replaced (i.e. is not 0.0).
+    #
+    assert len(arf.energ_lo) == nbins
+    assert (arf.energ_lo[1:] == arf.energ_hi[:-1]).all()
+    assert arf.energ_lo[0] == pytest.approx(EMIN)
+    assert arf.energ_hi[0] == pytest.approx(0.005)
+    assert arf.energ_lo[-1] == pytest.approx(11.995)
+    assert arf.energ_hi[-1] == pytest.approx(12.0)
+
+    # Rather than check each element, use some simple summary
+    # statistics.
+    #
+    assert len(arf.specresp) == nbins
+    assert arf.specresp.min() == pytest.approx(0.1506345272064209)
+    assert arf.specresp.max() == pytest.approx(145.38259887695312)
+    assert arf.specresp.sum() == pytest.approx(178696.1007297188)
+    assert np.argmax(arf.specresp) == 309
+
+    for field in ['bin_lo', 'bin_hi', 'exposure']:
+        assert getattr(arf, field) is None
+
+
+def check_rmf(rmf):
+    """Does the RMF contain the expected values?"""
+
+    assert isinstance(rmf, DataRMF)
+
+    nchans = 1024
+    nbins = 2400
+
+    assert rmf.detchans == nchans
+    assert rmf.offset == 0
+
+    for field in ['energ_lo', 'energ_hi', 'n_grp', 'f_chan',
+                  'n_chan']:
+        assert getattr(rmf, field).size == nbins
+
+    assert rmf.matrix.size == nchans * nbins
+
+    for field in ['e_min', 'e_max']:
+        assert getattr(rmf, field).size == nchans
+
+    assert (rmf.n_grp == 1).all()
+    assert (rmf.f_chan == 0).all()
+    assert (rmf.n_chan == nchans).all()
+
+    # Rather than check each element, use some simple summary
+    # statistics.
+    assert rmf.matrix.min() == pytest.approx(0.0)
+    assert rmf.matrix.max() == pytest.approx(0.05834391713142395)
+    assert rmf.matrix.sum() == pytest.approx(1133.8128197300257)
+    assert np.argmax(rmf.matrix) == 269443
+
+    # Expect the upper edge of bin j to equal the lower
+    # edge of bin j + 1. Note that we check that the low
+    # bin has been replaced (i.e. is not 0.0).
+    #
+    assert rmf.energ_lo[1:] == pytest.approx(rmf.energ_hi[:-1])
+    assert rmf.e_min[1:] == pytest.approx(rmf.e_max[:-1])
+
+    assert rmf.energ_lo[0] == pytest.approx(EMIN)
+    assert rmf.energ_hi[0] == pytest.approx(0.005)
+    assert rmf.energ_lo[-1] == pytest.approx(11.995)
+    assert rmf.energ_hi[-1] == pytest.approx(12.0)
+
+    assert rmf.e_min[0] == pytest.approx(0.0)
+    assert rmf.e_max[0] == pytest.approx(0.01)
+    assert rmf.e_min[-1] == pytest.approx(10.23)
+    assert rmf.e_max[-1] == pytest.approx(10.24)
+
+
+@requires_data
+@requires_fits
+def test_read_pha(make_data_path):
+    """Can we read in a Swift PHA file."""
+
+    infile = make_data_path(PHAFILE)
+    pha = io.read_pha(infile)
+    check_pha(pha)
+
+
+@requires_data
+@requires_fits
+def test_roundtrip_pha(make_data_path, tmp_path):
+    """Can we write out a Swift PHA file and then read it back in?"""
+
+    infile = make_data_path(PHAFILE)
+    pha1 = io.read_pha(infile)
+
+    outpath = tmp_path / "test.pha"
+    outfile = str(outpath)
+    io.write_pha(outfile, pha1, ascii=False, clobber=True)
+
+    pha2 = io.read_pha(outfile)
+    check_pha(pha2)
 
 
 # In the error checks (i.e. checking that invalid files fail),
@@ -183,31 +306,31 @@ def test_read_arf(make_data_path):
         arf = io.read_arf(infile)
 
     validate_replacement_warning(ws, 'ARF', infile)
+    check_arf(arf)
 
-    assert isinstance(arf, DataARF)
 
-    nbins = 2400
+@requires_data
+@requires_fits
+def test_roundtrip_arf(make_data_path, tmp_path):
+    """Can we write out a Swift ARF file and then read it back in?"""
 
-    # Expect the upper edge of bin j to equal the lower
-    # edge of bin j + 1.
+    infile = make_data_path(ARFFILE)
+
+    # Skip the warning check here.
     #
-    assert len(arf.energ_lo) == nbins
-    assert_allclose(arf.energ_lo[1:], arf.energ_hi[:-1])
-    assert_allclose(arf.energ_lo[0], EMIN)
-    assert_allclose(arf.energ_hi[0], 0.005)
-    assert_allclose(arf.energ_lo[-1], 11.995)
-    assert_allclose(arf.energ_hi[-1], 12.0)
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("ignore")
+        arf1 = io.read_arf(infile)
 
-    # Rather than check each element, use some simple summary
-    # statistics.
-    assert len(arf.specresp) == nbins
-    assert_allclose(arf.specresp.min(), 0.1506345272064209)
-    assert_allclose(arf.specresp.max(), 145.38259887695312)
-    assert_allclose(arf.specresp.sum(), 178696.1007297188)
-    assert np.argmax(arf.specresp) == 309
+    outpath = tmp_path / "test.arf"
+    outfile = str(outpath)
+    io.write_arf(outfile, arf1, ascii=False, clobber=True)
 
-    for field in ['bin_lo', 'bin_hi', 'exposure']:
-        assert getattr(arf, field) is None
+    # This should have no warnings as the ENERG_LO values were updated
+    # when creating arf1.
+    #
+    arf2 = io.read_arf(outfile)
+    check_arf(arf2)
 
 
 @requires_data
@@ -260,50 +383,31 @@ def test_read_rmf(make_data_path):
         rmf = io.read_rmf(infile)
 
     validate_replacement_warning(ws, 'RMF', infile)
+    check_rmf(rmf)
 
-    assert isinstance(rmf, DataRMF)
 
-    nchans = 1024
-    nbins = 2400
+@requires_data
+@requires_fits
+def test_roundtrip_rmf(make_data_path, tmp_path):
+    """Can we write out a Swift RMF file and then read it back in?"""
 
-    assert rmf.detchans == nchans
-    assert rmf.offset == 0
+    infile = make_data_path(RMFFILE)
 
-    for field in ['energ_lo', 'energ_hi', 'n_grp', 'f_chan',
-                  'n_chan']:
-        assert getattr(rmf, field).size == nbins
-
-    assert rmf.matrix.size == nchans * nbins
-
-    for field in ['e_min', 'e_max']:
-        assert getattr(rmf, field).size == nchans
-
-    assert (rmf.n_grp == 1).all()
-    assert (rmf.f_chan == 0).all()
-    assert (rmf.n_chan == nchans).all()
-
-    # Rather than check each element, use some simple summary
-    # statistics.
-    assert_allclose(rmf.matrix.min(), 0.0)
-    assert_allclose(rmf.matrix.max(), 0.05834391713142395)
-    assert_allclose(rmf.matrix.sum(), 1133.8128197300257)
-    assert np.argmax(rmf.matrix) == 269443
-
-    # Expect the upper edge of bin j to equal the lower
-    # edge of bin j + 1.
+    # Skip the warning check here.
     #
-    assert_allclose(rmf.energ_lo[1:], rmf.energ_hi[:-1])
-    assert_allclose(rmf.e_min[1:], rmf.e_max[:-1])
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("ignore")
+        rmf1 = io.read_rmf(infile)
 
-    assert_allclose(rmf.energ_lo[0], EMIN)
-    assert_allclose(rmf.energ_hi[0], 0.005)
-    assert_allclose(rmf.energ_lo[-1], 11.995)
-    assert_allclose(rmf.energ_hi[-1], 12.0)
+    outpath = tmp_path / "test.rmf"
+    outfile = str(outpath)
+    io.write_rmf(outfile, rmf1, clobber=True)
 
-    assert_allclose(rmf.e_min[0], 0.0)
-    assert_allclose(rmf.e_max[0], 0.01)
-    assert_allclose(rmf.e_min[-1], 10.23)
-    assert_allclose(rmf.e_max[-1], 10.24)
+    # This should have no warnings as the ENERG_LO values were updated
+    # when creating rmf1.
+    #
+    rmf2 = io.read_rmf(outfile)
+    check_rmf(rmf2)
 
 
 @requires_data
@@ -390,7 +494,7 @@ def test_can_use_swift_data(make_data_path, clean_astro_ui):
     # This check is purely a regression test, so the value has
     # not been externally validated.
     #
-    assert_allclose(stat, 58.2813692358182)
+    assert stat == pytest.approx(58.2813692358182)
 
     # Pick an energy range which isn't affected by the first
     # bin.
@@ -453,10 +557,9 @@ def test_can_use_swift_data(make_data_path, clean_astro_ui):
     #   chi sq = 203.88 from 771 bins with 769 dof
     #   cstat  = 568.52
     #
-    # There are known differences between XSPEC and Sherpa
-    # with chi2xspecvar. This only affects data sets where
-    # there is background subtraction, which is not the case
-    # here. See https://github.com/sherpa/sherpa/issues/356
+    # Histotically there have been issues with chi2xspecvar,
+    # such as https://github.com/sherpa/sherpa/issues/356
+    # so check with this setting.
     #
     ui.set_stat('chi2xspecvar')
     stat_xvar = ui.get_stat_info()
@@ -465,8 +568,8 @@ def test_can_use_swift_data(make_data_path, clean_astro_ui):
     stat_xvar = stat_xvar[0]
     assert stat_xvar.numpoints == 771
     assert stat_xvar.dof == 769
-    assert_allclose(stat_xvar.statval, 203.88,
-                    rtol=0, atol=0.005)
+    assert stat_xvar.statval == pytest.approx(203.88,
+                                              rel=0, abs=0.005)
 
     ui.set_stat('cstat')
     stat_cstat = ui.get_stat_info()
@@ -475,8 +578,8 @@ def test_can_use_swift_data(make_data_path, clean_astro_ui):
     stat_cstat = stat_cstat[0]
     assert stat_cstat.numpoints == 771
     assert stat_cstat.dof == 769
-    assert_allclose(stat_cstat.statval, 568.52,
-                    rtol=0, atol=0.005)
+    assert stat_cstat.statval == pytest.approx(568.52,
+                                               rel=0, abs=0.005)
 
 
 @requires_fits

--- a/sherpa/astro/tests/test_astro_data_xmm_unit.py
+++ b/sherpa/astro/tests/test_astro_data_xmm_unit.py
@@ -1,0 +1,780 @@
+#
+#  Copyright (C) 2024
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Test handling of XMM data.
+
+Most of the XMM testing is done in other files.
+
+"""
+
+import warnings
+
+import numpy as np
+
+import pytest
+
+from sherpa.astro.data import DataARF, DataPHA, DataRMF
+from sherpa.astro import io
+from sherpa.astro import ui
+from sherpa.utils.err import IOErr
+from sherpa.utils.logging import SherpaVerbosity
+from sherpa.utils.testing import requires_data, requires_fits, requires_xspec
+
+
+# We potentially have different instruments to test.
+#
+PHAFILE = "MNLup_2138_0670580101_EMOS1_S001_spec.15grp"
+ARFFILE = "MNLup_2138_0670580101_EMOS1_S001_spec.arf"
+RMFFILE = "MNLup_2138_0670580101_EMOS1_S001_spec.rmf"
+PHA_EXPOSURE = 42589.380
+
+PHAFILE_GRATING = "xmmrgs/P0112880201R1S004SRSPEC1003.FTZ"
+RMFFILE_GRATING = "xmmrgs/P0112880201R1S004RSPMAT1003.FTZ"
+
+EMIN = 1.0e-10
+
+
+def check_pha(pha, responses=True):
+    """Does the data match expectation?"""
+
+    assert isinstance(pha, DataPHA)
+
+    assert pha.exposure == pytest.approx(PHA_EXPOSURE)
+    assert pha.areascal == pytest.approx(1.0)
+    assert pha.backscal == pytest.approx(1136000.)
+
+    nchan = 800
+    assert pha.channel == pytest.approx(np.arange(1, nchan + 1))
+
+    # Rather than check each element, use some simple summary
+    # statistics.
+    #
+    assert len(pha.counts) == nchan
+    assert pha.counts.min() == pytest.approx(0.0)
+    assert pha.counts.max() == pytest.approx(40.0)
+    assert pha.counts.sum() == pytest.approx(1834)
+    assert np.argmax(pha.counts) == 61
+
+    assert len(pha.grouping) == nchan
+    assert (pha.grouping == 1).sum() == 223
+    assert (pha.grouping == -1).sum() == (nchan - 223)
+
+    assert len(pha.quality) == nchan
+    assert pha.quality.min() == 0
+    assert pha.quality.max() == 2
+    assert pha.quality.sum() == 276
+    assert pha.quality.argmax() == 662
+
+    for field in ['staterror', 'syserror',
+                  'bin_lo', 'bin_hi']:
+        assert getattr(pha, field) is None
+
+    assert pha.grouped is True
+    assert pha.subtracted is False
+    assert pha.rate
+    assert pha.plot_fac == 0
+
+    if responses:
+        assert pha.units == 'energy'
+        assert pha.response_ids == [1]
+        assert pha.background_ids == [1]
+
+        barf, brmf = pha.get_response()
+        assert barf.name.endswith("/MNLup_2138_0670580101_EMOS1_S001_spec.arf")
+        assert brmf.name.endswith("/MNLup_2138_0670580101_EMOS1_S001_spec.rmf")
+
+        b1 = pha.get_background(1)
+        assert b1.name.endswith("MNLup_2138_0670580101_EMOS1_S001_specbg.fits")
+        assert b1.areascal == pytest.approx(1.0)
+        assert b1.backscal == pytest.approx(19487580)
+        assert b1.exposure == pytest.approx(PHA_EXPOSURE)
+
+        assert b1.counts.min() == pytest.approx(0.0)
+        assert b1.counts.max() == pytest.approx(42.0)
+        assert b1.counts.sum() == pytest.approx(2880.0)
+
+    else:
+        assert pha.units == 'channel'
+        assert pha.response_ids == []
+        assert pha.background_ids == []
+
+        assert pha.get_background() is None
+
+    # Select a few header keywords. Some are OGIP related,
+    # some are "we expect them", and some are there just to
+    # check we encode the type / value correctly.
+    #
+    assert pha.header["HDUCLASS"] == "OGIP"
+    assert pha.header["HDUCLAS1"] == "SPECTRUM"
+    assert pha.header["HDUCLAS2"] == "TOTAL"
+    assert pha.header["HDUCLAS3"] == "COUNT"
+    assert pha.header["DETCHANS"] == nchan
+    assert pha.header["CHANTYPE"] == "PI"
+
+    # This keyword is removed from the header.
+    assert "POISERR" not in pha.header
+
+    assert pha.header["TELESCOP"] == "XMM"
+    assert pha.header["INSTRUME"] == "EMOS1"
+    assert "GRATING" not in pha.header
+    assert pha.header["FILTER"] == "Medium"
+    assert "OBJECT" not in pha.header
+
+
+def check_arf(arf):
+    """Does the ARF contain the expected values?"""
+
+    assert isinstance(arf, DataARF)
+
+    nbins = 2400
+
+    # Expect the upper edge of bin j to equal the lower
+    # edge of bin j + 1.
+    #
+    assert len(arf.energ_lo) == nbins
+    assert (arf.energ_lo[1:] == arf.energ_hi[:-1]).all()
+    assert arf.energ_lo[0] == pytest.approx(EMIN)
+    assert arf.energ_hi[0] == pytest.approx(0.005)
+    assert arf.energ_lo[-1] == pytest.approx(11.9949998856)
+    assert arf.energ_hi[-1] == pytest.approx(12.0)
+
+    assert arf.bin_lo is None
+    assert arf.bin_hi is None
+
+    # Rather than check each element, use some simple summary
+    # statistics.
+    #
+    assert len(arf.specresp) == nbins
+    assert arf.specresp.min() == pytest.approx(0.0)
+    assert arf.specresp.max() == pytest.approx(449.26184082)
+    assert arf.specresp.sum() == pytest.approx(396003.62812)
+    assert np.argmax(arf.specresp) == 367
+
+    assert arf.exposure is None
+
+
+def check_rmf(rmf):
+    """Does the RMF contain the expected values?"""
+
+    assert isinstance(rmf, DataRMF)
+
+    nchans = 800
+    nbins = 2400
+    nsize1 = 2394
+    nsize2 = 1281216
+
+    assert rmf.detchans == nchans
+    assert rmf.offset == 0
+
+    for field in ['energ_lo', 'energ_hi']:
+        assert getattr(rmf, field).size == nbins
+
+    assert rmf.n_grp.size == nbins
+    assert rmf.n_grp.min() == 0
+    assert rmf.n_grp.max() == 1
+    assert rmf.n_grp.sum() == nsize1
+
+    assert rmf.f_chan.size == nsize1
+    assert rmf.f_chan.min() == 0
+    assert rmf.f_chan.max() == 0
+
+    assert rmf.n_chan.size == nsize1
+    assert rmf.n_chan.min() == 24
+    assert rmf.n_chan.max() == 800
+    assert rmf.n_chan.sum() == nsize2
+
+    assert rmf.matrix.size == nsize2
+    assert rmf.matrix.min() == pytest.approx(1.0056578503281344e-06)
+    assert rmf.matrix.max() == pytest.approx(0.5105319619178772)
+    assert rmf.matrix.sum() == pytest.approx(2394.0000001526996)
+    assert np.argmax(rmf.matrix) == 0
+
+    for field in ['e_min', 'e_max']:
+        assert getattr(rmf, field).size == nchans
+
+    # Expect the upper edge of bin j to equal the lower
+    # edge of bin j + 1.
+    #
+    assert rmf.energ_lo[1:] == pytest.approx(rmf.energ_hi[:-1])
+
+    assert rmf.energ_lo[0] == pytest.approx(EMIN)
+    assert rmf.energ_hi[0] == pytest.approx(0.005)
+    assert rmf.energ_lo[-1] == pytest.approx(11.9949998856)
+    assert rmf.energ_hi[-1] == pytest.approx(12.0)
+
+    assert len(rmf.e_min) == nchans
+    assert rmf.e_min[1:] == pytest.approx(rmf.e_max[:-1])
+
+    assert rmf.e_min[0] == pytest.approx(0.0)
+    assert rmf.e_max[0] == pytest.approx(0.014999999665)
+    assert rmf.e_min[-1] == pytest.approx(11.984999657)
+    assert rmf.e_max[-1] == pytest.approx(12.0)
+
+
+def check_pha_grating(pha, errors=False):
+    """Does the data match expectation?"""
+
+    assert isinstance(pha, DataPHA)
+
+    assert pha.exposure == pytest.approx(28965.640625)
+    assert pha.backscal == pytest.approx(1.0)
+
+    nchan = 3600
+    assert pha.channel == pytest.approx(np.arange(1, nchan + 1))
+
+    # Rather than check each element, use some simple summary
+    # statistics.
+    #
+    assert len(pha.areascal) == nchan
+    assert pha.areascal.min() == pytest.approx(0.0)
+    assert pha.areascal.max() == pytest.approx(1.0)
+    assert pha.areascal.sum() == pytest.approx(2950.6953666)
+    assert pha.areascal.min() == pytest.approx(0.0)
+
+    non_zero = pha.areascal > 0
+    assert non_zero.sum() == 2964
+    assert pha.areascal[non_zero].min() == pytest.approx(0.01542056445)
+
+    assert len(pha.counts) == nchan
+    assert pha.counts.min() == pytest.approx(-6.0)
+    assert pha.counts.max() == pytest.approx(63.0)
+    assert pha.counts.sum() == pytest.approx(2724.0)
+    assert np.argmax(pha.counts) == 1498
+
+    for field in ['syserror', 'bin_lo', 'bin_hi',
+                  'grouping']:
+        assert getattr(pha, field) is None
+
+    if errors:
+        assert len(pha.staterror) == nchan
+        assert pha.staterror.min() == pytest.approx(1.0)
+        assert pha.staterror.max() == pytest.approx(7.937253952)
+        assert pha.staterror.sum() == pytest.approx(4496.9490242)
+    else:
+        assert pha.staterror is None
+
+    assert len(pha.quality) == nchan
+    assert pha.quality.min() == pytest.approx(0.0)
+    assert pha.quality.max() == pytest.approx(1.0)
+    assert pha.quality.sum() == pytest.approx(741.0)
+
+    assert pha.grouped is False
+    assert pha.subtracted is False
+    assert pha.units == 'channel'
+    assert pha.rate
+    assert pha.plot_fac == 0
+    assert pha.response_ids == []
+    assert pha.background_ids == []
+    assert pha.get_background() is None
+
+    # Select a few header keywords. Some are OGIP related,
+    # some are "we expect them", and some are there just to
+    # check we encode the type / value correctly.
+    #
+    assert pha.header["HDUCLASS"] == "OGIP"
+    assert pha.header["HDUCLAS1"] == "SPECTRUM"
+    assert pha.header["HDUCLAS2"] == "NET"
+    assert pha.header["HDUCLAS3"] == "COUNT"
+    assert pha.header["DETCHANS"] == nchan
+    assert pha.header["CHANTYPE"] == "PI"
+
+    # This keyword is removed from the header.
+    assert "POISERR" not in pha.header
+
+    assert pha.header["TELESCOP"] == "XMM"
+    assert pha.header["INSTRUME"] == "RGS1"
+    assert pha.header["FILTER"] == "UNKNOWN"
+    assert pha.header["OBJECT"] == "TW Hya"
+
+    assert pha.header["RA_OBJ"] == pytest.approx(165.4667511)
+    assert pha.header["DEC_OBJ"] == pytest.approx(-34.70463943)
+
+    assert pha.header["SOURCEID"] == 3
+
+
+def check_rmf_grating(rmf):
+    """Does the RMF contain the expected values?"""
+
+    assert isinstance(rmf, DataRMF)
+
+    nchans = 3600
+    nbins = 4000
+    nsize1 = 82878
+    nsize2 = 8475822
+
+    assert rmf.detchans == nchans
+    assert rmf.offset == 1
+
+    for field in ['energ_lo', 'energ_hi']:
+        assert getattr(rmf, field).size == nbins
+
+    assert rmf.n_grp.size == nbins
+    assert rmf.n_grp.min() == 12
+    assert rmf.n_grp.max() == 48
+    assert rmf.n_grp.sum() == nsize1
+
+    assert rmf.f_chan.size == nsize1
+    assert rmf.f_chan.min() == 114
+    assert rmf.f_chan.max() == 3417
+    assert rmf.f_chan.sum() == 173869713
+
+    assert rmf.n_chan.size == nsize1
+    assert rmf.n_chan.min() == 1
+    assert rmf.n_chan.max() == 281
+    assert rmf.n_chan.sum() == nsize2
+
+    assert rmf.matrix.size == nsize2
+    assert rmf.matrix.min() == pytest.approx(1.0000043459967856e-07)
+    assert rmf.matrix.max() == pytest.approx(5.669764518737793)
+    assert rmf.matrix.sum() == pytest.approx(102430.35533461263)
+    assert np.argmax(rmf.matrix) == 5859948
+
+    for field in ['e_min', 'e_max']:
+        assert getattr(rmf, field).size == nchans
+
+    # Expect the upper edge of bin j to equal the lower
+    # edge of bin j + 1. Note that we check that the low
+    # bin has been relpaced (i.e. is not 0.0).
+    #
+    assert rmf.energ_lo[1:] == pytest.approx(rmf.energ_hi[:-1])
+
+    assert rmf.energ_lo[0] == pytest.approx(0.30000001)
+    assert rmf.energ_hi[0] == pytest.approx(0.30006698)
+    assert rmf.energ_lo[-1] == pytest.approx(2.79407907)
+    assert rmf.energ_hi[-1] == pytest.approx(2.79989982)
+
+    # This is in reverse!
+    assert rmf.e_min[:-1] == pytest.approx(rmf.e_max[1:])
+    assert (rmf.e_min < rmf.e_max).all()
+
+    assert rmf.e_min[0] == pytest.approx(3.09187627)
+    assert rmf.e_max[0] == pytest.approx(3.09960628)
+    assert rmf.e_min[-1] == pytest.approx(0.3099606)
+    assert rmf.e_max[-1] == pytest.approx(0.31003815)
+
+
+def check_warning(ftype, fname, w):
+
+    assert w.category == UserWarning
+
+    # Can use startswith/endswith but if there is an error then it is
+    # harder to see the difference.
+    #
+    msg = str(w.message)
+    assert msg[:33] == f"The minimum ENERG_LO in the {ftype} '"
+    epos = len(fname)
+    assert msg[-(39 + epos):] == f"/{fname}' was 0 and has been replaced by 1e-10"
+
+
+def record_starts_with(r, start, level="INFO"):
+    """This only checks the start of the message, as it contains
+    test-specific information (the location of the file name).
+    """
+
+    assert r.name == "sherpa.astro.io"
+    assert r.levelname == level
+
+    # We use this, rather than msg.startswith(start), as the error
+    # message is more useful if there is a difference.
+    #
+    nchar = len(start)
+    msg = r.getMessage()
+    assert msg[:nchar] == start
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("errors", [False, pytest.param(True, marks=pytest.mark.xfail)])  # issue #2117
+def test_read_pha(errors, make_data_path, caplog):
+    """Can we read in a XMM PHA file."""
+
+    infile = make_data_path(PHAFILE)
+    with warnings.catch_warnings(record=True) as ws:
+        pha = io.read_pha(infile, use_errors=errors)
+
+    check_pha(pha, responses=True)
+
+    assert len(ws) == 2
+    check_warning("ARF", ARFFILE, ws[0])
+    check_warning("RMF", RMFFILE, ws[1])
+
+    if errors:
+        assert len(caplog.records) == 3
+        idx = 0
+
+    else:
+        assert len(caplog.records) == 5
+
+        record_starts_with(caplog.records[0],
+                           "systematic errors were not found in file '",
+                           level="WARNING")
+        record_starts_with(caplog.records[1],
+                           "statistical errors were found in file '")
+        idx = 2
+
+    record_starts_with(caplog.records[idx],
+                       "read ARF file /")
+    idx += 1
+    record_starts_with(caplog.records[idx],
+                       "read RMF file /")
+    idx += 1
+    record_starts_with(caplog.records[idx],
+                       "read background file /")
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("errors", [False, pytest.param(True, marks=pytest.mark.xfail)])  # issue #2117
+def test_roundtrip_pha(errors, make_data_path, tmp_path, caplog):
+    """Can we write out a XMM PHA file and then read it back in?"""
+
+    infile = make_data_path(PHAFILE)
+    with SherpaVerbosity("ERROR"):
+        with warnings.catch_warnings(record=True) as ws:
+            pha1 = io.read_pha(infile, use_errors=errors)
+
+    assert len(ws) == 2
+
+    outpath = tmp_path / "test.pha"
+    outfile = str(outpath)
+    io.write_pha(outfile, pha1, ascii=False, clobber=True)
+
+    pha2 = io.read_pha(outfile, use_errors=errors)
+    with SherpaVerbosity("INFO"):
+        with warnings.catch_warnings(record=True) as ws2:
+            check_pha(pha2, responses=False)
+
+    assert len(ws2) == 0
+
+    if errors:
+        assert len(caplog.records) == 3
+        idx = 0
+
+    else:
+        assert len(caplog.records) == 5
+
+        record_starts_with(caplog.records[0],
+                           "systematic errors were not found in file '",
+                           level="WARNING")
+        record_starts_with(caplog.records[1],
+                           "statistical errors were found in file '")
+
+        idx = 2
+
+    record_starts_with(caplog.records[idx],
+                       "unable to read ARF: ",
+                       level="WARNING")
+    idx += 1
+    record_starts_with(caplog.records[idx],
+                       "unable to read RMF: ",
+                       level="WARNING")
+    idx += 1
+    record_starts_with(caplog.records[idx],
+                       "unable to read background: ",
+                       level="WARNING")
+
+
+
+@requires_data
+@requires_fits
+def test_read_arf(make_data_path):
+    """Can we read in a XMM ARF."""
+
+    infile = make_data_path(ARFFILE)
+    with warnings.catch_warnings(record=True) as ws:
+        arf = io.read_arf(infile)
+
+    check_arf(arf)
+
+    assert len(ws) == 1
+    check_warning("ARF", ARFFILE, ws[0])
+
+
+@requires_data
+@requires_fits
+def test_roundtrip_arf(make_data_path, tmp_path):
+    """Can we write out a XMM ARF file and then read it back in?"""
+
+    infile = make_data_path(ARFFILE)
+    with warnings.catch_warnings(record=True) as ws:
+        arf1 = io.read_arf(infile)
+
+    assert len(ws) == 1
+
+    outpath = tmp_path / "test.arf"
+    outfile = str(outpath)
+    io.write_arf(outfile, arf1, ascii=False, clobber=True)
+
+    with warnings.catch_warnings(record=True) as ws2:
+        arf2 = io.read_arf(outfile)
+
+    check_arf(arf2)
+
+    assert len(ws2) == 0
+
+
+@requires_data
+@requires_fits
+def test_read_rmf(make_data_path):
+    """Can we read in a XMM RMF."""
+
+    infile = make_data_path(RMFFILE)
+    with warnings.catch_warnings(record=True) as ws:
+        rmf = io.read_rmf(infile)
+
+    check_rmf(rmf)
+
+    assert len(ws) == 1
+    check_warning("RMF", RMFFILE, ws[0])
+
+
+@requires_data
+@requires_fits
+def test_roundtrip_rmf(make_data_path, tmp_path):
+    """Can we write out a XMM RMF file and then read it back in?"""
+
+    infile = make_data_path(RMFFILE)
+    with warnings.catch_warnings(record=True) as ws:
+        rmf1 = io.read_rmf(infile)
+
+    assert len(ws) == 1
+
+    outpath = tmp_path / "test.rmf"
+    outfile = str(outpath)
+    io.write_rmf(outfile, rmf1, clobber=True)
+
+    with warnings.catch_warnings(record=True) as ws2:
+        rmf2 = io.read_rmf(outfile)
+
+    check_rmf(rmf2)
+
+    assert len(ws2) == 1
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("errors", [False, True])
+def test_read_pha_grating(errors, make_data_path, caplog):
+    """Can we read in a XMM grating PHA file."""
+
+    infile = make_data_path(PHAFILE_GRATING)
+    with SherpaVerbosity("INFO"):
+        pha = io.read_pha(infile, use_errors=errors)
+
+    check_pha_grating(pha, errors=errors)
+
+    if errors:
+        assert len(caplog.records) == 0
+        return
+
+    assert len(caplog.records) == 2
+
+    record_starts_with(caplog.records[0],
+                       "systematic errors were not found in file '",
+                       level="WARNING")
+    record_starts_with(caplog.records[1],
+                       "statistical errors were found in file '")
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("errors", [False, True])
+def test_roundtrip_pha_grating(errors, make_data_path, tmp_path, caplog):
+    """Can we write out a XMM grating PHA file and then read it back in?"""
+
+    infile = make_data_path(PHAFILE_GRATING)
+    with SherpaVerbosity("ERROR"):
+        pha1 = io.read_pha(infile, use_errors=errors)
+
+    assert len(caplog.records) == 0
+
+    outpath = tmp_path / "test.pha"
+    outfile = str(outpath)
+    io.write_pha(outfile, pha1, ascii=False, clobber=True)
+
+    pha2 = io.read_pha(outfile, use_errors=errors)
+    check_pha_grating(pha2, errors=errors)
+
+    # Unlike the original file there is no output when errors=False
+    #
+    assert len(caplog.records) == 0
+
+
+@requires_data
+@requires_fits
+def test_read_rmf_grating(make_data_path):
+    """Can we read in a XMM grating RMF."""
+
+    infile = make_data_path(RMFFILE_GRATING)
+    rmf = io.read_rmf(infile)
+    check_rmf_grating(rmf)
+
+
+@requires_data
+@requires_fits
+def test_roundtrip_rmf(make_data_path, tmp_path):
+    """Can we write out a XMM grating RMF file and then read it back in?"""
+
+    infile = make_data_path(RMFFILE_GRATING)
+    rmf1 = io.read_rmf(infile)
+
+    outpath = tmp_path / "test.rmf"
+    outfile = str(outpath)
+    io.write_rmf(outfile, rmf1, clobber=True)
+
+    rmf2 = io.read_rmf(outfile)
+    check_rmf_grating(rmf2)
+
+
+@requires_xspec
+@requires_data
+@requires_fits
+def test_can_use_pha_grating(make_data_path, clean_astro_ui):
+    """A basic check that we can use the XMM grating data.
+
+    Unlike the previous tests, that directly access the io module,
+    this uses the ui interface.
+    """
+
+    ui.set_stat("chi2xspecvar")
+
+    ui.load_pha(make_data_path(PHAFILE_GRATING), use_errors=True)
+    assert ui.get_analysis() == "channel"
+
+    ui.load_rmf(make_data_path(RMFFILE_GRATING))
+    assert ui.get_analysis() == "energy"
+
+    d = ui.get_data()
+    assert d.get_filter(format='%.4f') == "0.3100:3.0919"
+
+    # XSPEC 12.14.1 has the energy ranges for a plot
+    #
+    # 2.40980291
+    # 2.405128
+    # ...
+    # 0.324863762
+    # 0.324778676
+    #
+    # and there are 2859 elements.
+    #
+    # The EBOUNDS block has
+    #
+    #   #  CHANNEL    E_MIN                E_MAX
+    #             1         3.0918762684         3.0996062756
+    #             2         3.0841853619         3.0918762684
+    #             3         3.0765318871         3.0841853619
+    #   ...
+    #          3598     0.31011566519737     0.31019327044487
+    #          3599     0.31003814935684     0.31011566519737
+    #          3600     0.30996060371399     0.31003814935684
+    #
+    dp = ui.get_data_plot()
+    assert len(dp.x) == 3600
+    assert dp.x[0] == pytest.approx((3.0918762684 + 3.0996062756) / 2)
+    assert dp.x[1] == pytest.approx((3.0841853619 + 3.0918762684) / 2)
+    assert dp.x[-2] == pytest.approx((0.31003814935684 + 0.31011566519737) / 2)
+    assert dp.x[-1] == pytest.approx((0.30996060371399 + 0.31003814935684) / 2)
+
+    # If we ignore_bad we should match XSPEC.
+    #
+    ui.ignore_bad()
+
+    dp = ui.get_data_plot()
+    assert len(dp.x) == 2859
+    assert dp.x[0] == pytest.approx(2.40980291)
+    assert dp.x[1] == pytest.approx(2.405128)
+    assert dp.x[-2] == pytest.approx(0.324863762)
+    assert dp.x[-1] == pytest.approx(0.324778676)
+
+    # XSPEC 12.14.1 gives
+    #
+    #   XSPEC12>data xmmrgs/P0112880201R1S004SRSPEC1003.FTZ
+    #
+    #   1 spectrum  in use
+    #
+    #   Spectral Data File: xmmrgs/P0112880201R1S004SRSPEC1003.FTZ  Spectrum 1
+    #   Net count rate (cts/s) for Spectrum:1  9.342e-02 +/- 2.623e-03
+    #    Assigned to Data Group 1 and Plot Group 1
+    #     Noticed Channels:  1-2859
+    #     Telescope: XMM Instrument: RGS1  Channel Type: PI
+    #     Exposure Time: 2.897e+04 sec
+    #    Using fit statistic: chi
+    #    No response loaded.
+    #
+    #   ***Warning!  One or more spectra are missing responses,
+    #                  and are not suitable for fit.
+    #   XSPEC12>response xmmrgs/P0112880201R1S004RSPMAT1003.FTZ
+    #   Response successfully loaded.
+    #   XSPEC12>ignore **-0.64
+    #     1792 channels (1068-2859) ignored in spectrum #     1
+    #
+    #   XSPEC12>ignore 0.68-**
+    #      957 channels (1-957) ignored in spectrum #     1
+    #
+    #   XSPEC12>mo gauss
+    #
+    #   Input parameter value, delta, min, bot, top, and max values for ...
+    #
+    #   Input parameter value, delta, min, bot, top, and max values for ...
+    #               6.5       0.05(     0.065)          0          0      1e+06      1e+06
+    #   1:gaussian:LineE>0.6530
+    #               0.1       0.05(     0.001)          0          0         10         20
+    #   2:gaussian:Sigma>1e-4,-1
+    #                 1       0.01(      0.01)          0          0      1e+20      1e+24
+    #   3:gaussian:norm>3.63e-4
+    #
+    #   ========================================================================
+    #   Model gaussian<1> Source No.: 1   Active/On
+    #   Model Model Component  Parameter  Unit     Value
+    #    par  comp
+    #      1    1   gaussian   LineE      keV      0.653000     +/-  0.0
+    #      2    1   gaussian   Sigma      keV      1.00000E-04  frozen
+    #      3    1   gaussian   norm                3.63000E-04  +/-  0.0
+    #   ________________________________________________________________________
+    #
+    #
+    #   Fit statistic  : Chi-Squared                  118.23     using 110 bins.
+    #
+    #   Test statistic : Chi-Squared                  118.23     using 110 bins.
+    #    Null hypothesis probability of 2.36e-01 with 108 degrees of freedom
+    #    Current data and model not fit yet.
+    #
+
+    mdl = ui.create_model_component("xsgaussian", "gline")
+    mdl.linee = 0.6530
+    mdl.sigma.set(1e-4, frozen=True)
+    mdl.norm = 3.63e-4
+
+    ui.set_source("gline")
+
+    # This energy range contains two "bad-channel" ranges
+    # at ~ 0.655 keV and ~ 0.675 keV.
+    #
+    ui.ignore(hi=0.64)
+    ui.ignore(lo=0.68)
+
+    stats = ui.get_stat_info()
+    assert len(stats) == 1
+    stat = stats[0]
+
+    assert stat.numpoints == 110
+    assert stat.dof == 108
+
+    assert stat.statval == pytest.approx(118.23, rel=0, abs=0.005)

--- a/sherpa/astro/tests/test_astro_data_xmm_unit.py
+++ b/sherpa/astro/tests/test_astro_data_xmm_unit.py
@@ -351,7 +351,7 @@ def check_rmf_grating(rmf):
 
     # Expect the upper edge of bin j to equal the lower
     # edge of bin j + 1. Note that we check that the low
-    # bin has been relpaced (i.e. is not 0.0).
+    # bin has been replaced (i.e. is not 0.0).
     #
     assert rmf.energ_lo[1:] == pytest.approx(rmf.energ_hi[:-1])
 

--- a/sherpa/astro/tests/test_astro_data_xmm_unit.py
+++ b/sherpa/astro/tests/test_astro_data_xmm_unit.py
@@ -401,8 +401,8 @@ def record_starts_with(r, start, level="INFO"):
 
 @requires_data
 @requires_fits
-@pytest.mark.parametrize("errors", [False, pytest.param(True, marks=pytest.mark.xfail)])  # issue #2117
-def test_read_pha(errors, make_data_path, caplog):
+@pytest.mark.parametrize("errors", [False, True])
+def test_read_pha(errors, make_data_path,caplog):
     """Can we read in a XMM PHA file."""
 
     infile = make_data_path(PHAFILE)
@@ -415,33 +415,19 @@ def test_read_pha(errors, make_data_path, caplog):
     check_warning("ARF", ARFFILE, ws[0])
     check_warning("RMF", RMFFILE, ws[1])
 
-    if errors:
-        assert len(caplog.records) == 3
-        idx = 0
+    assert len(caplog.records) == 3
 
-    else:
-        assert len(caplog.records) == 5
-
-        record_starts_with(caplog.records[0],
-                           "systematic errors were not found in file '",
-                           level="WARNING")
-        record_starts_with(caplog.records[1],
-                           "statistical errors were found in file '")
-        idx = 2
-
-    record_starts_with(caplog.records[idx],
+    record_starts_with(caplog.records[0],
                        "read ARF file /")
-    idx += 1
-    record_starts_with(caplog.records[idx],
+    record_starts_with(caplog.records[1],
                        "read RMF file /")
-    idx += 1
-    record_starts_with(caplog.records[idx],
+    record_starts_with(caplog.records[2],
                        "read background file /")
 
 
 @requires_data
 @requires_fits
-@pytest.mark.parametrize("errors", [False, pytest.param(True, marks=pytest.mark.xfail)])  # issue #2117
+@pytest.mark.parametrize("errors", [False, True])
 def test_roundtrip_pha(errors, make_data_path, tmp_path, caplog):
     """Can we write out a XMM PHA file and then read it back in?"""
 
@@ -463,30 +449,15 @@ def test_roundtrip_pha(errors, make_data_path, tmp_path, caplog):
 
     assert len(ws2) == 0
 
-    if errors:
-        assert len(caplog.records) == 3
-        idx = 0
+    assert len(caplog.records) == 3
 
-    else:
-        assert len(caplog.records) == 5
-
-        record_starts_with(caplog.records[0],
-                           "systematic errors were not found in file '",
-                           level="WARNING")
-        record_starts_with(caplog.records[1],
-                           "statistical errors were found in file '")
-
-        idx = 2
-
-    record_starts_with(caplog.records[idx],
+    record_starts_with(caplog.records[0],
                        "unable to read ARF: ",
                        level="WARNING")
-    idx += 1
-    record_starts_with(caplog.records[idx],
+    record_starts_with(caplog.records[1],
                        "unable to read RMF: ",
                        level="WARNING")
-    idx += 1
-    record_starts_with(caplog.records[idx],
+    record_starts_with(caplog.records[2],
                        "unable to read background: ",
                        level="WARNING")
 


### PR DESCRIPTION
# Summary

Improve handling of STAT_ERR and SYS_ERR PHA columns which are set to 0.

# Details

This is built on #2111 just to avoid potential clashes.

This is partly a regression fix for #1921 but also a general fix-up of the handling of the STAT_ERR and SYS_ERR values. We have, for each "column"

- not set
- set as a column
- set as a scalar value

Prior to #1921 we had issues over differences in how the backends dealt with this, but now we handle this in the generic I/O code - e.g.
- #359
- #1876

There was a regression in #1921 that meant that files that had no STAT_ERR but did have SYS_ERR set would now fail.

In looking to fix this I realized that we needed to better handle the case when the value, or values, for a column are 0 - e.g. effectively "not set". We now - whether set as a keyword (single value of 0) or column (all values are 0), drop the column.

This leads to some user-visible changes

- you may no-longer get a message saying "hey, there was a systematic column set which you could use if you set read_errors=True" whicih ended up being a lie, since the errors would have been 0.
- you no longer get a column filled with zeros

However, this should not lead to any user-visible changes (e.g. the fit results should not change).

I started this to address a completely different issue (#1979 - see #2118) but in writing tests for that I came across #2117 and realized that needed fixing, and the tests I'd started to add were useful to diagnose the #2117 problem. 

# Example

## CIAO 4.16

```
sherpa In [1]: load_pha("s0_mar24_bin.pha")
systematic errors were found in file 's0_mar24_bin.pha' 
but not used; to use them, re-read with use_errors=True
read ARF file s0_mar24.arf
read RMF file s0_mar24.rmf
WARNING: File s0_bkg_sky.pha does not exist.

sherpa In [2]: load_pha("s0_mar24_bin.pha", use_errors=True)
read ARF file s0_mar24.arf
read RMF file s0_mar24.rmf
WARNING: File s0_bkg_sky.pha does not exist.

sherpa In [3]: get_syserror()
Out[3]: 
array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.])
```

So, we can see that it's told us about errors but then when you read them in they are all empty.

## HEAD

This is the issue I finally made #2117 about. 

Also note that it claims that both statistical and systematic errors are found in the file, which is technically true since it has a SYS_ERR column (all of 0) and a STAT_ERR keyword (but with a value of 0, which is "not actually set").

```
>>> from sherpa.astro import ui
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
>>> ui.load_pha("sherpa-test-data/sherpatest/s0_mar24_bin.pha")
statistical and systematic errors were found in file 'sherpa-test-data/sherpatest/s0_mar24_bin.pha'
but not used; to use them, re-read with use_errors=True
read ARF file sherpa-test-data/sherpatest/s0_mar24.arf
read RMF file sherpa-test-data/sherpatest/s0_mar24.rmf
WARNING: unable to read background: file 'sherpa-test-data/sherpatest/s0_bkg_sky.pha' not found
>>> ui.load_pha("sherpa-test-data/sherpatest/s0_mar24_bin.pha", use_errors=True)
read ARF file sherpa-test-data/sherpatest/s0_mar24.arf
read RMF file sherpa-test-data/sherpatest/s0_mar24.rmf
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in load_pha
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/astro/ui/utils.py", line 2356, in load_pha
    phasets = self.unpack_pha(arg, use_errors)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/astro/ui/utils.py", line 2159, in unpack_pha
    return sherpa.astro.io.read_pha(arg, use_errors)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/astro/io/__init__.py", line 1044, in read_pha
    data = _process_pha_block(filename, p,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/astro/io/__init__.py", line 843, in _process_pha_block
    pha = DataPHA(filename, counts=get("COUNTS"),
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/astro/data.py", line 1736, in __init__
    super().__init__(name, channel, counts, staterror, syserror)
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/data.py", line 1693, in __init__
    super().__init__(name, (x, ), y, staterror, syserror)
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/data.py", line 879, in __init__
    self.staterror = staterror
    ^^^^^^^^^^^^^^
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/utils/__init__.py", line 142, in __setattr__
    object.__setattr__(self, name, val)
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/data.py", line 1276, in staterror
    self._set_related("staterror", val)
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/astro/data.py", line 1756, in _set_related
    raise DataErr("notanarray")
sherpa.utils.err.DataErr: Array must be a sequence or None
```

## This PR

```
>>> from sherpa.astro import ui
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
>>> ui.load_pha("sherpa-test-data/sherpatest/s0_mar24_bin.pha")
read ARF file sherpa-test-data/sherpatest/s0_mar24.arf
read RMF file sherpa-test-data/sherpatest/s0_mar24.rmf
WARNING: unable to read background: file 'sherpa-test-data/sherpatest/s0_bkg_sky.pha' not found
>>> ui.load_pha("sherpa-test-data/sherpatest/s0_mar24_bin.pha", use_errors=True)
read ARF file sherpa-test-data/sherpatest/s0_mar24.arf
read RMF file sherpa-test-data/sherpatest/s0_mar24.rmf
WARNING: unable to read background: file 'sherpa-test-data/sherpatest/s0_bkg_sky.pha' not found
>>> ui.get_syserror()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in get_syserror
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/astro/ui/utils.py", line 3415, in get_syserror
    raise DataErr('nosyserr', idval)
```

So, we don't get a warning and we don't get the syserror field set in this case.


