### PR TITLE
UI: add calc_model/source commands

### DIFF
--- a/docs/ui/sherpa_astro_ui.rst
+++ b/docs/ui/sherpa_astro_ui.rst
@@ -25,9 +25,11 @@ burden...
       calc_data_sum2d
       calc_energy_flux
       calc_kcorr
+      calc_model
       calc_model_sum
       calc_model_sum2d
       calc_photon_flux
+      calc_source
       calc_source_sum
       calc_source_sum2d
       calc_stat

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -32,8 +32,7 @@ import numpy as np
 
 import pytest
 
-from sherpa.astro import io
-from sherpa.astro import ui
+from sherpa.astro import hc, io, ui
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
     IOErr
 from sherpa.utils.logging import SherpaVerbosity
@@ -396,3 +395,328 @@ def test_show_xsabund(clean_astro_ui, caplog):
     assert txt[9] == ""
 
     assert len(txt) == 10
+
+
+@pytest.mark.parametrize("name", ["model", "source"])
+@pytest.mark.parametrize("arg", [None, 1])
+@pytest.mark.parametrize("empty", [ui.Data1D("x", None, None),
+                                   # At present the code does not handle
+                                   # these cases well (i.e. they error out
+                                   # with an internal error thanks to there
+                                   # being no data).
+                                   #
+                                   # ui.Data1DInt("x", None, None, None),
+                                   # ui.DataPHA("x", None, None)
+                                   ])
+def test_calc_xxx_empty(name, arg, empty, clean_astro_ui):
+    """Does calc_source/model error out if empty?"""
+
+    if arg is None:
+        ui.set_data(empty)
+    else:
+        ui.set_data(arg, empty)
+
+    ui.set_source(1, ui.polynom1d.mdl)
+    mdl.c0 = 2
+    mdl.c1 = 4
+
+    getfunc = getattr(ui, f"calc_{name}")
+    with pytest.raises(DataErr,
+                       match="^The size of '1' has not been set$"):
+        getfunc(arg)
+
+
+@pytest.mark.parametrize("name", ["model", "source"])
+@pytest.mark.parametrize("arg", [None, 1])
+def test_calc_xxx_data1d(name, arg, clean_astro_ui):
+    """Does calc_source/model work?"""
+
+    ui.load_arrays(1, [1, 4, 9], [0, 0, 0])
+    ui.set_source(1, ui.polynom1d.mdl)
+    mdl.c0 = 2
+    mdl.c1 = 4
+
+    x = np.asarray([1, 4, 9])
+
+    getfunc = getattr(ui, f"calc_{name}")
+    xval, yval = getfunc(arg)
+
+    assert len(xval) == 1
+    assert xval[0] == pytest.approx(x)
+
+    # y = 4 x + 2
+    #
+    assert yval == pytest.approx(4 * x + 2)
+
+
+@pytest.mark.parametrize("name", ["model", "source"])
+@pytest.mark.parametrize("arg", [None, 1])
+def test_calc_xxx_data1d_int(name, arg, clean_astro_ui):
+    """Does calc_source/model work?"""
+
+    ui.load_arrays(1, [1, 4, 9], [2, 6, 10], [0, 0, 0], ui.Data1DInt)
+    ui.set_source(1, ui.polynom1d.mdl)
+    mdl.c0 = 2
+    mdl.c1 = 4
+
+    xlo = np.asarray([1, 4, 9])
+    xhi = np.asarray([2, 6, 10])
+
+    getfunc = getattr(ui, f"calc_{name}")
+    xval, yval = getfunc(arg)
+
+    assert len(xval) == 2
+    assert xval[0] == pytest.approx(xlo)
+    assert xval[1] == pytest.approx(xhi)
+
+    # y = 4 x + 2 integrated across each bin
+    # (1,2), (4,6), (9,10)
+    #
+    def integ(a, b):
+        return 2 * (b**2 - a**2) + 2 * (b - a)
+
+    assert yval == pytest.approx(integ(xlo, xhi))
+
+
+# Do not bother with id checks here.
+#
+def test_calc_model_datapha_no_response(clean_astro_ui):
+    """Does calc_model work? DataPHA no response"""
+
+    ui.load_arrays(1, [1, 2, 3], [0, 0, 0], ui.DataPHA)
+    ui.set_source(1, ui.polynom1d.mdl)
+
+    with pytest.raises(DataErr,
+                       match="^No instrument response found for dataset $"):
+        ui.calc_model()
+
+
+def create_test_datapha():
+    """Used in test_calc_model_datapha_xxx"""
+
+    ARFVAL = 12.8
+    EXPVAL = 2.0
+
+    ebins = np.asarray([0.1, 0.2, 0.4, 0.7])
+    elo = ebins[:-1]
+    ehi = ebins[1:]
+    arf = np.full(elo.shape, ARFVAL)
+
+    ui.load_arrays(1, [1, 2, 3], [0, 0, 0], ui.DataPHA)
+    ui.set_exposure(EXPVAL)
+    ui.set_rmf(ui.create_rmf(elo, ehi, e_min=elo, e_max=ehi))
+    ui.set_arf(ui.create_arf(elo, ehi, specresp=arf))
+
+    ui.set_source(1, ui.polynom1d.mdl)
+    mdl.c0 = 2
+    mdl.c1 = 4
+
+    def integ(a, b):
+        return 2 * (b**2 - a**2) + 2 * (b - a)
+
+    return (elo, ehi, integ, ARFVAL * EXPVAL)
+
+
+def test_calc_model_datapha_energy(clean_astro_ui):
+    """Does calc_model work? DataPHA, energy"""
+
+    (elo, ehi, integ, norm) = create_test_datapha()
+
+    assert ui.get_analysis() == "energy"
+
+    xval, yval = ui.calc_model()
+
+    assert len(xval) == 2
+    assert xval[0] == pytest.approx(elo)
+    assert xval[1] == pytest.approx(ehi)
+
+    # y = 4 x + 2 integrated across each bin
+    # (0.1,0.2), (0.2,0.4), (0.4,0.7) and then corrected
+    # for the arf (12.8 for each bin) and exposure time (2).
+    # Could have made the ARF vary per bin but leave that for
+    # other tests.
+    #
+    assert yval == pytest.approx(norm * integ(elo, ehi))
+
+    # Filter the data
+    #
+    ui.ignore(hi=0.15)
+    elo2 = elo[1:]
+    ehi2 = ehi[1:]
+
+    xval2, yval2 = ui.calc_model()
+    assert xval2[0] == pytest.approx(elo2)
+    assert xval2[1] == pytest.approx(ehi2)
+    assert yval2 == pytest.approx(norm * integ(elo2, ehi2))
+
+
+def test_calc_model_datapha_wavelength(clean_astro_ui):
+    """Does calc_model work? DataPHA, wavelength"""
+
+    (elo, ehi, integ, norm) = create_test_datapha()
+
+    ui.set_analysis("wave")
+    assert ui.get_analysis() == "wavelength"
+
+    xval, yval = ui.calc_model()
+
+    wlo = hc / elo
+    whi = hc / ehi
+
+    assert len(xval) == 2
+    assert xval[0] == pytest.approx(wlo)
+    assert xval[1] == pytest.approx(whi)
+
+    # y = 4 x + 2 integrated across each bin
+    # (0.1,0.2), (0.2,0.4), (0.4,0.7) and then corrected
+    # for the arf (12.8 for each bin) and exposure time (2).
+    # Could have made the ARF vary per bin but leave that for
+    # other tests.
+    #
+    # Note this uses whi,wlo to evaluate the model since this
+    # is not an XSPEC model. This is not ideal!
+    # See issue #850
+    #
+    assert yval == pytest.approx(norm * integ(whi, wlo))
+
+    # Filter the data
+    #
+    ui.ignore(hi=20)
+    wlo2 = wlo[:-1]
+    whi2 = whi[:-1]
+
+    xval2, yval2 = ui.calc_model()
+    assert xval2[0] == pytest.approx(wlo2)
+    assert xval2[1] == pytest.approx(whi2)
+    assert yval2 == pytest.approx(norm * integ(whi2, wlo2))
+
+
+def test_calc_model_datapha_channel(clean_astro_ui):
+    """Does calc_model work? DataPHA, channel"""
+
+    (elo, ehi, integ, norm) = create_test_datapha()
+
+    ui.set_analysis("bin")
+    assert ui.get_analysis() == "channel"
+
+    xval, yval = ui.calc_model()
+
+    xlo = np.arange(1, 4)
+    xhi = xlo + 1
+
+    assert len(xval) == 2
+    assert xval[0] == pytest.approx(xlo)
+    assert xval[1] == pytest.approx(xhi)
+
+    # y = 4 x + 2 integrated across each bin
+    # (0.1,0.2), (0.2,0.4), (0.4,0.7) and then corrected
+    # for the arf (12.8 for each bin) and exposure time (2).
+    # Could have made the ARF vary per bin but leave that for
+    # other tests.
+    #
+    # Note that this is not evaluated in channel units!
+    assert yval == pytest.approx(norm * integ(elo, ehi))
+
+    # Filter the data
+    #
+    ui.ignore(hi=1)
+    xlo2 = xlo[1:]
+    xhi2 = xhi[1:]
+
+    xval2, yval2 = ui.calc_model()
+    assert xval2[0] == pytest.approx(xlo2)
+    assert xval2[1] == pytest.approx(xhi2)
+    assert yval2 == pytest.approx(norm * integ(elo[1:], ehi[1:]))
+
+
+def test_calc_source_datapha_energy(clean_astro_ui):
+    """Does calc_source work? DataPHA, energy"""
+
+    (elo, ehi, integ, _) = create_test_datapha()
+
+    assert ui.get_analysis() == "energy"
+
+    xval, yval = ui.calc_source()
+
+    assert len(xval) == 2
+    assert xval[0] == pytest.approx(elo)
+    assert xval[1] == pytest.approx(ehi)
+
+    # Since the response is "perfect" - apart from the arf value and
+    # exposure - we can use the same integration term as for the
+    # calc_model tests.
+    #
+    assert yval == pytest.approx(integ(elo, ehi))
+
+    # Filter the data
+    #
+    ui.ignore(hi=0.15)
+
+    # Does not change calc_source.
+    #
+    xval2, yval2 = ui.calc_source()
+    assert xval2[0] == pytest.approx(elo)
+    assert xval2[1] == pytest.approx(ehi)
+    assert yval2 == pytest.approx(integ(elo, ehi))
+
+
+def test_calc_source_datapha_wavelength(clean_astro_ui):
+    """Does calc_source work? DataPHA, wavelength"""
+
+    (elo, ehi, integ, _) = create_test_datapha()
+
+    ui.set_analysis("wave")
+    assert ui.get_analysis() == "wavelength"
+
+    xval, yval = ui.calc_source()
+
+    # NOTE: this is different than calc_model!
+    wlo = hc / ehi
+    whi = hc / elo
+
+    assert len(xval) == 2
+    assert xval[0] == pytest.approx(wlo)
+    assert xval[1] == pytest.approx(whi)
+
+    assert yval == pytest.approx(integ(wlo, whi))
+
+    # Filter the data
+    #
+    ui.ignore(hi=20)
+
+    # Does not change calc_source.
+    #
+    xval2, yval2 = ui.calc_source()
+    assert xval2[0] == pytest.approx(wlo)
+    assert xval2[1] == pytest.approx(whi)
+    assert yval2 == pytest.approx(integ(wlo, whi))
+
+
+def test_calc_source_datapha_channel(clean_astro_ui):
+    """Does calc_source work? DataPHA, channel"""
+
+    (elo, ehi, integ, _) = create_test_datapha()
+
+    ui.set_analysis("bin")
+    assert ui.get_analysis() == "channel"
+
+    xval, yval = ui.calc_source()
+
+    # X axis is in keV, as channel is not appropriate.
+    #
+    assert len(xval) == 2
+    assert xval[0] == pytest.approx(elo)
+    assert xval[1] == pytest.approx(ehi)
+
+    assert yval == pytest.approx(integ(elo, ehi))
+
+    # Filter the data
+    #
+    ui.ignore(hi=1)
+
+    # Does not change calc_source.
+    #
+    xval2, yval2 = ui.calc_source()
+    assert xval2[0] == pytest.approx(elo)
+    assert xval2[1] == pytest.approx(ehi)
+    assert yval2 == pytest.approx(integ(elo, ehi))

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -478,6 +478,32 @@ def test_calc_xxx_data1d_int(name, arg, clean_astro_ui):
     assert yval == pytest.approx(integ(xlo, xhi))
 
 
+@pytest.mark.parametrize("name", ["model", "source"])
+@pytest.mark.parametrize("arg", [None, 1])
+def test_calc_xxx_data2d(name, arg, clean_astro_ui):
+    """Does calc_source/model work?"""
+
+    ui.load_arrays(1, [1, 1, 2], [2, 2, 2], [0, 0, 0], ui.Data2D)
+    ui.set_source(1, ui.polynom2d.mdl)
+    mdl.c = 2
+    mdl.cx1 = 4
+    mdl.cy1 = 10
+
+    x1 = np.asarray([1, 1, 2])
+    x2 = np.asarray([2, 2, 2])
+
+    getfunc = getattr(ui, f"calc_{name}")
+    xval, yval = getfunc(arg)
+
+    assert len(xval) == 2
+    assert xval[0] == pytest.approx(x1)
+    assert xval[1] == pytest.approx(x2)
+
+    # y = 4 * x1 + 10 * x2 + 2
+    #
+    assert yval == pytest.approx(4 * x1 + 10 * x2 + 2)
+
+
 # Do not bother with id checks here.
 #
 def test_calc_model_datapha_no_response(clean_astro_ui):

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -15339,7 +15339,7 @@ class Session(sherpa.ui.utils.Session):
         Returns
         -------
         xvals, yvals: tuple of ndarray, ndarray
-           The independent axis, which us a tuple as the number of
+           The independent axis, which uses a tuple as the number of
            elements depends on the dimensionality and type of data.
 
         See Also
@@ -15448,7 +15448,7 @@ class Session(sherpa.ui.utils.Session):
         Returns
         -------
         xvals, yvals: tuple of ndarray, ndarray
-           The independent axis, which us a tuple as the number of
+           The independent axis, which uses a tuple as the number of
            elements depends on the dimensionality and type of data.
 
         See Also

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -15341,6 +15341,9 @@ class Session(sherpa.ui.utils.Session):
         xvals, yvals: tuple of ndarray, ndarray
            The independent axis, which uses a tuple as the number of
            elements depends on the dimensionality and type of data.
+           The units depends on the data type: for PHA data the
+           X axis will be in the analysis units and Y axis will
+           generally be counts.
 
         See Also
         --------
@@ -15364,6 +15367,19 @@ class Session(sherpa.ui.utils.Session):
         >>> xvals, yvals = calc_model()
         >>> xlo = xvals[0]
         >>> xhi = xvals[1]
+
+        The results can be compared to the model output in plot_fit to
+        show agreement (note that calc_model returns grouped values,
+        as used by plot_fit, whereas plot_model shows the ungrouped
+        data):
+
+        >>> set_analysis("energy", type="rate", factor=0)
+        >>> plot_fit()
+        >>> plot_model(overplot=True, color="black", alpha=0.4)
+        >>> xvals, yvals = calc_model()
+        >>> elo, ehi = xvals
+        >>> exposure = get_exposure()
+        >>> plt.plot((elo + ehi) / 2, yvals / (ehi - elo) / exposure)
 
         Changing the analysis setting changes the x values, as xvals2
         is in Angstrom rather than keV (the model values are the same,
@@ -15450,6 +15466,9 @@ class Session(sherpa.ui.utils.Session):
         xvals, yvals: tuple of ndarray, ndarray
            The independent axis, which uses a tuple as the number of
            elements depends on the dimensionality and type of data.
+           The units depends on the data type: for PHA data the
+           X axis will be in the analysis units and Y axis will
+           generally be photon/cm^2/s.
 
         See Also
         --------
@@ -15473,6 +15492,15 @@ class Session(sherpa.ui.utils.Session):
         >>> xvals, yvals = calc_source()
         >>> xlo = xvals[0]
         >>> xhi = xvals[1]
+
+        The results can be compared to the output of plot_source to
+        show agreement:
+
+        >>> set_analysis("energy", type="rate", factor=0)
+        >>> plot_source()
+        >>> xvals, yvals = calc_source()
+        >>> elo, ehi = xvals
+        >>> plt.plot((elo + ehi) / 2, yvals / (ehi - elo))
 
         Changing the analysis setting changes the x values, as xvals2
         is in Angstrom rather than keV (the model values are the same,

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -15311,6 +15311,223 @@ class Session(sherpa.ui.utils.Session):
         data = self._get_data_or_bkg(id, bkg_id)
         return sherpa.astro.utils.calc_data_sum(data, lo, hi)
 
+    # This could also be done in the sherpa.ui version but for now
+    # leave here.
+    #
+    def calc_model(self,
+                   id: Optional[IdType] = None,
+                   bkg_id: Optional[IdType] = None
+                   ) -> tuple[tuple[np.ndarray, ...], np.ndarray]:
+        """Calculate the per-bin model values.
+
+        The values are filtered and grouped based on the data and will
+        use the analysis setting for PHA data, but not the other plot
+        options (such as whether to display as a rate).
+
+        .. versionadded:: 4.17.0
+
+        Parameters
+        ----------
+        id : int, str, or None, optional
+           Use the source expression associated with this data set. If
+           not given then the default identifier is used, as returned
+           by `get_default_id`.
+        bkg_id : int, str, or None, optional
+           If set, use the model associated with the given background
+           component rather than the source model.
+
+        Returns
+        -------
+        xvals, yvals: tuple of ndarray, ndarray
+           The independent axis, which us a tuple as the number of
+           elements depends on the dimensionality and type of data.
+
+        See Also
+        --------
+        calc_model_sum, calc_source, plot_model
+
+        Example
+        -------
+
+        For a PHA dataset the independent axis is a pair of values,
+        giving the low and high energies. The xlo and xhi values are
+        in keV, and represent the low and high edges of each bin, and
+        the yvals array is in counts.
+
+        >>> load_pha("3c273.pi")
+        >>> set_analysis("energy")
+        >>> notice(0.5, 6)
+        >>> set_source(xsphabs.gal * powlaw1d.pl)
+        >>> gal.nh = 0.1
+        >>> pl.gamma = 1.7
+        >>> pl.ampl = 2e-4
+        >>> xvals, yvals = calc_model()
+        >>> xlo = xvals[0]
+        >>> xhi = xvals[1]
+
+        Changing the analysis setting changes the x values, as xvals2
+        is in Angstrom rather than keV (the model values are the same,
+        although there may be small numerical differences that mean
+        the values do not exactly match):
+
+        >>> set_analysis("wave")
+        >>> xvals2, yvals2 = calc_model()
+
+        For 1D datasets the x axis is a single-element tuple:
+
+        >>> load_arrays(2, [1, 4, 7], [3, 12, 2])
+        >>> set_source(2, gauss1.gline)
+        >>> gline.pos = 4.2
+        >>> gline.fwhm = 3
+        >>> gline.ampl = 12
+        >>> xvals, yvals = calc_model(2)
+        >>> x = xvals[0]
+        >>> x
+        array([1, 4, 7])
+        >>> yvals
+        array([ 0.51187072, 11.85303595,  1.07215839])
+
+        """
+
+        # TODO: should there be a response_id argument?
+        #
+        idval = self._fix_id(id)
+        data = self._get_data_or_bkg(idval, bkg_id)
+
+        if isinstance(data, DataPHA):
+            # Returning the grid that this model represents is not as easy
+            # as it should be, since there is no obvious API.
+            #
+            bins = sherpa.astro.plot.calc_x(data)
+        else:
+            bins = data.get_indep(filter=True)
+
+        # Safety check, to ensure we have data. This could be done
+        # by checking whether data.size is None but it is easier
+        # for type checkers if the return value is checked.
+        #
+        if bins[0] is None:
+            raise DataErr("sizenotset", idval)
+
+        if bkg_id is None:
+            model = self.get_model(idval)
+        else:
+            model = self.get_bkg_model(idval, bkg_id)
+
+        # Evaluate the model.
+        #
+        mvals = data.eval_model_to_fit(model)
+
+        return bins, mvals
+
+    # This could also be done in the sherpa.ui version but for now
+    # leave here.
+    #
+    def calc_source(self,
+                   id: Optional[IdType] = None,
+                   bkg_id: Optional[IdType] = None
+                   ) -> tuple[tuple[np.ndarray, ...], np.ndarray]:
+        """Calculate the per-bin source values.
+
+        Unlike calc_model, the values are not filtered and grouped,
+        but the independent axis will use the analysis setting for PHA
+        data.
+
+        .. versionadded:: 4.17.0
+
+        Parameters
+        ----------
+        id : int, str, or None, optional
+           Use the source expression associated with this data set. If
+           not given then the default identifier is used, as returned
+           by `get_default_id`.
+        bkg_id : int, str, or None, optional
+           If set, use the model associated with the given background
+           component rather than the source model.
+
+        Returns
+        -------
+        xvals, yvals: tuple of ndarray, ndarray
+           The independent axis, which us a tuple as the number of
+           elements depends on the dimensionality and type of data.
+
+        See Also
+        --------
+        calc_source_sum, calc_model, plot_source
+
+        Example
+        -------
+
+        For a PHA dataset the independent axis is a pair of values,
+        giving the low and high energies. The xlo and xhi values are
+        in keV, and represent the low and high edges of each bin, and
+        the yvals array will generally be in photon/cm^2/s.
+
+        >>> load_pha("3c273.pi")
+        >>> set_analysis("energy")
+        >>> notice(0.5, 6)
+        >>> set_source(xsphabs.gal * powlaw1d.pl)
+        >>> gal.nh = 0.1
+        >>> pl.gamma = 1.7
+        >>> pl.ampl = 2e-4
+        >>> xvals, yvals = calc_source()
+        >>> xlo = xvals[0]
+        >>> xhi = xvals[1]
+
+        Changing the analysis setting changes the x values, as xvals2
+        is in Angstrom rather than keV (the model values are the same,
+        although there may be small numerical differences that mean
+        the values do not exactly match):
+
+        >>> set_analysis("wave")
+        >>> xvals2, yvals2 = calc_source()
+
+        For 1D datasets the x axis is a single-element tuple:
+
+        >>> load_arrays(2, [1, 4, 7], [3, 12, 2])
+        >>> set_source(2, gauss1.gline)
+        >>> gline.pos = 4.2
+        >>> gline.fwhm = 3
+        >>> gline.ampl = 12
+        >>> xvals, yvals = calc_source(2)
+        >>> x = xvals[0]
+        >>> x
+        array([1, 4, 7])
+        >>> yvals
+        array([ 0.51187072, 11.85303595,  1.07215839])
+
+        """
+
+        idval = self._fix_id(id)
+        data = self._get_data_or_bkg(idval, bkg_id)
+
+        if isinstance(data, DataPHA):
+            # Returning the grid that this model represents is not as easy
+            # as it should be, since there is no obvious API.
+            #
+            bins = data._get_indep(filter=False)
+        else:
+            bins = data.get_indep(filter=False)
+
+        # Safety check, to ensure we have data. This could be done
+        # by checking whether data.size is None but it is easier
+        # for type checkers if the return value is checked.
+        #
+        if bins[0] is None:
+            raise DataErr("sizenotset", idval)
+
+        if bkg_id is None:
+            model = self.get_source(idval)
+        else:
+            model = self.get_bkg_source(idval, bkg_id)
+
+        # Evaluate the model. Note there is no attempt to correct
+        # for the bin width or exposure time.
+        #
+        mvals = model(*bins)
+
+        return bins, mvals
+
     # DOC-TODO: better comparison of calc_source_sum and calc_model_sum
     # needed (e.g. integration or results in PHA case?)
     #
@@ -15350,11 +15567,8 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        calc_data_sum : Sum up the observed counts over a pass band.
-        calc_energy_flux : Integrate the unconvolved source model over a pass band.
-        calc_photon_flux : Integrate the unconvolved source model over a pass band.
-        calc_source_sum: Sum up the source model over a pass band.
-        set_model : Set the source model expression for a data set.
+        calc_data_sum, calc_energy_flux, calc_photon_flux,
+        calc_model, calc_source_sum, set_model
 
         Notes
         -----
@@ -15689,11 +15903,8 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        calc_data_sum : Sum up the observed counts over a pass band.
-        calc_model_sum : Sum up the fitted model over a pass band.
-        calc_energy_flux : Integrate the unconvolved source model over a pass band.
-        calc_photon_flux : Integrate the unconvolved source model over a pass band.
-        set_model : Set the source model expression for a data set.
+        calc_data_sum, calc_model_sum, calc_energy_flux,
+        calc_photon_flux, calc_source, set_model
 
         Notes
         -----


### PR DESCRIPTION
# Summary

Add calc_model and calc_source routines to return the model expression evaluated per bin.

# Details

If you want to evaluate a model to match the data then the easiest way has been to call get_model_plot and then use the y attribute of the plot object. However, this is annoying because users do not always want to use the plot options - e.g. normalize by the exposure time or divide by the bin width.

So, we add

    calc_model()
    calc_source()

routines which evaluate the model on the relevant grid and return

- the independent axis (if integrated will get both edges)
- the evaluated model value

The return values depend in part on the data object - e.g. the analysis setting for PHA data - and in part the model (i.e. what are its units).

There is an asymmetry in these two routines, since

- calc_model will filter (and group) the data
- calc_source does not filter (and can not group)

We could apply a filter to the calc_source data to "match" the chosen data filter, but it is not ideal (since notice/ignore act on the EBOUNDS energy grid and this is the MATRIX energy grid, which is technically different).

An alternative would be to follow plot_source and add lo/hi arguments so a user can say "only give me the data between these two limits" - but it's easy for a user to do this themselves, and it wouldn't reduce the time taken to make the call.

We **could** have the independent axis get returned as a `PointAxis`/`IntegratedAxis` object,  which may help users, but is also likely to just annoy them.

# Example

```
>>> from sherpa.astro import ui
>>> ui.load_pha("sherpa-test-data/sherpatest/3c273.pi")
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273.pi'
but not used; to use them, re-read with use_errors=True
read ARF file sherpa-test-data/sherpatest/3c273.arf
read RMF file sherpa-test-data/sherpatest/3c273.rmf
WARNING: systematic errors were not found in file 'sherpa-test-data/sherpatest/3c273_bg.pi'
statistical errors were found in file 'sherpa-test-data/sherpatest/3c273_bg.pi'
but not used; to use them, re-read with use_errors=True
read background file sherpa-test-data/sherpatest/3c273_bg.pi
>>> ui.set_source(ui.xsphabs.gal * ui.powlaw1d.pl)
>>> ui.get_analysis()
'energy'
```

Lets get the model values:

```
>>> xvals, yvals = ui.calc_model()
```

What is returned? Well, no filter has been applied so it returns each grouped bin - in this case there are 46 of them - and the units of this array are counts:

```
>>> len(yvals)
46
>>> yvals
array([  1613.46568051,   1131.29707659,   2482.8571051 ,   2018.20405277,
         1349.36184146,   1262.52815489,   1208.29028731,   1642.87037514,
         1527.5538973 ,   3044.06105677,   2435.78088516,   6357.51358037,
         6751.2154098 ,   8668.11827958,  14626.69090976,  13158.27344729,
        20151.60301463,  34808.69657739,  51105.44295191,  35363.19698612,
        70633.48125879,  56117.16362829,  99281.86153636,  90942.92885501,
        53753.38764127, 119638.69054736,  69868.01861931, 108968.30104452,
       110333.46941109, 125684.07097541, 168151.38472268, 117609.14374793,
       133046.50795065, 198625.88551729, 295758.49684844, 179032.52357683,
       250728.33823766, 263540.47863483, 254252.12826654, 547240.79074557,
       341220.24358439, 350031.91499559, 423956.19194663, 389876.38171632,
       481964.94944176,  12740.721433  ])
```

The X axis is in keV (to match the analysis setting)

```
>>> len(xvals)
2
>>> len(xvals[0])
46
>>> xvals[0]
array([1.46000006e-03, 2.48199999e-01, 3.06600004e-01, 4.67200011e-01,
       5.69400012e-01, 6.42400026e-01, 7.00800002e-01, 7.44599998e-01,
       7.88399994e-01, 8.17600012e-01, 8.61400008e-01, 8.90600026e-01,
       9.49000001e-01, 9.92799997e-01, 1.03659999e+00, 1.09500003e+00,
       1.13880002e+00, 1.19719994e+00, 1.28480005e+00, 1.40160000e+00,
       1.47459996e+00, 1.60599995e+00, 1.69360006e+00, 1.81040001e+00,
       1.89800000e+00, 1.94180000e+00, 2.02940011e+00, 2.08780003e+00,
       2.19000006e+00, 2.27760005e+00, 2.39439988e+00, 2.58419991e+00,
       2.71560001e+00, 2.86159992e+00, 3.08060002e+00, 3.38720012e+00,
       3.56240010e+00, 3.79600000e+00, 4.02960014e+00, 4.24860001e+00,
       4.71579981e+00, 5.02239990e+00, 5.37279987e+00, 5.89839983e+00,
       6.57000017e+00, 9.86960030e+00])
>>> xvals[1]
array([ 0.2482    ,  0.3066    ,  0.46720001,  0.56940001,  0.64240003,
        0.7008    ,  0.7446    ,  0.78839999,  0.81760001,  0.86140001,
        0.89060003,  0.949     ,  0.9928    ,  1.03659999,  1.09500003,
        1.13880002,  1.19719994,  1.28480005,  1.4016    ,  1.47459996,
        1.60599995,  1.69360006,  1.81040001,  1.898     ,  1.9418    ,
        2.02940011,  2.08780003,  2.19000006,  2.27760005,  2.39439988,
        2.58419991,  2.71560001,  2.86159992,  3.08060002,  3.38720012,
        3.5624001 ,  3.796     ,  4.02960014,  4.24860001,  4.71579981,
        5.0223999 ,  5.37279987,  5.89839983,  6.57000017,  9.8696003 ,
       14.95040035])
```

If we filter then we get less data

```
>>> ui.notice(0.5, 2)
dataset 1: 0.00146:14.9504 -> 0.4672:2.0294 Energy (keV)
>>> xvals2, yvals2 = ui.calc_model()
>>> len(yvals2)
23
>>> xvals2[0]
array([0.46720001, 0.56940001, 0.64240003, 0.7008    , 0.7446    ,
       0.78839999, 0.81760001, 0.86140001, 0.89060003, 0.949     ,
       0.9928    , 1.03659999, 1.09500003, 1.13880002, 1.19719994,
       1.28480005, 1.4016    , 1.47459996, 1.60599995, 1.69360006,
       1.81040001, 1.898     , 1.9418    ])
>>> xvals2[1]
array([0.56940001, 0.64240003, 0.7008    , 0.7446    , 0.78839999,
       0.81760001, 0.86140001, 0.89060003, 0.949     , 0.9928    ,
       1.03659999, 1.09500003, 1.13880002, 1.19719994, 1.28480005,
       1.4016    , 1.47459996, 1.60599995, 1.69360006, 1.81040001,
       1.898     , 1.9418    , 2.02940011])
>>> yvals2
array([  2018.20405277,   1349.36184146,   1262.52815489,   1208.29028731,
         1642.87037514,   1527.5538973 ,   3044.06105677,   2435.78088516,
         6357.51358037,   6751.2154098 ,   8668.11827958,  14626.69090976,
        13158.27344729,  20151.60301463,  34808.69657739,  51105.44295191,
        35363.19698612,  70633.48125879,  56117.16362829,  99281.86153636,
        90942.92885501,  53753.38764127, 119638.69054736])
```

If we use get_source then things are a little-bit different:

 - we do not apply any filter [this is something we can discuss, but there are reasons for it]
 - the x axis is again keV (this time it's the MATRIX block energies)
 - the y axis is in photon/cm^2/s

```
>>> xvals3, yvals3 = ui.calc_source()
>>> len(yvals3)
1090
>>> xvals3[0][0:5]
array([0.1 , 0.11, 0.12, 0.13, 0.14])
>>> xvals3[1][0:5]
array([0.11      , 0.12      , 0.13      , 0.14      , 0.15000001])
>>> yvals[0:5]
array([1613.46568051, 1131.29707659, 2482.8571051 , 2018.20405277,
       1349.36184146])
```