### PR TITLE
Data cleanups

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -125,7 +125,7 @@ import os
 from typing import Optional, Sequence, Union
 import warnings
 
-import numpy
+import numpy as np
 
 from sherpa.astro import hc
 from sherpa.data import Data1DInt, Data2D, Data, Data1D, \
@@ -171,7 +171,7 @@ __all__ = ('DataARF', 'DataRMF', 'DataPHA', 'DataIMG', 'DataIMGInt', 'DataRosatR
 
 # can arf/rmf be sent ARF1D/RMF1D too?
 #
-def _notice_resp(chans: numpy.ndarray,
+def _notice_resp(chans: np.ndarray,
                  arf: Optional[DataARF],
                  rmf: Optional[DataRMF]
                  ) -> None:
@@ -198,7 +198,7 @@ def _notice_resp(chans: numpy.ndarray,
         elif len(rmf.energ_lo) < len(arf.energ_lo):
             arf_mask = None
             if bin_mask is not None:
-                arf_mask = numpy.zeros(len(arf.energ_lo), dtype=bool)
+                arf_mask = np.zeros(len(arf.energ_lo), dtype=bool)
                 for ii, val in enumerate(bin_mask):
                     if val:
                         los = (rmf.energ_lo[ii],)
@@ -455,7 +455,7 @@ def _calc_erange(elo, ehi):
 
     # Randomly pick 1% as the cut-off for a constant bin width
     #
-    de = numpy.abs(ehi - elo)
+    de = np.abs(ehi - elo)
     demin = de.min()
     demax = de.max()
     if demin > 0.0:
@@ -493,7 +493,7 @@ def _calc_wrange(wlo, whi):
 
     # Randomly pick 1% as the cut-off for a constant bin width
     #
-    dw = numpy.abs(whi - wlo)
+    dw = np.abs(whi - wlo)
     dwmin = dw.min()
     dwmax = dw.max()
     if dwmin > 0.0:
@@ -556,8 +556,8 @@ def html_arf(arf):
         wrange = _calc_wrange(arf.bin_lo, arf.bin_hi)
         meta.append(('Wavelength range', wrange))
 
-    a1 = numpy.min(arf.specresp)
-    a2 = numpy.max(arf.specresp)
+    a1 = np.min(arf.specresp)
+    a2 = np.max(arf.specresp)
     meta.append(('Area range', f'{a1:g} - {a2:g} cm<sup>2</sup>'))
 
     ls.append(formatting.html_section(meta, summary='Summary',
@@ -837,7 +837,7 @@ class DataOgipResponse(Data1DInt):
         #
         # so the sum will be number of elements or 0
         #
-        increasing = numpy.diff(elo, n=1) > 0.0
+        increasing = np.diff(elo, n=1) > 0.0
         nincreasing = increasing.sum()
         if nincreasing > 0 and nincreasing != len(increasing):
             # raise DataErr('ogip-error', rtype, label,
@@ -1201,7 +1201,7 @@ class DataRMF(DataOgipResponse):
         return (self._lo, self._hi)
 
     def get_dep(self, filter=False):
-        return self.apply_rmf(numpy.ones(self.energ_lo.shape, SherpaFloat))
+        return self.apply_rmf(np.ones(self.energ_lo.shape, SherpaFloat))
 
 
 # FIXME There are places in the code that explicitly check if an object is an instance of sherpa.astro.data.DataRMF.
@@ -1358,8 +1358,8 @@ def replace_xspecvar_values(src_counts, bkg_counts,
     # - all components (source, background_1 .. n) are 0
     # - some are 0
     #
-    counts = numpy.asarray([src_counts] + bkg_counts)
-    numzero = numpy.sum(counts == 0, axis=0)
+    counts = np.asarray([src_counts] + bkg_counts)
+    numzero = np.sum(counts == 0, axis=0)
 
     nbkg = len(bkg_variances)
     ncpts = 1 + nbkg
@@ -1370,11 +1370,11 @@ def replace_xspecvar_values(src_counts, bkg_counts,
     # identifying them requires another loop as some_zero has
     # collapsed the data.
     #
-    idx, = numpy.asarray(src_counts == 0 & some_zero).nonzero()
+    idx, = np.asarray(src_counts == 0 & some_zero).nonzero()
     staterr[idx] = 0
 
     for bcnts, bvar in zip(bkg_counts, bkg_variances):
-        idx, = numpy.asarray(bcnts == 0 & some_zero).nonzero()
+        idx, = np.asarray(bcnts == 0 & some_zero).nonzero()
         bvar[idx] = 0
 
     # Do we have any bins where all source and background components
@@ -1419,10 +1419,10 @@ def replace_xspecvar_values(src_counts, bkg_counts,
     # as the source.
     #
     nelem = len(staterr)
-    scales = numpy.zeros((nbkg, nelem))
+    scales = np.zeros((nbkg, nelem))
     for idx, bscale in enumerate(bkg_scales):
-        if numpy.isscalar(bscale):
-            scales[idx] = numpy.ones(nelem) * bscale
+        if np.isscalar(bscale):
+            scales[idx] = np.ones(nelem) * bscale
         else:
             scales[idx] = bscale
 
@@ -1432,10 +1432,10 @@ def replace_xspecvar_values(src_counts, bkg_counts,
     #
     bkg_scale = scales.sum(axis=0) / nbkg
 
-    s = numpy.ones(nzero)
+    s = np.ones(nzero)
     b = (src_scale / bkg_scale)[all_zero]
-    combined = numpy.asarray([s, b])
-    minval = numpy.min(combined, axis=0)
+    combined = np.asarray([s, b])
+    minval = np.min(combined, axis=0)
 
     staterr[all_zero] = minval
     for bvar in bkg_variances:
@@ -1546,7 +1546,7 @@ class DataPHA(Data1D):
         if val == self._grouped:
             return
 
-        if not numpy.iterable(self.mask):
+        if not np.iterable(self.mask):
             self._grouped = val
             return
 
@@ -1661,7 +1661,7 @@ must be an integer.""")
         return self._response_ids
 
     def _set_response_ids(self, ids: Sequence[IdType]) -> None:
-        if not numpy.iterable(ids):
+        if not np.iterable(ids):
             raise DataErr('idsnotarray', 'response', str(ids))
 
         keys = list(self._responses.keys())
@@ -1682,7 +1682,7 @@ will be removed. The identifiers can be integers or strings.
         return self._background_ids
 
     def _set_background_ids(self, ids: Sequence[IdType]) -> None:
-        if not numpy.iterable(ids):
+        if not np.iterable(ids):
             raise DataErr('idsnotarray', 'background', str(ids))
 
         keys = list(self._backgrounds.keys())
@@ -1775,7 +1775,7 @@ will be removed. The identifiers can be integers or strings.
             setattr(self, f"_{attr}", None)
             return
 
-        if not numpy.iterable(val):
+        if not np.iterable(val):
             if not allow_scalar:
                 raise DataErr("notanarray")
 
@@ -1820,7 +1820,7 @@ will be removed. The identifiers can be integers or strings.
         # grouped and val is a sequence (so we test with isscalar
         # rather than iterable, to avoid selecting strings).
         #
-        if self.grouped and val is not None and not numpy.isscalar(val):
+        if self.grouped and val is not None and not np.isscalar(val):
             # The assumption is that if the data is grouped then it contains data.
             nexp = len(self.get_y(filter=False))
             if len(val) != nexp:
@@ -1895,7 +1895,7 @@ will be removed. The identifiers can be integers or strings.
         #
         if val is not None:
             try:
-                val = numpy.asarray(val, dtype=numpy.int16)
+                val = np.asarray(val, dtype=np.int16)
             except TypeError:
                 raise DataErr("notanintarray") from None
 
@@ -1907,7 +1907,7 @@ will be removed. The identifiers can be integers or strings.
         # has already been called).
         #
         ofilter = None
-        if self._NoNewAttributesAfterInit__initialized and numpy.iterable(self.mask):
+        if self._NoNewAttributesAfterInit__initialized and np.iterable(self.mask):
             ofilter = self.get_filter()
 
         self._set_related("grouping", val)
@@ -1958,7 +1958,7 @@ will be removed. The identifiers can be integers or strings.
         #
         if val is not None:
             try:
-                val = numpy.asarray(val, dtype=numpy.int16)
+                val = np.asarray(val, dtype=np.int16)
             except TypeError:
                 raise DataErr("notanintarray") from None
 
@@ -2623,7 +2623,7 @@ will be removed. The identifiers can be integers or strings.
                 elo, ehi, lookuptable = compile_energy_grid(energylist)
             elif (not energylist or
                   (len(energylist) == 1 and
-                      numpy.equal(energylist[0], None).any())):
+                      np.equal(energylist[0], None).any())):
                 raise DataErr('noenergybins', 'Response')
             else:
                 elo, ehi = energylist[0]
@@ -2653,8 +2653,8 @@ will be removed. The identifiers can be integers or strings.
         # Convert to an integer (this keeps the channel within
         # the group).
         #
-        mid = numpy.floor(mid)
-        val = numpy.asarray(val).astype(numpy.int_) - 1
+        mid = np.floor(mid)
+        val = np.asarray(val).astype(np.int_) - 1
         try:
             return mid[val]
         except IndexError:
@@ -2662,15 +2662,15 @@ will be removed. The identifiers can be integers or strings.
 
     def _channel_to_energy(self, val, group=True, response_id=None):
         elo, ehi = self._get_ebins(response_id=response_id, group=group)
-        val = numpy.asarray(val).astype(numpy.int_) - 1
+        val = np.asarray(val).astype(np.int_) - 1
         try:
             return (elo[val] + ehi[val]) / 2.0
         except IndexError:
             raise DataErr('invalidchannel', val) from None
 
     def _channel_to_wavelength(self, val, group=True, response_id=None):
-        tiny = numpy.finfo(numpy.float32).tiny
-        vals = numpy.asarray(self._channel_to_energy(val, group, response_id))
+        tiny = np.finfo(np.float32).tiny
+        vals = np.asarray(self._channel_to_energy(val, group, response_id))
         if vals.shape == ():
             if vals == 0.0:
                 vals = tiny
@@ -2781,7 +2781,7 @@ It is an integer or string.
             raise DataErr("The channel field of the background must be set")
 
         if len(self.channel) != len(bkg.channel) or \
-           numpy.any(self.channel != bkg.channel):
+           np.any(self.channel != bkg.channel):
             raise DataErr("The source and background channels differ")
 
         bkg_id = self._fix_background_id(id)
@@ -2973,11 +2973,11 @@ It is an integer or string.
             Negative values are replaced by 1.0.
 
         """
-        if numpy.isscalar(scale) and scale <= 0.0:
+        if np.isscalar(scale) and scale <= 0.0:
             return 1.0
 
-        if numpy.iterable(scale):
-            scale = numpy.asarray(scale, dtype=SherpaFloat)
+        if np.iterable(scale):
+            scale = np.asarray(scale, dtype=SherpaFloat)
             if group:
                 if filter:
                     scale = self.apply_filter(scale, self._middle)
@@ -3076,7 +3076,7 @@ It is an integer or string.
 
         return self._check_scale(self.areascal, group, filter)
 
-    def apply_filter(self, data, groupfunc=numpy.sum):
+    def apply_filter(self, data, groupfunc=np.sum):
         """Group and filter the supplied data to match the data set.
 
         Parameters
@@ -3199,7 +3199,7 @@ It is an integer or string.
             # Create an array for the full channel range and insert
             # the user-values into it.
             #
-            temp = numpy.zeros(nelem, dtype=SherpaFloat)
+            temp = np.zeros(nelem, dtype=SherpaFloat)
             temp[mask] = data
             data = temp
 
@@ -3219,7 +3219,7 @@ It is an integer or string.
         #
         return self._data_space.filter.apply(gdata)
 
-    def apply_grouping(self, data, groupfunc=numpy.sum):
+    def apply_grouping(self, data, groupfunc=np.sum):
         """Apply the grouping scheme of the data set to the supplied data.
 
         Parameters
@@ -3345,8 +3345,8 @@ It is an integer or string.
         if len(data) != nfilter or len(groups) != nfilter:
             raise DataErr("mismatchn", "quality filter", "array", nfilter, len(data))
 
-        filtered_data = numpy.asarray(data)[filter]
-        groups = numpy.asarray(groups)[filter]
+        filtered_data = np.asarray(data)[filter]
+        groups = np.asarray(groups)[filter]
         return do_group(filtered_data, groups, groupfunc.__name__)
 
     def ignore_bad(self):
@@ -3377,7 +3377,7 @@ It is an integer or string.
         if self.quality is None:
             raise DataErr("noquality", self.name)
 
-        qual_flags = ~numpy.asarray(self.quality, bool)
+        qual_flags = ~np.asarray(self.quality, bool)
 
         if self.grouped and (self.mask is not True):
             self.notice()
@@ -3446,7 +3446,7 @@ It is an integer or string.
         # that get_mask does it).
         #
         if "tabStops" in kwargs:
-            ts = numpy.asarray(kwargs["tabStops"])
+            ts = np.asarray(kwargs["tabStops"])
 
             # We only expand the array if it has the correct size
             # (expand_grouped_mask does not enforce length checks for
@@ -3458,7 +3458,7 @@ It is an integer or string.
             nts = len(ts)
             nchan = len(self.channel)
             if self.grouped and nts != nchan and \
-               numpy.iterable(self.mask) and len(self.mask) == nts:
+               np.iterable(self.mask) and len(self.mask) == nts:
                 ts = expand_grouped_mask(ts, self.grouping)
 
             kwargs["tabStops"] = ts
@@ -3471,7 +3471,7 @@ It is an integer or string.
             # b) get_mask can return None or an array.
             #
             mask = self.get_mask()
-            if numpy.iterable(mask):
+            if np.iterable(mask):
                 kwargs["tabStops"] = ~mask
 
         self.grouping, self.quality = group_func(*args, **kwargs)
@@ -4170,7 +4170,7 @@ It is an integer or string.
             bkgvar = sum(bkg_variances) / (nbkg * nbkg)
 
         statvar = staterr * staterr + bkgvar * src_scale * src_scale
-        return numpy.sqrt(statvar)
+        return np.sqrt(statvar)
 
     def get_syserror(self, filter=False):
         """Return any systematic error.
@@ -4256,7 +4256,7 @@ It is an integer or string.
 
         filter = bool_cast(filter)
         # make a copy of data for units manipulation
-        val = numpy.array(val, dtype=SherpaFloat)
+        val = np.array(val, dtype=SherpaFloat)
 
         if self.rate and self.exposure is not None:
             val /= self.exposure
@@ -4297,7 +4297,7 @@ It is an integer or string.
             else:  # Could be "energy" or "channel"
                 dx = xhi - xlo
 
-            val /= numpy.abs(dx)
+            val /= np.abs(dx)
 
         # The final step is to multiply by the X axis self.plot_fac
         # times.
@@ -4318,7 +4318,7 @@ It is an integer or string.
         #
         xlo, xhi = get_bin_edges()
         xmid = (xlo + xhi) / 2
-        val *= numpy.power(xmid, self.plot_fac)
+        val *= np.power(xmid, self.plot_fac)
         return val
 
     def get_y(self, filter=False, yfunc=None, response_id=None,
@@ -4391,7 +4391,7 @@ It is an integer or string.
                 # What should we do here? This indicates that all bins
                 # have been marked as bad (and grouping is present).
                 #
-                return numpy.asarray([])
+                return np.asarray([])
 
         # Issue #748 #1817 noted we should return the half-width
         # Issue #1985 notes that we need to support wavelength.
@@ -4447,22 +4447,22 @@ It is an integer or string.
 
     @staticmethod
     def _middle(array):
-        array = numpy.asarray(array)
+        array = np.asarray(array)
         return (array.min() + array.max()) / 2.0
 
     @staticmethod
     def _min(array):
-        array = numpy.asarray(array)
+        array = np.asarray(array)
         return array.min()
 
     @staticmethod
     def _max(array):
-        array = numpy.asarray(array)
+        array = np.asarray(array)
         return array.max()
 
     @staticmethod
     def _sum_sq(array):
-        return numpy.sqrt(numpy.sum(array * array))
+        return np.sqrt(np.sum(array * array))
 
     def get_noticed_channels(self):
         """Return the noticed channels.
@@ -4508,7 +4508,7 @@ It is an integer or string.
         if self.mask is True or not self.grouped:
             if self.quality_filter is not None:
                 return self.quality_filter
-            if numpy.iterable(self.mask):
+            if np.iterable(self.mask):
                 return self.mask
             return None
 
@@ -4858,7 +4858,7 @@ It is an integer or string.
             #   - iterable of int or str
             # it's a bit awkward to identify what is meant.
             #
-            if not isinstance(bkg_id, str) and numpy.iterable(bkg_id):
+            if not isinstance(bkg_id, str) and np.iterable(bkg_id):
                 bkg_ids = bkg_id
             else:
                 bkg_ids = [bkg_id]
@@ -4899,7 +4899,7 @@ It is an integer or string.
         try:
             elo, ehi = self._get_ebins(group=self.grouped)
         except DataErr as de:
-            info(f"Skipping dataset {self.name}: {de}")
+            info("Skipping dataset %s: %s", self.name, str(de))
             return
 
         emin = min(elo[[0, -1]])
@@ -5169,7 +5169,8 @@ class DataIMG(Data2D):
         # it is going to be wrong.
         #
         self.notice2d()
-        warning(f"Region filter has been removed from '{self.name}'")
+        warning("Region filter has been removed from '%s'",
+                self.name)
 
     def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the data
@@ -5240,7 +5241,8 @@ class DataIMG(Data2D):
         else:
             # If the region is "" then str() will produce '' so we want
             # double quotes about it.
-            warning(f'Unable to restore region="{self._region}" as region module is not available.')
+            warning('Unable to restore region="%s" as region module is not available.',
+                    str(self._region))
 
             self._region = None
 
@@ -5476,13 +5478,13 @@ class DataIMG(Data2D):
 
     def get_bounding_mask(self):
         mask = self.mask
-        if not numpy.iterable(self.mask):
+        if not np.iterable(self.mask):
             return mask, None
 
         # create bounding box around noticed image regions
-        mask = numpy.array(self.mask).reshape(*self.shape)
+        mask = np.array(self.mask).reshape(*self.shape)
 
-        x0_i, x1_i = numpy.where(mask)
+        x0_i, x1_i = np.where(mask)
 
         x0_lo = x0_i.min()
         x0_hi = x0_i.max()
@@ -5503,7 +5505,7 @@ class DataIMG(Data2D):
             return y_img
 
         m = self.eval_model_to_fit(yfunc)
-        if numpy.iterable(self.mask):
+        if np.iterable(self.mask):
             # if filtered, the calculated model must be padded up
             # to the data size to preserve img shape and WCS coord
             m = pad_bounding_box(m, self.mask)
@@ -5516,13 +5518,13 @@ class DataIMG(Data2D):
         self._check_shape()
 
         # dummy placeholders needed b/c img shape may not be square!
-        axis0 = numpy.arange(self.shape[1], dtype=float) + 1.
-        axis1 = numpy.arange(self.shape[0], dtype=float) + 1.
+        axis0 = np.arange(self.shape[1], dtype=float) + 1.
+        axis1 = np.arange(self.shape[0], dtype=float) + 1.
         if self.coord == 'logical':
             return (axis0, axis1)
 
-        dummy0 = numpy.ones(axis0.size, dtype=float)
-        dummy1 = numpy.ones(axis1.size, dtype=float)
+        dummy0 = np.ones(axis0.size, dtype=float)
+        dummy1 = np.ones(axis1.size, dtype=float)
 
         if self.coord == 'physical':
             axis0, dummy = self._logical_to_physical(axis0, dummy0)
@@ -5587,7 +5589,7 @@ class DataIMG(Data2D):
         y = self.filter_region(self.get_dep(False))
         if yfunc is not None:
             m = self.eval_model_to_fit(yfunc)
-            if numpy.iterable(self.mask):
+            if np.iterable(self.mask):
                 # if filtered, the calculated model must be padded up
                 # to the data size to preserve img shape and WCS coord
                 m = self.filter_region(pad_bounding_box(m, self.mask))
@@ -5600,7 +5602,7 @@ class DataIMG(Data2D):
                 self.get_x1label())
 
     def filter_region(self, data):
-        if data is None or not numpy.iterable(self.mask):
+        if data is None or not np.iterable(self.mask):
             return data
 
         # We do not want to change the data array hence the
@@ -5608,7 +5610,7 @@ class DataIMG(Data2D):
         # we convert to a type that can accept NaN values.
         #
         out = data.astype(dtype=SherpaFloat, casting="safe", copy=True)
-        out[~self.mask] = numpy.nan
+        out[~self.mask] = np.nan
         return out
 
 
@@ -5815,17 +5817,17 @@ class DataIMGInt(DataIMG):
         self._check_shape()
 
         # dummy placeholders needed b/c img shape may not be square!
-        axis0lo = numpy.arange(self.shape[1], dtype=float) - 0.5
-        axis1lo = numpy.arange(self.shape[0], dtype=float) - 0.5
+        axis0lo = np.arange(self.shape[1], dtype=float) - 0.5
+        axis1lo = np.arange(self.shape[0], dtype=float) - 0.5
 
-        axis0hi = numpy.arange(self.shape[1], dtype=float) + 0.5
-        axis1hi = numpy.arange(self.shape[0], dtype=float) + 0.5
+        axis0hi = np.arange(self.shape[1], dtype=float) + 0.5
+        axis1hi = np.arange(self.shape[0], dtype=float) + 0.5
 
         if self.coord == 'logical':
             return (axis0lo, axis1lo, axis0hi, axis1hi)
 
-        dummy0 = numpy.ones(axis0lo.size, dtype=float)
-        dummy1 = numpy.ones(axis1lo.size, dtype=float)
+        dummy0 = np.ones(axis0lo.size, dtype=float)
+        dummy1 = np.ones(axis1lo.size, dtype=float)
 
         if self.coord == 'physical':
             axis0lo, dummy = self._logical_to_physical(axis0lo, dummy0)

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -4644,3 +4644,49 @@ def test_dataimg_axis_ordering_1880():
     a0, a1 = orig.get_indep()
     assert a0 == pytest.approx([100, 110] * 3)
     assert a1 == pytest.approx([200, 200, 210, 210, 220, 220])
+
+
+def test_rmf_get_indep():
+    """Check this routine."""
+
+    ebins = np.asarray([3.0, 5., 8.0, 12.0])
+    rlo = ebins[:-1]
+    rhi = ebins[1:]
+    rmf = create_delta_rmf(rlo, rhi, e_min=rlo, e_max=rhi)
+
+    xlo, xhi = rmf.get_indep()
+    assert xlo == pytest.approx(rlo)
+    assert xhi == pytest.approx(rhi)
+
+
+def test_rmf_get_dep_simple():
+    """Check this routine."""
+
+    ebins = np.asarray([3.0, 5., 8.0, 12.0])
+    rlo = ebins[:-1]
+    rhi = ebins[1:]
+    rmf = create_delta_rmf(rlo, rhi, e_min=rlo, e_max=rhi)
+
+    # This is an "ideal" response.
+    #
+    y = rmf.get_dep()
+    assert y == pytest.approx([1, 1, 1])
+
+
+def test_rmf_get_dep_complex():
+    """Check this routine."""
+
+    ebins = np.asarray([1.1, 1.2, 1.5, 2.0, 3.0, 6.0])
+    rlo = ebins[:-1]
+    rhi = ebins[1:]
+    rmf = DataRMF("x", 5, rlo, rhi,
+                  [1, 1, 1, 1, 1],  # n_grp
+                  [2, 3, 4, 4, 3],  # f_chan
+                  [2, 1, 1, 1, 2],  # n_chan
+                  [0.4, 0.6, 1.0, 1.0, 1.0, 0.2, 0.8],  # matrix
+                  e_min=rlo, e_max=rhi)
+
+    # This RMF only fills in channels 2 to 4.
+    #
+    y = rmf.get_dep()
+    assert y == pytest.approx([0, 0.4, 1.8, 2.8, 0])

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1725,7 +1725,7 @@ class Data1D(Data):
     def get_xerr(self,
                  filter: bool = False,
                  yfunc=None
-                 ) -> None:
+                 ) -> Optional[np.ndarray]:
         """Return linear view of bin size in independent axis/axes.
 
         Parameters
@@ -2163,7 +2163,7 @@ class Data1DInt(Data1D):
     def get_xerr(self,
                  filter: bool = False,
                  model: Optional[ModelFunc] = None
-                 ) -> np.ndarray:
+                 ) -> Optional[np.ndarray]:
         """Returns an X "error".
 
         The error value for the independent axis is not well defined
@@ -2182,7 +2182,8 @@ class Data1DInt(Data1D):
         Returns
         -------
         xerr : ndarray
-           The half-width of each bin.
+           The half-width of each bin. Although the types suggest it
+           can be None, it will always be an array, even if empty.
 
         """
         indep = self.get_evaluation_indep(filter, model)

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -33,7 +33,8 @@ import pydoc
 import string
 import sys
 from types import FunctionType, MethodType
-from typing import Any, Callable, Generic, Optional, TypeVar
+from typing import Any, Callable, Generic, Optional, Sequence, \
+    TypeVar
 import warnings
 
 import numpy as np
@@ -966,7 +967,11 @@ def pad_bounding_box(kernel, mask):
 eps = np.finfo(np.float32).eps
 
 
-def filter_bins(mins, maxes, axislist, integrated=False):
+def filter_bins(mins: Sequence[Optional[float]],
+                maxes: Sequence[Optional[float]],
+                axislist: Sequence[Sequence[float]],
+                integrated: bool = False
+                ) -> Optional[np.ndarray]:
     """What mask represents the given set of filters?
 
     The ranges are treated as inclusive at both ends if integrated is


### PR DESCRIPTION
# Summary

Internal clean up of some of the data code.

# Details

This was written as part of #1944 but I know some of the changes have been "re-invented" for other PRs, so let's just get them merged to avoid conflicts.

This is all minor clean ups

- some style changes (e.g. "import numpy as np" and some lazy-logging changes)
- some fix ups to typing rules
- some additions of typing rules point out a place where we technically can return a None but do not deal with that (there is the thought that maybe we can not hit this case here, but it's hard to track down the requirements so easiest to explicitly fail rather than let Python fail with an `AttributeError`)
