### PR TITLE
UI: add documentation for table to show_xsabund

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -384,7 +384,17 @@ def test_show_xsabund(clean_astro_ui, caplog):
     #      Fe: ...
     #
     assert txt[0] == "Solar Abundance Table:"
-    assert txt[1] == table
+
+    # Assume all table names are 4 characters wide; do not bother
+    # trying to catch all cases.
+    #
+    if table == "angr":
+        assert txt[1] == "angr  Anders E. & Grevesse N. Geochimica et Cosmochimica Acta 53, 197 (1989)"
+    elif table == "grsa":
+        assert txt[1] == "grsa  Grevesse, N. & Sauval, A. J. Space Science Reviews 85, 161 (1998)"
+    else:
+        assert txt[1].startswith(f"{table}  ")
+
     assert txt[2].startswith("  H : 1.000e+00  He: ")
     assert txt[3].startswith("  C : ")
     assert txt[4].startswith("  Na: ")

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -16617,7 +16617,7 @@ class Session(sherpa.ui.utils.Session):
 
         >>> show_xsabund()
         Solar Abundance Table:
-        angr
+        angr  Anders E. & Grevesse N. Geochimica et Cosmochimica Acta 53, 197 (1989)
           H : 1.000e+00  He: 9.770e-02  Li: 1.450e-11  Be: 1.410e-11  B : 3.980e-10
           C : 3.630e-04  N : 1.120e-04  O : 8.510e-04  F : 3.630e-08  Ne: 1.230e-04
           Na: 2.140e-06  Mg: 3.800e-05  Al: 2.950e-06  Si: 3.550e-05  P : 2.820e-07
@@ -16646,7 +16646,7 @@ class Session(sherpa.ui.utils.Session):
         # This can be added but needs changes to the _xspec module.
         #
         lines = ["Solar Abundance Table:",
-                 f"{xspec.get_xsabund():4s}",
+                 f"{xspec.get_xsabund():4s}  {xspec.get_xsabund_doc()}",
                  ""]
 
         # Rely on get_xsbundances to be in order of atomic number.

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -246,8 +246,7 @@ def get_xsabund_doc(name: Optional[str] = None) -> str:
 
     aname = get_xsabund() if name is None else name
 
-    # Looks the return value includes a leading space so remove it.
-    # This could be done in the C++ code but much easier to do here.
+    # Remove any unwanted space characters.
     #
     return _xspec.get_xsabund_doc(aname).strip()
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -232,6 +232,10 @@ def get_xsabund_doc(name: Optional[str] = None) -> str:
     doc : str
         The documentation for the table
 
+    See Also
+    --------
+    get_xsabund
+
     Examples
     --------
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -219,6 +219,35 @@ def get_xsabundances() -> dict[str, float]:
             for name in get_xselements().keys()}
 
 
+def get_xsabund_doc(name: Optional[str] = None) -> str:
+    """Return the documentation for the abundance table.
+
+    Parameters
+    ----------
+    name : str or None, optional
+        If not set, use the current abundance table
+
+    Returns
+    -------
+    doc : str
+        The documentation for the table
+
+    Examples
+    --------
+
+    >>> get_xsabund_doc("angr")
+    'Anders E. & Grevesse N. Geochimica et Cosmochimica Acta 53, 197 (1989)'
+
+    """
+
+    aname = get_xsabund() if name is None else name
+
+    # Looks the return value includes a leading space so remove it.
+    # This could be done in the C++ code but much easier to do here.
+    #
+    return _xspec.get_xsabund_doc(aname).strip()
+
+
 # The current interface to the XSPEC model library makes this awkward
 # to write. Once the interface switches to using the FunctionUtility
 # interface this code will be a lot simpler internally, without

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -158,6 +158,22 @@ static PyObject* get_abund( PyObject *self, PyObject *args )
 }
 
 
+// Return the "nice" name for an abundance table - e.g.
+// "Anders E. & Grevesse N. Geochimica et Cosmochimica Acta 53, 197 (1989)"
+// for "angr".
+//
+static PyObject* get_abund_doc( PyObject *self, PyObject *args )
+{
+  char *name = NULL;
+  if ( !PyArg_ParseTuple( args, (char*)"s", &name ) )
+    return NULL;
+
+  std::string doc = FunctionUtility::abundDoc(std::string(name));
+
+  return Py_BuildValue( (char*)"s", doc.c_str() );
+}
+
+
 static PyObject* get_cosmo( PyObject *self )
 {
   // Assume these can not throw errors
@@ -370,6 +386,7 @@ static PyMethodDef XSpecMethods[] = {
   NOARGSPEC(get_xschatter, get_chatter),
   FCTSPEC(set_xschatter, set_chatter),
   FCTSPEC(get_xsabund, get_abund),
+  FCTSPEC(get_xsabund_doc, get_abund_doc),
   FCTSPEC(set_xsabund, set_abund),
   FCTSPEC(set_xscosmo, set_cosmo),
   NOARGSPEC(get_xscosmo, get_cosmo),

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -133,6 +133,39 @@ def test_expected_elements():
 
 
 @requires_xspec
+def test_abund_angr_doc():
+    """Check the doc string for angr.
+
+    This is assumed to be constant.
+    """
+
+    from sherpa.astro import xspec
+
+    doc = xspec.get_xsabund_doc("angr")
+    assert doc == "Anders E. & Grevesse N. Geochimica et Cosmochimica Acta 53, 197 (1989)"
+
+
+@requires_xspec
+def test_abund_selected_doc():
+    """Check the doc string for the selected table.
+
+    This is assumed to be constant.
+    """
+
+    from sherpa.astro import xspec
+
+    oval = xspec.get_xsabund()
+    try:
+        xspec.set_xsabund("lodd")
+        doc = xspec.get_xsabund_doc()
+
+    finally:
+        xspec.set_xsabund(oval)
+
+    assert doc == "Lodders, K. ApJ 591, 1220 (2003)"
+
+
+@requires_xspec
 def test_abund_default():
     """Check the expected default setting for the abundance.
 


### PR DESCRIPTION
# Summary

The show_xsabund command now includes a description of the abundance table.

# Details

Closer match to the XSPEC "show abund" command as we now include the "documentation" for the table as well as the table name.

This required providing access to the C++ FunctionUtility::abundDoc routine - fortunately it's easy to wrap and we can do most of the logic in the Python wrapper.

This has been taken from #1615

# Example

```
>>> from sherpa.astro import ui
>>> ui.show_xsabund()
Solar Abundance Table:
angr  Anders E. & Grevesse N. Geochimica et Cosmochimica Acta 53, 197 (1989)
  H : 1.000e+00  He: 9.770e-02  Li: 1.450e-11  Be: 1.410e-11  B : 3.980e-10
  C : 3.630e-04  N : 1.120e-04  O : 8.510e-04  F : 3.630e-08  Ne: 1.230e-04
  Na: 2.140e-06  Mg: 3.800e-05  Al: 2.950e-06  Si: 3.550e-05  P : 2.820e-07
  S : 1.620e-05  Cl: 3.160e-07  Ar: 3.630e-06  K : 1.320e-07  Ca: 2.290e-06
  Sc: 1.260e-09  Ti: 9.770e-08  V : 1.000e-08  Cr: 4.680e-07  Mn: 2.450e-07
  Fe: 4.680e-05  Co: 8.320e-08  Ni: 1.780e-06  Cu: 1.620e-08  Zn: 3.980e-08
```

Without this PR the second line would read:

```
angr
```

If you really want to get the description you have to import `sherpa.astro.xspec`:

```
>>> from sherpa.astro import xspec
>>> xspec.get_xsabund()
'angr'
>>> xspec.get_xsabund_doc()
'Anders E. & Grevesse N. Geochimica et Cosmochimica Acta 53, 197 (1989)'
>>> xspec.get_xsabund_doc("lodd")
'Lodders, K. ApJ 591, 1220 (2003)'
```