### PR TITLE
Tests: tweak tolerances for macOS ARM

### DIFF
--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -206,7 +206,7 @@ def test_sourceandbg(parallel, run_thread, fix_xspec):
         assert fit_results.numpoints == 1330
         assert fit_results.dof == 1325
 
-        assert covarerr[0] == approx(0.012097, rel=1.05e-3)
+        assert covarerr[0] == approx(0.012097, rel=1.07e-3)
         assert covarerr[1] == approx(0, rel=1e-3)
         assert covarerr[2] == approx(0.000280678, rel=1e-3)
         assert covarerr[3] == approx(0.00990783, rel=1e-3)

--- a/sherpa/astro/ui/tests/test_astro_ui_io.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_io.py
@@ -170,11 +170,11 @@ def check_fit_stats():
     # the relaxed tolerances.
     #
     assert pl.gamma.val == pytest.approx(1.6870563856336693,
-                                         rel=1.02e-5)
+                                         rel=3.5e-5)
     assert pl.ampl.val == pytest.approx(3.831373278007354e-05,
-                                        rel=2e-5)
+                                        rel=6.5e-5)
     assert gal.nH.val == pytest.approx(0.24914805790330877,
-                                       rel=3e-5)
+                                       rel=1.1e-4)
     assert ui.calc_stat() == pytest.approx(41.454087606314054,
                                            rel=1e-5)
 

--- a/sherpa/stats/tests/test_stats.py
+++ b/sherpa/stats/tests/test_stats.py
@@ -432,7 +432,11 @@ def test_chi2gehrels_stat(hide_logging, reset_xspec, setup_group):
             )
     }
 
-    compare_results(_fit_chi2gehrels_results_bench, results, tol=1e-5)
+    # The tolerance used to be 1e-5 but for macOS ARM it has jumped to
+    # 8e-5. Should the test values be re-evaluated for our supported
+    # platforms?
+    #
+    compare_results(_fit_chi2gehrels_results_bench, results, tol=8e-5)
 
 
 @requires_fits
@@ -667,8 +671,12 @@ def test_simul_stat_fit(stat, hide_logging, reset_xspec, setup_two):
         )
     }
 
+    # The tolerance used to be 1e-6 but for macOS ARM it has jumped to
+    # 2.1e-4. Should the test values be re-evaluated for our supported
+    # platforms?
+    #
     compare_results(_fit_simul_datavarstat_results_bench,
-                    result)
+                    result, tol=2.1e-4)
 
 
 @requires_data


### PR DESCRIPTION
Should these tests be re-evaluated for all platforms (e.g. maybe the best-fit location has changed enough it's worth changing the test values)?

Does this fix #2134 ?