### PR TITLE
Fix plot overplot

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -65,7 +65,7 @@ def _get_image_filter(data: DataIMG) -> str:
     There is a disconnect between 1D and 2D filters as an empty string
     means no data has been selected for the former, but all data is
     selected in the latter. For the logging of the filters this makes
-    things awkward, so we over-ride the image case and replace an empty
+    things awkward, so we override the image case and replace an empty
     string with "Field()". See also issue #1430 which points out that
     the empty string can also mean "all data has been ignored".
 
@@ -406,7 +406,7 @@ class Session(sherpa.ui.utils.Session):
             self._plot_types_alias[f"bkg{key}"] = f"bkg_{key}"
 
         # These are left-over from earlier, when they may have meant
-        # something different but no-longer do. It is probably
+        # something different but no longer do. It is probably
         # time to remove them.
         #
         self._plot_types_alias["astrocompsource"] = "source_component"
@@ -1019,7 +1019,7 @@ class Session(sherpa.ui.utils.Session):
            The separation between each grid point. This is not used if
            ``numbins`` is set.
         numbins : int, optional
-           The number of grid points. This over-rides the ``step``
+           The number of grid points. This overrides the ``step``
            setting.
         id : int, str, or None, optional
            The identifier for the data set to use. If not given then
@@ -3056,7 +3056,7 @@ class Session(sherpa.ui.utils.Session):
                       ) -> None:
         """Set the statistical errors on the dependent axis of a data set.
 
-        These values over-ride the errors calculated by any statistic,
+        These values override the errors calculated by any statistic,
         such as ``chi2gehrels`` or ``chi2datavar``.
 
         Parameters
@@ -4176,7 +4176,7 @@ class Session(sherpa.ui.utils.Session):
 
         .. versionchanged:: 4.12.2
            The bkg_id, counts, group, and filter parameters have been
-           added and the routine no-longer calculates the average
+           added and the routine no longer calculates the average
            scaling for all the background components but just for the
            given component.
 
@@ -15027,7 +15027,7 @@ class Session(sherpa.ui.utils.Session):
            The `id` parameter is now used if set (previously the
            default dataset was always used). The screen output is now
            controlled by the Sherpa logging setup. The flux
-           calculation no-longer excludes samples at the parameter
+           calculation no longer excludes samples at the parameter
            soft limits, as this could cause an over-estimation of the
            flux when a parameter is only an upper limit. The statistic
            value is now returned for each row, even those that were
@@ -16684,7 +16684,7 @@ class Session(sherpa.ui.utils.Session):
 
         .. versionchanged:: 4.16.0
            Any set_psf calls are now included in the output file. The
-           filter is no-longer included if it does not exclude any
+           filter is no longer included if it does not exclude any
            data, and the code tries to recreate manually-created
            datasets (e.g. use of `dataspace1d` or `load_arrays`), but
            not all situations are handled. XSPEC table models are now

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -1292,6 +1292,11 @@ class LRHistogram(HistogramPlot):
                           overplot=True, clearwindow=False)
 
 
+# The handling of the overplot/contour keywords is not ideal. To
+# address issue #2128 the UI code ended up accessing internal details
+# of this class. Ideally the API would be cleaned up but it's not
+# currently clear what the requirements are.
+#
 class SplitPlot(Plot, Contour):
     """Create multiple plots.
 

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -3269,6 +3269,24 @@ def test_plot_invalid_size(session, name, val):
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("nplots", [1, 2, 3, 4, 5])
+def test_plot_overplot_too_many_plots(session, nplots):
+    """Check we error out."""
+
+    s = session()
+    s.load_arrays(1, [1, 2], [1, 2])
+
+    # It's important to include non-square numbers in the test
+    args1 = ["data"] * nplots
+    args2 = ["data"] + args1
+
+    s.plot(*args1)
+    with pytest.raises(ArgumentErr,
+                       match="^Too many elements for overplot$"):
+        s.plot(*args2, overplot=True)
+
+
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
 @pytest.mark.parametrize("nrows,ncols,nplots",
                          [(1, 1, 1),
                           (2, 1, 2),
@@ -3440,23 +3458,71 @@ def test_plot_overplot(session, requires_pylab):
     #
     s.plot("data", 2, "data", overplot=True)
 
-    # It would be nice if this added the data to the plots, but
-    # it currently replaces them (and doesn't set up the labels).
-    #
     fig = plt.gcf()
     assert len(fig.axes) == 2
     for ax in fig.axes:
         assert ax.get_title() == ""
-        assert ax.xaxis.get_label().get_text() == ""
-        assert ax.yaxis.get_label().get_text() == ""
+        assert ax.xaxis.get_label().get_text() == "x"
+        assert ax.yaxis.get_label().get_text() == "y"
 
-        assert len(ax.lines) == 1
+        assert len(ax.lines) == 2
 
     l1 = fig.axes[0].lines[0]
     l2 = fig.axes[1].lines[0]
+    assert l1.get_xdata() == pytest.approx(x1)
+    assert l2.get_xdata() == pytest.approx(x2)
+    assert l1.get_ydata() == pytest.approx(y1)
+    assert l2.get_ydata() == pytest.approx(y2)
+
+    l1 = fig.axes[0].lines[1]
+    l2 = fig.axes[1].lines[1]
     assert l1.get_xdata() == pytest.approx(x2)
     assert l2.get_xdata() == pytest.approx(x1)
     assert l1.get_ydata() == pytest.approx(y2)
     assert l2.get_ydata() == pytest.approx(y1)
+
+    plt.close()
+
+
+@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+def test_plot_overplot_smaller(session, requires_pylab):
+    """Check we can overplot less plots than the original.
+
+    This is a regression test, to check the current behaviour.
+    """
+
+    from matplotlib import pyplot as plt
+
+    x1 = [1, 2, 3]
+    x2 = [21, 22, 23]
+    y1 = [4, 5, 6]
+    y2 = [-4, -5, -6]
+
+    s = session()
+    s.load_arrays(1, x1, y1)
+    s.load_arrays(2, x2, y2)
+
+    s.plot("data", "data", 2)
+    s.plot("data", 2, overplot=True, alpha=0.5)
+
+    fig = plt.gcf()
+    assert len(fig.axes) == 2
+    assert len(fig.axes[0].lines) == 2
+    assert len(fig.axes[1].lines) == 1
+
+    l1 = fig.axes[0].lines[0]
+    l2 = fig.axes[1].lines[0]
+    assert l1.get_xdata() == pytest.approx(x1)
+    assert l2.get_xdata() == pytest.approx(x2)
+    assert l1.get_ydata() == pytest.approx(y1)
+    assert l2.get_ydata() == pytest.approx(y2)
+
+    l1 = fig.axes[0].lines[1]
+    assert l1.get_xdata() == pytest.approx(x2)
+    assert l1.get_ydata() == pytest.approx(y2)
+
+    assert fig.axes[0].lines[0].get_alpha() is None
+    assert fig.axes[1].lines[0].get_alpha() is None
+    assert fig.axes[0].lines[1].get_alpha() == 0.5
 
     plt.close()

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -13734,6 +13734,11 @@ class Session(NoNewAttributesAfterInit):
         - try to go with a square display
         - fill in columns first
 
+        The handling of overplot/contour has been improved - see issue
+        #2128 - but this involves using internal features of the
+        SplitPlot class. This could be improved, once we have more
+        experience of how this all works.
+
         """
 
         # This is an internal routine so it is not expected to be
@@ -13755,9 +13760,9 @@ class Session(NoNewAttributesAfterInit):
         check = getattr(self, f"_check_{plotmeth}type")
 
         plots = []
-        args = list(args)
-        while args:
-            plottype = args.pop(0)
+        largs = list(args)
+        while largs:
+            plottype = largs.pop(0)
             _check_str_type(plottype, "plottype")
             plottype = get(plottype.lower())
 
@@ -13766,11 +13771,11 @@ class Session(NoNewAttributesAfterInit):
             # plot/contour type.
             #
             getargs = []
-            while args:
-                if check(args[0]):
+            while largs:
+                if check(largs[0]):
                     break
 
-                getargs.append(args.pop(0))
+                getargs.append(largs.pop(0))
 
             funcname = f"get_{plottype}_{plotmeth}"
             getfunc = getattr(self, funcname)
@@ -13783,6 +13788,14 @@ class Session(NoNewAttributesAfterInit):
 
         nplots = len(plots)
 
+        # What is the overplot/contour handling? To address #2128 we
+        # do not need to worry about the clearwindow option.  Note
+        # that the value (assumed to be a scalar) is not removed from
+        # kwargs.
+        #
+        over = kwargs.get(f"over{plotmeth}", False)
+        # clearwindow = kwargs.get("clearwindow", True)
+
         # Deconstruct the keyword arguments.
         #
         kwstore = get_per_plot_kwargs(nplots, kwargs)
@@ -13793,9 +13806,25 @@ class Session(NoNewAttributesAfterInit):
         nrows_orig = sp.rows
         ncols_orig = sp.cols
 
-        # What size to use?
+        plotfunc = getattr(sp, f"add{plotmeth}")
+
+        # We only care about the size when creating the display, that
+        # is, if overplot/contour is set then we assume the size is
+        # known. There is a check to make sure the user isn't trying
+        # to overplot too-many plots, but we allow less plots to be
+        # overplot than the original.
         #
-        if rows is None and cols is None:
+        # Should this care about clearwindow too?
+        #
+        if over:
+            # Dig inside the SplitPlot class to find this out.
+            #
+            nrows, ncols = sp._used.shape
+            nplots_used = sp._used.sum()
+            if nplots_used < nplots:
+                raise ArgumentErr(f"Too many elements for over{plotmeth}")
+
+        elif rows is None and cols is None:
             # Special case the single-plot call
             if nplots == 1:
                 nrows = 1
@@ -13809,6 +13838,14 @@ class Session(NoNewAttributesAfterInit):
 
         plotfunc = getattr(sp, f"add{plotmeth}")
         sp.reset(rows=nrows, cols=ncols)
+
+        # This is a hack as the SplitPlot API does not provide a way
+        # to do this. We want to avoid calling the _clear_window
+        # method when calling addplot/contour.
+        #
+        if over:
+            sp._cleared_window = True
+
         with sherpa.plot.backend:
             for plot, store in zip(plots, kwstore):
                 plotfunc(plot, **store)
@@ -14042,7 +14079,8 @@ class Session(NoNewAttributesAfterInit):
            The keyword arguments can now be set per plot by using a
            sequence of values. The layout can be changed with the
            rows and cols arguments and the automatic calculation
-           no longer forces two rows.
+           no longer forces two rows. Handling of the overplot flag
+           has been improved.
 
         .. versionchanged:: 4.15.0
            A number of labels, such as "bkgfit", are marked as
@@ -14252,6 +14290,12 @@ class Session(NoNewAttributesAfterInit):
         but only display plots in the first two:
 
         >>> plot("data", "model", cols=1, rows=3)
+
+        Draw the data and residuals for the default dataset and then
+        overplot those from dataset 2:
+
+        >>> plot("data", "resid", cols=1, color="black")
+        >>> plot("data", 2, "resid", 2, overplot=True, color="black", alpha=0.5)
 
         """
 
@@ -16023,7 +16067,8 @@ class Session(NoNewAttributesAfterInit):
            The keyword arguments can now be set per plot by using a
            sequence of values. The layout can be changed with the
            rows and cols arguments and the automatic calculation
-           no longer forces two rows.
+           no longer forces two rows. Handling of the overcontour
+           flag has been improved.
 
         .. versionchanged:: 4.12.2
            Keyword arguments, such as alpha, can be sent to

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -3545,7 +3545,7 @@ class Session(NoNewAttributesAfterInit):
     def set_staterror(self, id, val=None, fractional=False) -> None:
         """Set the statistical errors on the dependent axis of a data set.
 
-        These values over-ride the errors calculated by any statistic,
+        These values override the errors calculated by any statistic,
         such as ``chi2gehrels`` or ``chi2datavar``.
 
         Parameters
@@ -4273,7 +4273,7 @@ class Session(NoNewAttributesAfterInit):
            The separation between each grid point. This is not used if
            ``numbins`` is set.
         numbins : int, optional
-           The number of grid points. This over-rides the ``step``
+           The number of grid points. This overrides the ``step``
            setting.
         id : int, str, or None, optional
            The identifier for the data set to use. If not given then
@@ -8692,7 +8692,7 @@ class Session(NoNewAttributesAfterInit):
         change.
 
         .. versionchanged:: 4.16.1
-           Source models no-longer have to contain the linked parameter.
+           Source models no longer have to contain the linked parameter.
 
         Parameters
         ----------
@@ -13811,7 +13811,7 @@ class Session(NoNewAttributesAfterInit):
         # We only care about the size when creating the display, that
         # is, if overplot/contour is set then we assume the size is
         # known. There is a check to make sure the user isn't trying
-        # to overplot too-many plots, but we allow less plots to be
+        # to overplot too many plots, but we allow less plots to be
         # overplot than the original.
         #
         # Should this care about clearwindow too?
@@ -16624,7 +16624,7 @@ class Session(NoNewAttributesAfterInit):
            The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : number, optional
-           The step size for the parameter. Setting this over-rides
+           The step size for the parameter. Setting this overrides
            the `nloop` parameter. The default is ``None``.
         fac : number, optional
            When `min` or `max` is not given, multiply the covariance
@@ -16738,7 +16738,7 @@ class Session(NoNewAttributesAfterInit):
            The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : number, optional
-           The step size for the parameter. Setting this over-rides
+           The step size for the parameter. Setting this overrides
            the `nloop` parameter. The default is ``None``.
         fac : number, optional
            When `min` or `max` is not given, multiply the covariance
@@ -16856,7 +16856,7 @@ class Session(NoNewAttributesAfterInit):
            The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : pair of number, optional
-           The step size for the parameter. Setting this over-rides
+           The step size for the parameter. Setting this overrides
            the `nloop` parameter. The default is ``None``.
         fac : number, optional
            When `min` or `max` is not given, multiply the covariance
@@ -16872,7 +16872,7 @@ class Session(NoNewAttributesAfterInit):
            in units of sigma.
         levels : sequence of number, optional
            The numeric values at which to draw the contours. This
-           over-rides the `sigma` parameter, if set (the default is
+           overrides the `sigma` parameter, if set (the default is
            ``None``).
         numcores : optional
            The number of CPU cores to use. The default is to use all
@@ -16988,7 +16988,7 @@ class Session(NoNewAttributesAfterInit):
            The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : pair of number, optional
-           The step size for the parameter. Setting this over-rides
+           The step size for the parameter. Setting this overrides
            the `nloop` parameter. The default is ``None``.
         fac : number, optional
            When `min` or `max` is not given, multiply the covariance
@@ -17004,7 +17004,7 @@ class Session(NoNewAttributesAfterInit):
            in units of sigma.
         levels : sequence of number, optional
            The numeric values at which to draw the contours. This
-           over-rides the `sigma` parameter, if set (the default is
+           overrides the `sigma` parameter, if set (the default is
            ``None``).
         numcores : optional
            The number of CPU cores to use. The default is to use all
@@ -17122,7 +17122,7 @@ class Session(NoNewAttributesAfterInit):
            The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : number, optional
-           The step size for the parameter. Setting this over-rides
+           The step size for the parameter. Setting this overrides
            the `nloop` parameter. The default is ``None``.
         fac : number, optional
            When `min` or `max` is not given, multiply the covariance
@@ -17244,7 +17244,7 @@ class Session(NoNewAttributesAfterInit):
            The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : number, optional
-           The step size for the parameter. Setting this over-rides
+           The step size for the parameter. Setting this overrides
            the `nloop` parameter. The default is ``None``.
         fac : number, optional
            When `min` or `max` is not given, multiply the covariance
@@ -17369,7 +17369,7 @@ class Session(NoNewAttributesAfterInit):
            The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : pair of number, optional
-           The step size for the parameter. Setting this over-rides
+           The step size for the parameter. Setting this overrides
            the `nloop` parameter. The default is ``None``.
         fac : number, optional
            When `min` or `max` is not given, multiply the covariance
@@ -17385,7 +17385,7 @@ class Session(NoNewAttributesAfterInit):
            in units of sigma.
         levels : sequence of number, optional
            The numeric values at which to draw the contours. This
-           over-rides the `sigma` parameter, if set (the default is
+           overrides the `sigma` parameter, if set (the default is
            ``None``).
         numcores : optional
            The number of CPU cores to use. The default is to use all
@@ -17501,7 +17501,7 @@ class Session(NoNewAttributesAfterInit):
            The number of steps to use. This is used when `delv` is set
            to ``None``.
         delv : pair of number, optional
-           The step size for the parameter. Setting this over-rides
+           The step size for the parameter. Setting this overrides
            the `nloop` parameter. The default is ``None``.
         fac : number, optional
            When `min` or `max` is not given, multiply the covariance
@@ -17517,7 +17517,7 @@ class Session(NoNewAttributesAfterInit):
            in units of sigma.
         levels : sequence of number, optional
            The numeric values at which to draw the contours. This
-           over-rides the `sigma` parameter, if set (the default is
+           overrides the `sigma` parameter, if set (the default is
            ``None``).
         numcores : optional
            The number of CPU cores to use. The default is to use all


### PR DESCRIPTION
# Summary

Improve the behaviour of plot() and contour() when called with overplot=True or overcontour=True respectively. Fix #2128.

# Details

Fortunately with the changes made in #2126, in particular sorting out the rows/cols settings and dropping the special case of the "singleton" plot code, this turned out to be easier than  I'd thought. 

So, this PR needs #2126.

So, we need to be able to ask the SplitPlot class what

- the current number of rows and columns are
- how many plots are currently active
- not to clear the window when resetting

At present there is no actual API to do these, so we rely in access to internal fields of the class. Ideally we would add an API but

a) the UI code is basically the only real user of the SplitPlot API at the moment (the JointPlot class subplots SplitPlot but adds it's own API which means we skip this complexity for commands like plot_fit_resid)
b) it's not entirely clear what API we want, so I'd rather live with this code for now until we get more experience of what we want

I will say that the existing SplitPlot API - e.g. addplot, overplot, plot, is a bit covfusing and perhaps could be rewritten to better match the plot vs overplot needs, but I do not think it worth working on at this time.

# Examples

```
>>> plot("data", "data", 2, cols=1)
>>> plot("model", "model", 2, overplot=True)
```

![sherpa-1](https://github.com/user-attachments/assets/c3c8bc99-2e4b-4c5b-afa0-37075dc65365)

Now, what should happen when you supply too few plots in the overplot call - e.g.

```
>>> plot("data", "data", 2, cols=1)
>>> plot("model", overplot=True)
```
![sherpa-2](https://github.com/user-attachments/assets/a3bb7e78-3ae2-43af-8232-35f325d955bb)

For now we allow this, since it didn't seem worth making this an error.

However we do error out if you try to add too many plots [the error message isn't great, but we have overloaded the word "plot" here, particularly if this were a `contour(...)` call] - e.g.

```
>>> plot("data", "data", 2)
>>> plot("model", 1, "model", 2, "model", 3, overplot=True)
...
ArgumentErr: Too many elements for overplot
```

The following, where you try to change the plot layout, is ignored (so the cols and rows arguments are ignored when overplot/contour are given):

```
>>> plot("data", "data", 2, cols=1)
>>> plot("model", "model", 2, rows=5, cols=4,  overplot=True)
```

We could make this an error, but is it worth it?