### PR TITLE
Allow plot and contour to change the plot layout and have per-plot settings.

### DIFF
--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -3878,6 +3878,55 @@ class RegionUncertainty(Confidence2D):
             fit.model.thawedpars = oldpars
 
 
+def get_per_plot_kwargs(nplots: int,
+                        kwargs
+                        ) -> list[dict[str, Any]]:
+    """Separate the per-plot plot arguments.
+
+    .. versionadded:: 4.17.0
+
+    Parameters
+    ----------
+    nplots
+       The number of plots.
+    kwargs
+       The user-specified keyword arguments. Any values which are
+       sequences (not a string) need to contain nplots elements.
+
+    Returns
+    -------
+    kwstores
+       The keyword arguments for each plot.
+
+    """
+
+    # Allow kwargs to be specified per-plot. This is done by
+    # checking if any value is an iterable (and not a string) and
+    # extracting a single value per plot.
+    #
+    # Need these {} to be separate which means we can not just say
+    # `kwstore = [{}] * nplots`.
+    #
+    ## kwstore: list[dict[str, Any]]
+    kwstore = [{} for _ in range(nplots)]
+    for key, val in kwargs.items():
+        if is_iterable_not_str(val):
+            nval = len(val)
+            if nval != nplots:
+                raise ValueError(f"keyword '{key}': expected "
+                                 f"{nplots} elements but found "
+                                 f"{nval}")
+
+            for store, v in zip(kwstore, val):
+                store[key] = v
+
+        else:
+            for store in kwstore:
+                store[key] = val
+
+    return kwstore
+
+
 class MultiPlot:
     """Combine multiple line-style plots.
 
@@ -3950,32 +3999,8 @@ class MultiPlot:
 
         """
 
-        nplots = len(self.plots)
-
-        # Allow kwargs to be specified per-plot. This is done by
-        # checking if any value is an iterable (and not a string) and
-        # extracting a single value per plot.
-        #
-        # Need these {} to be separate which means we can not just say
-        # `kwstore = [{}] * nplots`.
-        #
-        kwstore: list[dict[str, Any]]
-        kwstore = [{} for _ in range(nplots)]
-        for key, val in kwargs.items():
-            if is_iterable_not_str(val):
-                nval = len(val)
-                if nval != nplots:
-                    raise ValueError(f"keyword '{key}': expected "
-                                     f"{nplots} elements but found "
-                                     f"{nval}")
-
-                for store, v in zip(kwstore, val):
-                    store[key] = v
-
-            else:
-                for store in kwstore:
-                    store[key] = val
-
+        kwstore = get_per_plot_kwargs(len(self.plots),
+                                      kwargs)
         for plot, store in zip(self.plots, kwstore):
             plot.plot(overplot=overplot, clearwindow=clearwindow,
                       **store)

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -1312,6 +1312,8 @@ class SplitPlot(Plot, Contour):
     def __str__(self) -> str:
         return display_fields(self, self._fields)
 
+    # Should this use the preferences to set the rows and cols?
+    #
     def reset(self, rows=2, cols=1):
         "Prepare for a new set of plots or contours."
         self.rows = rows

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -3354,10 +3354,13 @@ def test_plot_check_size_nrows_ncols_pylab(session, nrows, ncols, kwargs, requir
                                        (2, None), (2, 1),
                                        (2, 2)])
 def test_plot_singleton_ignores_sizes(session, rows, cols, requires_pylab):
-    """Single plots are special cased and ignore size arguments.
+    """Single plots used to be special cased to ignore size arguments.
 
-    Regression test, as we could change this behaviour.
+    This is no-longer the case, so test the new behavior.
     """
+
+    nrows = 1 if rows is None else rows
+    ncols = 1 if cols is None else cols
 
     from matplotlib import pyplot as plt
 
@@ -3367,7 +3370,7 @@ def test_plot_singleton_ignores_sizes(session, rows, cols, requires_pylab):
 
     fig = plt.gcf()
     assert len(fig.axes) == 1
-    assert fig.axes[0].get_subplotspec().get_geometry() == (1, 1, 0, 0)
+    assert fig.axes[0].get_subplotspec().get_geometry() == (nrows, ncols, 0, 0)
 
     plt.close()
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -342,7 +342,7 @@ def calc_multiplot_size(rows, cols, nplots):
     rows, cols
        The requested sizes, if set (one of them must be set).
     nplots
-       The nuber of plots.
+       The number of plots.
 
     Returns
     -------
@@ -13646,7 +13646,7 @@ class Session(NoNewAttributesAfterInit):
         plotmeth
             The call.
         rows, cols
-            The number of rows or columns (to over-ride split plot).
+            The number of rows or columns (to override split plot).
         kwargs
             The keyword arguments to apply to each plot or contour.
 
@@ -13746,7 +13746,7 @@ class Session(NoNewAttributesAfterInit):
         #
         kwstore = get_per_plot_kwargs(nplots, kwargs)
 
-        # Store the original values in case they are over-written.
+        # Store the original values in case they are overwritten.
         #
         sp = self._splitplot
         nrows_orig = sp.rows
@@ -14001,7 +14001,7 @@ class Session(NoNewAttributesAfterInit):
            The keyword arguments can now be set per plot by using a
            sequence of values. The layout can be changed with the
            rows and cols arguments and the automatic calculation
-           no-longer forces two rows.
+           no longer forces two rows.
 
         .. versionchanged:: 4.15.0
            A number of labels, such as "bkgfit", are marked as
@@ -15982,7 +15982,7 @@ class Session(NoNewAttributesAfterInit):
            The keyword arguments can now be set per plot by using a
            sequence of values. The layout can be changed with the
            rows and cols arguments and the automatic calculation
-           no-longer forces two rows.
+           no longer forces two rows.
 
         .. versionchanged:: 4.12.2
            Keyword arguments, such as alpha, can be sent to

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -13979,6 +13979,10 @@ class Session(NoNewAttributesAfterInit):
         """
         self._set_plot_item(plottype, 'ylog', False)
 
+    # This documentation is really for the sherpa.astro.ui version, as
+    # some of this is not relevant for the sherpa.ui code, but leave
+    # like this.
+    #
     def plot(self,
              *args,
              # At present export_method does not support this
@@ -14118,8 +14122,15 @@ class Session(NoNewAttributesAfterInit):
         such as the `set_analysis` command controlling the units
         used for PHA data sets.
 
-        See the documentation for the individual routines for
-        information on how to configure the plots.
+        Given a plot name, such as "data", the remaining arguments up
+        to the next plot name match those from the corresponding
+        plot_xxx call (in this case plot_data), ignoring the replot,
+        overplot, and clearwindow arguments. So the call
+
+        >>> plot("data", "bkg", 1, "up", ylog=True)
+
+        can be thought of as combining the plots created by calling
+        plot_data(ylog=True) and plot_bkg(1, "up", ylog=True).
 
         The plot capabilities depend on what plotting backend, if any,
         is installed. If there is none available, a warning message
@@ -14163,20 +14174,22 @@ class Session(NoNewAttributesAfterInit):
 
         >>> plot("data", "model", ylog=True)
 
-        Plot the backgrounds for dataset 1 using the "up" and "down"
-        components (in this case the background identifier):
+        Plot the background data components "up" and "down" for
+        dataset 1:
 
         >>> plot("bkg", 1, "up", "bkg", 1, "down")
 
-        Draw both data sets in black, but with partial opacity:
+        Draw both data and model for the default dataset in black, but
+        with partial opacity:
 
         >>> plot("data", "model", color="black", alpha=0.5)
 
         Draw the two plots in black but with different opacities:
 
-        >>> plot("data", "model", color="black", alpha=[1., 0.5])
+        >>> plot("data", "model", color="black", alpha=[1, 0.5])
 
-        Label each plot
+        Label each plot (the output depends on the backend and the
+        plot options):
 
         >>> plot("data", "model", label=["data", "model"])
 
@@ -14193,6 +14206,11 @@ class Session(NoNewAttributesAfterInit):
 
         >>> plot("data", "data", 2, "model", "model", 2,
         ...      "resid", "resid", 2, rows=3, cols=2)
+
+        Create a display for three plots, vertically aligned,
+        but only display plots in the first two:
+
+        >>> plot("data", "model", cols=1, rows=3)
 
         """
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -14174,7 +14174,7 @@ class Session(NoNewAttributesAfterInit):
 
         Draw the two plots in black but with different opacities:
 
-        >>> plot("data", "model", color="black", alpha=[1. 0.5])
+        >>> plot("data", "model", color="black", alpha=[1., 0.5])
 
         Label each plot
 
@@ -16456,7 +16456,7 @@ class Session(NoNewAttributesAfterInit):
         plot2obj = self.get_resid_contour(id, recalc=not replot)
 
         # This does not use _jointplot because the X axis is not
-        # obviously shared between the twp plots.
+        # obviously shared between the two plots.
         #
         self._splitplot.reset(rows=2, cols=1)
         with sherpa.plot.backend:


### PR DESCRIPTION
# Summary

Expand the plot and contour commands to allow per-plot options to be given, matching the plot_model_components/plot_source_components commands. Improve the algorithm for deciding how to arrange multiple plots, so it isn't fixed to a maximum of 2 rows. Add the rows and cols arguments so that the layout can be specified by the user.

# Details

When answering 

- #2119 

I remembered how much I found the `plot` command to be lacking with regard to plot control. Well, this adresses some of my complaints (there is an issue to do with `overplot`, but that is addressed in #2129, and this adds useful functionality as is).

Extend the logic of #2125 to allow you to say

```
>>> plot("data", "model", label=["data", "model"], ylog=[False, True], color=["gray", "mauve"])
```

Previously we had no control over the layout, and we had

- single plot -> single plot
- two plots -> a column of two plots
- three or four plots -> two columns, two rows
- 2 * n + 1 to 2 * n + 2 plots -> n + 1 columns, two rows
 
We now allow the user to specify the number of rows or columns (or both) to use, so that

- if both rows and cols are set by the user, use them, unless they don't cover all the plots, then we assume neither are set
- if one is set then use it and calculate the other value
- if neither are set then set the number of colums to ceil(sqrt(nplots)) and then calculate the number of rows

So

```
>>> plot("data", cols=2)
```

now creates a plot in the top-half of the window (there was code special-casing the single-plot behaviour but I found it was easiest to remove it to support #2129 and avoid special-case rules here).

The following will create a 3 column and 2 row display (which matches what it did in 4.16.1):

```
>>> plot("data", "model", "data", 2, "model", 2, "data", 3, "model", 3)
```

We can now change it to 2 columns by 3 rows with any of

```
>>> plot("data", "model", "data", 2, "model", 2, "data", 3, "model", 3, cols=2)
>>> plot("data", "model", "data", 2, "model", 2, "data", 3, "model", 3, rows=3)
>>> plot("data", "model", "data", 2, "model", 2, "data", 3, "model", 3, cols=2, rows=3)
>>> sp = get_split_plot()
>>> sp.rows = 3; sp.cols = 2
>>> plot("data", "model", "data", 2, "model", 2, "data", 3, "model", 3)
```

The last version will persist the setting, so then

```
>>> plot("data", "model")
```

would still use 3 rows by 2 columns.

We can now get a single-column of plots with

```
>>> plot(....., cols=1)
```

# Question

So, should it be

```
>>> plot("data", "model", "resid", cols=1)
```

or

```
>>> plot("data", "model", "resid", ncols=1)
```

Should we use `cols`,`rows` or `ncols`,`nrows`?