### PR TITLE
UI: calc_model/source now return Axis objects

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -48,6 +48,7 @@ from sherpa.sim import NormalParameterSampleFromScaleMatrix
 from sherpa.stats import Cash, CStat, WStat
 from sherpa.models.basic import TableModel
 from sherpa.models.model import Model
+from sherpa.models.regrid import Axis, IntegratedAxis, PointAxis
 from sherpa.astro import fake
 from sherpa.astro.data import DataIMG, DataIMGInt, DataPHA
 import sherpa.astro.instrument
@@ -15762,7 +15763,7 @@ class Session(sherpa.ui.utils.Session):
     def calc_model(self,
                    id: Optional[IdType] = None,
                    bkg_id: Optional[IdType] = None
-                   ) -> tuple[tuple[np.ndarray, ...], np.ndarray]:
+                   ) -> tuple[tuple[Axis, ...], np.ndarray]:
         """Calculate the per-bin model values.
 
         The values are filtered and grouped based on the data and will
@@ -15783,12 +15784,12 @@ class Session(sherpa.ui.utils.Session):
 
         Returns
         -------
-        xvals, yvals: tuple of ndarray, ndarray
-           The independent axis, which uses a tuple as the number of
-           elements depends on the dimensionality and type of data.
-           The units depends on the data type: for PHA data the
-           X axis will be in the analysis units and Y axis will
-           generally be counts.
+        xvals, yvals: tuple of Axis, ndarray
+           The independent axis, where the size matches the data
+           dimentionality and the values are Axis objects (so point or
+           integrated).  The units depends on the data type: for PHA
+           data the X axis will be in the analysis units and Y axis
+           will generally be counts.
 
         See Also
         --------
@@ -15810,8 +15811,8 @@ class Session(sherpa.ui.utils.Session):
         >>> pl.gamma = 1.7
         >>> pl.ampl = 2e-4
         >>> xvals, yvals = calc_model()
-        >>> xlo = xvals[0]
-        >>> xhi = xvals[1]
+        >>> xlo = xvals[0].lo
+        >>> xhi = xvals[0].hi
 
         The results can be compared to the model output in plot_fit to
         show agreement (note that calc_model returns grouped values,
@@ -15822,7 +15823,7 @@ class Session(sherpa.ui.utils.Session):
         >>> plot_fit()
         >>> plot_model(overplot=True, color="black", alpha=0.4)
         >>> xvals, yvals = calc_model()
-        >>> elo, ehi = xvals
+        >>> elo, ehi = xvals[0].lo, xvals[0].hi
         >>> exposure = get_exposure()
         >>> plt.plot((elo + ehi) / 2, yvals / (ehi - elo) / exposure)
 
@@ -15842,7 +15843,7 @@ class Session(sherpa.ui.utils.Session):
         >>> gline.fwhm = 3
         >>> gline.ampl = 12
         >>> xvals, yvals = calc_model(2)
-        >>> x = xvals[0]
+        >>> x = xvals[0].x
         >>> x
         array([1, 4, 7])
         >>> yvals
@@ -15855,20 +15856,35 @@ class Session(sherpa.ui.utils.Session):
         idval = self._fix_id(id)
         data = self._get_data_or_bkg(idval, bkg_id)
 
+        if data.size is None:
+            raise DataErr("sizenotset", idval)
+
         if isinstance(data, DataPHA):
-            # Returning the grid that this model represents is not as easy
-            # as it should be, since there is no obvious API.
+            # Returning the grid that this model represents is not as
+            # easy as it should be, since there is no obvious API.
             #
             bins = sherpa.astro.plot.calc_x(data)
         else:
             bins = data.get_indep(filter=True)
 
-        # Safety check, to ensure we have data. This could be done
-        # by checking whether data.size is None but it is easier
-        # for type checkers if the return value is checked.
+        # There should be a better way to get at this data. This only
+        # works because for now there is no data class with a mix of
+        # integrated and point axes.
         #
-        if bins[0] is None:
-            raise DataErr("sizenotset", idval)
+        axis = []
+        nbins = len(bins)
+        if nbins == data.ndim:
+            for i in range(data.ndim):
+                axis.append(PointAxis(bins[i]))
+
+        elif nbins == 2 * data.ndim:
+            for i in range(data.ndim):
+                axis.append(IntegratedAxis(bins[2 * i],
+                                           bins[2 * i + 1]))
+
+        else:
+            # This is an internal error
+            raise DataErr("incorrect number of axes")
 
         if bkg_id is None:
             model = self.get_model(idval)
@@ -15879,7 +15895,7 @@ class Session(sherpa.ui.utils.Session):
         #
         mvals = data.eval_model_to_fit(model)
 
-        return bins, mvals
+        return tuple(axis), mvals
 
     # This could also be done in the sherpa.ui version but for now
     # leave here.
@@ -15935,8 +15951,8 @@ class Session(sherpa.ui.utils.Session):
         >>> pl.gamma = 1.7
         >>> pl.ampl = 2e-4
         >>> xvals, yvals = calc_source()
-        >>> xlo = xvals[0]
-        >>> xhi = xvals[1]
+        >>> xlo = xvals[0].lo
+        >>> xhi = xvals[0].hi
 
         The results can be compared to the output of plot_source to
         show agreement:
@@ -15944,7 +15960,7 @@ class Session(sherpa.ui.utils.Session):
         >>> set_analysis("energy", type="rate", factor=0)
         >>> plot_source()
         >>> xvals, yvals = calc_source()
-        >>> elo, ehi = xvals
+        >>> elo, ehi = xvals[0].lo, xvals[0].hi
         >>> plt.plot((elo + ehi) / 2, yvals / (ehi - elo))
 
         Changing the analysis setting changes the x values, as xvals2
@@ -15963,7 +15979,7 @@ class Session(sherpa.ui.utils.Session):
         >>> gline.fwhm = 3
         >>> gline.ampl = 12
         >>> xvals, yvals = calc_source(2)
-        >>> x = xvals[0]
+        >>> x = xvals[0].x
         >>> x
         array([1, 4, 7])
         >>> yvals
@@ -15974,20 +15990,35 @@ class Session(sherpa.ui.utils.Session):
         idval = self._fix_id(id)
         data = self._get_data_or_bkg(idval, bkg_id)
 
+        if data.size is None:
+            raise DataErr("sizenotset", idval)
+
         if isinstance(data, DataPHA):
-            # Returning the grid that this model represents is not as easy
-            # as it should be, since there is no obvious API.
+            # Returning the grid that this model represents is not as
+            # easy as it should be, since there is no obvious API.
             #
             bins = data._get_indep(filter=False)
         else:
             bins = data.get_indep(filter=False)
 
-        # Safety check, to ensure we have data. This could be done
-        # by checking whether data.size is None but it is easier
-        # for type checkers if the return value is checked.
+        # There should be a better way to get at this data. This only
+        # works because for now there is no data class with a mix of
+        # integrated and point axes.
         #
-        if bins[0] is None:
-            raise DataErr("sizenotset", idval)
+        axis = []
+        nbins = len(bins)
+        if nbins == data.ndim:
+            for i in range(data.ndim):
+                axis.append(PointAxis(bins[i]))
+
+        elif nbins == 2 * data.ndim:
+            for i in range(data.ndim):
+                axis.append(IntegratedAxis(bins[2 * i],
+                                           bins[2 * i + 1]))
+
+        else:
+            # This is an internal error
+            raise DataErr("incorrect number of axes")
 
         if bkg_id is None:
             model = self.get_source(idval)
@@ -15999,7 +16030,7 @@ class Session(sherpa.ui.utils.Session):
         #
         mvals = model(*bins)
 
-        return bins, mvals
+        return tuple(axis), mvals
 
     # DOC-TODO: better comparison of calc_source_sum and calc_model_sum
     # needed (e.g. integration or results in PHA case?)


### PR DESCRIPTION
This is an experiment to see whether we should use the `Axis` class in more user-facing situations.

# Summary

The calc_source and calc_model functions now return the independent axis as Axis objects rather than plain ndarrays.

# Details

In #2121 we added `calc_source` and `calc_model` commands to the astro UI layer to make it easier to get the "actual" values for a model/source, rather than have to dreconstruct them from `get_model_plot()` [not quite `get_fit_plot().modelplot` as that is grouped and we don't support that here yet].

One question I has was whether we should use an internal class  (`sherpa.models.regrid.Axis`) for returning the X / independent axis, rather than just a tuple of numpy arrays. Well, this PR asks the question of whether it's worth it.

I like it, since to me it's more obvious, but I can imagine that actually using this would be annoying (since generally you know if you are getting a single value or a pair).