### PR TITLE
Improve the documentation of the id/bkg_id/resp_id arguments

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4531,7 +4531,11 @@ It is an integer or string.
 
         return create_expr(chans, format='%i')
 
-    def get_filter(self, group=True, format='%.12f', delim=':'):
+    def get_filter(self,
+                   group: bool = True,
+                   format: str = '%.12f',
+                   delim: str = ':'
+                   ) -> str:
         """Return the data filter as a string.
 
         The filter expression depends on the analysis setting.
@@ -4681,7 +4685,7 @@ It is an integer or string.
 
         return create_expr_integrated(xlo[mask], xhi[mask], mask=mask, format=format, delim=delim)
 
-    def get_filter_expr(self):
+    def get_filter_expr(self) -> str:
         return (self.get_filter(format='%.4f', delim='-') +
                 ' ' + self.get_xlabel())
 

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -4387,6 +4387,23 @@ def test_pha_check_background_ids_basic():
     assert pha.background_ids == pytest.approx([1, "up"])
 
 
+@pytest.mark.parametrize("bkg_id", [None, 1, "foo"])
+def test_pha_delete_unknown_background(bkg_id):
+    """What happens if we delete an unknown background?"""
+
+    pha = DataPHA("src", [1, 2, 3], [1, 1, 1])
+    b1 = DataPHA("b1", [1, 2, 3], [1, 1, 1])
+    b2 = DataPHA("b2", [1, 2, 3], [1, 1, 1])
+
+    pha.set_background(b1, id="up")
+    pha.set_background(b1, id="down")
+
+    # This is treated as a no-op
+    pha.delete_background(bkg_id)
+
+    assert pha.background_ids == pytest.approx(["up", "down"])
+
+
 def test_pha_check_response_ids_basic():
     """Check response_ids can be used.
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -18,6 +18,8 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 import logging
 import os
@@ -57,7 +59,7 @@ info = logging.getLogger(__name__).info
 __all__ = ('Session',)
 
 
-def _get_image_filter(data):
+def _get_image_filter(data: DataIMG) -> str:
     """When reporting filters, we need to handle images separately.
 
     There is a disconnect between 1D and 2D filters as an empty string
@@ -96,7 +98,7 @@ def _get_image_filter(data):
     return data.get_filter()
 
 
-def _pha_report_filter_change(session,
+def _pha_report_filter_change(session: Session,
                               idval: Optional[IdType],
                               bkg_id: Optional[IdType],
                               changefunc: Callable[[DataPHA], None]
@@ -179,7 +181,7 @@ def _check_pha_tabstops(data: DataPHA,
     return np.zeros(data.size)
 
 
-def _save_errorcol(session,
+def _save_errorcol(session: Session,
                    idval: Optional[IdType],
                    filename,
                    bkg_id: Optional[IdType],
@@ -319,7 +321,7 @@ class Session(sherpa.ui.utils.Session):
         super().__setstate__(state)
 
     def clean(self) -> None:
-        self._pileup_models = {}
+        self._pileup_models: dict[IdType, Model] = {}
 
         # First key is id, second key is bkg_id.
         #
@@ -356,7 +358,7 @@ class Session(sherpa.ui.utils.Session):
     clean.__doc__ = sherpa.ui.utils.Session.clean.__doc__
     clean.__annotations__ = sherpa.ui.utils.Session.clean.__annotations__
 
-    def _set_plot_types(self):
+    def _set_plot_types(self) -> None:
         """Set up the plot types."""
 
         # The keys are used by the set_xlog/... calls to identify what
@@ -416,7 +418,7 @@ class Session(sherpa.ui.utils.Session):
     # Add ability to save attributes specific to the astro package.
     # Save XSPEC module settings that need to be restored.
     #
-    def save(self, filename='sherpa.save', clobber=False):
+    def save(self, filename='sherpa.save', clobber=False) -> None:
         """Save the current Sherpa session to a file.
 
         Parameters
@@ -476,7 +478,7 @@ class Session(sherpa.ui.utils.Session):
 
         super().save(filename, clobber)
 
-    def restore(self, filename='sherpa.save'):
+    def restore(self, filename='sherpa.save') -> None:
         """Load in a Sherpa session from a file.
 
         .. warning::
@@ -883,7 +885,7 @@ class Session(sherpa.ui.utils.Session):
         ids, f = self._get_bkg_fit(id, otherids)
         return f.calc_stat()
 
-    def calc_bkg_stat_info(self):
+    def calc_bkg_stat_info(self) -> None:
         """Display the statistic values for the current background models.
 
         Returns the statistics values for background datasets with
@@ -1121,7 +1123,9 @@ class Session(sherpa.ui.utils.Session):
         data.set_background(bkg, bkg_id)
 
     # DOC-NOTE: also in sherpa.utils
-    def dataspace2d(self, dims, id=None, dstype=DataIMG):
+    def dataspace2d(self, dims,
+                    id: Optional[IdType] = None,
+                    dstype=DataIMG) -> None:
         """Create the independent axis for a 2D data set.
 
         Create an "empty" two-dimensional data set by defining the
@@ -1132,7 +1136,7 @@ class Session(sherpa.ui.utils.Session):
         ----------
         dims : sequence of 2 number
            The dimensions of the grid in ``(width,height)`` order.
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
@@ -1246,7 +1250,7 @@ class Session(sherpa.ui.utils.Session):
     # DOC-NOTE: also in sherpa.utils
     # DOC-TODO: rework the Data type notes section (also needed for
     # unpack_arrays)
-    def load_arrays(self, id, *args):
+    def load_arrays(self, id: IdType, *args) -> None:
         """Create a data set from array values.
 
         Parameters
@@ -1415,7 +1419,7 @@ class Session(sherpa.ui.utils.Session):
     # DataX class documentation, but users may not find it)
     # DOC-TODO: what do the shape arguments for Data2D/Data2DInt mean?
     def load_table(self, id, filename=None, ncols=2, colkeys=None,
-                   dstype=Data1D):
+                   dstype=Data1D) -> None:
         """Load a FITS binary file as a data set.
 
         Parameters
@@ -1611,7 +1615,8 @@ class Session(sherpa.ui.utils.Session):
     # DOC-TODO: how best to include datastack support?
     # DOC-TODO: what does shape mean here (how is it encoded)?
     def load_ascii(self, id, filename=None, ncols=2, colkeys=None,
-                   dstype=Data1D, sep=' ', comment='#'):
+                   dstype=Data1D, sep=' ',
+                   comment='#') -> None:
         """Load an ASCII file as a data set.
 
         The standard behavior is to create a single data set, but
@@ -1786,7 +1791,8 @@ class Session(sherpa.ui.utils.Session):
                     return self.unpack_ascii(filename, *args, **kwargs)
 
     def load_ascii_with_errors(self, id, filename=None, colkeys=None, sep=' ',
-                               comment='#', func=np.average, delta=False):
+                               comment='#', func=np.average,
+                               delta=False) -> None:
         """Load an ASCII file with asymmetric errors as a data set.
 
         Create a dataset with asymmetric error bars which can be used
@@ -1899,14 +1905,17 @@ class Session(sherpa.ui.utils.Session):
 
         data.staterror = staterror
 
-    def _load_data(self, id, datasets):
+    def _load_data(self,
+                   id: Optional[IdType],
+                   datasets: Union[Data, Sequence[Data]]
+                   ) -> None:
         """Load one or more datasets.
 
         Used by load_data and load_pha.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None
            The identifier for the data set to use. For multi-dataset
            files, currently only PHA2, the id value indicates the
            first dataset: if it is an integer then the numbering
@@ -1952,7 +1961,8 @@ class Session(sherpa.ui.utils.Session):
     # DOC-NOTE: also in sherpa.utils without the support for
     #           multiple datasets.
     #
-    def load_data(self, id, filename=None, *args, **kwargs):
+    def load_data(self, id, filename=None, *args,
+                  **kwargs) -> None:
         # pylint: disable=W1113
         """Load a data set from a file.
 
@@ -2085,7 +2095,7 @@ class Session(sherpa.ui.utils.Session):
         return sherpa.astro.io.read_image(arg, coord, dstype)
 
     def load_image(self, id, arg=None, coord='logical',
-                   dstype=DataIMG):
+                   dstype=DataIMG) -> None:
         """Load an image as a data set.
 
         .. versionchanged:: 4.16.0
@@ -2257,7 +2267,8 @@ class Session(sherpa.ui.utils.Session):
         return sherpa.astro.io.read_pha(arg, use_errors, True)
 
     # DOC-TODO: how best to include datastack support?
-    def load_pha(self, id, arg=None, use_errors=False):
+    def load_pha(self, id, arg=None,
+                 use_errors=False) -> None:
         """Load a PHA data set.
 
         This will load the PHA data and any related information, such
@@ -2465,7 +2476,7 @@ class Session(sherpa.ui.utils.Session):
 
         return self.get_bkg(id, bkg_id)
 
-    def _get_img_data(self, id):
+    def _get_img_data(self, id: Optional[IdType]) -> DataIMG:
         """Ensure the dataset is an image"""
         idval = self._fix_id(id)
         data = self.get_data(idval)
@@ -4399,7 +4410,7 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-NOTE: also in sherpa.utils with a different interface
     def save_arrays(self, filename, args, fields=None, ascii=True,
-                    clobber=False):
+                    clobber=False) -> None:
         """Write a list of arrays to a file.
 
         Parameters
@@ -5545,7 +5556,8 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: setting ascii=True is not supported for crates
     # and in pyfits it seems to just be a 1D array (needs thinking about)
-    def save_image(self, id, filename=None, ascii=False, clobber=False):
+    def save_image(self, id, filename=None, ascii=False,
+                   clobber=False) -> None:
         """Save the pixel values of a 2D data set to a file.
 
         Parameters
@@ -5613,7 +5625,8 @@ class Session(sherpa.ui.utils.Session):
                                     ascii=ascii, clobber=clobber)
 
     # DOC-TODO: the output for an image is "excessive"
-    def save_table(self, id, filename=None, ascii=False, clobber=False):
+    def save_table(self, id, filename=None, ascii=False,
+                   clobber=False) -> None:
         """Save a data set to a file as a table.
 
         Parameters
@@ -5860,7 +5873,7 @@ class Session(sherpa.ui.utils.Session):
 
     @staticmethod
     def create_arf(elo, ehi, specresp=None, exposure=None, ethresh=None,
-                   name='test-arf'):
+                   name='test-arf') -> DataARF:
         """Create an ARF.
 
         .. versionadded:: 4.10.1
@@ -5915,7 +5928,8 @@ class Session(sherpa.ui.utils.Session):
 
     @staticmethod
     def create_rmf(rmflo, rmfhi, startchan=1, e_min=None, e_max=None,
-                   ethresh=None, fname=None, name='delta-rmf'):
+                   ethresh=None, fname=None,
+                   name='delta-rmf') -> DataRMF:
         """Create an RMF.
 
         If fname is set to `None` then this creates a "perfect" RMF,
@@ -7131,7 +7145,9 @@ class Session(sherpa.ui.utils.Session):
     # DOC-TODO: docs need to be added to sherpa.astro.data.set_analysis
     # DOC-TODO: should the arguments be renamed to better match optional
     # nature of the routine (e.g. can call set_analysis('energy'))?
-    def set_analysis(self, id, quantity=None, type='rate', factor=0):
+    #
+    def set_analysis(self, id, quantity=None, type='rate',
+                     factor=0) -> None:
         """Set the units used when fitting and displaying spectral data.
 
         The set_analysis command sets the units for spectral
@@ -9611,7 +9627,7 @@ class Session(sherpa.ui.utils.Session):
     def fake_pha(self, id, arf=None, rmf=None, exposure=None,
                  backscal=None, areascal=None, grouping=None,
                  grouped=False, quality=None, bkg=None,
-                 method=None):
+                 method=None) -> None:
         """Simulate a PHA data set from a model.
 
         The function creates a simulated PHA data set based on a source
@@ -9938,7 +9954,8 @@ class Session(sherpa.ui.utils.Session):
     # PSF
     ###########################################################################
 
-    def load_psf(self, modelname, filename_or_model, *args, **kwargs):
+    def load_psf(self, modelname, filename_or_model, *args,
+                 **kwargs) -> None:
         kernel = filename_or_model
         if _is_str(filename_or_model):
             try:
@@ -9961,7 +9978,7 @@ class Session(sherpa.ui.utils.Session):
     ###########################################################################
 
     # DOC-NOTE: also in sherpa.utils
-    def set_full_model(self, id, model=None):
+    def set_full_model(self, id, model=None) -> None:
         """Define the convolved model expression for a data set.
 
         The model expression created by `set_model` can be modified by
@@ -10275,7 +10292,8 @@ class Session(sherpa.ui.utils.Session):
     # DOC-NOTE: should this be made a general function, since it
     # presumably does not care about pileup, just adds the
     # given model into the expression? Or is it PHA specific?
-    def set_pileup_model(self, id, model=None):
+    #
+    def set_pileup_model(self, id, model=None) -> None:
         """Include a model of the Chandra ACIS pile up when fitting PHA data.
 
         Chandra observations of bright sources can be affected by
@@ -10468,7 +10486,6 @@ class Session(sherpa.ui.utils.Session):
             resp = sherpa.astro.instrument.Response1D(data)
 
         return resp(src)
-
 
     def set_bkg_full_model(self, id, model=None,
                            bkg_id: Optional[IdType] = None
@@ -10776,7 +10793,8 @@ class Session(sherpa.ui.utils.Session):
 
         return (x, y)
 
-    def load_xstable_model(self, modelname, filename, etable=False):
+    def load_xstable_model(self, modelname, filename,
+                           etable=False) -> None:
         """Load a XSPEC table model.
 
         Create an additive ('atable', [1]), multiplicative
@@ -10872,7 +10890,8 @@ class Session(sherpa.ui.utils.Session):
     # DOC-NOTE: can filename be a crate/hdulist?
     # DOC-TODO: how to describe the supported args/kwargs (not just for this function)?
     def load_table_model(self, modelname, filename,
-                         method=sherpa.utils.linear_interp, *args, **kwargs):
+                         method=sherpa.utils.linear_interp, *args,
+                         **kwargs) -> None:
         # pylint: disable=W1113
         """Load tabular or image data and use it as a model component.
 
@@ -10973,7 +10992,9 @@ class Session(sherpa.ui.utils.Session):
     # ## also in sherpa.utils
     # DOC-TODO: how to describe *args/**kwargs
     # DOC-TODO: how is the _y value used if set
-    def load_user_model(self, func, modelname, filename=None, *args, **kwargs):
+    #
+    def load_user_model(self, func, modelname, filename=None,
+                        *args, **kwargs) -> None:
         # pylint: disable=W1113
         """Create a user-defined model.
 
@@ -12011,7 +12032,6 @@ class Session(sherpa.ui.utils.Session):
         plotobj.prepare(arf, data)
         return plotobj
 
-
     def get_rmf_plot(self,
                      id: Optional[IdType] = None,
                      resp_id: Optional[IdType] = None,
@@ -12075,7 +12095,6 @@ class Session(sherpa.ui.utils.Session):
 
         plotobj.prepare(rmf, data)
         return plotobj
-
 
     def get_bkg_fit_plot(self,
                          id: Optional[IdType] = None,
@@ -12965,7 +12984,8 @@ class Session(sherpa.ui.utils.Session):
                  id: Optional[IdType] = None,
                  resp_id: Optional[IdType] = None,
                  replot=False, overplot=False,
-                 clearwindow=True, **kwargs) -> None:
+                 clearwindow=True,
+                 **kwargs) -> None:
         """Plot the ARF associated with a data set.
 
         Display the effective area curve from the ARF
@@ -13039,7 +13059,8 @@ class Session(sherpa.ui.utils.Session):
                  id: Optional[IdType] = None,
                  resp_id: Optional[IdType] = None,
                  replot=False, overplot=False,
-                 clearwindow=True, **kwargs) -> None:
+                 clearwindow=True,
+                 **kwargs) -> None:
         """Plot the RMF associated with a data set.
 
         Display the energy redistribution from the RMF

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -41,7 +41,7 @@ from sherpa.data import Data1D, Data1DAsymmetricErrs, Data2D, Data2DInt
 import sherpa.astro.all
 import sherpa.astro.plot
 from sherpa.astro.ui import serialize
-from sherpa.fit import Fit, FitResults
+from sherpa.fit import Fit
 from sherpa.sim import NormalParameterSampleFromScaleMatrix
 from sherpa.stats import Cash, CStat, WStat
 from sherpa.models.basic import TableModel

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 import logging
 import os
 import sys
-from typing import Optional, Union
+from typing import Callable, Optional, Sequence, Union
 import warnings
 
 import numpy as np
@@ -96,7 +96,11 @@ def _get_image_filter(data):
     return data.get_filter()
 
 
-def _pha_report_filter_change(session, idval, bkg_id, changefunc):
+def _pha_report_filter_change(session,
+                              idval: Optional[IdType],
+                              bkg_id: Optional[IdType],
+                              changefunc: Callable[[DataPHA], None]
+                              ) -> None:
     """Change the PHA object and report the filter change
 
     This reports the filter change even if the data is not grouped, as
@@ -108,7 +112,7 @@ def _pha_report_filter_change(session, idval, bkg_id, changefunc):
     session : sherpa.astro.ui.utils.Session instance
     idval : int, str, or None
         The dataset identifier, which must represent a DataPHA object.
-    bkg_id : int or None
+    bkg_id : int, str, or None
         The background identifier (if set)
     changefunc : callable
         This takes a DataPHA instance and changes it, possibly
@@ -136,7 +140,8 @@ def _pha_report_filter_change(session, idval, bkg_id, changefunc):
 
 
 def _check_pha_tabstops(data: DataPHA,
-                        tabStops: Optional[Union[str, list, np.ndarray]]) -> Union[None, np.ndarray]:
+                        tabStops: Optional[Union[str, list, np.ndarray]]
+                        ) -> Optional[np.ndarray]:
     """Validate the tabStops argument for the group_xxx calls.
 
     This converts from "nofilter" to numpy.zeros(nchan), where
@@ -174,19 +179,25 @@ def _check_pha_tabstops(data: DataPHA,
     return np.zeros(data.size)
 
 
-def _save_errorcol(session, idval, filename, bkg_id,
-                   clobber, asciiflag,
-                   get_err, colname):
+def _save_errorcol(session,
+                   idval: Optional[IdType],
+                   filename,
+                   bkg_id: Optional[IdType],
+                   clobber,
+                   asciiflag,
+                   get_err,
+                   colname
+                   ) -> None:
     """Write out the error column.
 
     Parameters
     ----------
     session : AstroSession instance
-    idval : int or str or None
+    idval : int, str, or None
         The identifier (or filename)
     filename : str or None
         The filename (when idval is not None)
-    bkg_id : int or None
+    bkg_id : int, str, or None
         The background identifier (if wanted).
     clobber : bool
         Do we clobber the file if it exists?
@@ -227,7 +238,7 @@ def _save_errorcol(session, idval, filename, bkg_id,
 class BkgFitStore(sherpa.ui.utils.FitStore):
     """Store per-dataset information for a background fit"""
 
-    bkg_id : Union[int, str]
+    bkg_id : IdType
 
 
 class Session(sherpa.ui.utils.Session):
@@ -236,7 +247,7 @@ class Session(sherpa.ui.utils.Session):
     # Standard methods
     ###########################################################################
 
-    def __init__(self):
+    def __init__(self) -> None:
 
         self.clean()
         super().__init__()
@@ -245,7 +256,10 @@ class Session(sherpa.ui.utils.Session):
     # High-level utilities
     ###########################################################################
 
-    def _fix_background_id(self, id, bkg_id):
+    def _fix_background_id(self,
+                           id: Optional[IdType],
+                           bkg_id: Optional[IdType]
+                           ) -> IdType:
         """Validate the background id.
 
         The identifier has the same restrictions as the dataset
@@ -253,10 +267,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str or None
+        id : int, str, or None
             The dataset identifier. This is only used if bkg_id is
             None and must refer to a DataPHA dataset.
-        bkg_id : int or str or None
+        bkg_id : int, str, or None
             The identifier to check. If None then the default background
             identifier will be used, taken from the id dataset.
 
@@ -304,10 +318,13 @@ class Session(sherpa.ui.utils.Session):
 
         super().__setstate__(state)
 
-    def clean(self):
+    def clean(self) -> None:
         self._pileup_models = {}
-        self._background_models = {}
-        self._background_sources = {}
+
+        # First key is id, second key is bkg_id.
+        #
+        self._background_models: dict[IdType, dict[IdType, Model]] = {}
+        self._background_sources: dict[IdType, dict[IdType, Model]] = {}
 
         # The fit-model for PHA data does not get stored in a field
         # (it is created whenever needed), so we should probably do
@@ -514,7 +531,7 @@ class Session(sherpa.ui.utils.Session):
                 sherpa.astro.xspec.set_xsstate(self._xspec_state)
                 self._xspec_state = None
 
-    def _get_show_data(self, id=None):
+    def _get_show_data(self, id: Optional[IdType] = None) -> str:
         """Show the data"""
 
         if id is None:
@@ -571,7 +588,10 @@ class Session(sherpa.ui.utils.Session):
 
         return data_str
 
-    def _get_show_bkg(self, id=None, bkg_id=None):
+    def _get_show_bkg(self,
+                      id: Optional[IdType] = None,
+                      bkg_id: Optional[IdType] = None
+                      ) -> str:
         """Show the background"""
 
         if id is None:
@@ -610,7 +630,10 @@ class Session(sherpa.ui.utils.Session):
 
         return data_str
 
-    def _get_show_bkg_model(self, id=None, bkg_id=None):
+    def _get_show_bkg_model(self,
+                            id: Optional[IdType] = None,
+                            bkg_id: Optional[IdType] = None
+                            ) -> str:
         """Show the background model"""
 
         if id is None:
@@ -633,7 +656,10 @@ class Session(sherpa.ui.utils.Session):
 
         return model_str
 
-    def _get_show_bkg_source(self, id=None, bkg_id=None):
+    def _get_show_bkg_source(self,
+                             id: Optional[IdType] = None,
+                             bkg_id: Optional[IdType] = None
+                             ) -> str:
         """Show the background source"""
 
         if id is None:
@@ -646,7 +672,7 @@ class Session(sherpa.ui.utils.Session):
             if bkg_id is not None:
                 bkg_ids = [bkg_id]
             else:
-                bkg_ids = self._background_sources.get(idval, {}).keys()
+                bkg_ids = list(self._background_sources.get(idval, {}).keys())
 
             for bidval in bkg_ids:
                 model_str += f'Background Source: {idval}:{bidval}\n'
@@ -654,7 +680,12 @@ class Session(sherpa.ui.utils.Session):
 
         return model_str
 
-    def show_bkg(self, id=None, bkg_id=None, outfile=None, clobber=False):
+    def show_bkg(self,
+                 id: Optional[IdType] = None,
+                 bkg_id: Optional[IdType] = None,
+                 outfile=None,
+                 clobber: bool = False
+                 ) -> None:
         """Show the details of the PHA background data sets.
 
         This displays information about the background, or
@@ -665,10 +696,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then all background data sets
            are displayed.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            The background component to display. The default is all
            components.
         outfile : str, optional
@@ -696,7 +727,12 @@ class Session(sherpa.ui.utils.Session):
         txt = self._get_show_bkg(id, bkg_id)
         send_to_pager(txt, outfile, clobber)
 
-    def show_bkg_source(self, id=None, bkg_id=None, outfile=None, clobber=False):
+    def show_bkg_source(self,
+                        id: Optional[IdType] = None,
+                        bkg_id: Optional[IdType] = None,
+                        outfile=None,
+                        clobber: bool = False
+                        ) -> None:
         """Display the background model expression for a data set.
 
         This displays the background model for a data set, that is,
@@ -707,10 +743,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then all background expressions
            are displayed.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            The background component to display. The default is all
            components.
         outfile : str, optional
@@ -740,7 +776,12 @@ class Session(sherpa.ui.utils.Session):
         txt = self._get_show_bkg_source(id, bkg_id)
         send_to_pager(txt, outfile, clobber)
 
-    def show_bkg_model(self, id=None, bkg_id=None, outfile=None, clobber=False):
+    def show_bkg_model(self,
+                       id: Optional[IdType] = None,
+                       bkg_id: Optional[IdType] = None,
+                       outfile=None,
+                       clobber: bool = False
+                       ) -> None:
         """Display the background model expression used to fit a data set.
 
         This displays the model used to the the background data set,
@@ -752,10 +793,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then all background expressions are
            displayed.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            The background component to display. The default is all
            components.
         outfile : str, optional
@@ -785,7 +826,9 @@ class Session(sherpa.ui.utils.Session):
         txt = self._get_show_bkg_model(id, bkg_id)
         send_to_pager(txt, outfile, clobber)
 
-    def calc_bkg_stat(self, id=None, *otherids):
+    def calc_bkg_stat(self,
+                      id: Optional[IdType] = None,
+                      *otherids: IdType):
         """Calculate the fit statistic for a background data set.
 
         Evaluate the current background models for the background
@@ -799,7 +842,7 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then all
            background data sets with an associated background model
            are used simultaneously.
@@ -954,7 +997,10 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-NOTE: also in sherpa.utils
     def dataspace1d(self, start, stop, step=1, numbins=None,
-                    id=None, bkg_id=None, dstype=sherpa.data.Data1DInt):
+                    id: Optional[IdType] = None,
+                    bkg_id: Optional[IdType] = None,
+                    dstype=sherpa.data.Data1DInt
+                    ) -> None:
         """Create the independent axis for a 1D data set.
 
         Create an "empty" one-dimensional data set by defining the
@@ -973,11 +1019,11 @@ class Session(sherpa.ui.utils.Session):
         numbins : int, optional
            The number of grid points. This over-rides the ``step``
            setting.
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            If set, the grid is for the background component of the
            data set.
         dstype : data class to use, optional
@@ -2356,15 +2402,18 @@ class Session(sherpa.ui.utils.Session):
         phasets = self.unpack_pha(arg, use_errors)
         self._load_data(id, phasets)
 
-    def _get_pha_data(self, id, bkg_id=None):
+    def _get_pha_data(self,
+                      id: Optional[IdType],
+                      bkg_id: Optional[IdType] = None
+                      ) -> DataPHA:
         """Ensure the dataset is a PHA.
 
         Parameters
         ----------
-        id : int or str or None
+        id : int, str, or None
             The dataset identifier. A value of None means the
             default identifier is used.
-        bkg_id : int or None
+        bkg_id : int, str, or None
             If set then pick the background component instead.
 
         Returns
@@ -2388,7 +2437,10 @@ class Session(sherpa.ui.utils.Session):
         raise IdentifierErr('getitem', 'background data set', bkg_id,
                             f'in PHA data set {idval} has not been set')
 
-    def _get_data_or_bkg(self, id, bkg_id=None):
+    def _get_data_or_bkg(self,
+                         id: Optional[IdType],
+                         bkg_id: Optional[IdType] = None
+                         ) -> sherpa.data.Data:
         """Return the given dataset (may be a background).
 
         Unlike _get_pha_data it does not force the data to
@@ -2396,10 +2448,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str or None
+        id : int, str, or None
             The dataset identifier. A value of None means the
             default identifier is used.
-        bkg_id : int or None
+        bkg_id : int, str, or None
             If set then pick the background component instead.
 
         Returns
@@ -2443,8 +2495,10 @@ class Session(sherpa.ui.utils.Session):
     # DOC-NOTE: also in sherpa.utils
     # DOC-TODO: does ncols make sense here? (have removed for now)
     #
-    def load_filter(self, id, filename=None, bkg_id=None, ignore=False,
-                    ncols=2, *args, **kwargs):
+    def load_filter(self, id, filename=None,
+                    bkg_id: Optional[IdType] = None,
+                    ignore=False, ncols=2,
+                    *args, **kwargs) -> None:
         # pylint: disable=W1113
         """Load the filter array from a file and add to a data set.
 
@@ -2459,7 +2513,7 @@ class Session(sherpa.ui.utils.Session):
            information. This file can be a FITS table or an ASCII
            file. Selection of the relevant column depends on the I/O
            library in use (Crates or AstroPy).
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the filter array should be associated with the
            background associated with the data set.
         ignore : bool, optional
@@ -2525,7 +2579,9 @@ class Session(sherpa.ui.utils.Session):
     # DOC-TODO: prob. needs a review as the existing ahelp documentation
     # talks about 2 cols, but experimentation suggests 1 col.
     #
-    def load_grouping(self, id, filename=None, bkg_id=None, *args, **kwargs):
+    def load_grouping(self, id, filename=None,
+                      bkg_id: Optional[IdType] = None,
+                      *args, **kwargs) -> None:
         # pylint: disable=W1113
         """Load the grouping scheme from a file and add to a PHA data set.
 
@@ -2545,7 +2601,7 @@ class Session(sherpa.ui.utils.Session):
            information. This file can be a FITS table or an ASCII
            file. Selection of the relevant column depends on the I/O
            library in use (Crates or AstroPy).
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the grouping scheme should be associated with the
            background associated with the data set.
         colkeys : array of str, optional
@@ -2612,7 +2668,9 @@ class Session(sherpa.ui.utils.Session):
         grouping = self._read_user_model(filename, *args, **kwargs)[1]
         self.set_grouping(id, grouping, bkg_id=bkg_id)
 
-    def load_quality(self, id, filename=None, bkg_id=None, *args, **kwargs):
+    def load_quality(self, id, filename=None,
+                     bkg_id: Optional[IdType] = None,
+                     *args, **kwargs) -> None:
         # pylint: disable=W1113
         """Load the quality array from a file and add to a PHA data set.
 
@@ -2631,7 +2689,7 @@ class Session(sherpa.ui.utils.Session):
            information. This file can be a FITS table or an ASCII
            file. Selection of the relevant column depends on the I/O
            library in use (Crates or AstroPy).
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the quality array should be associated with the
            background associated with the data set.
         colkeys : array of str, optional
@@ -2689,7 +2747,10 @@ class Session(sherpa.ui.utils.Session):
         mdata = self._read_user_model(filename, *args, **kwargs)
         self.set_quality(id, mdata[1], bkg_id=bkg_id)
 
-    def set_filter(self, id, val=None, bkg_id=None, ignore=False):
+    def set_filter(self, id, val=None,
+                   bkg_id: Optional[IdType] = None,
+                   ignore=False
+                   ) -> None:
         """Set the filter array of a data set.
 
         Parameters
@@ -2700,7 +2761,7 @@ class Session(sherpa.ui.utils.Session):
         val : array
            The array of filter values (``0`` or ``1``). The size should
            match the array returned by `get_dep`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to identify which background component to set. The
            default value (``None``) means that this is for the source
            component of the data set.
@@ -2744,7 +2805,9 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-NOTE: also in sherpa.utils
     # DOC-TODO: does ncols make sense here? (have removed for now)
-    def load_staterror(self, id, filename=None, bkg_id=None, *args, **kwargs):
+    def load_staterror(self, id, filename=None,
+                       bkg_id: Optional[IdType] = None,
+                       *args, **kwargs) -> None:
         # pylint: disable=W1113
         """Load the statistical errors from a file.
 
@@ -2763,7 +2826,7 @@ class Session(sherpa.ui.utils.Session):
            The name of the file to read in. Supported formats depends
            on the I/O library in use (Crates or AstroPy) and the
            type of data set (e.g. 1D or 2D).
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to identify which background component to set. The
            default value (``None``) means that this is for the source
            component of the data set.
@@ -2829,7 +2892,9 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-NOTE: also in sherpa.utils
     # DOC-NOTE: is ncols really 2 here? Does it make sense?
-    def load_syserror(self, id, filename=None, bkg_id=None, *args, **kwargs):
+    def load_syserror(self, id, filename=None,
+                      bkg_id: Optional[IdType] = None,
+                      *args, **kwargs) -> None:
         # pylint: disable=W1113
         """Load the systematic errors from a file.
 
@@ -2846,7 +2911,7 @@ class Session(sherpa.ui.utils.Session):
            The name of the file to read in. Supported formats depends
            on the I/O library in use (Crates or AstroPy) and the
            type of data set (e.g. 1D or 2D).
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to identify which background component to set. The
            default value (``None``) means that this is for the source
            component of the data set.
@@ -2913,7 +2978,9 @@ class Session(sherpa.ui.utils.Session):
                           self._read_user_model(filename, *args, **kwargs)[1], bkg_id=bkg_id)
 
     # also in sherpa.utils
-    def set_dep(self, id, val=None, bkg_id=None):
+    def set_dep(self, id, val=None,
+                bkg_id: Optional[IdType] = None
+                ) -> None:
         """Set the dependent axis of a data set.
 
         Parameters
@@ -2969,7 +3036,9 @@ class Session(sherpa.ui.utils.Session):
     set_counts = set_dep
 
     # DOC-NOTE: also in sherpa.utils
-    def set_staterror(self, id, val=None, fractional=False, bkg_id=None):
+    def set_staterror(self, id, val=None, fractional= False,
+                      bkg_id: Optional[IdType] = None
+                      ) -> None:
         """Set the statistical errors on the dependent axis of a data set.
 
         These values over-ride the errors calculated by any statistic,
@@ -2989,7 +3058,7 @@ class Session(sherpa.ui.utils.Session):
            represents the fractional error, so the absolute value is
            calculated as ``get_dep() * val`` (and `val` must be
            a scalar).
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to identify which background component to set. The
            default value (``None``) means that this is for the source
            component of the data set.
@@ -3031,7 +3100,9 @@ class Session(sherpa.ui.utils.Session):
         sherpa.ui.utils.set_error(d, "staterror", val, fractional=fractional)
 
     # DOC-NOTE: also in sherpa.utils
-    def set_syserror(self, id, val=None, fractional=False, bkg_id=None):
+    def set_syserror(self, id, val=None, fractional=False,
+                     bkg_id: Optional[IdType] = None
+                     ) -> None:
         """Set the systematic errors on the dependent axis of a data set.
 
         Parameters
@@ -3048,7 +3119,7 @@ class Session(sherpa.ui.utils.Session):
            represents the fractional error, so the absolute value is
            calculated as ``get_dep() * val`` (and `val` must be
            a scalar).
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to identify which background component to set. The
            default value (``None``) means that this is for the source
            component of the data set.
@@ -3089,7 +3160,9 @@ class Session(sherpa.ui.utils.Session):
         d = self._get_data_or_bkg(id, bkg_id)
         sherpa.ui.utils.set_error(d, "syserror", val, fractional=fractional)
 
-    def set_exposure(self, id, exptime=None, bkg_id=None):
+    def set_exposure(self, id, exptime=None,
+                     bkg_id: Optional[IdType] = None
+                     ) -> None:
         """Change the exposure time of a PHA data set.
 
         The exposure time of a PHA data set is taken from the
@@ -3104,7 +3177,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         exptime : num
            The exposure time, in seconds.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to identify which background component to set.  The
            default value (``None``) means that this is for the source
            component of the data set.
@@ -3154,7 +3227,9 @@ class Session(sherpa.ui.utils.Session):
         d = self._get_pha_data(id, bkg_id)
         d.exposure = exptime
 
-    def set_backscal(self, id, backscale=None, bkg_id=None):
+    def set_backscal(self, id, backscale=None,
+                     bkg_id: Optional[IdType] = None
+                     ) -> None:
         """Change the area scaling of a PHA data set.
 
         The area scaling factor of a PHA data set is taken from the
@@ -3169,7 +3244,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         backscale : number or array
            The scaling factor.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to identify which background component to set.  The
            default value (``None``) means that this is for the source
            component of the data set.
@@ -3203,7 +3278,9 @@ class Session(sherpa.ui.utils.Session):
         d.backscal = backscale
 
     # DOC-TODO: the description needs improving.
-    def set_areascal(self, id, area=None, bkg_id=None):
+    def set_areascal(self, id, area=None,
+                     bkg_id: Optional[IdType] = None
+                     ) -> None:
         """Change the fractional area factor of a PHA data set.
 
         The area scaling factor of a PHA data set is taken from the
@@ -3218,7 +3295,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         area : number
            The scaling factor.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to identify which background component to set.  The
            default value (``None``) means that this is for the source
            component of the data set.
@@ -3252,7 +3329,11 @@ class Session(sherpa.ui.utils.Session):
     # DOC-NOTE: also in sherpa.utils, where it does not have
     #           the bkg_id parameter.
     #
-    def get_staterror(self, id=None, filter=False, bkg_id=None):
+    def get_staterror(self,
+                      id: Optional[IdType] = None,
+                      filter=False,
+                      bkg_id: Optional[IdType] = None
+                      ):
         """Return the statistical error on the dependent axis of a data set.
 
         The function returns the statistical errors on the values
@@ -3263,14 +3344,14 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
         filter : bool, optional
            Should the filter attached to the data set be applied to
            the return value or not. The default is ``False``.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the values returned should be from the given
            background component, instead of the source data set.
 
@@ -3339,7 +3420,11 @@ class Session(sherpa.ui.utils.Session):
     # DOC-NOTE: also in sherpa.utils, where it does not have
     #           the bkg_id parameter.
     #
-    def get_syserror(self, id=None, filter=False, bkg_id=None):
+    def get_syserror(self,
+                     id: Optional[IdType] = None,
+                     filter=False,
+                     bkg_id: Optional[IdType] = None
+                     ):
         """Return the systematic error on the dependent axis of a data set.
 
         The function returns the systematic errors on the values
@@ -3349,14 +3434,14 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
         filter : bool, optional
            Should the filter attached to the data set be applied to
            the return value or not. The default is ``False``.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the values returned should be from the given
            background component, instead of the source data set.
 
@@ -3415,7 +3500,11 @@ class Session(sherpa.ui.utils.Session):
     # DOC-NOTE: also in sherpa.utils, where it does not have
     #           the bkg_id parameter.
     #
-    def get_error(self, id=None, filter=False, bkg_id=None):
+    def get_error(self,
+                  id: Optional[IdType] = None,
+                  filter=False,
+                  bkg_id: Optional[IdType] = None
+                  ):
         """Return the errors on the dependent axis of a data set.
 
         The function returns the total errors (a quadrature addition
@@ -3426,14 +3515,14 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
         filter : bool, optional
            Should the filter attached to the data set be applied to
            the return value or not. The default is ``False``.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the values returned should be from the given
            background component, instead of the source data set.
 
@@ -3491,7 +3580,10 @@ class Session(sherpa.ui.utils.Session):
         return d.get_error(filter, self.get_stat().calc_staterror)
 
     # DOC-NOTE: also in sherpa.utils
-    def get_indep(self, id=None, filter=False, bkg_id=None):
+    def get_indep(self,
+                  id: Optional[IdType] = None,
+                  filter=False,
+                  bkg_id: Optional[IdType] = None):
         """Return the independent axes of a data set.
 
         This function returns the coordinates of each point, or pixel,
@@ -3500,7 +3592,7 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
@@ -3602,7 +3694,9 @@ class Session(sherpa.ui.utils.Session):
         d = self._get_data_or_bkg(id, bkg_id)
         return d.get_indep(filter=filter)
 
-    def get_axes(self, id=None, bkg_id=None):
+    def get_axes(self,
+                 id: Optional[IdType] = None,
+                 bkg_id: Optional[IdType] = None):
         """Return information about the independent axes of a data set.
 
         This function returns the coordinates of each point, or pixel,
@@ -3611,11 +3705,11 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the values returned should be from the given
            background component, instead of the source data set.
 
@@ -3699,7 +3793,10 @@ class Session(sherpa.ui.utils.Session):
         return d.get_indep()
 
     # DOC-NOTE: also in sherpa.utils
-    def get_dep(self, id=None, filter=False, bkg_id=None):
+    def get_dep(self,
+                id: Optional[IdType] = None,
+                filter=False,
+                bkg_id: Optional[IdType] = None):
         """Return the dependent axis of a data set.
 
         This function returns the data values (the dependent axis)
@@ -3707,14 +3804,14 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
         filter : bool, optional
            Should the filter attached to the data set be applied to
            the return value or not. The default is ``False``.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the values returned should be from the given
            background component, instead of the source data set.
 
@@ -3796,7 +3893,10 @@ class Session(sherpa.ui.utils.Session):
 
     get_counts = get_dep
 
-    def get_rate(self, id=None, filter=False, bkg_id=None):
+    def get_rate(self,
+                 id: Optional[IdType] = None,
+                 filter=False,
+                 bkg_id: Optional[IdType] = None):
         """Return the count rate of a PHA data set.
 
         Return an array of count-rate values for each bin in the
@@ -3806,14 +3906,14 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
         filter : bool, optional
            Should the filter attached to the data set be applied to
            the return value or not. The default is ``False``.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the rate should be taken from the background
            associated with the data set.
 
@@ -3896,19 +3996,22 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: how to get the corresponding x bins for this data?
     # i.e. what are the X values for these points
-    def get_specresp(self, id=None, filter=False, bkg_id=None):
+    def get_specresp(self,
+                     id: Optional[IdType] = None,
+                     filter=False,
+                     bkg_id: Optional[IdType] = None):
         """Return the effective area values for a PHA data set.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
         filter : bool, optional
            Should the filter attached to the data set be applied to
            the ARF or not. The default is ``False``.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the ARF should be taken from a background set
            associated with the data set.
 
@@ -3934,7 +4037,9 @@ class Session(sherpa.ui.utils.Session):
         d = self._get_pha_data(id, bkg_id)
         return d.get_specresp(filter)
 
-    def get_exposure(self, id=None, bkg_id=None):
+    def get_exposure(self,
+                     id: Optional[IdType] = None,
+                     bkg_id: Optional[IdType] = None):
         """Return the exposure time of a PHA data set.
 
         The exposure time of a PHA data set is taken from the
@@ -3943,11 +4048,11 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to identify which background component to use.  The
            default value (``None``) means that the time is for the
            source component of the data set.
@@ -3984,7 +4089,9 @@ class Session(sherpa.ui.utils.Session):
         d = self._get_pha_data(id, bkg_id)
         return d.exposure
 
-    def get_backscal(self, id=None, bkg_id=None):
+    def get_backscal(self,
+                     id: Optional[IdType] = None,
+                     bkg_id: Optional[IdType] = None):
         """Return the BACKSCAL scaling of a PHA data set.
 
         Return the BACKSCAL setting for the source or background
@@ -3992,11 +4099,11 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to identify which background component to use.  The
            default value (``None``) means that the value is for the
            source component of the data set.
@@ -4041,8 +4148,10 @@ class Session(sherpa.ui.utils.Session):
         d = self._get_pha_data(id, bkg_id)
         return d.backscal
 
-    def get_bkg_scale(self, id=None, bkg_id=1, units='counts',
-                      group=True, filter=False):
+    def get_bkg_scale(self,
+                      id: Optional[IdType] = None,
+                      bkg_id: IdType = 1,
+                      units='counts', group=True, filter=False):
         """Return the background scaling factor for a background data set.
 
         Return the factor applied to the background component to scale
@@ -4058,7 +4167,7 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
@@ -4137,7 +4246,9 @@ class Session(sherpa.ui.utils.Session):
 
         return scale
 
-    def get_areascal(self, id=None, bkg_id=None):
+    def get_areascal(self,
+                     id: Optional[IdType] = None,
+                     bkg_id: Optional[IdType] = None):
         """Return the fractional area factor of a PHA data set.
 
         Return the AREASCAL setting for the source or background
@@ -4145,11 +4256,11 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to identify which background component to use.  The
            default value (``None``) means that the value is for the
            source component of the data set.
@@ -4192,7 +4303,9 @@ class Session(sherpa.ui.utils.Session):
         d = self._get_pha_data(id, bkg_id)
         return d.areascal
 
-    def _save_type(self, objtype, id, filename, bkg_id=None, **kwargs):
+    def _save_type(self, objtype, id, filename,
+                   bkg_id: Optional[IdType] = None,
+                   **kwargs) -> None:
         if filename is None:
             id, filename = filename, id
         _check_str_type(filename, 'filename')
@@ -4340,8 +4453,10 @@ class Session(sherpa.ui.utils.Session):
                                      ascii=ascii, clobber=clobber)
 
     # DOC-NOTE: also in sherpa.utils with a different API
-    def save_source(self, id, filename=None, bkg_id=None, ascii=False,
-                    clobber=False):
+    def save_source(self, id, filename=None,
+                    bkg_id: Optional[IdType] = None,
+                    ascii=False, clobber=False
+                    ) -> None:
         """Save the model values to a file.
 
         The model is evaluated on the grid of the data set, but does
@@ -4357,7 +4472,7 @@ class Session(sherpa.ui.utils.Session):
         filename : str
            The name of the file to write the array to. The format
            is determined by the `ascii` argument.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the background model should be written out
            rather than the source.
         ascii : bool, optional
@@ -4424,8 +4539,10 @@ class Session(sherpa.ui.utils.Session):
                         bkg_id=bkg_id)
 
     # DOC-NOTE: also in sherpa.utils with a different API
-    def save_model(self, id, filename=None, bkg_id=None, ascii=False,
-                   clobber=False):
+    def save_model(self, id, filename=None,
+                   bkg_id: Optional[IdType] = None,
+                   ascii=False, clobber=False
+                   ) -> None:
         """Save the model values to a file.
 
         The model is evaluated on the grid of the data set, including
@@ -4440,7 +4557,7 @@ class Session(sherpa.ui.utils.Session):
         filename : str
            The name of the file to write the array to. The format
            is determined by the `ascii` argument.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the background model should be written out
            rather than the source.
         ascii : bool, optional
@@ -4507,8 +4624,10 @@ class Session(sherpa.ui.utils.Session):
                         bkg_id=bkg_id)
 
     # DOC-NOTE: also in sherpa.utils with a different API
-    def save_resid(self, id, filename=None, bkg_id=None, ascii=False,
-                   clobber=False):
+    def save_resid(self, id, filename=None,
+                   bkg_id: Optional[IdType] = None,
+                   ascii=False, clobber=False
+                   ) -> None:
         """Save the residuals (data-model) to a file.
 
         Parameters
@@ -4520,7 +4639,7 @@ class Session(sherpa.ui.utils.Session):
         filename : str
            The name of the file to write the array to. The format
            is determined by the `ascii` argument.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the background residuals should be written out
            rather than the source.
         ascii : bool, optional
@@ -4579,8 +4698,10 @@ class Session(sherpa.ui.utils.Session):
                         bkg_id=bkg_id)
 
     # DOC-NOTE: also in sherpa.utils with a different API
-    def save_delchi(self, id, filename=None, bkg_id=None, ascii=True,
-                    clobber=False):
+    def save_delchi(self, id, filename=None,
+                    bkg_id: Optional[IdType] = None,
+                    ascii=True, clobber=False
+                    ) -> None:
         """Save the ratio of residuals (data-model) to error to a file.
 
         Parameters
@@ -4592,7 +4713,7 @@ class Session(sherpa.ui.utils.Session):
         filename : str
            The name of the file to write the array to. The format
            is determined by the `ascii` argument.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the background residuals should be written out
            rather than the source.
         ascii : bool, optional
@@ -4651,8 +4772,10 @@ class Session(sherpa.ui.utils.Session):
                         bkg_id=bkg_id)
 
     # DOC-NOTE: also in sherpa.utils with a different interface
-    def save_filter(self, id, filename=None, bkg_id=None, ascii=True,
-                    clobber=False):
+    def save_filter(self, id, filename=None,
+                    bkg_id: Optional[IdType] = None,
+                    ascii=True, clobber=False
+                    ) -> None:
         """Save the filter array to a file.
 
         Parameters
@@ -4664,7 +4787,7 @@ class Session(sherpa.ui.utils.Session):
         filename : str
            The name of the file to write the array to. The format
            is determined by the `ascii` argument.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the background should be written out rather
            than the source.
         ascii : bool, optional
@@ -4744,8 +4867,10 @@ class Session(sherpa.ui.utils.Session):
                          ascii=ascii, clobber=clobber)
 
     # DOC-NOTE: also in sherpa.utils with a different interface
-    def save_staterror(self, id, filename=None, bkg_id=None,
-                       ascii=True, clobber=False):
+    def save_staterror(self, id, filename=None,
+                       bkg_id: Optional[IdType] = None,
+                       ascii=True, clobber=False
+                       ) -> None:
         """Save the statistical errors to a file.
 
         If the statistical errors have not been set explicitly, then
@@ -4761,7 +4886,7 @@ class Session(sherpa.ui.utils.Session):
         filename : str
            The name of the file to write the array to. The format
            is determined by the `ascii` argument.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the background should be written out rather
            than the source.
         ascii : bool, optional
@@ -4821,8 +4946,10 @@ class Session(sherpa.ui.utils.Session):
                        self.get_staterror, 'STAT_ERR')
 
     # DOC-NOTE: also in sherpa.utils with a different interface
-    def save_syserror(self, id, filename=None, bkg_id=None,
-                      ascii=True, clobber=False):
+    def save_syserror(self, id, filename=None,
+                      bkg_id: Optional[IdType] = None,
+                      ascii=True, clobber=False
+                      ) -> None:
         """Save the systematic errors to a file.
 
         Parameters
@@ -4834,7 +4961,7 @@ class Session(sherpa.ui.utils.Session):
         filename : str
            The name of the file to write the array to. The format
            is determined by the `ascii` argument.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the background should be written out rather
            than the source.
         ascii : bool, optional
@@ -4896,8 +5023,10 @@ class Session(sherpa.ui.utils.Session):
                        self.get_syserror, 'SYS_ERR')
 
     # DOC-NOTE: also in sherpa.utils with a different interface
-    def save_error(self, id, filename=None, bkg_id=None, ascii=True,
-                   clobber=False):
+    def save_error(self, id, filename=None,
+                   bkg_id: Optional[IdType] = None,
+                   ascii=True, clobber=False
+                   ) -> None:
         """Save the errors to a file.
 
         The total errors for a data set are the quadrature combination
@@ -4915,7 +5044,7 @@ class Session(sherpa.ui.utils.Session):
         filename : str
            The name of the file to write the array to. The format
            is determined by the `ascii` argument.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the background should be written out rather
            than the source.
         ascii : bool, optional
@@ -4977,8 +5106,10 @@ class Session(sherpa.ui.utils.Session):
         _save_errorcol(self, id, filename, bkg_id, clobber, ascii,
                        self.get_error, 'ERR')
 
-    def save_pha(self, id, filename=None, bkg_id=None, ascii=False,
-                 clobber=False):
+    def save_pha(self, id, filename=None,
+                 bkg_id: Optional[IdType] = None,
+                 ascii=False, clobber=False
+                 ) -> None:
         """Save a PHA data set to a file.
 
         Parameters
@@ -4990,7 +5121,7 @@ class Session(sherpa.ui.utils.Session):
         filename : str
            The name of the file to write the array to. The format
            is determined by the `ascii` argument.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the background should be written out rather
            than the source.
         ascii : bool, optional
@@ -5058,8 +5189,11 @@ class Session(sherpa.ui.utils.Session):
     # but the existing logic used to create the ui module does not
     # handle KEYWORD_ONLY so for now do not do this. See #1901.
     #
-    def save_arf(self, id, filename=None, resp_id=None, bkg_id=None,
-                 ascii=False, clobber=False):
+    def save_arf(self, id, filename=None,
+                 resp_id=None,
+                 bkg_id: Optional[IdType] = None,
+                 ascii=False, clobber=False
+                 ) -> None:
         """Save an ARF data set to a file.
 
         .. versionadded:: 4.16.0
@@ -5075,10 +5209,10 @@ class Session(sherpa.ui.utils.Session):
            The name of the file to write the ARF to (when the id value
            is explicitly given). The format is determined by the
            `ascii` argument.
-        resp_id : int or str, optional
+        resp_id : int, str, or None, optional
            The identifier for the ARF within this data set, if there
            are multiple responses.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the background ARF should be written out rather
            than the source ARF.
         ascii : bool, optional
@@ -5155,8 +5289,11 @@ class Session(sherpa.ui.utils.Session):
     # but the existing logic used to create the ui module does not
     # handle KEYWORD_ONLY so for now do not do this. See #1901.
     #
-    def save_rmf(self, id, filename=None, resp_id=None, bkg_id=None,
-                 clobber=False):
+    def save_rmf(self, id, filename=None,
+                 resp_id=None,
+                 bkg_id: Optional[IdType] = None,
+                 clobber=False
+                 ) -> None:
         """Save an RMF data set to a file.
 
         .. versionadded:: 4.16.0
@@ -5171,10 +5308,10 @@ class Session(sherpa.ui.utils.Session):
         filename : str or None
            The name of the file to write the RMF to (when the id value
            is explicitly given). Note that the format is always FITS.
-        resp_id : int or str, optional
+        resp_id : int, str, or None, optional
            The identifier for the RMF within this data set, if there
            are multiple responses.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the background RMF should be written out rather
            than the source RMF.
         clobber : bool, optional
@@ -5236,8 +5373,10 @@ class Session(sherpa.ui.utils.Session):
 
         sherpa.astro.io.write_rmf(filename, rmf, clobber=clobber)
 
-    def save_grouping(self, id, filename=None, bkg_id=None,
-                      ascii=True, clobber=False):
+    def save_grouping(self, id, filename=None,
+                      bkg_id: Optional[IdType] = None,
+                      ascii=True, clobber=False
+                      ) -> None:
         """Save the grouping scheme to a file.
 
         The output is a two-column file, containing the channel and
@@ -5252,7 +5391,7 @@ class Session(sherpa.ui.utils.Session):
         filename : str
            The name of the file to write the array to. The format
            is determined by the `ascii` argument.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the grouping array should be taken from the
            background associated with the data set.
         ascii : bool, optional
@@ -5319,7 +5458,10 @@ class Session(sherpa.ui.utils.Session):
                                      fields=['CHANNEL', 'GROUPS'], ascii=ascii,
                                      clobber=clobber)
 
-    def save_quality(self, id, filename=None, bkg_id=None, ascii=True, clobber=False):
+    def save_quality(self, id, filename=None,
+                     bkg_id: Optional[IdType] = None,
+                     ascii=True, clobber=False
+                     ) -> None:
         """Save the quality array to a file.
 
         The output is a two-column file, containing the channel and
@@ -5334,7 +5476,7 @@ class Session(sherpa.ui.utils.Session):
         filename : str
            The name of the file to write the array to. The format
            is determined by the `ascii` argument.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the quality array should be taken from the
            background associated with the data set.
         ascii : bool, optional
@@ -5540,7 +5682,10 @@ class Session(sherpa.ui.utils.Session):
                                     ascii=ascii, clobber=clobber)
 
     # DOC-NOTE: also in sherpa.utils
-    def save_data(self, id, filename=None, bkg_id=None, ascii=True, clobber=False):
+    def save_data(self, id, filename=None,
+                  bkg_id: Optional[IdType] = None,
+                  ascii=True, clobber=False
+                  ) -> None:
         """Save the data to a file.
 
         Parameters
@@ -5552,7 +5697,7 @@ class Session(sherpa.ui.utils.Session):
         filename : str
            The name of the file to write the array to. The data is
            written out as an ASCII file.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the background should be written out rather
            than the source (for a PHA data set).
         ascii : bool, optional
@@ -5638,12 +5783,12 @@ class Session(sherpa.ui.utils.Session):
                     sherpa.io.write_data(filename, d, clobber=clobber)
 
     # TODO: could add bkg_id parameter
-    def pack_pha(self, id=None):
+    def pack_pha(self, id: Optional[IdType] = None):
         """Convert a PHA data set into a file structure.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set to use. If not given then the default
            identifier is used, as returned by `get_default_id`.
 
@@ -5666,12 +5811,12 @@ class Session(sherpa.ui.utils.Session):
         """
         return sherpa.astro.io.pack_pha(self._get_pha_data(id))
 
-    def pack_image(self, id=None):
+    def pack_image(self, id: Optional[IdType] = None):
         """Convert a data set into an image structure.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set to use. If not given then the default
            identifier is used, as returned by `get_default_id`.
 
@@ -5689,12 +5834,12 @@ class Session(sherpa.ui.utils.Session):
         """
         return sherpa.astro.io.pack_image(self.get_data(id))
 
-    def pack_table(self, id=None):
+    def pack_table(self, id: Optional[IdType] = None):
         """Convert a data set into a table structure.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set to use. If not given then the default
            identifier is used, as returned by `get_default_id`.
 
@@ -5833,18 +5978,21 @@ class Session(sherpa.ui.utils.Session):
                                     e_max=e_max, ethresh=ethresh,
                                     name=name)
 
-    def get_arf(self, id=None, resp_id=None, bkg_id=None):
+    def get_arf(self,
+                id: Optional[IdType] = None,
+                resp_id: Optional[IdType] = None,
+                bkg_id: Optional[IdType] = None):
         """Return the ARF associated with a PHA data set.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set to use. If not given then the default
            identifier is used, as returned by `get_default_id`.
-        resp_id : int or str, optional
+        resp_id : int, str, or None, optional
            The identifier for the ARF within this data set, if there
            are multiple responses.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set this to return the given background component.
 
         Returns
@@ -5909,7 +6057,10 @@ class Session(sherpa.ui.utils.Session):
         return arf
 
     # DOC-TODO: add an example of a grating/multiple response
-    def set_arf(self, id, arf=None, resp_id=None, bkg_id=None):
+    def set_arf(self, id, arf=None,
+                resp_id: Optional[IdType] = None,
+                bkg_id: Optional[IdType] = None
+                ) -> None:
         """Set the ARF for use by a PHA data set.
 
         Set the effective area curve for a PHA data set, or its
@@ -5922,10 +6073,10 @@ class Session(sherpa.ui.utils.Session):
            identifier is used, as returned by `get_default_id`.
         arf
            An ARF, such as returned by `get_arf` or `unpack_arf`.
-        resp_id : int or str, optional
+        resp_id : int, str, or None, optional
            The identifier for the ARF within this data set, if there
            are multiple responses.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set this to identify the ARF as being for use with the
            background.
 
@@ -6041,7 +6192,10 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: add an example of a grating/multiple response
     # DOC-TODO: how to describe I/O backend support?
-    def load_arf(self, id, arg=None, resp_id=None, bkg_id=None):
+    def load_arf(self, id, arg=None,
+                 resp_id: Optional[IdType] = None,
+                 bkg_id: Optional[IdType] = None
+                 ) -> None:
         """Load an ARF from a file and add it to a PHA data set.
 
         Load in the effective area curve for a PHA data set, or its
@@ -6058,10 +6212,10 @@ class Session(sherpa.ui.utils.Session):
            representing the data to use, as used by the I/O backend in
            use by Sherpa: a ``TABLECrate`` for crates, as used by CIAO,
            or a list of AstroPy HDU objects.
-        resp_id : int or str, optional
+        resp_id : int, str, or None, optional
            The identifier for the ARF within this data set, if there
            are multiple responses.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set this to identify the ARF as being for use with the
            background.
 
@@ -6120,7 +6274,8 @@ class Session(sherpa.ui.utils.Session):
             id, arg = arg, id
         self.set_arf(id, self.unpack_arf(arg), resp_id, bkg_id)
 
-    def get_bkg_arf(self, id=None):
+    def get_bkg_arf(self,
+                    id: Optional[IdType] = None):
         """Return the background ARF associated with a PHA data set.
 
         This is for the case when there is only one background
@@ -6129,7 +6284,7 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set to use. If not given then the default
            identifier is used, as returned by `get_default_id`.
 
@@ -6170,7 +6325,7 @@ class Session(sherpa.ui.utils.Session):
         return self.get_arf(id, resp_id, bkg_id)
 
     # DOC-TODO: how to describe I/O backend support?
-    def load_bkg_arf(self, id, arg=None):
+    def load_bkg_arf(self, id, arg=None) -> None:
         """Load an ARF from a file and add it to the background of a
         PHA data set.
 
@@ -6231,7 +6386,7 @@ class Session(sherpa.ui.utils.Session):
         resp_id = self._get_pha_data(id).primary_response_id
         self.set_arf(id, self.unpack_arf(arg), resp_id, bkg_id)
 
-    def load_multi_arfs(self, id, filenames, resp_ids=None):
+    def load_multi_arfs(self, id, filenames, resp_ids=None) -> None:
         """Load multiple ARFs for a PHA data set.
 
         A grating observation - such as a Chandra LETGS data set - may
@@ -6306,18 +6461,21 @@ class Session(sherpa.ui.utils.Session):
         for filename, resp_id in zip(filenames, resp_ids):
             self.load_arf(id, filename, resp_id)
 
-    def get_rmf(self, id=None, resp_id=None, bkg_id=None):
+    def get_rmf(self,
+                id: Optional[IdType] = None,
+                resp_id: Optional[IdType] = None,
+                bkg_id: Optional[IdType] = None):
         """Return the RMF associated with a PHA data set.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set to use. If not given then the default
            identifier is used, as returned by `get_default_id`.
-        resp_id : int or str, optional
+        resp_id : int, str, or None, optional
            The identifier for the RMF within this data set, if there
            are multiple responses.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set this to return the given background component.
 
         Returns
@@ -6377,7 +6535,10 @@ class Session(sherpa.ui.utils.Session):
         return rmf
 
     # DOC-TODO: add an example of a grating/multiple response
-    def set_rmf(self, id, rmf=None, resp_id=None, bkg_id=None):
+    def set_rmf(self, id, rmf=None,
+                resp_id: Optional[IdType] = None,
+                bkg_id: Optional[IdType] = None
+                ) -> None:
         """Set the RMF for use by a PHA data set.
 
         Set the redistribution matrix for a PHA data set, or its
@@ -6390,10 +6551,10 @@ class Session(sherpa.ui.utils.Session):
            identifier is used, as returned by `get_default_id`.
         rmf
            An RMF, such as returned by `get_rmf` or `unpack_rmf`.
-        resp_id : int or str, optional
+        resp_id : int, str, or None, optional
            The identifier for the RMF within this data set, if there
            are multiple responses.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set this to identify the RMF as being for use with the
            background.
 
@@ -6514,7 +6675,10 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: add an example of a grating/multiple response
     # DOC-TODO: how to describe I/O backend support?
-    def load_rmf(self, id, arg=None, resp_id=None, bkg_id=None):
+    def load_rmf(self, id, arg=None,
+                 resp_id: Optional[IdType] = None,
+                 bkg_id: Optional[IdType] = None
+                 ) -> None:
         """Load a RMF from a file and add it to a PHA data set.
 
         Load in the redistribution matrix function for a PHA data set,
@@ -6536,10 +6700,10 @@ class Session(sherpa.ui.utils.Session):
            representing the data to use, as used by the I/O
            backend in use by Sherpa: a ``RMFCrateDataset`` for
            crates, as used by CIAO, or an AstroPy ``HDUList`` object.
-        resp_id : int or str, optional
+        resp_id : int, str, or None, optional
            The identifier for the RMF within this data set, if there
            are multiple responses.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set this to identify the RMF as being for use with the
            background.
 
@@ -6598,7 +6762,8 @@ class Session(sherpa.ui.utils.Session):
             id, arg = arg, id
         self.set_rmf(id, self.unpack_rmf(arg), resp_id, bkg_id)
 
-    def get_bkg_rmf(self, id=None):
+    def get_bkg_rmf(self,
+                    id: Optional[IdType] = None):
         """Return the background RMF associated with a PHA data set.
 
         This is for the case when there is only one background
@@ -6607,7 +6772,7 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set to use. If not given then the default
            identifier is used, as returned by `get_default_id`.
 
@@ -6643,7 +6808,7 @@ class Session(sherpa.ui.utils.Session):
         return self.get_rmf(id, resp_id, bkg_id)
 
     # DOC-TODO: how to describe I/O backend support?
-    def load_bkg_rmf(self, id, arg=None):
+    def load_bkg_rmf(self, id, arg=None) -> None:
         """Load a RMF from a file and add it to the background of a
         PHA data set.
 
@@ -6704,7 +6869,7 @@ class Session(sherpa.ui.utils.Session):
         resp_id = self._get_pha_data(id).primary_response_id
         self.set_rmf(id, self.unpack_rmf(arg), resp_id, bkg_id)
 
-    def load_multi_rmfs(self, id, filenames, resp_ids=None):
+    def load_multi_rmfs(self, id, filenames, resp_ids=None) -> None:
         """Load multiple RMFs for a PHA data set.
 
         A grating observation - such as a Chandra LETGS data set - may
@@ -6724,7 +6889,7 @@ class Session(sherpa.ui.utils.Session):
            identifier is used, as returned by `get_default_id`.
         filenames : iterable of str
            An array of file names.
-        resp_ids : iterable of int or str
+        resp_ids : iterable of int or str, or None
            The identifiers for the RMF within this data set.
            The length should match the filenames argument.
 
@@ -6779,7 +6944,10 @@ class Session(sherpa.ui.utils.Session):
         for filename, resp_id in zip(filenames, resp_ids):
             self.load_rmf(id, filename, resp_id)
 
-    def get_bkg(self, id=None, bkg_id=None):
+    def get_bkg(self,
+                id: Optional[IdType] = None,
+                bkg_id: Optional[IdType] = None
+                ) -> DataPHA:
         """Return the background for a PHA data set.
 
         Function to return the background for a PHA data set.
@@ -6788,10 +6956,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default
            identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            The identifier for this background, which is needed if
            there are multiple background estimates for the source.
 
@@ -6830,7 +6998,9 @@ class Session(sherpa.ui.utils.Session):
 
         return bkg
 
-    def set_bkg(self, id, bkg=None, bkg_id=None):
+    def set_bkg(self, id, bkg=None,
+                bkg_id: Optional[IdType] = None
+                ) -> None:
         """Set the background for a PHA data set.
 
         The background can either be fit with a model - using
@@ -6845,7 +7015,7 @@ class Session(sherpa.ui.utils.Session):
         bkg
            A PHA data set, such as returned by `get_data` or
            `unpack_pha`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            The identifier for this background, which is needed if
            there are multiple background estimates for the source.
 
@@ -6894,7 +7064,9 @@ class Session(sherpa.ui.utils.Session):
         _check_type(bkg, DataPHA, 'bkg', 'a PHA data set')
         data.set_background(bkg, bkg_id)
 
-    def list_bkg_ids(self, id=None):
+    def list_bkg_ids(self,
+                     id: Optional[IdType] = None
+                     ) -> list[IdType]:
         """List all the background identifiers for a data set.
 
         A PHA data set can contain multiple background datasets, each
@@ -6903,7 +7075,7 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set to query. If not given then the default
            identifier is used, as returned by `get_default_id`.
 
@@ -6921,7 +7093,10 @@ class Session(sherpa.ui.utils.Session):
         """
         return list(self._get_pha_data(id)._backgrounds.keys())
 
-    def list_response_ids(self, id=None, bkg_id=None):
+    def list_response_ids(self,
+                          id: Optional[IdType] = None,
+                          bkg_id: Optional[IdType] = None
+                          ) -> list[IdType]:
         """List all the response identifiers of a data set.
 
         A PHA data set can contain multiple responses, that is,
@@ -6931,10 +7106,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set to query. If not given then the default
            identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set this to identify the background component to query.
 
         Returns
@@ -7067,12 +7242,14 @@ class Session(sherpa.ui.utils.Session):
 
             info("dataset %s: %s", idval, fstring)
 
-    def get_analysis(self, id=None):
+    def get_analysis(self,
+                     id: Optional[IdType] = None
+                     ) -> str:
         """Return the units used when fitting spectral data.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set to query. If not given then the default
            identifier is used, as returned by `get_default_id`.
 
@@ -7110,7 +7287,7 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: docs need to be added to sherpa.astro.data.set_coord
     # DOC-TODO: how best to document the wcssubs support?
-    def set_coord(self, id, coord=None):
+    def set_coord(self, id, coord=None) -> None:
         """Set the coordinate system to use for image analysis.
 
         The default coordinate system - that is, the mapping between
@@ -7197,12 +7374,12 @@ class Session(sherpa.ui.utils.Session):
             self._get_img_data(id).set_coord(coord)
 
     # DOC-TODO: docs need to be added to sherpa.astro.data.get_coord
-    def get_coord(self, id=None):
+    def get_coord(self, id: Optional[IdType] = None) -> str:
         """Get the coordinate system used for image analysis.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set to query. If not given then the default
            identifier is used, as returned by `get_default_id`.
 
@@ -7225,7 +7402,10 @@ class Session(sherpa.ui.utils.Session):
         """
         return self._get_img_data(id).coord
 
-    def ignore_bad(self, id=None, bkg_id=None):
+    def ignore_bad(self,
+                   id: Optional[IdType] = None,
+                   bkg_id: Optional[IdType] = None
+                   ) -> None:
         """Exclude channels marked as bad in a PHA data set.
 
         Ignore any bin in the PHA data set which has a quality value
@@ -7237,10 +7417,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set to change. If not given then the default
            identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            The identifier for the background (the default of ``None``
            uses the first component).
 
@@ -7305,7 +7485,7 @@ class Session(sherpa.ui.utils.Session):
     # There is no need to override ignore to add unit checking since
     # ignore just ends up calling notice anyway.
     #
-    def notice(self, lo=None, hi=None, **kwargs):
+    def notice(self, lo=None, hi=None, **kwargs) -> None:
 
         if lo is not None or hi is not None:
             units = set(data.get_analysis()
@@ -7325,7 +7505,7 @@ class Session(sherpa.ui.utils.Session):
     # DOC-TODO: how best to document the region support?
     # DOC-TODO: I have not mentioned the support for radii in arcsec/minutes/degrees
     # or sexagessimal formats. Is this supported here?
-    def notice2d(self, val=None):
+    def notice2d(self, val=None) -> None:
         """Include a spatial region of all data sets.
 
         Select a spatial region to include in the fit. The filter is
@@ -7494,7 +7674,7 @@ class Session(sherpa.ui.utils.Session):
             idstr = f"dataset {idval}"
             sherpa.ui.utils.report_filter_change(idstr, ofilter, nfilter)
 
-    def ignore2d(self, val=None):
+    def ignore2d(self, val=None) -> None:
         """Exclude a spatial region from all data sets.
 
         Select a spatial region to exclude in the fit. The filter is
@@ -7574,7 +7754,10 @@ class Session(sherpa.ui.utils.Session):
             idstr = f"dataset {idval}"
             sherpa.ui.utils.report_filter_change(idstr, ofilter, nfilter)
 
-    def notice2d_id(self, ids, val=None):
+    def notice2d_id(self,
+                    ids: Union[IdType, Sequence[IdType]],
+                    val: Optional[str] = None
+                    ) -> None:
         """Include a spatial region of a data set.
 
         Select a spatial region to include in the fit. The filter is
@@ -7634,17 +7817,17 @@ class Session(sherpa.ui.utils.Session):
 
         """
         if self._valid_id(ids):
-            ids = (ids,)
+            idvals = (ids,)
         else:
             try:
-                ids = tuple(ids)
+                idvals = tuple(ids)
             except TypeError:
                 raise ArgumentTypeErr('badarg', 'ids',
                                       'an identifier or list of identifiers') from None
 
         # Unlike notice2d we use the order supplied by the user.
         #
-        for idval in ids:
+        for idval in idvals:
             # d = self._get_img_data(idval)   would be better
             d = self.get_data(idval)
             _check_type(d, DataIMG, 'img', 'a image data set')
@@ -7656,7 +7839,10 @@ class Session(sherpa.ui.utils.Session):
             idstr = f"dataset {idval}"
             sherpa.ui.utils.report_filter_change(idstr, ofilter, nfilter)
 
-    def ignore2d_id(self, ids, val=None):
+    def ignore2d_id(self,
+                    ids: Union[IdType, Sequence[IdType]],
+                    val: Optional[str] = None
+                    ) -> None:
         """Exclude a spatial region from a data set.
 
         Select a spatial region to exclude in the fit. The filter is
@@ -7667,7 +7853,7 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        ids : int or str, or array of int or str
+        ids : int, str, or array of int or str
            The data set, or sets, to use.
         val : str, optional
            A region specification as a string or the name of a file
@@ -7711,15 +7897,15 @@ class Session(sherpa.ui.utils.Session):
         # explicit argument that supports this.
         #
         if self._valid_id(ids):
-            ids = (ids,)
+            idvals = (ids,)
         else:
             try:
-                ids = tuple(ids)
+                idvals = tuple(ids)
             except TypeError:
                 raise ArgumentTypeErr('badarg', 'ids',
                                       'an identifier or list of identifiers') from None
 
-        for idval in ids:
+        for idval in idvals:
             # d = self._get_img_data(idval)   would be better
             d = self.get_data(idval)
             _check_type(d, DataIMG, 'img', 'a image data set')
@@ -7731,7 +7917,9 @@ class Session(sherpa.ui.utils.Session):
             idstr = f"dataset {idval}"
             sherpa.ui.utils.report_filter_change(idstr, ofilter, nfilter)
 
-    def notice2d_image(self, ids=None):
+    def notice2d_image(self,
+                       ids: Optional[Union[IdType, Sequence[IdType]]] = None
+                       ) -> None:
         """Include pixels using the region defined in the image viewer.
 
         Include points that lie within the region defined in the image
@@ -7742,7 +7930,7 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        ids : int or str, or sequence of int or str, optional
+        ids : int, str, None, or sequence of int or str, optional
            The data set, or sets, to use. If ``None`` (the default)
            then the default identifier is used, as returned by
            `get_default_id`.
@@ -7779,15 +7967,15 @@ class Session(sherpa.ui.utils.Session):
         if ids is None:
             ids = self._default_id
         if self._valid_id(ids):
-            ids = (ids,)
+            idvals = (ids,)
         else:
             try:
-                ids = tuple(ids)
+                idvals = tuple(ids)
             except TypeError:
                 raise ArgumentTypeErr('badarg', 'ids',
                                       'an identifier or list of identifiers') from None
 
-        for idval in ids:
+        for idval in idvals:
             # d = self._get_img_data(idval)   would be better
             d = self.get_data(idval)
             _check_type(d, DataIMG, 'img', 'a image data set')
@@ -7801,7 +7989,9 @@ class Session(sherpa.ui.utils.Session):
             regions = self.image_getregion(coord).replace(';', '')
             self.notice2d_id(idval, regions)
 
-    def ignore2d_image(self, ids=None):
+    def ignore2d_image(self,
+                       ids: Optional[Union[IdType, Sequence[IdType]]] = None
+                       ) -> None:
         """Exclude pixels using the region defined in the image viewer.
 
         Exclude points that lie within the region defined in the image
@@ -7812,7 +8002,7 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        ids : int or str, or sequence of int or str, optional
+        ids : int, str, None, or sequence of int or str, optional
            The data set, or sets, to ignore. If ``None`` (the default)
            then the default identifier is used, as returned by
            `get_default_id`.
@@ -7853,15 +8043,15 @@ class Session(sherpa.ui.utils.Session):
         if ids is None:
             ids = self._default_id
         if self._valid_id(ids):
-            ids = (ids,)
+            idvals = (ids,)
         else:
             try:
-                ids = tuple(ids)
+                idvals = tuple(ids)
             except TypeError:
                 raise ArgumentTypeErr('badarg', 'ids',
                                       'an identifier or list of identifiers') from None
 
-        for idval in ids:
+        for idval in idvals:
             # d = self._get_img_data(idval)   would be better
             d = self.get_data(idval)
             _check_type(d, DataIMG, 'img', 'a image data set')
@@ -7876,7 +8066,9 @@ class Session(sherpa.ui.utils.Session):
             self.ignore2d_id(idval, regions)
 
     # DOC-TODO: how best to include datastack support? How is it handled here?
-    def load_bkg(self, id, arg=None, use_errors=False, bkg_id=None):
+    def load_bkg(self, id, arg=None, use_errors=False,
+                 bkg_id: Optional[IdType] = None
+                 ) -> None:
         """Load the background from a file and add it to a PHA data set.
 
         This will load the PHA data and any response information - so
@@ -7898,7 +8090,7 @@ class Session(sherpa.ui.utils.Session):
            If ``True`` then the statistical errors are taken from the
            input data, rather than calculated by Sherpa from the
            count values. The default is ``False``.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            The identifier for the background (the default of ``None``
            uses the first component).
 
@@ -7950,7 +8142,10 @@ class Session(sherpa.ui.utils.Session):
         else:
             self.set_bkg(id, bkgsets, bkg_id)
 
-    def group(self, id=None, bkg_id=None):
+    def group(self,
+              id: Optional[IdType] = None,
+              bkg_id: Optional[IdType] = None
+              ) -> None:
         """Turn on the grouping for a PHA data set.
 
         A PHA data set can be grouped either because it contains
@@ -7969,11 +8164,11 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to group the background associated with the data set.
 
         Raises
@@ -8059,7 +8254,9 @@ class Session(sherpa.ui.utils.Session):
 
         _pha_report_filter_change(self, id, bkg_id, change)
 
-    def set_grouping(self, id, val=None, bkg_id=None):
+    def set_grouping(self, id, val=None,
+                     bkg_id: Optional[IdType] = None
+                     ) -> None:
         """Apply a set of grouping flags to a PHA data set.
 
         A group is indicated by a sequence of flag values starting
@@ -8082,7 +8279,7 @@ class Session(sherpa.ui.utils.Session):
         val : array of int
            This must be an array of grouping values of the same length
            as the data array.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to group the background associated with the data set.
 
         Raises
@@ -8150,7 +8347,9 @@ class Session(sherpa.ui.utils.Session):
 
         _pha_report_filter_change(self, id, bkg_id, change)
 
-    def get_grouping(self, id=None, bkg_id=None):
+    def get_grouping(self,
+                     id: Optional[IdType] = None,
+                     bkg_id: Optional[IdType] = None):
         """Return the grouping array for a PHA data set.
 
         The function returns the grouping value for each channel in
@@ -8158,11 +8357,11 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the grouping flags should be taken from a background
            associated with the data set.
 
@@ -8218,7 +8417,9 @@ class Session(sherpa.ui.utils.Session):
         data = self._get_pha_data(id, bkg_id)
         return data.grouping
 
-    def set_quality(self, id, val=None, bkg_id=None):
+    def set_quality(self, id, val=None,
+                    bkg_id: Optional[IdType] = None
+                    ) -> None:
         """Apply a set of quality flags to a PHA data set.
 
         A quality value of 0 indicates a good channel,
@@ -8235,7 +8436,7 @@ class Session(sherpa.ui.utils.Session):
         val : array of int
            This must be an array of quality values of the same length
            as the data array.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the quality values should be associated with the
            background associated with the data set.
 
@@ -8304,7 +8505,9 @@ class Session(sherpa.ui.utils.Session):
     # direct object access
     # get_data().exposure [= ...]
 
-    def get_quality(self, id=None, bkg_id=None):
+    def get_quality(self,
+                    id: Optional[IdType] = None,
+                    bkg_id: Optional[IdType] = None):
         """Return the quality flags for a PHA data set.
 
         The function returns the quality value for each channel in
@@ -8312,11 +8515,11 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set if the quality flags should be taken from a background
            associated with the data set.
 
@@ -8382,7 +8585,10 @@ class Session(sherpa.ui.utils.Session):
         data = self._get_pha_data(id, bkg_id)
         return data.quality
 
-    def ungroup(self, id=None, bkg_id=None):
+    def ungroup(self,
+                id: Optional[IdType] = None,
+                bkg_id: Optional[IdType] = None
+                ) -> None:
         """Turn off the grouping for a PHA data set.
 
         A PHA data set can be grouped either because it contains
@@ -8394,11 +8600,11 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to ungroup the background associated with the data set.
 
         Raises
@@ -8476,7 +8682,9 @@ class Session(sherpa.ui.utils.Session):
     # DOC-TODO: how to set the quality if using tabstops to indicate
     # "bad" channels, rather than ones to ignore
 
-    def group_bins(self, id, num=None, bkg_id=None, tabStops=None):
+    def group_bins(self, id, num=None,
+                   bkg_id: Optional[IdType] = None,
+                   tabStops=None) -> None:
         """Group into a fixed number of bins.
 
         Combine the data so that there `num` equal-width bins (or
@@ -8502,7 +8710,7 @@ class Session(sherpa.ui.utils.Session):
         num : int
            The number of bins in the grouped data set. Each bin
            will contain the same number of channels.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to group the background associated with the data set.
            When ``bkg_id`` is None (which is the default), the
            grouping is applied to all the associated background
@@ -8605,7 +8813,10 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: should num= be renamed val= to better match
     # underlying code/differ from group_bins?
-    def group_width(self, id, num=None, bkg_id=None, tabStops=None):
+    def group_width(self, id, num=None,
+                    bkg_id: Optional[IdType] = None,
+                    tabStops=None
+                    ) -> None:
         """Group into a fixed bin width.
 
         Combine the data so that each bin contains `num` channels.
@@ -8630,7 +8841,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         num : int
            The number of channels to combine into a group.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to group the background associated with the data set.
            When ``bkg_id`` is None (which is the default), the
            grouping is applied to all the associated background
@@ -8731,8 +8942,11 @@ class Session(sherpa.ui.utils.Session):
 
         _pha_report_filter_change(self, id, bkg_id, change)
 
-    def group_counts(self, id, num=None, bkg_id=None,
-                     maxLength=None, tabStops=None):
+    def group_counts(self, id, num=None,
+                     bkg_id: Optional[IdType] = None,
+                     maxLength=None,
+                     tabStops=None
+                     ) -> None:
         """Group into a minimum number of counts per bin.
 
         Combine the data so that each bin contains `num` or more
@@ -8759,7 +8973,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         num : int
            The number of channels to combine into a group.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to group the background associated with the data set.
            When ``bkg_id`` is None (which is the default), the
            grouping is applied to all the associated background
@@ -8865,8 +9079,12 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: check the Poisson stats claim; I'm guessing it means
     #           gaussian (i.e. sqrt(n))
-    def group_snr(self, id, snr=None, bkg_id=None,
-                  maxLength=None, tabStops=None, errorCol=None):
+    def group_snr(self, id, snr=None,
+                  bkg_id: Optional[IdType] = None,
+                  maxLength=None,
+                  tabStops=None,
+                  errorCol=None
+                  ) -> None:
         """Group into a minimum signal-to-noise ratio.
 
         Combine the data so that each bin has a signal-to-noise ratio
@@ -8895,7 +9113,7 @@ class Session(sherpa.ui.utils.Session):
         snr : number
            The minimum signal-to-noise ratio that must be reached
            to form a group of channels.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to group the background associated with the data set.
            When ``bkg_id`` is None (which is the default), the
            grouping is applied to all the associated background
@@ -8992,8 +9210,11 @@ class Session(sherpa.ui.utils.Session):
 
         _pha_report_filter_change(self, id, bkg_id, change)
 
-    def group_adapt(self, id, min=None, bkg_id=None,
-                    maxLength=None, tabStops=None):
+    def group_adapt(self, id, min=None,
+                    bkg_id: Optional[IdType] = None,
+                    maxLength=None,
+                    tabStops=None
+                    ) -> None:
         """Adaptively group to a minimum number of counts.
 
         Combine the data so that each bin contains `min` or more
@@ -9023,7 +9244,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         min : int
            The number of channels to combine into a group.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to group the background associated with the data set.
            When ``bkg_id`` is ``None`` (which is the default), the
            grouping is applied to all the associated background
@@ -9117,8 +9338,12 @@ class Session(sherpa.ui.utils.Session):
         _pha_report_filter_change(self, id, bkg_id, change)
 
     # DOC-TODO: shouldn't this be snr=None rather than min=None
-    def group_adapt_snr(self, id, min=None, bkg_id=None,
-                        maxLength=None, tabStops=None, errorCol=None):
+    def group_adapt_snr(self, id, min=None,
+                        bkg_id: Optional[IdType] = None,
+                        maxLength=None,
+                        tabStops=None,
+                        errorCol=None
+                        ) -> None:
         """Adaptively group to a minimum signal-to-noise ratio.
 
         Combine the data so that each bin has a signal-to-noise ratio
@@ -9150,7 +9375,7 @@ class Session(sherpa.ui.utils.Session):
         num : number
            The minimum signal-to-noise ratio that must be reached
            to form a group of channels.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Set to group the background associated with the data set.
            When ``bkg_id`` is ``None`` (which is the default), the
            grouping is applied to all the associated background
@@ -9248,7 +9473,7 @@ class Session(sherpa.ui.utils.Session):
 
         _pha_report_filter_change(self, id, bkg_id, change)
 
-    def subtract(self, id=None):
+    def subtract(self, id: Optional[IdType] = None) -> None:
         """Subtract the background estimate from a data set.
 
         The ``subtract`` function performs a channel-by-channel
@@ -9259,7 +9484,7 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
@@ -9331,7 +9556,7 @@ class Session(sherpa.ui.utils.Session):
         if not d.subtracted:
             d.subtract()
 
-    def unsubtract(self, id=None):
+    def unsubtract(self, id: Optional[IdType] = None) -> None:
         """Undo any background subtraction for the data set.
 
         The `unsubtract` function undoes any changes made by
@@ -9342,7 +9567,7 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
@@ -9842,7 +10067,9 @@ class Session(sherpa.ui.utils.Session):
     set_full_model.__doc__ = sherpa.ui.utils.Session.set_full_model.__doc__
     set_full_model.__annotations__ = sherpa.ui.utils.Session.set_full_model.__annotations__
 
-    def _add_convolution_models(self, id, data, model, is_source):
+    def _add_convolution_models(self,
+                                id: Optional[IdType],
+                                data, model, is_source):
         """Add in "hidden" components to the model expression.
 
         This includes PSF and pileup models and, for PHA data sets,
@@ -9871,7 +10098,7 @@ class Session(sherpa.ui.utils.Session):
 
         return sherpa.astro.background.add_response(self, id, data, model)
 
-    def _get_response(self, id, pha):
+    def _get_response(self, id: IdType, pha: DataPHA):
         """Calculate the response for the dataset.
 
         Parameter
@@ -9891,7 +10118,10 @@ class Session(sherpa.ui.utils.Session):
         pileup_model = self._pileup_models.get(id)
         return pha.get_full_response(pileup_model)
 
-    def get_response(self, id=None, bkg_id=None):
+    def get_response(self,
+                     id: Optional[IdType] = None,
+                     bkg_id: Optional[IdType] = None
+                     ):
         """Return the response information applied to a PHA data set.
 
         For a PHA data set, the source model - created by `set_model`
@@ -9903,11 +10133,11 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set containing the instrument response. If not given
            then the default identifier is used, as returned by
            `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            If given, return the response for the given background
            component, rather than the source.
 
@@ -9950,14 +10180,14 @@ class Session(sherpa.ui.utils.Session):
         pha = self._get_pha_data(idval, bkg_id)
         return self._get_response(idval, pha)
 
-    def get_pileup_model(self, id=None):
+    def get_pileup_model(self, id: Optional[IdType] = None):
         """Return the pile up model for a data set.
 
         Return the pile up model set by a call to `set_pileup_model`.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set containing the source expression. If not given
            then the default identifier is used, as returned by
            `get_default_id`.
@@ -9991,7 +10221,7 @@ class Session(sherpa.ui.utils.Session):
         return self._get_item(id, self._pileup_models, 'pileup model',
                               'has not been set')
 
-    def delete_pileup_model(self, id=None):
+    def delete_pileup_model(self, id: Optional[IdType] = None) -> None:
         """Delete the pile up model for a data set.
 
         Remove the pile up model applied to a source model.
@@ -10000,7 +10230,7 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the
            default identifier is used, as returned by `get_default_id`.
 
@@ -10021,7 +10251,7 @@ class Session(sherpa.ui.utils.Session):
         id = self._fix_id(id)
         self._pileup_models.pop(id, None)
 
-    def list_pileup_model_ids(self):
+    def list_pileup_model_ids(self) -> list[IdType]:
         """List of all the data sets with a pile up model.
 
         .. versionadded:: 4.12.2
@@ -10106,7 +10336,10 @@ class Session(sherpa.ui.utils.Session):
         self._set_item(id, model, self._pileup_models, Model,
                        'model', 'a model object or model expression string')
 
-    def get_bkg_source(self, id=None, bkg_id=None):
+    def get_bkg_source(self,
+                       id: Optional[IdType] = None,
+                       bkg_id: Optional[IdType] = None
+                       ):
         """Return the model expression for the background of a PHA data set.
 
         This returns the model expression created by `set_bkg_model`
@@ -10115,10 +10348,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set to use. If not given then the default
            identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
 
@@ -10157,7 +10390,10 @@ class Session(sherpa.ui.utils.Session):
 
         return model
 
-    def get_bkg_model(self, id=None, bkg_id=None):
+    def get_bkg_model(self,
+                      id: Optional[IdType] = None,
+                      bkg_id: Optional[IdType] = None
+                      ):
         """Return the model expression for the background of a PHA data set.
 
         This returns the model expression for the background of a data
@@ -10171,10 +10407,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set to use. If not given then the default
            identifier is used, as returned by ``get_default_id``.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
 
@@ -10234,7 +10470,9 @@ class Session(sherpa.ui.utils.Session):
         return resp(src)
 
 
-    def set_bkg_full_model(self, id, model=None, bkg_id=None):
+    def set_bkg_full_model(self, id, model=None,
+                           bkg_id: Optional[IdType] = None
+                           ) -> None:
         """Define the convolved background model expression for a PHA data set.
 
         Set a model expression for a background data set in the same
@@ -10251,7 +10489,7 @@ class Session(sherpa.ui.utils.Session):
         model : str or sherpa.models.Model object
            This defines the model used to fit the data. It can be a
            Python expression or a string version of it.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            The identifier for the background of the data set, in
            cases where multiple backgrounds are provided.
 
@@ -10343,7 +10581,9 @@ class Session(sherpa.ui.utils.Session):
         self._runparamprompt(model.pars)
 
     # DOC-TODO: should probably explain more about how backgrounds are fit?
-    def set_bkg_model(self, id, model=None, bkg_id=None):
+    def set_bkg_model(self, id, model=None,
+                      bkg_id: Optional[IdType] = None
+                      ) -> None:
         """Set the background model expression for a PHA data set.
 
         The background emission can be fit by a model, defined by the
@@ -10360,7 +10600,7 @@ class Session(sherpa.ui.utils.Session):
         model : str or sherpa.models.Model object
            This defines the model used to fit the data. It can be a
            Python expression or a string version of it.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            The identifier for the background of the data set, in
            cases where multiple backgrounds are provided.
 
@@ -10446,7 +10686,10 @@ class Session(sherpa.ui.utils.Session):
 
     set_bkg_source = set_bkg_model
 
-    def delete_bkg_model(self, id=None, bkg_id=None):
+    def delete_bkg_model(self,
+                         id: Optional[IdType] = None,
+                         bkg_id: Optional[IdType] = None
+                         ) -> None:
         """Delete the background model expression for a data set.
 
         This removes the model expression, created by `set_bkg_model`,
@@ -10456,11 +10699,11 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set containing the source expression. If not given
            then the default identifier is used, as returned by
            `get_default_id`.
-        bkg_id : int or string, optional
+        bkg_id : int, str, or None, optional
            The identifier for the background component to use.
 
         See Also
@@ -10485,14 +10728,14 @@ class Session(sherpa.ui.utils.Session):
         >>> delete_bkg_model('src', 'down')
 
         """
-        id = self._fix_id(id)
-        bkg_id = self._fix_background_id(id, bkg_id)
+        idval = self._fix_id(id)
+        bkg_id = self._fix_background_id(idval, bkg_id)
 
         # remove dependency of having a loaded PHA dataset at the time
         # of bkg model init.
         #  bkg_id = self._get_pha_data(id)._fix_background_id(bkg_id)
-        self._background_models.get(id, {}).pop(bkg_id, None)
-        self._background_sources.get(id, {}).pop(bkg_id, None)
+        self._background_models.get(idval, {}).pop(bkg_id, None)
+        self._background_sources.get(idval, {}).pop(bkg_id, None)
 
     def _read_user_model(self, filename, *args, **kwargs):
         x = None
@@ -10826,16 +11069,19 @@ class Session(sherpa.ui.utils.Session):
     # Fitting
     ###########################################################################
 
-    def _prepare_fit(self, id, otherids=()):
+    def _prepare_fit(self,
+                     id: Optional[IdType],
+                     otherids: Sequence[IdType] = ()
+                     ) -> list[sherpa.ui.utils.FitStore]:
         """Ensure we have all the requested ids, datasets, and models.
 
         Background datasets are included if present.
 
         Parameters
         ----------
-        id: int or str or None
+        id: int, str, or None
             If None then this fits all data.
-        otherids: sequence of int or str or None, or None
+        otherids: sequence of int, str, or None, or None
             When id is not None, the other identifiers to use.
 
         Returns
@@ -10891,20 +11137,24 @@ class Session(sherpa.ui.utils.Session):
             for bkg_id in s.data.background_ids:
                 bkg_data = s.data.get_background(bkg_id)
                 bkg_model = self.get_bkg_model(s.idval, bkg_id)
+                # At this point we know bkg_data is not None
                 out.append(BkgFitStore(s.idval, bkg_data, bkg_model, bkg_id))
 
         return out
 
-    def _prepare_bkg_fit(self, id, otherids=()):
+    def _prepare_bkg_fit(self,
+                         id: Optional[IdType],
+                         otherids: Sequence[IdType] = ()
+                         ) -> list[BkgFitStore]:
         """Ensure we have all the requested background ids, datasets, and models.
 
         Unlike _prepare_fit this is only for background datasets.
 
         Parameters
         ----------
-        id: int or str or None
+        id: int, str, or None
             If None then this fits all background data.
-        otherids: sequence of int or str or None, or None
+        otherids: sequence of int, str, or None, or None
             When id is not None, the other identifiers to use.
 
         Returns
@@ -10954,7 +11204,11 @@ class Session(sherpa.ui.utils.Session):
 
         return out
 
-    def _get_bkg_fit(self, id, otherids=(), estmethod=None, numcores=1):
+    def _get_bkg_fit(self,
+                     id: Optional[IdType],
+                     otherids: Sequence[IdType] = (),
+                     estmethod=None, numcores=1
+                     ) -> tuple[tuple[IdType, ...], Fit]:
         """Create the fit object for the given identifiers.
 
         Given the identifiers (the id and otherids arguments), find
@@ -10962,7 +11216,7 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str or None
+        id : int, str, or None
             The identifier to fit. A value of None means all available
             background datasets with models.
         otherids : sequence of int or str
@@ -11188,7 +11442,11 @@ class Session(sherpa.ui.utils.Session):
         kwargs['bkg_only'] = True
         self._fit(id, *otherids, **kwargs)
 
-    def _fit(self, id=None, *otherids, **kwargs) -> None:
+    def _fit(self,
+             id: Optional[IdType] = None,
+             *otherids: IdType,
+             **kwargs
+             ) -> None:
         # pylint: disable=W1113
 
         # validate the kwds to f.fit() so user typos do not
@@ -11254,7 +11512,9 @@ class Session(sherpa.ui.utils.Session):
     # Plotting
     ###########################################################################
 
-    def get_data_plot(self, id=None, recalc=True):
+    def get_data_plot(self,
+                      id: Optional[IdType] = None,
+                      recalc=True):
         if recalc:
             data = self.get_data(id)
         else:
@@ -11272,7 +11532,9 @@ class Session(sherpa.ui.utils.Session):
     get_data_plot.__doc__ = sherpa.ui.utils.Session.get_data_plot.__doc__
     get_data_plot.__annotations__ = sherpa.ui.utils.Session.get_data_plot.__annotations__
 
-    def get_model_plot(self, id=None, recalc=True):
+    def get_model_plot(self,
+                       id: Optional[IdType] = None,
+                       recalc=True):
         if recalc:
             data = self.get_data(id)
         else:
@@ -11291,12 +11553,14 @@ class Session(sherpa.ui.utils.Session):
     get_model_plot.__annotations__ = sherpa.ui.utils.Session.get_model_plot.__annotations__
 
     # also in sherpa.utils, but without the lo/hi arguments
-    def get_source_plot(self, id=None, lo=None, hi=None, recalc=True):
+    def get_source_plot(self,
+                        id: Optional[IdType] = None,
+                        lo=None, hi=None, recalc=True):
         """Return the data used by plot_source.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
         lo : number, optional
@@ -11380,7 +11644,9 @@ class Session(sherpa.ui.utils.Session):
 
         return super().get_source_plot(id, recalc=recalc)
 
-    def get_fit_plot(self, id=None, recalc=True):
+    def get_fit_plot(self,
+                     id: Optional[IdType] = None,
+                     recalc=True):
 
         plotobj = self._plot_types["fit"][0]
         if not recalc:
@@ -11528,7 +11794,9 @@ class Session(sherpa.ui.utils.Session):
     get_source_component_plot.__doc__ = sherpa.ui.utils.Session.get_source_component_plot.__doc__
     get_source_component_plot.__annotations__ = sherpa.ui.utils.Session.get_source_component_plot.__annotations__
 
-    def get_ratio_plot(self, id=None, recalc=True):
+    def get_ratio_plot(self,
+                       id: Optional[IdType] = None,
+                       recalc=True):
         if recalc:
             data = self.get_data(id)
         else:
@@ -11546,7 +11814,9 @@ class Session(sherpa.ui.utils.Session):
     get_ratio_plot.__doc__ = sherpa.ui.utils.Session.get_ratio_plot.__doc__
     get_ratio_plot.__annotations__ = sherpa.ui.utils.Session.get_ratio_plot.__annotations__
 
-    def get_resid_plot(self, id=None, recalc=True):
+    def get_resid_plot(self,
+                       id: Optional[IdType] = None,
+                       recalc=True):
         if recalc:
             data = self.get_data(id)
         else:
@@ -11564,7 +11834,9 @@ class Session(sherpa.ui.utils.Session):
     get_resid_plot.__doc__ = sherpa.ui.utils.Session.get_resid_plot.__doc__
     get_resid_plot.__annotations__ = sherpa.ui.utils.Session.get_resid_plot.__annotations__
 
-    def get_delchi_plot(self, id=None, recalc=True):
+    def get_delchi_plot(self,
+                        id: Optional[IdType] = None,
+                        recalc=True):
         if recalc:
             data = self.get_data(id)
         else:
@@ -11582,7 +11854,9 @@ class Session(sherpa.ui.utils.Session):
     get_delchi_plot.__doc__ = sherpa.ui.utils.Session.get_delchi_plot.__doc__
     get_delchi_plot.__annotations__ = sherpa.ui.utils.Session.get_delchi_plot.__annotations__
 
-    def get_chisqr_plot(self, id=None, recalc=True):
+    def get_chisqr_plot(self,
+                        id: Optional[IdType] = None,
+                        recalc=True):
         if recalc:
             data = self.get_data(id)
         else:
@@ -11601,7 +11875,9 @@ class Session(sherpa.ui.utils.Session):
     get_chisqr_plot.__annotations__ = sherpa.ui.utils.Session.get_chisqr_plot.__annotations__
 
     def get_pvalue_plot(self, null_model=None, alt_model=None, conv_model=None,
-                        id=1, otherids=(), num=500, bins=25, numcores=None,
+                        id: IdType = 1,
+                        otherids: Sequence[IdType] = (),
+                        num=500, bins=25, numcores=None,
                         recalc=False):
 
         if recalc and conv_model is None and \
@@ -11616,12 +11892,14 @@ class Session(sherpa.ui.utils.Session):
     get_pvalue_plot.__doc__ = sherpa.ui.utils.Session.get_pvalue_plot.__doc__
     get_pvalue_plot.__annotations__ = sherpa.ui.utils.Session.get_pvalue_plot.__annotations__
 
-    def get_order_plot(self, id=None, orders=None, recalc=True):
+    def get_order_plot(self,
+                       id: Optional[IdType] = None,
+                       orders=None, recalc=True):
         """Return the data used by plot_order.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None,optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
         orders : optional
@@ -11669,15 +11947,18 @@ class Session(sherpa.ui.utils.Session):
 
         return plotobj
 
-    def get_arf_plot(self, id=None, resp_id=None, recalc=True):
+    def get_arf_plot(self,
+                     id: Optional[IdType] = None,
+                     resp_id: Optional[IdType] = None,
+                     recalc=True):
         """Return the data used by plot_arf.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set with an ARF. If not given then the default
            identifier is used, as returned by `get_default_id`.
-        resp_id : int or str, optional
+        resp_id : int, str, or None, optional
            Which ARF to use in the case that multiple ARFs are
            associated with a data set. The default is ``None``,
            which means the first one.
@@ -11731,17 +12012,20 @@ class Session(sherpa.ui.utils.Session):
         return plotobj
 
 
-    def get_rmf_plot(self, id=None, resp_id=None, recalc=True):
+    def get_rmf_plot(self,
+                     id: Optional[IdType] = None,
+                     resp_id: Optional[IdType] = None,
+                     recalc=True):
         """Return the data used by plot_rmf.
 
         .. versionadded:: 4.16.0
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set with a RMF. If not given then the default
            identifier is used, as returned by `get_default_id`.
-        resp_id : int or str, optional
+        resp_id : int, str, or None, optional
            Which RMF to use in the case that multiple RMFs are
            associated with a data set. The default is ``None``,
            which means the first one.
@@ -11793,15 +12077,18 @@ class Session(sherpa.ui.utils.Session):
         return plotobj
 
 
-    def get_bkg_fit_plot(self, id=None, bkg_id=None, recalc=True):
+    def get_bkg_fit_plot(self,
+                         id: Optional[IdType] = None,
+                         bkg_id: Optional[IdType] = None,
+                         recalc=True):
         """Return the data used by plot_bkg_fit.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         recalc : bool, optional
@@ -11883,15 +12170,18 @@ class Session(sherpa.ui.utils.Session):
         plotobj.prepare(dataobj, modelobj)
         return plotobj
 
-    def get_bkg_model_plot(self, id=None, bkg_id=None, recalc=True):
+    def get_bkg_model_plot(self,
+                           id: Optional[IdType] = None,
+                           bkg_id: Optional[IdType] = None,
+                           recalc=True):
         """Return the data used by plot_bkg_model.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         recalc : bool, optional
@@ -11940,15 +12230,18 @@ class Session(sherpa.ui.utils.Session):
 
         return plotobj
 
-    def get_bkg_plot(self, id=None, bkg_id=None, recalc=True):
+    def get_bkg_plot(self,
+                     id: Optional[IdType] = None,
+                     bkg_id: Optional[IdType] = None,
+                     recalc=True):
         """Return the data used by plot_bkg.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         recalc : bool, optional
@@ -12006,7 +12299,8 @@ class Session(sherpa.ui.utils.Session):
         return plotobj
 
     def get_bkg_source_plot(self, id=None, lo=None, hi=None,
-                            bkg_id=None, recalc=True):
+                            bkg_id: Optional[IdType] = None,
+                            recalc=True):
         """Return the data used by plot_bkg_source.
 
         Parameters
@@ -12018,7 +12312,7 @@ class Session(sherpa.ui.utils.Session):
            The low value to plot.
         hi : number, optional
            The high value to plot.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         recalc : bool, optional
@@ -12098,15 +12392,18 @@ class Session(sherpa.ui.utils.Session):
 
         return plotobj
 
-    def get_bkg_resid_plot(self, id=None, bkg_id=None, recalc=True):
+    def get_bkg_resid_plot(self,
+                           id: Optional[IdType] = None,
+                           bkg_id: Optional[IdType] = None,
+                           recalc=True):
         """Return the data used by plot_bkg_resid.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         recalc : bool, optional
@@ -12156,15 +12453,18 @@ class Session(sherpa.ui.utils.Session):
 
         return plotobj
 
-    def get_bkg_ratio_plot(self, id=None, bkg_id=None, recalc=True):
+    def get_bkg_ratio_plot(self,
+                           id: Optional[IdType] = None,
+                           bkg_id: Optional[IdType] = None,
+                           recalc=True):
         """Return the data used by plot_bkg_ratio.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         recalc : bool, optional
@@ -12214,15 +12514,18 @@ class Session(sherpa.ui.utils.Session):
 
         return plotobj
 
-    def get_bkg_delchi_plot(self, id=None, bkg_id=None, recalc=True):
+    def get_bkg_delchi_plot(self,
+                            id: Optional[IdType] = None,
+                            bkg_id: Optional[IdType] = None,
+                            recalc=True):
         """Return the data used by plot_bkg_delchi.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         recalc : bool, optional
@@ -12273,15 +12576,18 @@ class Session(sherpa.ui.utils.Session):
 
         return plotobj
 
-    def get_bkg_chisqr_plot(self, id=None, bkg_id=None, recalc=True):
+    def get_bkg_chisqr_plot(self,
+                            id: Optional[IdType] = None,
+                            bkg_id: Optional[IdType] = None,
+                            recalc=True):
         """Return the data used by plot_bkg_chisqr.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         recalc : bool, optional
@@ -12333,8 +12639,10 @@ class Session(sherpa.ui.utils.Session):
         return plotobj
 
     def _prepare_energy_flux_plot(self, plot, lo, hi, id, num, bins,
-                                  correlated, numcores, bkg_id,
-                                  scales=None, model=None, otherids=(),
+                                  correlated, numcores,
+                                  bkg_id: Optional[IdType],
+                                  scales=None, model=None,
+                                  otherids: Sequence[IdType] = (),
                                   clip='hard'):
         """Run sample_energy_flux and convert to a plot.
         """
@@ -12346,8 +12654,10 @@ class Session(sherpa.ui.utils.Session):
         return plot
 
     def _prepare_photon_flux_plot(self, plot, lo, hi, id, num, bins,
-                                  correlated, numcores, bkg_id,
-                                  scales=None, model=None, otherids=(),
+                                  correlated, numcores,
+                                  bkg_id: Optional[IdType],
+                                  scales=None, model=None,
+                                  otherids: Sequence[IdType]=(),
                                   clip='hard'):
         """Run sample_photon_flux and convert to a plot.
         """
@@ -12358,9 +12668,17 @@ class Session(sherpa.ui.utils.Session):
         plot.prepare(dist, bins)
         return plot
 
-    def get_energy_flux_hist(self, lo=None, hi=None, id=None, num=7500, bins=75,
-                             correlated=False, numcores=None, bkg_id=None,
-                             scales=None, model=None, otherids=(), recalc=True,
+    def get_energy_flux_hist(self, lo=None, hi=None,
+                             id: Optional[IdType] = None,
+                             num=7500,
+                             bins=75,
+                             correlated=False,
+                             numcores=None,
+                             bkg_id: Optional[IdType] = None,
+                             scales=None,
+                             model=None,
+                             otherids: Sequence[IdType] = (),
+                             recalc=True,
                              clip='hard'):
         """Return the data displayed by plot_energy_flux.
 
@@ -12382,7 +12700,7 @@ class Session(sherpa.ui.utils.Session):
         hi : optional
            The upper limit to use when summing up the signal. If not
            given then the upper value of the data grid is used.
-        id : int or string, optional
+        id : int or string or None, optional
            The identifier of the data set to use. If `None`, the
            default value, then all datasets with associated models are
            used to calculate the errors and the model evaluation is
@@ -12399,7 +12717,7 @@ class Session(sherpa.ui.utils.Session):
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
-        bkg_id : int or string, optional
+        bkg_id : int, str, or None, optional
            The identifier of the background component to use. This
            should only be set when the line to be measured is in the
            background model.
@@ -12497,9 +12815,17 @@ class Session(sherpa.ui.utils.Session):
 
         return plotobj
 
-    def get_photon_flux_hist(self, lo=None, hi=None, id=None, num=7500, bins=75,
-                             correlated=False, numcores=None, bkg_id=None,
-                             scales=None, model=None, otherids=(), recalc=True,
+    def get_photon_flux_hist(self, lo=None, hi=None,
+                             id: Optional[IdType] = None,
+                             num=7500,
+                             bins=75,
+                             correlated=False,
+                             numcores=None,
+                             bkg_id: Optional[IdType] = None,
+                             scales=None,
+                             model=None,
+                             otherids: Sequence[IdType] = (),
+                             recalc=True,
                              clip='hard'):
         """Return the data displayed by plot_photon_flux.
 
@@ -12520,7 +12846,7 @@ class Session(sherpa.ui.utils.Session):
         hi : optional
            The upper limit to use when summing up the signal. If not
            given then the upper value of the data grid is used.
-        id : int or string, optional
+        id : int, str, or None, optional
            The identifier of the data set to use. If `None`, the
            default value, then all datasets with associated models are
            used to calculate the errors and the model evaluation is
@@ -12537,7 +12863,7 @@ class Session(sherpa.ui.utils.Session):
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
-        bkg_id : int or string, optional
+        bkg_id : int, str, or None, optional
            The identifier of the background component to use. This
            should only be set when the line to be measured is in the
            background model.
@@ -12635,8 +12961,11 @@ class Session(sherpa.ui.utils.Session):
 
         return plotobj
 
-    def plot_arf(self, id=None, resp_id=None, replot=False, overplot=False,
-                 clearwindow=True, **kwargs):
+    def plot_arf(self,
+                 id: Optional[IdType] = None,
+                 resp_id: Optional[IdType] = None,
+                 replot=False, overplot=False,
+                 clearwindow=True, **kwargs) -> None:
         """Plot the ARF associated with a data set.
 
         Display the effective area curve from the ARF
@@ -12644,10 +12973,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set with an ARF. If not given then the default
            identifier is used, as returned by `get_default_id`.
-        resp_id : int or str, optional
+        resp_id : int, str, or None, optional
            Which ARF to use in the case that multiple ARFs are
            associated with a data set. The default is ``None``,
            which means the first one.
@@ -12706,8 +13035,11 @@ class Session(sherpa.ui.utils.Session):
                    **kwargs)
 
 
-    def plot_rmf(self, id=None, resp_id=None, replot=False, overplot=False,
-                 clearwindow=True, **kwargs):
+    def plot_rmf(self,
+                 id: Optional[IdType] = None,
+                 resp_id: Optional[IdType] = None,
+                 replot=False, overplot=False,
+                 clearwindow=True, **kwargs) -> None:
         """Plot the RMF associated with a data set.
 
         Display the energy redistribution from the RMF
@@ -12719,10 +13051,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set with a RMF. If not given then the default
            identifier is used, as returned by `get_default_id`.
-        resp_id : int or str, optional
+        resp_id : int, str, or None, optional
            Which RMF to use in the case that multiple RMFs are
            associated with a data set. The default is ``None``,
            which means the first one.
@@ -12781,8 +13113,11 @@ class Session(sherpa.ui.utils.Session):
 
 
     # DOC-NOTE: also in sherpa.utils, but without the lo/hi arguments
-    def plot_source(self, id=None, lo=None, hi=None, replot=False,
-                    overplot=False, clearwindow=True, **kwargs):
+    def plot_source(self,
+                    id: Optional[IdType] = None,
+                    lo=None, hi=None,
+                    replot=False, overplot=False, clearwindow=True,
+                    **kwargs) -> None:
         """Plot the source expression for a data set.
 
         This function plots the source model for a data set. This does
@@ -12792,7 +13127,7 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
         lo : number, optional
@@ -12860,8 +13195,12 @@ class Session(sherpa.ui.utils.Session):
                             clearwindow=clearwindow, **kwargs)
 
     # DOC-TODO: is orders the same as resp_id?
-    def plot_order(self, id=None, orders=None, replot=False, overplot=False,
-                   clearwindow=True, **kwargs):
+    def plot_order(self,
+                   id: Optional[IdType] = None,
+                   orders=None,
+                   replot=False, overplot=False,
+                   clearwindow=True,
+                   **kwargs) -> None:
         """Plot the model for a data set convolved by the given response.
 
         Some data sets - such as grating PHA data - can have multiple
@@ -12919,16 +13258,19 @@ class Session(sherpa.ui.utils.Session):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_bkg(self, id=None, bkg_id=None, replot=False, overplot=False,
-                 clearwindow=True, **kwargs):
+    def plot_bkg(self,
+                 id: Optional[IdType] = None,
+                 bkg_id: Optional[IdType] = None,
+                 replot=False, overplot=False, clearwindow=True,
+                 **kwargs) -> None:
         """Plot the background values for a PHA data set.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         replot : bool, optional
@@ -12984,8 +13326,11 @@ class Session(sherpa.ui.utils.Session):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_bkg_model(self, id=None, bkg_id=None, replot=False,
-                       overplot=False, clearwindow=True, **kwargs):
+    def plot_bkg_model(self,
+                       id: Optional[IdType] = None,
+                       bkg_id: Optional[IdType] = None,
+                       replot=False, overplot=False, clearwindow=True,
+                       **kwargs) -> None:
         """Plot the model for the background of a PHA data set.
 
         This function plots the model for the background of a PHA data
@@ -12994,10 +13339,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         replot : bool, optional
@@ -13041,8 +13386,11 @@ class Session(sherpa.ui.utils.Session):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_bkg_resid(self, id=None, bkg_id=None, replot=False,
-                       overplot=False, clearwindow=True, **kwargs):
+    def plot_bkg_resid(self,
+                       id: Optional[IdType] = None,
+                       bkg_id: Optional[IdType] = None,
+                       replot=False, overplot=False, clearwindow=True,
+                       **kwargs) -> None:
         """Plot the residual (data-model) values for the background of a PHA data set.
 
         Display the residuals for the background of a PHA data set
@@ -13053,10 +13401,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         replot : bool, optional
@@ -13107,8 +13455,11 @@ class Session(sherpa.ui.utils.Session):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_bkg_ratio(self, id=None, bkg_id=None, replot=False,
-                       overplot=False, clearwindow=True, **kwargs):
+    def plot_bkg_ratio(self,
+                       id: Optional[IdType] = None,
+                       bkg_id: Optional[IdType] = None,
+                       replot=False, overplot=False, clearwindow=True,
+                       **kwargs) -> None:
         """Plot the ratio of data to model values for the background of a PHA data set.
 
         Display the ratio of data to model values for the background
@@ -13120,10 +13471,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         replot : bool, optional
@@ -13173,8 +13524,11 @@ class Session(sherpa.ui.utils.Session):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_bkg_delchi(self, id=None, bkg_id=None, replot=False,
-                        overplot=False, clearwindow=True, **kwargs):
+    def plot_bkg_delchi(self,
+                        id: Optional[IdType] = None,
+                        bkg_id: Optional[IdType] = None,
+                        replot=False, overplot=False, clearwindow=True,
+                        **kwargs) -> None:
         """Plot the ratio of residuals to error for the background of a PHA data set.
 
         Display the ratio of the residuals (data-model) to the error
@@ -13186,10 +13540,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         replot : bool, optional
@@ -13239,8 +13593,11 @@ class Session(sherpa.ui.utils.Session):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_bkg_chisqr(self, id=None, bkg_id=None, replot=False,
-                        overplot=False, clearwindow=True, **kwargs):
+    def plot_bkg_chisqr(self,
+                        id: Optional[IdType] = None,
+                        bkg_id: Optional[IdType] = None,
+                        replot=False, overplot=False, clearwindow=True,
+                        **kwargs) -> None:
         """Plot the chi-squared value for each point of the background of a PHA data set.
 
         Display the square of the residuals (data-model) divided by
@@ -13249,10 +13606,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         replot : bool, optional
@@ -13297,16 +13654,19 @@ class Session(sherpa.ui.utils.Session):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_bkg_fit(self, id=None, bkg_id=None, replot=False,
-                     overplot=False, clearwindow=True, **kwargs):
+    def plot_bkg_fit(self,
+                     id: Optional[IdType] = None,
+                     bkg_id: Optional[IdType] = None,
+                     replot=False, overplot=False, clearwindow=True,
+                     **kwargs) -> None:
         """Plot the fit results (data, model) for the background of a PHA data set.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         replot : bool, optional
@@ -13354,9 +13714,12 @@ class Session(sherpa.ui.utils.Session):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_bkg_source(self, id=None, lo=None, hi=None, bkg_id=None,
+    def plot_bkg_source(self,
+                        id: Optional[IdType] = None,
+                        lo=None, hi=None,
+                        bkg_id: Optional[IdType] = None,
                         replot=False, overplot=False, clearwindow=True,
-                        **kwargs):
+                        **kwargs) -> None:
         """Plot the model expression for the background of a PHA data set.
 
         This function plots the model for the background of a PHA data
@@ -13365,14 +13728,14 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
         lo : number, optional
            The low value to plot.
         hi : number, optional
            The high value to plot.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         replot : bool, optional
@@ -13416,12 +13779,16 @@ class Session(sherpa.ui.utils.Session):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_energy_flux(self, lo=None, hi=None, id=None, num=7500, bins=75,
-                         correlated=False, numcores=None, bkg_id=None,
-                         scales=None, model=None, otherids=(),
+    def plot_energy_flux(self, lo=None, hi=None,
+                         id: Optional[IdType] = None,
+                         num=7500, bins=75,
+                         correlated=False, numcores=None,
+                         bkg_id: Optional[IdType] = None,
+                         scales=None, model=None,
+                         otherids: Sequence[IdType] = (),
                          recalc=True, clip='hard',
                          overplot=False, clearwindow=True,
-                         **kwargs):
+                         **kwargs) -> None:
         """Display the energy flux distribution.
 
         For each iteration, draw the parameter values of the model
@@ -13445,7 +13812,7 @@ class Session(sherpa.ui.utils.Session):
         hi : optional
            The upper limit to use when summing up the signal. If not
            given then the upper value of the data grid is used.
-        id : int or string, optional
+        id : int, str, or None, optional
            The identifier of the data set to use. If `None`, the
            default value, then all datasets with associated models are
            used to calculate the errors and the model evaluation is
@@ -13462,7 +13829,7 @@ class Session(sherpa.ui.utils.Session):
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
-        bkg_id : int or string, optional
+        bkg_id : int, str, or None, optional
            The identifier of the background component to use. This
            should only be set when the line to be measured is in the
            background model.
@@ -13571,12 +13938,16 @@ class Session(sherpa.ui.utils.Session):
         self._plot(efplot, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_photon_flux(self, lo=None, hi=None, id=None, num=7500, bins=75,
-                         correlated=False, numcores=None, bkg_id=None,
-                         scales=None, model=None, otherids=(),
+    def plot_photon_flux(self, lo=None, hi=None,
+                         id: Optional[IdType] = None,
+                         num=7500, bins=75,
+                         correlated=False, numcores=None,
+                         bkg_id: Optional[IdType] = None,
+                         scales=None, model=None,
+                         otherids: Sequence[IdType] = (),
                          recalc=True, clip='hard',
                          overplot=False, clearwindow=True,
-                         **kwargs):
+                         **kwargs) -> None:
         """Display the photon flux distribution.
 
         For each iteration, draw the parameter values of the model
@@ -13600,7 +13971,7 @@ class Session(sherpa.ui.utils.Session):
         hi : optional
            The upper limit to use when summing up the signal. If not
            given then the upper value of the data grid is used.
-        id : int or string, optional
+        id : int, str, or None, optional
            The identifier of the data set to use. If `None`, the
            default value, then all datasets with associated models are
            used to calculate the errors and the model evaluation is
@@ -13617,7 +13988,7 @@ class Session(sherpa.ui.utils.Session):
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
-        bkg_id : int or string, optional
+        bkg_id : int, str, or None, optional
            The identifier of the background component to use. This
            should only be set when the line to be measured is in the
            background model.
@@ -13727,7 +14098,7 @@ class Session(sherpa.ui.utils.Session):
                    **kwargs)
 
     def _bkg_jointplot2(self, plot1, plot2, overplot=False,
-                        clearwindow=True, **kwargs):
+                        clearwindow=True, **kwargs) -> None:
         """Create a joint plot for bkg, vertically aligned, fit data on the top.
 
         Parameters
@@ -13768,8 +14139,11 @@ class Session(sherpa.ui.utils.Session):
 
             p2prefs['xlog'] = oldval
 
-    def plot_bkg_fit_ratio(self, id=None, bkg_id=None, replot=False,
-                           overplot=False, clearwindow=True, **kwargs):
+    def plot_bkg_fit_ratio(self,
+                           id: Optional[IdType] = None,
+                           bkg_id: Optional[IdType] = None,
+                           replot=False, overplot=False, clearwindow=True,
+                           **kwargs) -> None:
         """Plot the fit results, and the data/model ratio, for the background of
         a PHA data set.
 
@@ -13783,10 +14157,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         replot : bool, optional
@@ -13844,8 +14218,11 @@ class Session(sherpa.ui.utils.Session):
                              overplot=overplot, clearwindow=clearwindow,
                              **kwargs)
 
-    def plot_bkg_fit_resid(self, id=None, bkg_id=None, replot=False,
-                           overplot=False, clearwindow=True, **kwargs):
+    def plot_bkg_fit_resid(self,
+                           id: Optional[IdType] = None,
+                           bkg_id: Optional[IdType] = None,
+                           replot=False, overplot=False, clearwindow=True,
+                           **kwargs) -> None:
         """Plot the fit results, and the residuals, for the background of
         a PHA data set.
 
@@ -13861,10 +14238,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         replot : bool, optional
@@ -13921,8 +14298,11 @@ class Session(sherpa.ui.utils.Session):
                              overplot=overplot, clearwindow=clearwindow,
                              **kwargs)
 
-    def plot_bkg_fit_delchi(self, id=None, bkg_id=None, replot=False,
-                            overplot=False, clearwindow=True, **kwargs):
+    def plot_bkg_fit_delchi(self,
+                            id: Optional[IdType] = None,
+                            bkg_id: Optional[IdType] = None,
+                            replot=False, overplot=False, clearwindow=True,
+                            **kwargs) -> None:
         """Plot the fit results, and the residuals, for the background of
         a PHA data set.
 
@@ -13938,10 +14318,10 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            Identify the background component to use, if there are
            multiple ones associated with the data set.
         replot : bool, optional
@@ -14003,7 +14383,9 @@ class Session(sherpa.ui.utils.Session):
     # Analysis Functions
     ###########################################################################
 
-    def resample_data(self, id=None, niter=1000, seed=None):
+    def resample_data(self,
+                      id: Optional[IdType] = None,
+                      niter=1000, seed=None):
         """Resample data with asymmetric error bars.
 
         The function performs a parametric bootstrap assuming a skewed
@@ -14026,7 +14408,7 @@ class Session(sherpa.ui.utils.Session):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier of the data set to use.
         niter : int, optional
            The number of iterations to use. The default is ``1000``.
@@ -14101,10 +14483,15 @@ class Session(sherpa.ui.utils.Session):
         return resampledata(niter=niter, seed=seed,
                             rng=self.get_rng())
 
-    def sample_photon_flux(self, lo=None, hi=None, id=None, num=1,
+    def sample_photon_flux(self, lo=None, hi=None,
+                           id: Optional[IdType] = None,
+                           num=1,
                            scales=None, correlated=False,
-                           numcores=None, bkg_id=None, model=None,
-                           otherids=(), clip='hard'):
+                           numcores=None,
+                           bkg_id: Optional[IdType] = None,
+                           model=None,
+                           otherids: Sequence[IdType] = (),
+                           clip='hard'):
         """Return the photon flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -14129,7 +14516,7 @@ class Session(sherpa.ui.utils.Session):
         hi : optional
            The upper limit to use when summing up the signal. If not
            given then the upper value of the data grid is used.
-        id : int or string, optional
+        id : int, str, or None, optional
            The identifier of the data set to use. If `None`, the
            default value, then all datasets with associated models are
            used to calculate the errors and the model evaluation is
@@ -14159,7 +14546,7 @@ class Session(sherpa.ui.utils.Session):
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
-        bkg_id : int or string, optional
+        bkg_id : int, str, or None, optional
            The identifier of the background component to use. This
            should only be set when the line to be measured is in the
            background model.
@@ -14337,10 +14724,15 @@ class Session(sherpa.ui.utils.Session):
                                              samples=scales, clip=clip,
                                              rng=self.get_rng())
 
-    def sample_energy_flux(self, lo=None, hi=None, id=None, num=1,
+    def sample_energy_flux(self, lo=None, hi=None,
+                           id: Optional[IdType] = None,
+                           num=1,
                            scales=None, correlated=False,
-                           numcores=None, bkg_id=None, model=None,
-                           otherids=(), clip='hard'):
+                           numcores=None,
+                           bkg_id: Optional[IdType] = None,
+                           model=None,
+                           otherids: Sequence[IdType] = (),
+                           clip='hard'):
         """Return the energy flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -14365,7 +14757,7 @@ class Session(sherpa.ui.utils.Session):
         hi : optional
            The upper limit to use when summing up the signal. If not
            given then the upper value of the data grid is used.
-        id : int or string, optional
+        id : int, str, or None, optional
            The identifier of the data set to use. If `None`, the
            default value, then all datasets with associated models are
            used to calculate the errors and the model evaluation is
@@ -14395,7 +14787,7 @@ class Session(sherpa.ui.utils.Session):
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
-        bkg_id : int or string, optional
+        bkg_id : int, str, or None, optional
            The identifier of the background component to use. This
            should only be set when the line to be measured is in the
            background model.
@@ -14573,9 +14965,12 @@ class Session(sherpa.ui.utils.Session):
                                              samples=scales, clip=clip,
                                              rng=self.get_rng())
 
-    def sample_flux(self, modelcomponent=None, lo=None, hi=None, id=None,
+    def sample_flux(self, modelcomponent=None, lo=None, hi=None,
+                    id: Optional[IdType] = None,
                     num=1, scales=None, correlated=False,
-                    numcores=None, bkg_id=None, Xrays=True, confidence=68):
+                    numcores=None,
+                    bkg_id: Optional[IdType] = None,
+                    Xrays=True, confidence=68):
         """Return the flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -14613,7 +15008,7 @@ class Session(sherpa.ui.utils.Session):
         hi : optional
            The upper limit to use when summing up the signal. If not
            given then the upper value of the data grid is used.
-        id : int or string, optional
+        id : int, str, or None, optional
            The identifier of the data set to use. The default value
            (``None``) means that the default identifier, as returned by
            `get_default_id`, is used.
@@ -14633,7 +15028,7 @@ class Session(sherpa.ui.utils.Session):
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
-        bkg_id : int or string, optional
+        bkg_id : int, str, or None, optional
            The identifier of the background component to use. This
            should only be set when the line to be measured is in the
            background model.
@@ -14795,8 +15190,13 @@ class Session(sherpa.ui.utils.Session):
                                                   modelcomponent=modelcomponent,
                                                   confidence=confidence)
 
-    def eqwidth(self, src, combo, id=None, lo=None, hi=None, bkg_id=None,
-                error=False, params=None, otherids=(), niter=1000,
+    def eqwidth(self, src, combo,
+                id: Optional[IdType] = None,
+                lo=None, hi=None,
+                bkg_id: Optional[IdType] = None,
+                error=False, params=None,
+                otherids: Sequence[IdType] = (),
+                niter=1000,
                 covar_matrix=None):
         """Calculate the equivalent width of an emission or absorption line.
 
@@ -14828,10 +15228,10 @@ class Session(sherpa.ui.utils.Session):
            The upper limit for the calculation (the units are set by
            `set_analysis` for the data set). The default value (``None``)
            means that the upper range of the data set is used.
-        id : int or string, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then
            all data sets with an associated model are used simultaneously.
-        bkg_id : int or string, optional
+        bkg_id : int, str, or None, optional
            The identifier of the background component to use. This
            should only be set when the line to be measured is in the
            background model.
@@ -14985,7 +15385,9 @@ class Session(sherpa.ui.utils.Session):
         ####################################################
         return sherpa.astro.utils.eqwidth(data, src, combo, lo, hi)
 
-    def calc_photon_flux(self, lo=None, hi=None, id=None, bkg_id=None,
+    def calc_photon_flux(self, lo=None, hi=None,
+                         id: Optional[IdType] = None,
+                         bkg_id: Optional[IdType] = None,
                          model=None):
         """Integrate the unconvolved source model over a pass band.
 
@@ -15003,11 +15405,11 @@ class Session(sherpa.ui.utils.Session):
            over the given band. If only one is set then calculate
            the flux density at that point. The units for `lo` and `hi`
            are given by the current analysis setting.
-        id : int or str, optional
+        id : int, str, or None, optional
            Use the source expression associated with this data set. If
            not given then the default identifier is used, as returned
            by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            If set, use the model associated with the given background
            component rather than the source model.
         model : model, optional
@@ -15104,7 +15506,9 @@ class Session(sherpa.ui.utils.Session):
 
         return sherpa.astro.utils.calc_photon_flux(data, model, lo, hi)
 
-    def calc_energy_flux(self, lo=None, hi=None, id=None, bkg_id=None,
+    def calc_energy_flux(self, lo=None, hi=None,
+                         id: Optional[IdType] = None,
+                         bkg_id: Optional[IdType] = None,
                          model=None):
         """Integrate the unconvolved source model over a pass band.
 
@@ -15123,11 +15527,11 @@ class Session(sherpa.ui.utils.Session):
            over the given band. If only one is set then calculate
            the flux density at that point. The units for `lo` and `hi`
            are given by the current analysis setting.
-        id : int or str, optional
+        id : int, str, or None, optional
            Use the source expression associated with this data set. If
            not given then the default identifier is used, as returned
            by ``get_default_id``.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            If set, use the model associated with the given background
            component rather than the source model.
         model : model, optional
@@ -15222,7 +15626,9 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: how do lo/hi limits interact with bin edges;
     # is it all in or partially in or ...
-    def calc_data_sum(self, lo=None, hi=None, id=None, bkg_id=None):
+    def calc_data_sum(self, lo=None, hi=None,
+                      id: Optional[IdType] = None,
+                      bkg_id: Optional[IdType] = None):
         """Sum up the data values over a pass band.
 
         This function is for one-dimensional data sets: use
@@ -15234,11 +15640,11 @@ class Session(sherpa.ui.utils.Session):
            If both are None or both are set then sum up the data
            over the given band. If only one is set then return
            the data count in the given bin.
-        id : int or str, optional
+        id : int, str, or None, optional
            Use the source expression associated with this data set. If
            not given then the default identifier is used, as returned
            by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            If set, use the model associated with the given background
            component rather than the source model.
 
@@ -15318,7 +15724,9 @@ class Session(sherpa.ui.utils.Session):
     #           to show the difference between calc_model_sum and
     #           calc_source_sum
     #
-    def calc_model_sum(self, lo=None, hi=None, id=None, bkg_id=None):
+    def calc_model_sum(self, lo=None, hi=None,
+                       id: Optional[IdType] = None,
+                       bkg_id: Optional[IdType] = None):
         """Sum up the fitted model over a pass band.
 
         Sum up M(E) over a range of bins, where M(E) is the per-bin model
@@ -15335,11 +15743,11 @@ class Session(sherpa.ui.utils.Session):
            band. If only one is set then use the model value in the
            selected bin. The units for `lo` and `hi` are given by the
            current analysis setting.
-        id : int or str, optional
+        id : int, str, or None, optional
            Use the source expression associated with this data set. If
            not given then the default identifier is used, as returned
            by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            If set, use the model associated with the given background
            component rather than the source model.
 
@@ -15424,7 +15832,9 @@ class Session(sherpa.ui.utils.Session):
 
         return sherpa.astro.utils.calc_model_sum(data, model, lo, hi)
 
-    def calc_data_sum2d(self, reg=None, id=None):
+    def calc_data_sum2d(self,
+                        reg=None,
+                        id: Optional[IdType] = None):
         """Sum up the data values of a 2D data set.
 
         This function is for two-dimensional data sets: use
@@ -15435,7 +15845,7 @@ class Session(sherpa.ui.utils.Session):
         reg : str, optional
            The spatial filter to use. The default, ``None``, is to
            use the whole data set.
-        id : int or str, optional
+        id : int, str, or None, optional
            Use the source expression associated with this data set. If
            not given then the default identifier is used, as returned
            by `get_default_id`.
@@ -15501,7 +15911,8 @@ class Session(sherpa.ui.utils.Session):
     #           and change the model (to a non-flat distribution, otherwise
     #           the PSF doesn't really help)
     # DOC-TODO: this needs testing as doesn't seem to be working for me
-    def calc_model_sum2d(self, reg=None, id=None):
+    def calc_model_sum2d(self, reg=None,
+                         id: Optional[IdType] = None):
         """Sum up the convolved model for a 2D data set.
 
         This function is for two-dimensional data sets: use
@@ -15512,7 +15923,7 @@ class Session(sherpa.ui.utils.Session):
         reg : str, optional
            The spatial filter to use. The default, ``None``, is to
            use the whole data set.
-        id : int or str, optional
+        id : int, str, or None, optional
            Use the source expression associated with this data set. If
            not given then the default identifier is used, as returned
            by `get_default_id`.
@@ -15579,7 +15990,8 @@ class Session(sherpa.ui.utils.Session):
         model = self.get_model(id)
         return sherpa.astro.utils.calc_model_sum2d(data, model, reg)
 
-    def calc_source_sum2d(self, reg=None, id=None):
+    def calc_source_sum2d(self, reg=None,
+                          id: Optional[IdType] = None):
         """Sum up the unconvolved model for a 2D data set.
 
         This function is for two-dimensional data sets: use
@@ -15590,7 +16002,7 @@ class Session(sherpa.ui.utils.Session):
         reg : str, optional
            The spatial filter to use. The default, ``None``, is to
            use the whole data set.
-        id : int or str, optional
+        id : int, str, or None, optional
            Use the source expression associated with this data set. If
            not given then the default identifier is used, as returned
            by `get_default_id`.
@@ -15657,7 +16069,9 @@ class Session(sherpa.ui.utils.Session):
         src = self.get_source(id)
         return sherpa.astro.utils.calc_model_sum2d(data, src, reg)
 
-    def calc_source_sum(self, lo=None, hi=None, id=None, bkg_id=None):
+    def calc_source_sum(self, lo=None, hi=None,
+                        id: Optional[IdType] = None,
+                        bkg_id: Optional[IdType] = None):
         """Sum up the source model over a pass band.
 
         Sum up S(E) over a range of bins, where S(E) is the per-bin model
@@ -15674,11 +16088,11 @@ class Session(sherpa.ui.utils.Session):
            band. If only one is set then use the model value in the
            selected bin. The units for `lo` and `hi` are given by the
            current analysis setting.
-        id : int or str, optional
+        id : int, str, or None, optional
            Use the source expression associated with this data set. If
            not given then the default identifier is used, as returned
            by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            If set, use the model associated with the given background
            component rather than the source model.
 
@@ -15771,7 +16185,8 @@ class Session(sherpa.ui.utils.Session):
     # DOC-TODO: no reason can't k-correct wavelength range,
     # but need to work out how to identify the units
     def calc_kcorr(self, z, obslo, obshi, restlo=None, resthi=None,
-                   id=None, bkg_id=None):
+                   id: Optional[IdType] = None,
+                   bkg_id: Optional[IdType] = None):
         """Calculate the K correction for a model.
 
         The K correction ([1], [2], [3], [4]) is the numeric
@@ -15797,11 +16212,11 @@ class Session(sherpa.ui.utils.Session):
         resthi : number or ``None``
            The maximum energy of the rest-frame band. It must be
            larger than ``restlo``. If ``None`` then use ``obshi``.
-        id : int or str, optional
+        id : int, str, or None, optional
            Use the source expression associated with this data set. If
            not given then the default identifier is used, as returned
            by `get_default_id`.
-        bkg_id : int or str, optional
+        bkg_id : int, str, or None, optional
            If set, use the model associated with the given background
            component rather than the source model.
 
@@ -15972,7 +16387,7 @@ class Session(sherpa.ui.utils.Session):
     # Session Text Save Function
     ###########################################################################
 
-    def save_all(self, outfile=None, clobber=False):
+    def save_all(self, outfile=None, clobber=False) -> None:
         """Save the information about the current session to a text file.
 
         This differs to the `save` command in that the output is human

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -27,7 +27,7 @@ import logging
 import os
 import pickle
 import sys
-from typing import Callable, Optional, Union
+from typing import Any, Callable, Optional, Sequence, TypeVar, Union
 
 import numpy as np
 
@@ -66,6 +66,7 @@ _builtin_symbols_ = tuple(BUILTINS.__dict__.keys())
 
 
 ModelType = Union[Model, str]
+T = TypeVar("T")
 
 
 ###############################################################################
@@ -182,7 +183,10 @@ def _get_filter(data):
         return None
 
 
-def report_filter_change(idstr, ofilter, nfilter, xlabel=None):
+def report_filter_change(idstr: str,
+                         ofilter: Optional[str],
+                         nfilter: Optional[str],
+                         xlabel: Optional[str] = None):
     """Report the filter change for ignore/filter.
 
     Parameters
@@ -254,7 +258,10 @@ def report_filter_change(idstr, ofilter, nfilter, xlabel=None):
     info(ostr)
 
 
-def notice_data_range(get_data, ids, lo, hi, kwargs):
+def notice_data_range(get_data: Callable[[IdType], Data],
+                      ids: Sequence[IdType],
+                      lo, hi,
+                      kwargs) -> None:
     """Filter each dataset and report the change in filter.
 
     Parameters
@@ -744,7 +751,7 @@ class Session(NoNewAttributesAfterInit):
     # Standard methods
     ###########################################################################
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.clean()
         self._model_types = {}
         self._model_globals = np.__dict__.copy()
@@ -840,7 +847,7 @@ class Session(NoNewAttributesAfterInit):
         self._sherpa_version = sherpa.__version__
         self._sherpa_version_string = sherpa.__version__
 
-        self._default_id = 1
+        self._default_id: IdType = 1
         self._paramprompt = False
 
         self._methods = {}
@@ -876,15 +883,15 @@ class Session(NoNewAttributesAfterInit):
 
         reset_interpolators()
 
-        self._data = {}
+        self._data: dict[IdType, Data] = {}
         self._psf = {}
         self._tbl_models = []
         self._psf_models = []
 
         self._model_autoassign_func = _assign_model_to_main
         self._model_components = {}
-        self._models = {}
-        self._sources = {}
+        self._models: dict[IdType, Model] = {}
+        self._sources: dict[IdType, Model] = {}
 
         self._fit_results = None
         self._pvalue_results = None
@@ -1221,7 +1228,7 @@ class Session(NoNewAttributesAfterInit):
             for name, cmpt in self._model_components.items():
                 self._model_autoassign_func(name, cmpt)
 
-    def _get_show_data(self, id=None):
+    def _get_show_data(self, id: Optional[IdType] = None) -> str:
         data_str = ''
         ids = self.list_data_ids()
         if id is not None:
@@ -1231,7 +1238,7 @@ class Session(NoNewAttributesAfterInit):
             data_str += str(self.get_data(id)) + '\n\n'
         return data_str
 
-    def _get_show_filter(self, id=None):
+    def _get_show_filter(self, id: Optional[IdType] = None) -> str:
         filt_str = ''
         ids = self.list_data_ids()
         if id is not None:
@@ -1241,7 +1248,7 @@ class Session(NoNewAttributesAfterInit):
             filt_str += self.get_data(id).get_filter_expr() + '\n\n'
         return filt_str
 
-    def _get_show_model(self, id=None):
+    def _get_show_model(self, id: Optional[IdType] = None) -> str:
         model_str = ''
         ids = self.list_data_ids()
         mdl_ids = self.list_model_ids()
@@ -1253,7 +1260,7 @@ class Session(NoNewAttributesAfterInit):
                 model_str += str(self.get_model(id)) + '\n\n'
         return model_str
 
-    def _get_show_source(self, id=None):
+    def _get_show_source(self, id: Optional[IdType] = None) -> str:
         model_str = ''
         ids = self.list_data_ids()
         src_ids = self._sources.keys()
@@ -1265,7 +1272,7 @@ class Session(NoNewAttributesAfterInit):
                 model_str += str(self.get_source(id)) + '\n\n'
         return model_str
 
-    def _get_show_kernel(self, id=None):
+    def _get_show_kernel(self, id: Optional[IdType] = None) -> str:
         kernel_str = ''
         ids = self.list_data_ids()
         if id is not None:
@@ -1277,7 +1284,7 @@ class Session(NoNewAttributesAfterInit):
                 kernel_str += str(self.get_psf(id)) + '\n\n'
         return kernel_str
 
-    def _get_show_psf(self, id=None):
+    def _get_show_psf(self, id: Optional[IdType] = None) -> str:
         psf_str = ''
         ids = self.list_data_ids()
         if id is not None:
@@ -1456,7 +1463,9 @@ class Session(NoNewAttributesAfterInit):
         txt = self._get_show_fit()
         send_to_pager(txt, outfile, clobber)
 
-    def show_data(self, id=None, outfile=None, clobber=False):
+    def show_data(self,
+                  id: Optional[IdType] = None,
+                  outfile=None, clobber=False):
         """Summarize the available data sets.
 
         Display information on the data sets that have been
@@ -1465,7 +1474,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then all data sets are
            displayed.
         outfile : str, optional
@@ -1492,7 +1501,9 @@ class Session(NoNewAttributesAfterInit):
         txt = self._get_show_data(id)
         send_to_pager(txt, outfile, clobber)
 
-    def show_filter(self, id=None, outfile=None, clobber=False):
+    def show_filter(self,
+                    id: Optional[IdType] = None,
+                    outfile=None, clobber=False):
         """Show any filters applied to a data set.
 
         Display any filters that have been applied to the independent
@@ -1500,7 +1511,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then all data sets are
            displayed.
         outfile : str, optional
@@ -1531,7 +1542,9 @@ class Session(NoNewAttributesAfterInit):
         txt = self._get_show_filter(id)
         send_to_pager(txt, outfile, clobber)
 
-    def show_model(self, id=None, outfile=None, clobber=False):
+    def show_model(self,
+                   id: Optional[IdType] = None,
+                   outfile=None, clobber=False):
         """Display the model expression used to fit a data set.
 
         This displays the model used to fit the data set, that is,
@@ -1543,7 +1556,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then all source expressions are
            displayed.
         outfile : str, optional
@@ -1573,7 +1586,9 @@ class Session(NoNewAttributesAfterInit):
         txt += self._get_show_model(id)
         send_to_pager(txt, outfile, clobber)
 
-    def show_source(self, id=None, outfile=None, clobber=False):
+    def show_source(self,
+                    id: Optional[IdType] = None,
+                    outfile=None, clobber=False):
         """Display the source model expression for a data set.
 
         This displays the source model for a data set, that is, the
@@ -1584,7 +1599,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then all source expressions are
            displayed.
         outfile : str, optional
@@ -1615,7 +1630,9 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-TODO: how and where to describe the PSF/kernel difference
     # as the Notes section below is inadequate
-    def show_kernel(self, id=None, outfile=None, clobber=False):
+    def show_kernel(self,
+                    id: Optional[IdType] = None,
+                    outfile=None, clobber=False):
         """Display any kernel applied to a data set.
 
         The kernel represents the subset of the PSF model that is used
@@ -1624,7 +1641,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then all data sets are
            displayed.
         outfile : str, optional
@@ -1670,7 +1687,9 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-TODO: how and where to describe the PSF/kernel difference
     # as the Notes section below is inadequate
-    def show_psf(self, id=None, outfile=None, clobber=False):
+    def show_psf(self,
+                 id: Optional[IdType] = None,
+                 outfile=None, clobber=False):
         """Display any PSF model applied to a data set.
 
         The PSF model represents the full model or data set that is
@@ -1679,7 +1698,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then all data sets are
            displayed.
         outfile : str, optional
@@ -1822,7 +1841,9 @@ class Session(NoNewAttributesAfterInit):
         txt = self._get_show_covar()
         send_to_pager(txt, outfile, clobber)
 
-    def show_all(self, id=None, outfile=None, clobber=False):
+    def show_all(self,
+                 id: Optional[IdType] = None,
+                 outfile=None, clobber=False):
         """Report the current state of the Sherpa session.
 
         Display information about one or all of the data sets that
@@ -1832,7 +1853,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then all data sets are
            displayed.
         outfile : str, optional
@@ -1941,14 +1962,14 @@ class Session(NoNewAttributesAfterInit):
     ###########################################################################
 
     @staticmethod
-    def _valid_id(id):
+    def _valid_id(id: Any) -> bool:  # TODO: mark as TypeGuard[IdType] instead
         """Is the identifier valid for Sherpa?
 
         This does not treat None as a valid identifier.
         """
         return (_is_integer(id) or _is_str(id))
 
-    def _fix_id(self, id):
+    def _fix_id(self, id: Optional[IdType]) -> IdType:
         """Validate the dataset id.
 
         The identifier can be any string or integer except for the
@@ -2062,14 +2083,25 @@ class Session(NoNewAttributesAfterInit):
 
         return plottype in self._contour_types
 
-    def _get_item(self, id, itemdict, itemdesc, errdesc):
+    # The assumption is that itemdict has a single type for its
+    # values.
+    #
+    def _get_item(self,
+                  id: Optional[IdType],
+                  itemdict: dict[IdType, T],
+                  itemdesc: str,
+                  errdesc: str
+                  ) -> T:
         id = self._fix_id(id)
         item = itemdict.get(id)
         if item is None:
             raise IdentifierErr('getitem', itemdesc, id, errdesc)
         return item
 
-    def _set_item(self, id, item, itemdict, itemtype, itemname, itemdesc):
+    def _set_item(self,
+                  id: Optional[IdType],
+                  item, itemdict, itemtype, itemname, itemdesc
+                  ) -> None:
         id = self._fix_id(id)
         _check_type(item, itemtype, itemname, itemdesc)
         itemdict[id] = item
@@ -2983,7 +3015,7 @@ class Session(NoNewAttributesAfterInit):
         keys.sort(key=str)  # always sort by string value.
         return keys
 
-    def get_data(self, id=None):
+    def get_data(self, id: Optional[IdType] = None) -> Data:
         """Return the data set by identifier.
 
         The object returned by the call can be used to query and
@@ -2991,7 +3023,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default
            identifier is used, as returned by `get_default_id`.
 
@@ -3030,7 +3062,7 @@ class Session(NoNewAttributesAfterInit):
         """
         return self._get_item(id, self._data, 'data set', 'has not been set')
 
-    def _get_data(self, id):
+    def _get_data(self, id: Optional[IdType]) -> Optional[Data]:
         """Return a data set or None.
 
         The same as get_data except that it returns None if the
@@ -3038,7 +3070,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default
            identifier is used, as returned by `get_default_id`.
 
@@ -3523,7 +3555,9 @@ class Session(NoNewAttributesAfterInit):
         set_error(d, "syserror", val, fractional=fractional)
 
     # DOC-NOTE: also in sherpa.astro.utils
-    def get_staterror(self, id=None, filter=False):
+    def get_staterror(self,
+                      id: Optional[IdType] = None,
+                      filter=False):
         """Return the statistical error on the dependent axis of a data set.
 
         The function returns the statistical errors on the values
@@ -3534,7 +3568,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
@@ -3602,7 +3636,9 @@ class Session(NoNewAttributesAfterInit):
                                                self.get_stat().calc_staterror)
 
     # DOC-NOTE: also in sherpa.astro.utils
-    def get_syserror(self, id=None, filter=False):
+    def get_syserror(self,
+                     id: Optional[IdType] = None,
+                     filter=False):
         """Return the systematic error on the dependent axis of a data set.
 
         The function returns the systematic errors on the values
@@ -3612,7 +3648,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
@@ -3673,7 +3709,9 @@ class Session(NoNewAttributesAfterInit):
         return err
 
     # DOC-NOTE: also in sherpa.astro.utils
-    def get_error(self, id=None, filter=False):
+    def get_error(self,
+                  id: Optional[IdType] = None,
+                  filter=False):
         """Return the errors on the dependent axis of a data set.
 
         The function returns the total errors (a quadrature addition
@@ -3684,7 +3722,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
@@ -3743,7 +3781,8 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-NOTE: also in sherpa.astro.utils
     # DOC-NOTE: shouldn't this expose a filter parameter?
-    def get_indep(self, id=None):
+    def get_indep(self,
+                  id: Optional[IdType] = None):
         """Return the independent axes of a data set.
 
         This function returns the coordinates of each point, or pixel,
@@ -3751,7 +3790,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
@@ -3794,7 +3833,9 @@ class Session(NoNewAttributesAfterInit):
         return self.get_data(id).get_indep()
 
     # DOC-NOTE: also in sherpa.astro.utils
-    def get_dep(self, id=None, filter=False):
+    def get_dep(self,
+                id: Optional[IdType] = None,
+                filter=False):
         """Return the dependent axis of a data set.
 
         This function returns the data values (the dependent axis)
@@ -3802,7 +3843,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
@@ -3854,12 +3895,14 @@ class Session(NoNewAttributesAfterInit):
         """
         return self.get_data(id).get_y(filter)
 
-    def get_dims(self, id=None, filter=False):
+    def get_dims(self,
+                 id: Optional[IdType] = None,
+                 filter=False):
         """Return the dimensions of the data set.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int . str, or None, optional
            The data set. If not given then the default
            identifier is used, as returned by `get_default_id`.
         filter : bool, optional
@@ -3895,7 +3938,8 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-NOTE: should there be a version in sherpa.astro.utils with a bkg_id
     # parameter?
-    def get_filter(self, id=None):
+    def get_filter(self,
+                   id: Optional[IdType] = None):
         """Return the filter expression for a data set.
 
         This returns the filter expression, created by one or more
@@ -3909,7 +3953,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
@@ -4053,7 +4097,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set to delete. If not given then the default
            identifier is used, as returned by `get_default_id`.
 
@@ -4081,12 +4125,14 @@ class Session(NoNewAttributesAfterInit):
         >>> delete_data('src')
 
         """
-        id = self._fix_id(id)
-        self._data.pop(id, None)
+        idval = self._fix_id(id)
+        self._data.pop(idval, None)
 
     # DOC-NOTE: also in sherpa.astro.utils
     def dataspace1d(self, start, stop, step=1, numbins=None,
-                    id=None, dstype=sherpa.data.Data1DInt):
+                    id: Optional[IdType] = None,
+                    dstype=sherpa.data.Data1DInt
+                    ) -> None:
         """Create the independent axis for a 1D data set.
 
         Create an "empty" one-dimensional data set by defining the
@@ -4105,7 +4151,7 @@ class Session(NoNewAttributesAfterInit):
         numbins : int, optional
            The number of grid points. This over-rides the ``step``
            setting.
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
@@ -4171,7 +4217,10 @@ class Session(NoNewAttributesAfterInit):
         self.set_data(id, dstype('dataspace1d', *args))
 
     # DOC-NOTE: also in sherpa.astro.utils
-    def dataspace2d(self, dims, id=None, dstype=sherpa.data.Data2D):
+    def dataspace2d(self, dims,
+                    id: Optional[IdType] = None,
+                    dstype=sherpa.data.Data2D
+                    ) -> None:
         """Create the independent axis for a 2D data set.
 
         Create an "empty" two-dimensional data set by defining the
@@ -4182,7 +4231,7 @@ class Session(NoNewAttributesAfterInit):
         ----------
         dims : sequence of 2 number
            The dimensions of the grid in ``(width,height)`` order.
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
@@ -4222,7 +4271,10 @@ class Session(NoNewAttributesAfterInit):
 
         self.set_data(id, dataset)
 
-    def fake(self, id=None, method=sherpa.utils.poisson_noise):
+    def fake(self,
+             id: Optional[IdType] = None,
+             method=sherpa.utils.poisson_noise
+             ) -> None:
         """Simulate a data set.
 
         Take a data set, evaluate the model for each bin, and then use
@@ -4232,7 +4284,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The identifier for the data set to use. If not given then
            the default identifier is used, as returned by
            `get_default_id`.
@@ -4542,7 +4594,9 @@ class Session(NoNewAttributesAfterInit):
     # DOC-NOTE: also in sherpa.astro.utils
     # DOC-TODO: rework the Data type notes section (also needed by unpack_arrays)
     # @loggable(with_id = True)
-    def load_arrays(self, id, *args):
+    def load_arrays(self,
+                    id: IdType,
+                    *args) -> None:
         """Create a data set from array values.
 
         Parameters
@@ -5656,7 +5710,10 @@ class Session(NoNewAttributesAfterInit):
     # should only be in the sherpa.astro.ui version, but it is not
     # worth creating a copy of the routine just for this.
     #
-    def notice_id(self, ids, lo=None, hi=None, **kwargs):
+    def notice_id(self,
+                  ids: Union[IdType, Sequence[IdType]],
+                  lo=None, hi=None, **kwargs
+                  ) -> None:
         """Include data from the fit for a data set.
 
         Select one or more ranges of data to include by filtering on
@@ -5746,28 +5803,31 @@ class Session(NoNewAttributesAfterInit):
                                   'an identifier or list of identifiers')
 
         if self._valid_id(ids):
-            ids = (ids,)
+            idvals = (ids,)
         else:
             try:
-                ids = tuple(ids)
+                idvals = tuple(ids)
             except TypeError:
                 raise ArgumentTypeErr('badarg', 'ids',
                                       'an identifier or list of identifiers') from None
 
         # TODO: do we still expect to get bytes here?
         if lo is not None and isinstance(lo, (str, np.bytes_)):
-            return self._notice_expr_id(ids, lo, **kwargs)
+            return self._notice_expr_id(idvals, lo, **kwargs)
 
         # Unlike notice() we do not sort the id list as this
         # was set by the user.
         #
-        notice_data_range(self.get_data, ids, lo, hi, kwargs)
+        notice_data_range(self.get_data, idvals, lo, hi, kwargs)
 
     # DOC-NOTE: inclusion of bkg_id is technically wrong, as it
     # should only be in the sherpa.astro.ui version, but it is not
     # worth creating a copy of the routine just for this.
     #
-    def ignore_id(self, ids, lo=None, hi=None, **kwargs):
+    def ignore_id(self,
+                  ids: Union[IdType, Sequence[IdType]],
+                  lo=None, hi=None, **kwargs
+                  ) -> None:
         """Exclude data from the fit for a data set.
 
         Select one or more ranges of data to exclude by filtering on
@@ -6376,7 +6436,9 @@ class Session(NoNewAttributesAfterInit):
         self._model_components[name] = model
         return model
 
-    def reset(self, model=None, id=None):
+    def reset(self, model=None,
+              id: Optional[IdType] = None
+              ) -> None:
         """Reset the model parameters to their default settings.
 
         The `reset` function restores the parameter values to the
@@ -6391,7 +6453,7 @@ class Session(NoNewAttributesAfterInit):
         model : optional
            The model component or expression to reset. The default
            is to use all source expressions.
-        id : int or string, optional
+        id : int, str, or None, optional
            The data set to use. The default is to use all
            data sets with a source expression.
 
@@ -6426,15 +6488,17 @@ class Session(NoNewAttributesAfterInit):
         >>> reset(get_source(2))
 
         """
-        ids = [id]
-        if id is None:
-            ids = self._sources.keys()
-
         if model is not None:
             model.reset()
+            return
+
+        if id is None:
+            ids = list(self._sources.keys())
         else:
-            for id in ids:
-                self.get_source(id).reset()
+            ids = [id]
+
+        for id in ids:
+            self.get_source(id).reset()
 
     def delete_model_component(self, name):
         """Delete a model component.
@@ -6536,7 +6600,8 @@ class Session(NoNewAttributesAfterInit):
 
     # Return full model for fitting, plotting, etc.  Expects a corresponding
     # data set to be available.
-    def _get_model_status(self, id=None):
+    def _get_model_status(self,
+                          id: Optional[IdType] = None):
         id = self._fix_id(id)
         src = self._sources.get(id)
         mdl = self._models.get(id)
@@ -6553,7 +6618,9 @@ class Session(NoNewAttributesAfterInit):
 
         return (model, is_source)
 
-    def _add_convolution_models(self, id, data, model, is_source):
+    def _add_convolution_models(self,
+                                id: Optional[IdType],
+                                data, model, is_source):
         """Add in "hidden" components to the model expression.
 
         This handles PSF and table models (ensuring that the
@@ -6575,7 +6642,9 @@ class Session(NoNewAttributesAfterInit):
 
         return model
 
-    def get_source(self, id=None):
+    def get_source(self,
+                   id: Optional[IdType] = None
+                   ) -> Model:
         """Return the source model expression for a data set.
 
         This returns the model expression created by `set_model` or
@@ -6583,7 +6652,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set containing the source expression. If not given
            then the default identifier is used, as returned by
            `get_default_id`.
@@ -6625,16 +6694,20 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        id = self._fix_id(id)
-        mdl = self._models.get(id, None)
+        idval = self._fix_id(id)
+        mdl = self._models.get(idval, None)
         if mdl is not None:
-            raise IdentifierErr("Convolved model\n'%s'\n is set for dataset %s. You should use get_model instead." %
-                                (mdl.name, str(id)))
-        return self._get_item(id, self._sources, 'source',
-                              'has not been set, consider using set_source()' +
-                              ' or set_model()')
+            raise IdentifierErr("Convolved model\n"
+                                f"'{mdl.name}'\n is set for "
+                                f"dataset {idval}. You should use "
+                                "get_model instead.")
+        return self._get_item(idval, self._sources, 'source',
+                              'has not been set, consider using '
+                              'set_source() or set_model()')
 
-    def get_model(self, id=None):
+    def get_model(self,
+                  id: Optional[IdType] = None
+                  ) -> Model:
         """Return the model expression for a data set.
 
         This returns the model expression for a data set, including
@@ -6643,7 +6716,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set containing the source expression. If not given
            then the default identifier is used, as returned by
            `get_default_id`.
@@ -6936,7 +7009,9 @@ class Session(NoNewAttributesAfterInit):
 
     set_source = set_model
 
-    def delete_model(self, id=None):
+    def delete_model(self,
+                     id: Optional[IdType] = None
+                     ) -> None:
         """Delete the model expression for a data set.
 
         This removes the model expression, created by `set_model`,
@@ -6945,7 +7020,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set containing the source expression. If not given
            then the default identifier is used, as returned by
            `get_default_id`.
@@ -6971,9 +7046,9 @@ class Session(NoNewAttributesAfterInit):
         >>> delete_model('src')
 
         """
-        id = self._fix_id(id)
-        self._models.pop(id, None)
-        self._sources.pop(id, None)
+        idval = self._fix_id(id)
+        self._models.pop(idval, None)
+        self._sources.pop(idval, None)
 
     def _check_model(self, model: ModelType) -> Model:
         """Return a Model instance.
@@ -7119,7 +7194,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set containing the model expression. If not given
            then the default identifier is used, as returned by
            `get_default_id`.
@@ -7171,7 +7246,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set containing the model expression. If not given
            then the default identifier is used, as returned by
            `get_default_id`.
@@ -7223,7 +7298,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set containing the model expression. If not given
            then the default identifier is used, as returned by
            `get_default_id`.
@@ -8110,7 +8185,7 @@ class Session(NoNewAttributesAfterInit):
             except NotImplementedError:
                 pass
 
-    def get_psf(self, id=None):
+    def get_psf(self, id: Optional[IdType] = None):
         """Return the PSF model defined for a data set.
 
         Return the parameter settings for the PSF model assigned to
@@ -8118,7 +8193,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the
            default identifier is used, as returned by `get_default_id`.
 
@@ -8152,14 +8227,14 @@ class Session(NoNewAttributesAfterInit):
         """
         return self._get_item(id, self._psf, 'psf model', 'has not been set')
 
-    def delete_psf(self, id=None):
+    def delete_psf(self, id: Optional[IdType] = None) -> None:
         """Delete the PSF model for a data set.
 
         Remove the PSF convolution applied to a source model.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the
            default identifier is used, as returned by `get_default_id`.
 
@@ -8178,10 +8253,10 @@ class Session(NoNewAttributesAfterInit):
         >>> delete_psf('core')
 
         """
-        id = self._fix_id(id)
-        self._psf.pop(id, None)
+        idval = self._fix_id(id)
+        self._psf.pop(idval, None)
 
-    def list_psf_ids(self):
+    def list_psf_ids(self) -> list[IdType]:
         """List of all the data sets with a PSF.
 
         .. versionadded:: 4.12.2
@@ -8202,9 +8277,9 @@ class Session(NoNewAttributesAfterInit):
         keys = list(self._psf.keys())
         return sorted(keys, key=str)
 
-    def _add_psf(self, id, data, model):
-        id = self._fix_id(id)
-        psf = self._psf.get(id, None)
+    def _add_psf(self, id: Optional[IdType], data, model):
+        idval = self._fix_id(id)
+        psf = self._psf.get(idval, None)
 
         if psf is not None:
             model = psf(model)
@@ -8553,7 +8628,10 @@ class Session(NoNewAttributesAfterInit):
     # Fitting
     ###########################################################################
 
-    def _get_fit_ids(self, id, otherids=None):
+    def _get_fit_ids(self,
+                     id: Optional[IdType],
+                     otherids: Optional[Sequence[IdType]] = None
+                     ) -> list[IdType]:
         """Return the identifiers that will be used for a fit.
 
         This routine does not ensure that the dataset actually exists.
@@ -8591,7 +8669,10 @@ class Session(NoNewAttributesAfterInit):
 
         return ids
 
-    def _get_fit_obj(self, store, estmethod, numcores=1):
+    def _get_fit_obj(self,
+                     store: Sequence[FitStore],
+                     estmethod, numcores=1
+                     ) -> tuple[tuple[IdType, ...], Fit]:
         """Create the fit object given the data and models.
 
         Parameters
@@ -8626,6 +8707,9 @@ class Session(NoNewAttributesAfterInit):
                     raise ModelErr(
                         "You are trying to fit a model which has a discrete template model component with a continuous optimization method. Since CIAO4.6 this is not possible anymore. Please use gridsearch as the optimization method and make sure that the 'sequence' option is correctly set, or enable interpolation for the templates you are loading (which is the default behavior).")
 
+        # Data and DataSimulFit do not have a common base class.
+        #
+        d: Union[Data, DataSimulFit]
         if len(store) == 1:
             d = store[0].data
             m = store[0].model
@@ -8648,7 +8732,10 @@ class Session(NoNewAttributesAfterInit):
         return tuple(idvals), Fit(d, m, self._current_stat, self._current_method,
                                   estmethod, self._current_itermethod)
 
-    def _prepare_fit(self, id, otherids=()):
+    def _prepare_fit(self,
+                     id: Optional[IdType],
+                     otherids: Sequence[IdType] = ()
+                     ) -> list[FitStore]:
         """Ensure we have all the requested ids, datasets, and models.
 
         This checks whether the dataset is loaded and has an
@@ -8698,7 +8785,11 @@ class Session(NoNewAttributesAfterInit):
 
         return out
 
-    def _get_fit(self, id, otherids=(), estmethod=None, numcores=1):
+    def _get_fit(self,
+                 id: Optional[IdType],
+                 otherids: Sequence[IdType] = (),
+                 estmethod=None, numcores=1
+                 ) -> tuple[tuple[IdType, ...], Fit]:
         """Create the fit object for the given identifiers.
 
         Given the identifiers (the id and otherids arguments), find
@@ -8931,7 +9022,7 @@ class Session(NoNewAttributesAfterInit):
         """
         return self._get_stat_info()
 
-    def get_fit_results(self):
+    def get_fit_results(self) -> FitResults:
         """Return the results of the last fit.
 
         This function returns the results from the most-recent fit.
@@ -9170,7 +9261,9 @@ class Session(NoNewAttributesAfterInit):
         except NotImplementedError:
             warning('No guess found for %s', self.get_model(idval).name)
 
-    def calc_stat(self, id=None, *otherids):
+    def calc_stat(self,
+                  id: Optional[IdType] = None,
+                  *otherids: IdType):
         """Calculate the fit statistic for a data set.
 
         Evaluate the model for one or more data sets, compare it to
@@ -9180,7 +9273,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then
            all data sets with an associated model are used simultaneously.
         *otherids : int or str, optional
@@ -9227,7 +9320,9 @@ class Session(NoNewAttributesAfterInit):
         ids, f = self._get_fit(id, otherids)
         return f.calc_stat()
 
-    def calc_chisqr(self, id=None, *otherids):
+    def calc_chisqr(self,
+                    id: Optional[IdType] = None,
+                    *otherids: IdType):
         """Calculate the per-bin chi-squared statistic.
 
         Evaluate the model for one or more data sets, compare it to the
@@ -9237,7 +9332,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then
            all data sets with an associated model are used simultaneously.
         *otherids : int or str, optional
@@ -9499,7 +9594,9 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-TODO: improve discussion of how the simulations are done.
     def plot_pvalue(self, null_model, alt_model, conv_model=None,
-                    id=1, otherids=(), num=500, bins=25, numcores=None,
+                    id: IdType = 1,
+                    otherids: Sequence[IdType] = (),
+                    num=500, bins=25, numcores=None,
                     replot=False, overplot=False, clearwindow=True,
                     **kwargs):
         """Compute and plot a histogram of likelihood ratios by simulating data.
@@ -9604,7 +9701,9 @@ class Session(NoNewAttributesAfterInit):
                    **kwargs)
 
     def get_pvalue_plot(self, null_model=None, alt_model=None, conv_model=None,
-                        id=1, otherids=(), num=500, bins=25, numcores=None,
+                        id: IdType = 1,
+                        otherids: Sequence[IdType] = (),
+                        num=500, bins=25, numcores=None,
                         recalc=False):
         """Return the data used by plot_pvalue.
 
@@ -9708,7 +9807,9 @@ class Session(NoNewAttributesAfterInit):
     # to see how to do
 
     def normal_sample(self, num=1, sigma=1, correlate=True,
-                      id=None, otherids=(), numcores=None):
+                      id: Optional[IdType] = None,
+                      otherids: Sequence[IdType] = (),
+                      numcores=None):
         """Sample the fit statistic by taking the parameter values
         from a normal distribution.
 
@@ -9727,7 +9828,7 @@ class Session(NoNewAttributesAfterInit):
            Should a multi-variate normal be used, with parameters
            set by the covariance matrix (``True``) or should a
            uni-variate normal be used (``False``)?
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then
            all data sets with an associated model are used simultaneously.
         otherids : sequence of int or str, optional
@@ -9778,7 +9879,9 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-TODO: improve the description of factor parameter
     def uniform_sample(self, num=1, factor=4,
-                       id=None, otherids=(), numcores=None):
+                       id: Optional[IdType] = None,
+                       otherids: Sequence[IdType] = (),
+                       numcores=None):
         """Sample the fit statistic by taking the parameter values
         from an uniform distribution.
 
@@ -9792,7 +9895,7 @@ class Session(NoNewAttributesAfterInit):
            The number of samples to use (default is 1).
         factor : number, optional
            Multiplier to expand the scale parameter (default is 4).
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then
            all data sets with an associated model are used simultaneously.
         otherids : sequence of int or str, optional
@@ -9832,7 +9935,10 @@ class Session(NoNewAttributesAfterInit):
         ids, fit = self._get_fit(id, otherids)
         return sherpa.sim.uniform_sample(fit, num, factor, numcores)
 
-    def t_sample(self, num=1, dof=None, id=None, otherids=(), numcores=None):
+    def t_sample(self, num=1, dof=None,
+                 id: Optional[IdType] = None,
+                 otherids: Sequence[IdType] = (),
+                 numcores=None):
         """Sample the fit statistic by taking the parameter values from
         a Student's t-distribution.
 
@@ -9847,7 +9953,7 @@ class Session(NoNewAttributesAfterInit):
         dof : optional
            The number of degrees of freedom to use (the default
            is to use the number from the current fit).
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then
            all data sets with an associated model are used simultaneously.
         otherids : sequence of int or str, optional
@@ -11549,7 +11655,10 @@ class Session(NoNewAttributesAfterInit):
         return self._pyblocxs.list_samplers()
 
     # DOC-TODO: add pointers on what to do with the return values
-    def get_draws(self, id=None, otherids=(), niter=1000, covar_matrix=None):
+    def get_draws(self,
+                  id: Optional[IdType] = None,
+                  otherids: Sequence[IdType] = (),
+                  niter=1000, covar_matrix=None):
         """Run the pyBLoCXS MCMC algorithm.
 
         The function runs a Markov Chain Monte Carlo (MCMC) algorithm
@@ -11563,7 +11672,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then
            all data sets with an associated model are used simultaneously.
         otherids : sequence of int or str, optional
@@ -11685,12 +11794,14 @@ class Session(NoNewAttributesAfterInit):
         """
         return self._splitplot
 
-    def get_data_plot(self, id=None, recalc=True):
+    def get_data_plot(self,
+                      id: Optional[IdType] = None,
+                      recalc=True):
         """Return the data used by plot_data.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -11739,7 +11850,10 @@ class Session(NoNewAttributesAfterInit):
     # DOC-TODO: discussion of preferences needs better handling
     # of how it interacts with the chosen plot backend.
     #
-    def get_plot_prefs(self, plottype, id=None, **kwargs):
+    def get_plot_prefs(self,
+                       plottype: str,
+                       id: Optional[IdType] = None,
+                       **kwargs):
         """Return the preferences for the given plot type.
 
         .. versionadded:: 4.16.0
@@ -11749,7 +11863,7 @@ class Session(NoNewAttributesAfterInit):
         plottype : str
            The type of plt, such as "data", "model", or "resid". The
            "fit" argument is not supported.
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
 
@@ -11808,7 +11922,8 @@ class Session(NoNewAttributesAfterInit):
         plotobj = get(id, recalc=False, **kwargs)
         return get_plot_prefs(plotobj)
 
-    def get_data_plot_prefs(self, id=None):
+    def get_data_plot_prefs(self,
+                            id: Optional[IdType] = None):
         """Return the preferences for plot_data.
 
         The plot preferences may depend on the data set,
@@ -11819,7 +11934,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
 
@@ -11913,12 +12028,14 @@ class Session(NoNewAttributesAfterInit):
         return get_plot_prefs(plotobj)
 
     # also in sherpa.astro.utils (copies this docstring)
-    def get_model_plot(self, id=None, recalc=True):
+    def get_model_plot(self,
+                       id: Optional[IdType] = None,
+                       recalc=True):
         """Return the data used to create the model plot.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -11959,12 +12076,14 @@ class Session(NoNewAttributesAfterInit):
         return plotobj
 
     # also in sherpa.astro.utils (does not copy this docstring)
-    def get_source_plot(self, id=None, recalc=True):
+    def get_source_plot(self,
+                        id: Optional[IdType] = None,
+                        recalc=True):
         """Return the data used to create the source plot.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -12010,22 +12129,22 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        id = self._fix_id(id)
-        mdl = self._models.get(id, None)
+        idval = self._fix_id(id)
+        mdl = self._models.get(idval, None)
         if mdl is not None:
             raise IdentifierErr(f"Convolved model\n'{mdl.name}'\n"
-                                f" is set for dataset {id}. "
+                                f" is set for dataset {idval}. "
                                 "You should use get_model_plot instead.")
 
         if recalc:
-            data = self.get_data(id)
+            data = self.get_data(idval)
         else:
-            data = self._get_data(id)
+            data = self._get_data(idval)
 
         idx = isinstance(data, sherpa.data.Data1DInt)
         plotobj = self._plot_types["source"][idx]
         if recalc:
-            plotobj.prepare(data, self.get_source(id), self.get_stat())
+            plotobj.prepare(data, self.get_source(idval), self.get_stat())
 
         return plotobj
 
@@ -12102,14 +12221,15 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_model_components_plot(self, id=None):
+    def get_model_components_plot(self,
+                                  id: Optional[IdType] = None):
         """Return the data used by plot_model_components.
 
         .. versionadded:: 4.16.1
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
 
@@ -12226,14 +12346,15 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_source_components_plot(self, id=None):
+    def get_source_components_plot(self,
+                                   id: Optional[IdType] = None):
         """Return the data used by plot_source_components.
 
         .. versionadded:: 4.16.1
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
 
@@ -12272,7 +12393,7 @@ class Session(NoNewAttributesAfterInit):
         return get_components_helper(self.get_source_component_plot,
                                      model=model, idval=idval)
 
-    def get_model_plot_prefs(self, id=None):
+    def get_model_plot_prefs(self, id: Optional[IdType] = None):
         """Return the preferences for plot_model.
 
         The plot preferences may depend on the data set,
@@ -12283,7 +12404,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
 
@@ -12325,12 +12446,14 @@ class Session(NoNewAttributesAfterInit):
         plotobj = self.get_model_plot(id, recalc=False)
         return get_plot_prefs(plotobj)
 
-    def get_fit_plot(self, id=None, recalc=True):
+    def get_fit_plot(self,
+                     id: Optional[IdType] = None,
+                     recalc=True):
         """Return the data used to create the fit plot.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -12392,12 +12515,14 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_resid_plot(self, id=None, recalc=True):
+    def get_resid_plot(self,
+                       id: Optional[IdType] = None,
+                       recalc=True):
         """Return the data used by plot_resid.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -12466,12 +12591,14 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_delchi_plot(self, id=None, recalc=True):
+    def get_delchi_plot(self,
+                        id: Optional[IdType] = None,
+                        recalc=True):
         """Return the data used by plot_delchi.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -12541,12 +12668,14 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_chisqr_plot(self, id=None, recalc=True):
+    def get_chisqr_plot(self,
+                        id: Optional[IdType] = None,
+                        recalc=True):
         """Return the data used by plot_chisqr.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -12616,12 +12745,14 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_ratio_plot(self, id=None, recalc=True):
+    def get_ratio_plot(self,
+                       id: Optional[IdType] = None,
+                       recalc=True):
         """Return the data used by plot_ratio.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -12691,12 +12822,14 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_data_contour(self, id=None, recalc=True):
+    def get_data_contour(self,
+                         id: Optional[IdType] = None,
+                         recalc=True):
         """Return the data used by contour_data.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -12740,7 +12873,9 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_contour_prefs(self, contourtype, id=None):
+    def get_contour_prefs(self,
+                          contourtype: str,
+                          id: Optional[IdType] = None):
         """Return the preferences for the given contour type.
 
         .. versionadded:: 4.16.0
@@ -12750,7 +12885,7 @@ class Session(NoNewAttributesAfterInit):
         contourtype : str
            The contour type, such as "data", "model", or "resid". The
            "fit" argument is not supported.
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
 
@@ -12850,12 +12985,14 @@ class Session(NoNewAttributesAfterInit):
         """
         return self.get_data_contour(id, recalc=False).contour_prefs
 
-    def get_model_contour(self, id=None, recalc=True):
+    def get_model_contour(self,
+                          id: Optional[IdType] = None,
+                          recalc=True):
         """Return the data used by contour_model.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -12899,12 +13036,14 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_source_contour(self, id=None, recalc=True):
+    def get_source_contour(self,
+                           id: Optional[IdType] = None,
+                           recalc=True):
         """Return the data used by contour_source.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -12998,12 +13137,14 @@ class Session(NoNewAttributesAfterInit):
         """
         return self.get_model_contour(id, recalc=False).contour_prefs
 
-    def get_fit_contour(self, id=None, recalc=True):
+    def get_fit_contour(self,
+                        id: Optional[IdType] = None,
+                        recalc=True):
         """Return the data used by contour_fit.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -13053,12 +13194,14 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_resid_contour(self, id=None, recalc=True):
+    def get_resid_contour(self,
+                          id: Optional[IdType] = None,
+                          recalc=True):
         """Return the data used by contour_resid.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -13103,12 +13246,14 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_ratio_contour(self, id=None, recalc=True):
+    def get_ratio_contour(self,
+                          id: Optional[IdType] = None,
+                          recalc=True):
         """Return the data used by contour_ratio.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -13153,12 +13298,14 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_psf_contour(self, id=None, recalc=True):
+    def get_psf_contour(self,
+                        id: Optional[IdType] = None,
+                        recalc=True):
         """Return the data used by contour_psf.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -13198,12 +13345,14 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_kernel_contour(self, id=None, recalc=True):
+    def get_kernel_contour(self,
+                           id: Optional[IdType] = None,
+                           recalc=True):
         """Return the data used by contour_kernel.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -13244,12 +13393,14 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_psf_plot(self, id=None, recalc=True):
+    def get_psf_plot(self,
+                     id: Optional[IdType] = None,
+                     recalc=True):
         """Return the data used by plot_psf.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -13288,12 +13439,14 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_kernel_plot(self, id=None, recalc=True):
+    def get_kernel_plot(self,
+                        id: Optional[IdType] = None,
+                        recalc=True):
         """Return the data used by plot_kernel.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         recalc : bool, optional
@@ -13820,13 +13973,15 @@ class Session(NoNewAttributesAfterInit):
         """
         self._multi_plot(args, **kwargs)
 
-    def plot_data(self, id=None, replot=False, overplot=False,
+    def plot_data(self,
+                  id: Optional[IdType] = None,
+                  replot=False, overplot=False,
                   clearwindow=True, **kwargs):
         r"""Plot the data values.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
         replot : bool, optional
@@ -13934,7 +14089,9 @@ class Session(NoNewAttributesAfterInit):
     #  - we include a description of the DataPHA handling here
     #    even though its only relevant to sherpa.astro.ui
     #
-    def plot_model(self, id=None, replot=False, overplot=False,
+    def plot_model(self,
+                   id: Optional[IdType] = None,
+                   replot=False, overplot=False,
                    clearwindow=True, **kwargs):
         """Plot the model for a data set.
 
@@ -13944,7 +14101,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
         replot : bool, optional
@@ -14088,7 +14245,9 @@ class Session(NoNewAttributesAfterInit):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_source_components(self, id=None, overplot=False,
+    def plot_source_components(self,
+                               id: Optional[IdType] = None,
+                               overplot=False,
                                clearwindow=True, **kwargs):
         """Plot all the components of a source.
 
@@ -14098,7 +14257,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
         overplot : bool, optional
@@ -14224,7 +14383,9 @@ class Session(NoNewAttributesAfterInit):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_model_components(self, id=None, overplot=False,
+    def plot_model_components(self,
+                              id: Optional[IdType] = None,
+                              overplot=False,
                               clearwindow=True, **kwargs):
         """Plot all the components of a model.
 
@@ -14234,7 +14395,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
         overplot : bool, optional
@@ -14271,7 +14432,9 @@ class Session(NoNewAttributesAfterInit):
                    clearwindow=clearwindow, **kwargs)
 
     # DOC-NOTE: also in sherpa.astro.utils, but with extra lo/hi arguments
-    def plot_source(self, id=None, replot=False,
+    def plot_source(self,
+                    id: Optional[IdType] = None,
+                    replot=False,
                     overplot=False, clearwindow=True, **kwargs):
         """Plot the source expression for a data set.
 
@@ -14281,7 +14444,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
         replot : bool, optional
@@ -14339,18 +14502,20 @@ class Session(NoNewAttributesAfterInit):
         # about get_source_plot. Perhaps we should just use a single
         # error message?
         #
-        id = self._fix_id(id)
-        mdl = self._models.get(id, None)
+        idval = self._fix_id(id)
+        mdl = self._models.get(idval, None)
         if mdl is not None:
             raise IdentifierErr(f"Convolved model\n'{mdl.name}'\n"
-                                f" is set for dataset {id}. "
+                                f" is set for dataset {idval}. "
                                 "You should use plot_model instead.")
 
-        plotobj = self.get_source_plot(id, recalc=not replot)
+        plotobj = self.get_source_plot(idval, recalc=not replot)
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_fit(self, id=None, replot=False, overplot=False,
+    def plot_fit(self,
+                 id: Optional[IdType] = None,
+                 replot=False, overplot=False,
                  clearwindow=True, **kwargs):
         """Plot the fit results (data, model) for a data set.
 
@@ -14359,7 +14524,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         replot : bool, optional
@@ -14437,7 +14602,9 @@ class Session(NoNewAttributesAfterInit):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_resid(self, id=None, replot=False, overplot=False,
+    def plot_resid(self,
+                   id: Optional[IdType] = None,
+                   replot=False, overplot=False,
                    clearwindow=True, **kwargs):
         """Plot the residuals (data - model) for a data set.
 
@@ -14449,7 +14616,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         replot : bool, optional
@@ -14519,7 +14686,9 @@ class Session(NoNewAttributesAfterInit):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_chisqr(self, id=None, replot=False, overplot=False,
+    def plot_chisqr(self,
+                    id: Optional[IdType] = None,
+                    replot=False, overplot=False,
                     clearwindow=True, **kwargs):
         """Plot the chi-squared value for each point in a data set.
 
@@ -14528,7 +14697,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         replot : bool, optional
@@ -14580,7 +14749,9 @@ class Session(NoNewAttributesAfterInit):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_delchi(self, id=None, replot=False, overplot=False,
+    def plot_delchi(self,
+                    id: Optional[IdType] = None,
+                    replot=False, overplot=False,
                     clearwindow=True, **kwargs):
         """Plot the ratio of residuals to error for a data set.
 
@@ -14592,7 +14763,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         replot : bool, optional
@@ -14658,7 +14829,9 @@ class Session(NoNewAttributesAfterInit):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_ratio(self, id=None, replot=False, overplot=False,
+    def plot_ratio(self,
+                   id: Optional[IdType] = None,
+                   replot=False, overplot=False,
                    clearwindow=True, **kwargs):
         """Plot the ratio of data to model for a data set.
 
@@ -14669,7 +14842,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         replot : bool, optional
@@ -14734,7 +14907,9 @@ class Session(NoNewAttributesAfterInit):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_psf(self, id=None, replot=False, overplot=False,
+    def plot_psf(self,
+                 id: Optional[IdType] = None,
+                 replot=False, overplot=False,
                  clearwindow=True, **kwargs):
         """Plot the 1D PSF model applied to a data set.
 
@@ -14743,7 +14918,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         replot : bool, optional
@@ -14793,7 +14968,9 @@ class Session(NoNewAttributesAfterInit):
         self._plot(plotobj, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def plot_kernel(self, id=None, replot=False, overplot=False,
+    def plot_kernel(self,
+                    id: Optional[IdType] = None,
+                    replot=False, overplot=False,
                     clearwindow=True, **kwargs):
         """Plot the 1D kernel applied to a data set.
 
@@ -14802,7 +14979,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         replot : bool, optional
@@ -14904,7 +15081,9 @@ class Session(NoNewAttributesAfterInit):
 
             p2prefs['xlog'] = oldval
 
-    def plot_fit_resid(self, id=None, replot=False, overplot=False,
+    def plot_fit_resid(self,
+                       id: Optional[IdType] = None,
+                       replot=False, overplot=False,
                        clearwindow=True, **kwargs):
         """Plot the fit results, and the residuals, for a data set.
 
@@ -14920,7 +15099,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         replot : bool, optional
@@ -14995,7 +15174,9 @@ class Session(NoNewAttributesAfterInit):
                          overplot=overplot, clearwindow=clearwindow,
                          **kwargs)
 
-    def plot_fit_ratio(self, id=None, replot=False, overplot=False,
+    def plot_fit_ratio(self,
+                       id: Optional[IdType] = None,
+                       replot=False, overplot=False,
                        clearwindow=True, **kwargs):
         """Plot the fit results, and the ratio of data to model, for a data set.
 
@@ -15009,7 +15190,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         replot : bool, optional
@@ -15084,7 +15265,9 @@ class Session(NoNewAttributesAfterInit):
                          overplot=overplot, clearwindow=clearwindow,
                          **kwargs)
 
-    def plot_fit_delchi(self, id=None, replot=False, overplot=False,
+    def plot_fit_delchi(self,
+                        id: Optional[IdType] = None,
+                        replot=False, overplot=False,
                         clearwindow=True, **kwargs):
         """Plot the fit results, and the residuals, for a data set.
 
@@ -15100,7 +15283,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
         replot : bool, optional
@@ -15582,12 +15765,14 @@ class Session(NoNewAttributesAfterInit):
         """
         self._multi_plot(args, plotmeth='contour', **kwargs)
 
-    def contour_data(self, id=None, replot=False, overcontour=False, **kwargs):
+    def contour_data(self,
+                     id: Optional[IdType] = None,
+                     replot=False, overcontour=False, **kwargs):
         """Contour the values of an image data set.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then the
            default identifier is used, as returned by `get_default_id`.
         replot : bool, optional
@@ -15623,7 +15808,9 @@ class Session(NoNewAttributesAfterInit):
         plotobj = self.get_data_contour(id, recalc=not replot)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
-    def contour_model(self, id=None, replot=False, overcontour=False, **kwargs):
+    def contour_model(self,
+                      id: Optional[IdType] = None,
+                      replot=False, overcontour=False, **kwargs):
         """Create a contour plot of the model.
 
         Displays a contour plot of the values of the model,
@@ -15632,7 +15819,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the model. If not given then the
            default identifier is used, as returned by `get_default_id`.
         replot : bool, optional
@@ -15670,7 +15857,9 @@ class Session(NoNewAttributesAfterInit):
         plotobj = self.get_model_contour(id, recalc=not replot)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
-    def contour_source(self, id=None, replot=False, overcontour=False, **kwargs):
+    def contour_source(self,
+                       id: Optional[IdType] = None,
+                       replot=False, overcontour=False, **kwargs):
         """Create a contour plot of the unconvolved spatial model.
 
         Displays a contour plot of the values of the model,
@@ -15679,7 +15868,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the model. If not given then the
            default identifier is used, as returned by `get_default_id`.
         replot : bool, optional
@@ -15716,7 +15905,9 @@ class Session(NoNewAttributesAfterInit):
         plotobj = self.get_source_contour(id, recalc=not replot)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
-    def contour_fit(self, id=None, replot=False, overcontour=False, **kwargs):
+    def contour_fit(self,
+                    id: Optional[IdType] = None,
+                    replot=False, overcontour=False, **kwargs):
         """Contour the fit to a data set.
 
         Overplot the model - including any PSF - on the data. The
@@ -15725,7 +15916,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data and model. If not given
            then the default identifier is used, as returned by
            `get_default_id`.
@@ -15761,7 +15952,9 @@ class Session(NoNewAttributesAfterInit):
         plotobj = self.get_fit_contour(id, recalc=not replot)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
-    def contour_resid(self, id=None, replot=False, overcontour=False, **kwargs):
+    def contour_resid(self,
+                      id: Optional[IdType] = None,
+                      replot=False, overcontour=False, **kwargs):
         """Contour the residuals of the fit.
 
         The residuals are formed by subtracting the current model -
@@ -15770,7 +15963,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data and model. If not given
            then the default identifier is used, as returned by
            `get_default_id`.
@@ -15805,7 +15998,9 @@ class Session(NoNewAttributesAfterInit):
         plotobj = self.get_resid_contour(id, recalc=not replot)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
-    def contour_ratio(self, id=None, replot=False, overcontour=False, **kwargs):
+    def contour_ratio(self,
+                      id: Optional[IdType] = None,
+                      replot=False, overcontour=False, **kwargs):
         """Contour the ratio of data to model.
 
         The ratio image is formed by dividing the data by the current
@@ -15814,7 +16009,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data and model. If not given
            then the default identifier is used, as returned by
            `get_default_id`.
@@ -15849,7 +16044,9 @@ class Session(NoNewAttributesAfterInit):
         plotobj = self.get_ratio_contour(id, recalc=not replot)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
-    def contour_psf(self, id=None, replot=False, overcontour=False, **kwargs):
+    def contour_psf(self,
+                    id: Optional[IdType] = None,
+                    replot=False, overcontour=False, **kwargs):
         """Contour the PSF applied to the model of an image data set.
 
         If the data set has no PSF applied to it, the model is
@@ -15857,7 +16054,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the model. If not given then the
            default identifier is used, as returned by `get_default_id`.
         replot : bool, optional
@@ -15881,7 +16078,9 @@ class Session(NoNewAttributesAfterInit):
         plotobj = self.get_psf_contour(id, recalc=not replot)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
-    def contour_kernel(self, id=None, replot=False, overcontour=False, **kwargs):
+    def contour_kernel(self,
+                       id: Optional[IdType] = None,
+                       replot=False, overcontour=False, **kwargs):
         """Contour the kernel applied to the model of an image data set.
 
         If the data set has no PSF applied to it, the model is
@@ -15889,7 +16088,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the model. If not given then the
            default identifier is used, as returned by `get_default_id`.
         replot : bool, optional
@@ -15913,7 +16112,9 @@ class Session(NoNewAttributesAfterInit):
         plotobj = self.get_kernel_contour(id, recalc=not replot)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
-    def contour_fit_resid(self, id=None, replot=False, overcontour=False, **kwargs):
+    def contour_fit_resid(self,
+                          id: Optional[IdType] = None,
+                          replot=False, overcontour=False, **kwargs):
         """Contour the fit and the residuals to a data set.
 
         Overplot the model - including any PSF - on the data. In a
@@ -15922,7 +16123,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data and model. If not given
            then the default identifier is used, as returned by
            `get_default_id`.
@@ -15968,7 +16169,10 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-NOTE: I am not convinced that this code is working when recalc=True
     # DOC-NOTE: needs to support the fast option of int_proj
-    def get_int_proj(self, par=None, id=None, otherids=None, recalc=False,
+    def get_int_proj(self, par=None,
+                     id: Optional[IdType] = None,
+                     otherids: Optional[Sequence[IdType]] = None,
+                     recalc=False,
                      fast=True, min=None, max=None, nloop=20, delv=None, fac=1,
                      log=False, numcores=None):
         """Return the interval-projection object.
@@ -15987,10 +16191,10 @@ class Session(NoNewAttributesAfterInit):
         par
            The parameter to plot. This argument is only used if `recalc` is
            set to `True`.
-        id : str or int, optional
+        id : str, int, or None, optional
            The data set that provides the data. If not given then
            all data sets with an associated model are used simultaneously.
-        otherids : list of str or int, optional
+        otherids : list of str or int, or None, optional
            Other data sets to use in the calculation.
         recalc : bool, optional
            The default value (``False``) means that the results from the
@@ -16083,7 +16287,10 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-NOTE: Check that this works (since get_int_proj may not) when
     # recalc=True
-    def get_int_unc(self, par=None, id=None, otherids=None, recalc=False,
+    def get_int_unc(self, par=None,
+                    id: Optional[IdType] = None,
+                    otherids: Optional[Sequence[IdType]] = None,
+                    recalc=False,
                     min=None, max=None, nloop=20, delv=None, fac=1, log=False,
                     numcores=None):
         """Return the interval-uncertainty object.
@@ -16102,10 +16309,10 @@ class Session(NoNewAttributesAfterInit):
         par
            The parameter to plot. This argument is only used if `recalc` is
            set to `True`.
-        id : str or int, optional
+        id : str, int, or None, optional
            The data set that provides the data. If not given then
            all data sets with an associated model are used simultaneously.
-        otherids : list of str or int, optional
+        otherids : list of str or int, or None, optional
            Other data sets to use in the calculation.
         recalc : bool, optional
            The default value (``False``) means that the results from the
@@ -16193,7 +16400,9 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_reg_proj(self, par0=None, par1=None, id=None, otherids=None,
+    def get_reg_proj(self, par0=None, par1=None,
+                     id: Optional[IdType] = None,
+                     otherids: Optional[Sequence[IdType]] = None,
                      recalc=False, fast=True, min=None, max=None,
                      nloop=(10, 10), delv=None, fac=4, log=(False, False),
                      sigma=(1, 2, 3), levels=None, numcores=None):
@@ -16214,10 +16423,10 @@ class Session(NoNewAttributesAfterInit):
         par0, par1
            The parameters to plot on the X and Y axes, respectively.
            These arguments are only used if recalc is set to `True`.
-        id : str or int, optional
+        id : str, int, or None, optional
            The data set that provides the data. If not given then
            all data sets with an associated model are used simultaneously.
-        otherids : list of str or int, optional
+        otherids : list of str or int, or None, optional
            Other data sets to use in the calculation.
         recalc : bool, optional
            The default value (``False``) means that the results from the
@@ -16323,7 +16532,9 @@ class Session(NoNewAttributesAfterInit):
 
         return plotobj
 
-    def get_reg_unc(self, par0=None, par1=None, id=None, otherids=None,
+    def get_reg_unc(self, par0=None, par1=None,
+                    id: Optional[IdType] = None,
+                    otherids: Optional[Sequence[IdType]] = None,
                     recalc=False, min=None, max=None, nloop=(10, 10),
                     delv=None, fac=4, log=(False, False), sigma=(1, 2, 3),
                     levels=None, numcores=None):
@@ -16344,10 +16555,10 @@ class Session(NoNewAttributesAfterInit):
         par0, par1
            The parameters to plot on the X and Y axes, respectively.
            These arguments are only used if `recalc` is set to `True`.
-        id : str or int, optional
+        id : str, int, or None, optional
            The data set that provides the data. If not given then
            all data sets with an associated model are used simultaneously.
-        otherids : list of str or int, optional
+        otherids : list of str or int, or None, optional
            Other data sets to use in the calculation.
         recalc : bool, optional
            The default value (``False``) means that the results from the
@@ -16456,7 +16667,10 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-NOTE: I am not convinced I have fac described correctly
     # DOC-NOTE: same synopsis as int_unc
-    def int_proj(self, par, id=None, otherids=None, replot=False, fast=True,
+    def int_proj(self, par,
+                 id: Optional[IdType] = None,
+                 otherids: Optional[Sequence[IdType]] = None,
+                 replot=False, fast=True,
                  min=None, max=None, nloop=20, delv=None, fac=1, log=False,
                  numcores=None, overplot=False):
         """Calculate and plot the fit statistic versus fit parameter value.
@@ -16476,10 +16690,10 @@ class Session(NoNewAttributesAfterInit):
         ----------
         par
            The parameter to plot.
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then
            all data sets with an associated model are used simultaneously.
-        otherids : sequence of int or str, optional
+        otherids : sequence of int or str, or None, optional
            Other data sets to use in the calculation.
         replot : bool, optional
            Set to ``True`` to use the values calculated by the last
@@ -16578,7 +16792,10 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-NOTE: I am not convinced I have fac described correctly
     # DOC-NOTE: same synopsis as int_proj
-    def int_unc(self, par, id=None, otherids=None, replot=False, min=None,
+    def int_unc(self, par,
+                id: Optional[IdType] = None,
+                otherids: Optional[Sequence[IdType]] = None,
+                replot=False, min=None,
                 max=None, nloop=20, delv=None, fac=1, log=False,
                 numcores=None, overplot=False):
         """Calculate and plot the fit statistic versus fit parameter value.
@@ -16598,10 +16815,10 @@ class Session(NoNewAttributesAfterInit):
         ----------
         par
            The parameter to plot.
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then
            all data sets with an associated model are used simultaneously.
-        otherids : sequence of int or str, optional
+        otherids : sequence of int or str, or None, optional
            Other data sets to use in the calculation.
         replot : bool, optional
            Set to ``True`` to use the values calculated by the last
@@ -16697,7 +16914,10 @@ class Session(NoNewAttributesAfterInit):
         self._plot(plotobj, overplot=overplot)
 
     # DOC-TODO: how is sigma converted into delta_stat
-    def reg_proj(self, par0, par1, id=None, otherids=None, replot=False,
+    def reg_proj(self, par0, par1,
+                 id: Optional[IdType] = None,
+                 otherids: Optional[Sequence[IdType]] = None,
+                 replot=False,
                  fast=True, min=None, max=None, nloop=(10, 10), delv=None,
                  fac=4, log=(False, False), sigma=(1, 2, 3), levels=None,
                  numcores=None, overplot=False):
@@ -16715,10 +16935,10 @@ class Session(NoNewAttributesAfterInit):
         ----------
         par0, par1
            The parameters to plot on the X and Y axes, respectively.
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then
            all data sets with an associated model are used simultaneously.
-        otherids : sequence of int or str, optional
+        otherids : sequence of int or str, or None, optional
            Other data sets to use in the calculation.
         replot : bool, optional
            Set to ``True`` to use the values calculated by the last
@@ -16829,7 +17049,10 @@ class Session(NoNewAttributesAfterInit):
         self._contour(plotobj, overcontour=overplot)
 
     # DOC-TODO: how is sigma converted into delta_stat
-    def reg_unc(self, par0, par1, id=None, otherids=None, replot=False,
+    def reg_unc(self, par0, par1,
+                id: Optional[IdType] = None,
+                otherids: Optional[Sequence[IdType]] = None,
+                replot=False,
                 min=None, max=None, nloop=(10, 10), delv=None, fac=4,
                 log=(False, False), sigma=(1, 2, 3), levels=None,
                 numcores=None, overplot=False):
@@ -16847,10 +17070,10 @@ class Session(NoNewAttributesAfterInit):
         ----------
         par0, par1
            The parameters to plot on the X and Y axes, respectively.
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set that provides the data. If not given then
            all data sets with an associated model are used simultaneously.
-        otherids : sequence of int or str, optional
+        otherids : sequence of int or str, or None, optional
            Other data sets to use in the calculation.
         replot : bool, optional
            Set to ``True`` to use the values calculated by the last
@@ -16976,12 +17199,13 @@ class Session(NoNewAttributesAfterInit):
     # Image object access
     #
 
-    def get_data_image(self, id=None):
+    def get_data_image(self,
+                       id: Optional[IdType] = None):
         """Return the data used by image_data.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
 
@@ -17019,7 +17243,8 @@ class Session(NoNewAttributesAfterInit):
         imageobj.prepare_image(data)
         return imageobj
 
-    def get_model_image(self, id=None):
+    def get_model_image(self,
+                        id: Optional[IdType] = None):
         """Return the data used by image_model.
 
         Evaluate the source expression for the image pixels -
@@ -17028,7 +17253,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
 
@@ -17071,7 +17296,8 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-TODO: it looks like get_source_image doesn't raise DataErr with
     # a non-2D data set
-    def get_source_image(self, id=None):
+    def get_source_image(self,
+                         id: Optional[IdType] = None):
         """Return the data used by image_source.
 
         Evaluate the source expression for the image pixels - without
@@ -17079,7 +17305,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None. optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
 
@@ -17242,12 +17468,13 @@ class Session(NoNewAttributesAfterInit):
         imageobj.prepare_image(data, model)
         return imageobj
 
-    def get_ratio_image(self, id=None):
+    def get_ratio_image(self,
+                        id: Optional[IdType] = None):
         """Return the data used by image_ratio.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
 
@@ -17285,12 +17512,13 @@ class Session(NoNewAttributesAfterInit):
         imageobj.prepare_image(data, model)
         return imageobj
 
-    def get_resid_image(self, id=None):
+    def get_resid_image(self,
+                        id: Optional[IdType] = None):
         """Return the data used by image_resid.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
 
@@ -17328,12 +17556,13 @@ class Session(NoNewAttributesAfterInit):
         imageobj.prepare_image(data, model)
         return imageobj
 
-    def get_psf_image(self, id=None):
+    def get_psf_image(self,
+                      id: Optional[IdType] = None):
         """Return the data used by image_psf.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
 
@@ -17368,12 +17597,13 @@ class Session(NoNewAttributesAfterInit):
         imageobj.prepare_image(psf, data)
         return imageobj
 
-    def get_kernel_image(self, id=None):
+    def get_kernel_image(self,
+                         id: Optional[IdType] = None):
         """Return the data used by image_kernel.
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
 
@@ -17412,7 +17642,9 @@ class Session(NoNewAttributesAfterInit):
     # Images
     #
 
-    def image_data(self, id=None, newframe=False, tile=False):
+    def image_data(self,
+                   id: Optional[IdType] = None,
+                   newframe=False, tile=False):
         """Display a data set in the image viewer.
 
         The image viewer is automatically started if it is not
@@ -17420,7 +17652,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default
            identifier is used, as returned by `get_default_id`.
         newframe : bool, optional
@@ -17470,7 +17702,9 @@ class Session(NoNewAttributesAfterInit):
         imageobj = self.get_data_image(id)
         imageobj.image(newframe=newframe, tile=tile)
 
-    def image_model(self, id=None, newframe=False, tile=False):
+    def image_model(self,
+                    id: Optional[IdType] = None,
+                    newframe=False, tile=False):
         """Display the model for a data set in the image viewer.
 
         This function evaluates and displays the model expression for
@@ -17483,7 +17717,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default
            identifier is used, as returned by `get_default_id`.
         newframe : bool, optional
@@ -17683,7 +17917,9 @@ class Session(NoNewAttributesAfterInit):
         imageobj = self.get_model_component_image(id, model)
         imageobj.image(newframe=newframe, tile=tile)
 
-    def image_source(self, id=None, newframe=False, tile=False):
+    def image_source(self,
+                     id: Optional[IdType] = None,
+                     newframe=False, tile=False):
         """Display the source expression for a data set in the image viewer.
 
         This function evaluates and displays the model expression for
@@ -17694,7 +17930,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default
            identifier is used, as returned by `get_default_id`.
         newframe : bool, optional
@@ -17750,7 +17986,9 @@ class Session(NoNewAttributesAfterInit):
         imageobj.image(newframe=newframe, tile=tile)
 
     # DOC-TODO: does newframe make sense here?
-    def image_fit(self, id=None, newframe=True, tile=True, deleteframes=True):
+    def image_fit(self,
+                  id: Optional[IdType] = None,
+                  newframe=True, tile=True, deleteframes=True):
         """Display the data, model, and residuals for a data set in the image viewer.
 
         This function displays the data, model (including any
@@ -17762,7 +18000,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default
            identifier is used, as returned by `get_default_id`.
         newframe : bool, optional
@@ -17820,7 +18058,9 @@ class Session(NoNewAttributesAfterInit):
         model.image(None, newframe, tile)
         resid.image(None, newframe, tile)
 
-    def image_resid(self, id=None, newframe=False, tile=False):
+    def image_resid(self,
+                    id: Optional[IdType] = None,
+                    newframe=False, tile=False):
         """Display the residuals (data - model) for a data set in the image viewer.
 
         This function displays the residuals (data - model) for a data
@@ -17831,7 +18071,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default
            identifier is used, as returned by `get_default_id`.
         newframe : bool, optional
@@ -17887,7 +18127,9 @@ class Session(NoNewAttributesAfterInit):
         imageobj = self.get_resid_image(id)
         imageobj.image(newframe=newframe, tile=tile)
 
-    def image_ratio(self, id=None, newframe=False, tile=False):
+    def image_ratio(self,
+                    id: Optional[IdType] = None,
+                    newframe=False, tile=False):
         """Display the ratio (data/model) for a data set in the image viewer.
 
         This function displays the ratio data/model for a data
@@ -17898,7 +18140,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default
            identifier is used, as returned by `get_default_id`.
         newframe : bool, optional
@@ -17942,7 +18184,9 @@ class Session(NoNewAttributesAfterInit):
         imageobj.image(newframe=newframe, tile=tile)
 
     # DOC-TODO: what gets displayed when there is no PSF?
-    def image_psf(self, id=None, newframe=False, tile=False):
+    def image_psf(self,
+                  id: Optional[IdType] = None,
+                  newframe=False, tile=False):
         """Display the 2D PSF model for a data set in the image viewer.
 
         The image viewer is automatically started if it is not
@@ -17950,7 +18194,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default
            identifier is used, as returned by `get_default_id`.
         newframe : bool, optional
@@ -17995,7 +18239,9 @@ class Session(NoNewAttributesAfterInit):
     # DOC-TODO: what gets displayed when there is no PSF?
     # DOC-TODO: where to point to for PSF/kernel discussion/description
     # (as it appears in a number of places)?
-    def image_kernel(self, id=None, newframe=False, tile=False):
+    def image_kernel(self,
+                     id: Optional[IdType] = None,
+                     newframe=False, tile=False):
         """Display the 2D kernel for a data set in the image viewer.
 
         The image viewer is automatically started if it is not
@@ -18003,7 +18249,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int or str, optional
+        id : int, str, or None, optional
            The data set. If not given then the default
            identifier is used, as returned by `get_default_id`.
         newframe : bool, optional

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -23,7 +23,6 @@ import copy
 import copyreg as copy_reg
 from dataclasses import dataclass
 import importlib
-import inspect
 import logging
 import os
 import pickle

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -903,7 +903,7 @@ class Session(NoNewAttributesAfterInit):
         # types for the value? The current hierarchy doesn't help, as
         # the "base" class is often a "virtual" class which ends up
         # missing some of the methods that the actual instances rely
-        # on, or that it has different parameters than it's
+        # on, or that it has different parameters than its
         # sub-classes (e.g. the plot classes), or that maybe a
         # more-specialized class than Model would be helpful
         # (e.g. _tbl_models).
@@ -3945,7 +3945,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int . str, or None, optional
+        id : int, str, or None, optional
            The data set. If not given then the default
            identifier is used, as returned by `get_default_id`.
         filter : bool, optional
@@ -17419,7 +17419,7 @@ class Session(NoNewAttributesAfterInit):
 
         Parameters
         ----------
-        id : int, str, or None. optional
+        id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
 


### PR DESCRIPTION
# Summary

Improve the documentation and typing of the various dataset identifier arguments (`id`, `bkg_id`, `resp_id`).

# Details

This was created as part of #2114 but I've separated it out as this part is hopefully less problematic, as it doesn't really add anything to the code. I have also reworked the code so the commits are different to those in #2114, but the content is essentially the same.

The changes:

- improves the documentation of `id`/`bkg_id`/`resp_id` arguments to better match the code
  - this is mainly to better describe when the argument can be None, or either a single value or sequence of them
- add typing rules for these variables.
- there are some minor code changes, which are basically
  - remove unused imports
  - minor pylint changes (e.g. use f-strings)
  - avoid changing the type of a variable within a routine when it confuses mypy

As mentioned in the discussion of #2114, we **could** add more typing rules, but this is surprisingly hard to do in many cases, so I'd rather get some rules added rather than address all cases. I have added some typing rules that are generally "obvious" , such as mark an argument as `str` or a function as returning `None`, but some changes are a bit-more complex. These tend to be those enabled by adding types to internal fields (normally a `dict[str, ...]` or `dict[IdType, ...]`) where we can take advantage of this knowledge.

As mentioned in previous PRs, sometimes the types given are not-quite-true; for example

- I have tended to label all data objects as being `Data`, but this then can cause type checkers to complain because sometimes the base/"virtual" class doesn't provide the methods the actual instances do, and other times it's because there is a type check on the return value which we currently can't easily type (having `TypeGuard` from 3.10 would help, but I can't guarantee it will fix it)
- the plot classes have a similar issue, where the current hierarchy is not useful for typing, and resolving that is a big issue, such as the following, which is why the plot code isn't touched here
  - #2076
- the response instrument code `ARF1D`/`RMF1D` mimics `DataARF`/`DataRMF` so you can often use them interchangeably, but it's awkward to type as `DataARF | ARF1D | None` when forward imports would be needed, so we currently just use `DataARF` and `DataRMF`

This is quite a disruptive PR (i.e. collides with many other PRs) so I'd rather get it in sooner rather than later.



