### PR TITLE
Allow per plot kwargs for plot_xxx_components calls

### DIFF
--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -22,9 +22,45 @@
 
 Classes provide access to common plotting tasks, which is done by the
 plotting backend defined in the ``options.plot_pkg`` setting of the
-Sherpa configuration file. Note that plot objects can be created
-and used even when only the `sherpa.plot.backends.BasicBackend` is
-available.
+Sherpa configuration file. Note that plot objects can be created and
+used even when only the `sherpa.plot.backends.BasicBackend` is
+available, it is just that no graphical display will be created.
+
+Which backend is used?
+----------------------
+
+When this module is first imported, Sherpa tries to import the
+backends installed with Sherpa in the order listed in the
+``options.plot_pkg`` setting from the ``sherpa.rc`` startup file.
+The first module that imports successfully is set as the active
+backend. The following command prints the name of the backend:
+
+   >>> from sherpa import plot
+   >>> print(plot.backend.name)
+
+Change the backend
+------------------
+
+After the initial import, the backend can be changed by loading one of
+the plotting backends shipped with sherpa (or any other module that
+provides the same interface):
+
+  >>> import sherpa.plot.pylab_backend
+  >>> plot.backend = sherpa.plot.pylab_backend
+
+Creating a plot
+---------------
+
+The plot backend acts as a context manager::
+
+    from sherpa.plot import backend
+    with backend:
+        # Now call the plot/overplot or contor/overcontour methods
+        obj.plot()
+
+This handles setting up the backend, handles any error handling,
+and then ends the session.
+
 """
 
 from __future__ import annotations

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -51,12 +51,15 @@ provides the same interface):
 Creating a plot
 ---------------
 
-The plot backend acts as a context manager::
+A plot backend can act as a context manager to apply a specific backend to just one plot
+without globally changing the backend for the rest of the session:
 
-    from sherpa.plot import backend
-    with backend:
-        # Now call the plot/overplot or contor/overcontour methods
-        obj.plot()
+.. doctest-skip::
+
+    >>> from sherpa.plot import backend
+    >>> with backend:
+    ...     # Now call the plot/overplot or contor/overcontour methods
+    ...     obj.plot()
 
 This handles setting up the backend, handles any error handling,
 and then ends the session.

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -58,7 +58,7 @@ without globally changing the backend for the rest of the session:
 
     >>> from sherpa.plot import backend
     >>> with backend:
-    ...     # Now call the plot/overplot or contor/overcontour methods
+    ...     # Now call the plot/overplot or contour/overcontour methods
     ...     obj.plot()
 
 This handles setting up the backend, handles any error handling,
@@ -3929,7 +3929,7 @@ class MultiPlot:
         """Plot the data.
 
         .. versionchanged:: 4.17.0
-           The keyword arguments an now be set per plot by sending in
+           The keyword arguments can now be set per plot by sending in
            a sequence of values.
 
         Parameters

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -3226,14 +3226,14 @@ def test_plot_xxx_components_kwargs_bokeh(session, ptype):
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 @pytest.mark.parametrize("ptype", ["source", "model"])
-@pytest.mark.parametrize("kwargs",
-                         [{"color": ["orange", "black", "green"]},
-                          {"color": ["black", "black"],
-                           "alpha": [0.8]},
-                          {"color": ["black", "black", "black"],
-                           "alpha": [0.8, 0.7, 1.0]}
+@pytest.mark.parametrize("kwargs,badarg",
+                         [({"color": ["orange", "black", "green"]}, "color"),
+                          ({"color": ["black", "black"],
+                            "alpha": [0.8]}, "alpha"),
+                          ({"color": ["black", "black", "black"],
+                            "alpha": [0.8, 0.7, 1.0]}, "color")
                           ])
-def test_plot_xxx_components_kwargs_mismatch(kwargs, session, ptype, plot_backends):
+def test_plot_xxx_components_kwargs_mismatch(kwargs, badarg, session, ptype, plot_backends):
     """Incorrect number of kwargs - what happens?
 
     It is okay to use plot_backends here because this is not
@@ -3251,5 +3251,6 @@ def test_plot_xxx_components_kwargs_mismatch(kwargs, session, ptype, plot_backen
     s.set_source(c1 * (c2 + c3))
 
     pfunc = getattr(s, f"plot_{ptype}_components")
-    with pytest.raises(ValueError):
+    msg = f"keyword '{badarg}': expected 2 elements but found "
+    with pytest.raises(ValueError, match=f"^{msg}"):
         pfunc(**kwargs)

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -3178,15 +3178,11 @@ def test_plot_xxx_components_kwargs_mpl(session, ptype, requires_pylab):
     s.set_source(c1 * (c2 + c3))
 
     pfunc = getattr(s, f"plot_{ptype}_components")
-    with pytest.raises(TypeError):
-        pfunc(color=["orange", "black"],
-              alpha=0.5,
-              linestyle=["dashed", "dotted"]
-              )
+    pfunc(color=["orange", "black"],
+          alpha=0.5,
+          linestyle=["dashed", "dotted"]
+          )
 
-    return
-
-    # Once support for multipe keywords is added
     axes = plt.gca()
     assert len(axes.lines) == 2
     assert axes.lines[0].get_color() == "orange"
@@ -3220,11 +3216,10 @@ def test_plot_xxx_components_kwargs_bokeh(session, ptype):
     s.set_source(c1 * (c2 + c3))
 
     pfunc = getattr(s, f"plot_{ptype}_components")
-    with pytest.raises(TypeError):
-        pfunc(color=["orange", "black"],
-              alpha=0.5,
-              linestyle=["dashed", "dotted"]
-              )
+    pfunc(color=["orange", "black"],
+          alpha=0.5,
+          linestyle=["dashed", "dotted"]
+          )
 
     # For now there is no check the kwargs were used
 

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -3090,3 +3090,171 @@ def test_plot_xxx_components_simple_bokeh(session, ptype):
     assert fig0.title.text == "Component plot"
 
     # Unlike the matplotlib case we do not check the plotted data.
+
+
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("ptype", ["source", "model"])
+def test_plot_xxx_components_scalar_mpl(session, ptype, requires_pylab):
+    """Can I set a kwarg to a scalar using matpotlib"""
+
+    from matplotlib import pyplot as plt
+
+    s = session()
+    s._add_model_types(basic)
+
+    s.set_default_id("x")
+    s.load_arrays("x", [1, 10, 50], [2, 3, 4])
+
+    c1 = s.create_model_component("scale1d", "c1")
+    c2 = s.create_model_component("const1d", "c2")
+    c3 = s.create_model_component("box1d", "c3")
+
+    c1.c0 = 0.5
+    c2.c0 = 2
+    c3.ampl = 4
+    c3.xhi = 100
+    c3.xlow = 7
+    s.set_source(c1 * (c2 + c3))
+
+    pfunc = getattr(s, f"plot_{ptype}_components")
+    pfunc(color="black", alpha=0.5, linestyle="dashed")
+
+    axes = plt.gca()
+    assert len(axes.lines) == 2
+    for l in axes.lines:
+        assert l.get_color() == "black"
+        assert l.get_alpha() == 0.5
+        assert l.get_linestyle() == "--"
+
+
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("ptype", ["source", "model"])
+def test_plot_xxx_components_scalar_bokeh(session, ptype):
+    """Can I set a kwarg to a scalar using bokeh"""
+
+    backend_mod = pytest.importorskip("sherpa.plot.bokeh_backend")
+    backend = backend_mod.BokehBackend()
+
+    s = session()
+    s._add_model_types(basic)
+
+    s.set_plot_backend(backend)
+
+    s.set_default_id("x")
+    s.load_arrays("x", [1, 10, 50], [2, 3, 4])
+
+    c1 = s.create_model_component("scale1d", "c1")
+    c2 = s.create_model_component("const1d", "c2")
+    c3 = s.create_model_component("box1d", "c3")
+
+    c1.c0 = 0.5
+    c2.c0 = 2
+    c3.ampl = 4
+    c3.xhi = 100
+    c3.xlow = 7
+    s.set_source(c1 * (c2 + c3))
+
+    pfunc = getattr(s, f"plot_{ptype}_components")
+    pfunc(color="black", alpha=0.5, linestyle="dashed")
+
+    # For now there is no check the kwargs were used
+
+
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("ptype", ["source", "model"])
+def test_plot_xxx_components_kwargs_mpl(session, ptype, requires_pylab):
+    """Can we have per-plot kwargs? matplotlib"""
+
+    from matplotlib import pyplot as plt
+
+    s = session()
+    s._add_model_types(basic)
+
+    s.load_arrays(1, [1, 10, 50], [2, 3, 4])
+
+    c1 = s.create_model_component("scale1d", "c1")
+    c2 = s.create_model_component("const1d", "c2")
+    c3 = s.create_model_component("box1d", "c3")
+    s.set_source(c1 * (c2 + c3))
+
+    pfunc = getattr(s, f"plot_{ptype}_components")
+    with pytest.raises(TypeError):
+        pfunc(color=["orange", "black"],
+              alpha=0.5,
+              linestyle=["dashed", "dotted"]
+              )
+
+    return
+
+    # Once support for multipe keywords is added
+    axes = plt.gca()
+    assert len(axes.lines) == 2
+    assert axes.lines[0].get_color() == "orange"
+    assert axes.lines[1].get_color() == "black"
+
+    assert axes.lines[0].get_alpha() == 0.5
+    assert axes.lines[1].get_alpha() == 0.5
+
+    assert axes.lines[0].get_linestyle() == "--"
+    assert axes.lines[1].get_linestyle() == ":"
+
+
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("ptype", ["source", "model"])
+def test_plot_xxx_components_kwargs_bokeh(session, ptype):
+    """Can we have per-plot kwargs? bokeh"""
+
+    backend_mod = pytest.importorskip("sherpa.plot.bokeh_backend")
+    backend = backend_mod.BokehBackend()
+
+    s = session()
+    s._add_model_types(basic)
+
+    s.set_plot_backend(backend)
+
+    s.load_arrays(1, [1, 10, 50], [2, 3, 4])
+
+    c1 = s.create_model_component("scale1d", "c1")
+    c2 = s.create_model_component("const1d", "c2")
+    c3 = s.create_model_component("box1d", "c3")
+    s.set_source(c1 * (c2 + c3))
+
+    pfunc = getattr(s, f"plot_{ptype}_components")
+    with pytest.raises(TypeError):
+        pfunc(color=["orange", "black"],
+              alpha=0.5,
+              linestyle=["dashed", "dotted"]
+              )
+
+    # For now there is no check the kwargs were used
+
+
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("ptype", ["source", "model"])
+@pytest.mark.parametrize("kwargs",
+                         [{"color": ["orange", "black", "green"]},
+                          {"color": ["black", "black"],
+                           "alpha": [0.8]},
+                          {"color": ["black", "black", "black"],
+                           "alpha": [0.8, 0.7, 1.0]}
+                          ])
+def test_plot_xxx_components_kwargs_mismatch(kwargs, session, ptype, plot_backends):
+    """Incorrect number of kwargs - what happens?
+
+    It is okay to use plot_backends here because this is not
+    the global Session but a temporary one.
+    """
+
+    s = session()
+    s._add_model_types(basic)
+
+    s.load_arrays(1, [1, 10, 50], [2, 3, 4])
+
+    c1 = s.create_model_component("scale1d", "c1")
+    c2 = s.create_model_component("const1d", "c2")
+    c3 = s.create_model_component("box1d", "c3")
+    s.set_source(c1 * (c2 + c3))
+
+    pfunc = getattr(s, f"plot_{ptype}_components")
+    with pytest.raises(ValueError):
+        pfunc(**kwargs)

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -14372,7 +14372,7 @@ class Session(NoNewAttributesAfterInit):
         >>> set_source(xsphabs.gal * (powlaw1d.pl + xsgaussian.line))
         >>> plot_source_components(alpha=0.6)
 
-        Plot the combnined source and then overplot the two components
+        Plot the combined source and then overplot the two components
         in black, partly opaque, and using dotted and dashed line
         styles:
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -741,7 +741,7 @@ class FitStore:
 
 def get_components_helper(getfunc: Callable[..., Plot],
                           model: Model,
-                          idval: Union[int, str]) -> MultiPlot:
+                          idval: IdType) -> MultiPlot:
     """Handle get_source/model_components_plot.
 
     Iterate through each term in the source model.
@@ -12302,7 +12302,8 @@ class Session(NoNewAttributesAfterInit):
         return plotobj
 
     def get_model_components_plot(self,
-                                  id: Optional[IdType] = None):
+                                  id: Optional[IdType] = None
+                                  ) -> MultiPlot:
         """Return the data used by plot_model_components.
 
         .. versionadded:: 4.16.1
@@ -12315,10 +12316,8 @@ class Session(NoNewAttributesAfterInit):
 
         Returns
         -------
-        instances : list of objects
-           A list of objects representing the data used to create the
-           plot by `plot_model_components`. The return value depends
-           on the data set (e.g. 1D binned or un-binned).
+        plot : MultiPlot
+           A plot object containing the individual plot objects.
 
         See Also
         --------
@@ -12427,7 +12426,8 @@ class Session(NoNewAttributesAfterInit):
         return plotobj
 
     def get_source_components_plot(self,
-                                   id: Optional[IdType] = None):
+                                   id: Optional[IdType] = None
+                                   ) -> Multiplot:
         """Return the data used by plot_source_components.
 
         .. versionadded:: 4.16.1
@@ -12440,10 +12440,8 @@ class Session(NoNewAttributesAfterInit):
 
         Returns
         -------
-        instances : list of objects
-           A list of objects representing the data used to create the
-           plot by `plot_source_components`. The return value depends
-           on the data set (e.g. 1D binned or un-binned).
+        plot : MultiPlot
+           A plot object containing the individual plot objects.
 
         See Also
         --------

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -14336,6 +14336,10 @@ class Session(NoNewAttributesAfterInit):
 
         Display the individual components of a source expression.
 
+        .. versionchanged:: 4.17.0
+           The keyword arguments can now be set per plot by using a
+           sequence of values.
+
         .. versionadded:: 4.16.1
 
         Parameters
@@ -14369,6 +14373,16 @@ class Session(NoNewAttributesAfterInit):
 
         >>> set_source(xsphabs.gal * (powlaw1d.pl + xsgaussian.line))
         >>> plot_source_components(alpha=0.6)
+
+        Plot the combnined source and then overplot the two components
+        in black, partly opaque, and using dotted and dashed line
+        styles:
+
+        >>> plot_source(label="combined")
+        >>> plot_source_components(overplot=True, color="black",
+        ...                        linestyle=["dotted", "dashed"],
+        ...                        label=["model 1", "model 2"],
+        ...                        alpha=0.5)
 
         """
 
@@ -14476,6 +14490,10 @@ class Session(NoNewAttributesAfterInit):
 
         Display the individual model components of a source expression.
 
+        .. versionchanged:: 4.17.0
+           The keyword arguments can now be set per plot by using a
+           sequence of values.
+
         .. versionadded:: 4.16.1
 
         Parameters
@@ -14509,6 +14527,16 @@ class Session(NoNewAttributesAfterInit):
 
         >>> set_source(xsphabs.gal * (powlaw1d.pl + xsgaussian.line))
         >>> plot_model_components(alpha=0.6)
+
+        Plot the combnined model and then overplot the two components
+        in black, partly opaque, and using dotted and dashed line
+        styles:
+
+        >>> plot_model(label="combined")
+        >>> plot_model_components(overplot=True, color="black",
+        ...                       linestyle=["dotted", "dashed"],
+        ...                       label=["model 1", "model 2"],
+        ...                       alpha=0.5)
 
         """
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -14526,7 +14526,7 @@ class Session(NoNewAttributesAfterInit):
         >>> set_source(xsphabs.gal * (powlaw1d.pl + xsgaussian.line))
         >>> plot_model_components(alpha=0.6)
 
-        Plot the combnined model and then overplot the two components
+        Plot the combined model and then overplot the two components
         in black, partly opaque, and using dotted and dashed line
         styles:
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -25,6 +25,7 @@ moved, changed, or removed.
 
 """
 
+from collections.abc import Iterable
 import inspect
 import logging
 import operator
@@ -2639,6 +2640,13 @@ def is_in(arg, seq):
 
 def is_iterable(arg):
     return isinstance(arg, (list, tuple, np.ndarray)) or np.iterable(arg)
+
+
+# Can this return TypeGuard[Sequence]?
+def is_iterable_not_str(arg: Any) -> bool:
+    """It is iterable but not a string."""
+
+    return not isinstance(arg, str) and isinstance(arg, Iterable)
 
 
 def is_sequence(start, mid, end):


### PR DESCRIPTION
# Summary

Allow per-plot keyword arguments for plot_model_components and plot_source_components.

# Details

Inspired by (but implementation is different)
 
- #1712 

since we have code that can use it now thanks to 
- #1679

Fortunately the implementation is easy, the main conceptual difficulty is determining whether color="black" is a sequence or a single value (since a string can be thought of as both a scalar and a sequence). So we special case this condition.

An alternative would be to make the user identify which are the sequence values by - for example - use a pluralized version - so `alphas`, `colors`, `linestyles`, `labels`, ... - which have to take a sequence. This is conceptually better, but

- I am not sure how to actually code this, since I am not convinced we can guarantee that all existing keywords do not end in `s`, so how do I know that a given keyword is a scalar or not
- for a user I'm not sure it's better

However, maybe I'm wrong.

# Example

You can now

```
In [24]: plot_model(xlog=True)

In [25]: plot_model_components(color="black", alpha=0.5, linestyle=["dashed", "dotted"], overplot=True, label=["continuum", "line"])
```

![sherpa-1](https://github.com/user-attachments/assets/1a047d10-54b0-4c06-aba0-1142e1300ae1)
