### PR TITLE
Update LaTeX labels and docs for bokeh

### DIFF
--- a/docs/plots/backends.rst
+++ b/docs/plots/backends.rst
@@ -36,12 +36,14 @@ on disk of that module::
 
    >>> from sherpa import plot
    >>> print(plot.backend.name)
+   pylab
 
 .. warning::
     Of course, you could be tempted to write::
 
       >>> from sherpa.plot import backend
       >>> print(backend.name)
+      pylab
 
     However, ``backend`` is now a reference to the backend that
     was active when the import was done. If the backend is changed
@@ -73,7 +75,7 @@ provides the same interface)::
 Sherpa also provides a context manager to change the backend for just one plot::
 
   >>> from sherpa.plot import TemporaryPlottingBackend
-  >>> with TemporarypPlottingBackend('pylab'):
+  >>> with TemporaryPlottingBackend('pylab'):
   ...     x = [1,2,3,4]
   ...     # do some plotting with x
 
@@ -81,10 +83,12 @@ The list of available plotting backend names and the classes that implement them
 
   >>> from sherpa.plot.backends import PLOT_BACKENDS
   >>> print(PLOT_BACKENDS.keys())
+  dict_keys(['BaseBackend', 'BasicBackend', 'IndepOnlyBackend', 'pylab', 'PylabErrorArea', 'BokehBackend'])
 
 Which backends are available depends on which packages are installed in your Python
 environment, e.g. the ``"pylab"`` backend requires :term:`matplotlib`.
 
+.. _backend-independent-plotting-options:
 
 Backend-independent plotting options
 ====================================
@@ -183,7 +187,7 @@ will pass them through to the plotting backend:
   >>> d = Data1D('example data', [1, 2, 3], [3, 2, 5])
   >>> dplot = DataPlot()
   >>> dplot.prepare(d)
-  >>> dplot.plot(url='https://www.example.com')
+  >>> dplot.plot(marker='*')
 
 Since Sherpa does not process those options itself, but just passes them on to
 the underlying backend module, they are not documented here - see the
@@ -293,8 +297,8 @@ Interaction with interactive plots in the UI
 Each backend also acts as a context manager: All plotting commands
 in the UI are wrapped in a ``with`` statement like this::
 
-    >>> with sherpa.backend():
-    ...     plotobj.plot()
+    >>> with sherpa.plot.backend():  # doctest: +SKIP
+    ...     plotobj.plot()  # doctest: +SKIP
 
 That allows the backend to execute any finishing code after the plots are done,
 e.g. to save the plot to disk or to display it in a window.

--- a/docs/plots/bokeh_backend.rst
+++ b/docs/plots/bokeh_backend.rst
@@ -68,17 +68,33 @@ The same is true for the UI interface::
     >>> from sherpa.astro import ui
     >>> from sherpa import plot
     >>> from sherpa.astro.data import DataPHA
-    >>> session = Session()
     >>> ui.load_arrays(1, [1, 2, 3], [1, 2, 3], DataPHA)
     >>> ui.plot_data()
     >>> show(plot.backend.current_fig)
     >>> # or
-    >>> save(plot.backend.current_fig, filename='plot.html')
+    >>> save(plot.backend.current_fig, filename='plot.html')  # doctest: +SKIP
 
 Suggestions on how to integrate that better into the Sherpa UI are welcome.
 
 
+Differences to matplotlib
+-------------------------
+The :term:`bokeh` backend is intrinsically different from the :term:`matplotlib` backend,
+but Sherpa will automatically translate some settings.
+For example, if the color `'k'` (black) is passed into a sherpa plotting routine, it
+will be internally translated to bokeh's representation of black (`'black'`).
+However, this is limited to a subset of the available options that are commonly
+used, see :ref:`backend-independent-plotting-options`.
+A user can pass a additional backend specific options to the plotting
+routines, such as `marker="*"` in matplotlib. This will cause an error in
+bokeh, as bokeh does not have a `"*"` marker; a similar look can be achieved
+with `marker="star"`.
 
+Similarly, in bokeh, text for labels can be formatted with LaTeX by
+enclosing it in `'$$'` (e.g. `label=r"$$\alpha$$"`), while in matplotlib
+it is done with `label=r"$\alpha$"`. All labels that sherpa itself sets will be set
+correctly, but if a user wants to manually set a label, they need adjust it
+for the backend that is currently active.
 
 Limitations
 -----------

--- a/docs/plots/bokeh_backend.rst
+++ b/docs/plots/bokeh_backend.rst
@@ -85,7 +85,7 @@ For example, if the color `'k'` (black) is passed into a sherpa plotting routine
 will be internally translated to bokeh's representation of black (`'black'`).
 However, this is limited to a subset of the available options that are commonly
 used, see :ref:`backend-independent-plotting-options`.
-A user can pass a additional backend specific options to the plotting
+A user can pass additional backend specific options to the plotting
 routines, such as `marker="*"` in matplotlib. This will cause an error in
 bokeh, as bokeh does not have a `"*"` marker; a similar look can be achieved
 with `marker="star"`.

--- a/docs/plots/index.rst
+++ b/docs/plots/index.rst
@@ -145,7 +145,7 @@ classes:
    >>> mdl.pars[2].val = 22
    >>> mdl.pars[3].val = 10
    >>> print(mdl)
-   (base - line)
+   base - line
       Param        Type          Value          Min          Max      Units
       -----        ----          -----          ---          ---      -----
       base.c0      thawed           10 -3.40282e+38  3.40282e+38
@@ -223,7 +223,7 @@ the plot object, for the DataPlot it is
    :include-source:
 
     >>> print(dplot.plot_prefs)
-    {'xerrorbars': False, 'yerrorbars': True, 'ecolor': None, 'capsize': None, 'barsabove': False, 'xlog': False, 'ylog': False, 'linestyle': 'None', 'linecolor': None, 'color': None, 'marker': '.', 'markerfacecolor': None, 'markersize': None}
+    {'xlog': False, 'ylog': False, 'label': None, 'xerrorbars': False, 'yerrorbars': True, 'color': None, 'linestyle': 'None', 'linewidth': None, 'marker': '.', 'alpha': None, 'markerfacecolor': None, 'markersize': None, 'ecolor': None, 'capsize': None}
 
 Here we set the y scale of the data plot to be drawn with a log
 scale - by changing the preference setting - and then override
@@ -271,7 +271,7 @@ accepts plot objects rather than data and model objects.
    >>> from sherpa.stats import Cash
    >>> from sherpa.fit import Fit
    >>> f = Fit(d, mdl, stat=Cash(), method=NelderMead())
-   >>> f.fit()
+   >>> fit_res = f.fit()
 
 The model plot needs to be updated to reflect the new parameter values
 before we can replot the fit:
@@ -279,7 +279,7 @@ before we can replot the fit:
 .. plot::
    :context:
    :include-source:
-   
+
    >>> mplot.prepare(d, mdl)
    >>> fplot.plot()
 
@@ -300,12 +300,7 @@ line position (which corresponds to `mdl.pars[2]`):
     >>> from sherpa.plot import IntervalProjection
     >>> iproj = IntervalProjection()
     >>> iproj.calc(f, mdl.pars[2])
-    WARNING: hard minimum hit for parameter base.c0
-    WARNING: hard maximum hit for parameter base.c0
-    WARNING: hard minimum hit for parameter line.fwhm
-    WARNING: hard maximum hit for parameter line.fwhm
-    WARNING: hard minimum hit for parameter line.ampl
-    WARNING: hard maximum hit for parameter line.ampl
+    ...
     >>> iproj.plot()
 
 More plot customization

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,7 +32,7 @@ doctest_norecursedirs =
     docs/models
     docs/optimisers
     docs/overview
-    docs/plots
+    #docs/plots
     docs/statistics
     docs/ui
     sherpa/__init__.py

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -97,6 +97,19 @@ MODEL_NORM = 1.02e2
 BGND_NORM = 0.4
 
 
+def normalize_latex(s):
+    r'''Bokeh and matplotlib use different markup for LaTeX
+
+    This function brings that into the same form, so that it is easier
+    to run tests.
+
+    In matplotlib, the markup is `$...$`, while bokeh allows
+    `$$...$$`, `\[...\]`, and `\(...\)`. Only the first of those forms
+    is used in Sherpa, so we only deal with that.
+    '''
+    return s.replace('$$', '$')
+
+
 def example_pha_data():
     """Create an example data set."""
 
@@ -778,8 +791,8 @@ def test_get_source_plot_energy(idval, clean_astro_ui):
     assert sp.title == 'Source Model of example'
     assert sp.xlabel == 'Energy (keV)'
 
-    # y label depends on the backend
-    # assert sp.ylabel == 'f(E)  Photons/sec/cm$^2$/keV'
+    #y label depends on the backend
+    assert normalize_latex(sp.ylabel) == 'f(E)  Photons/sec/cm$^2$/keV'
 
 
 @pytest.mark.parametrize("idval", [None, 1, "one", 23])
@@ -1154,8 +1167,8 @@ def check_bkg_chisqr(plotfunc, idval, isfit=True):
     # once we have multiple backends.
     #
     assert plot.xlabel == 'Channel'
-    assert plot.ylabel == '$\\chi^2$'
-    assert plot.title == '$\\chi^2$ for example-bkg'
+    assert normalize_latex(plot.ylabel) == '$\\chi^2$'
+    assert normalize_latex(plot.title) == '$\\chi^2$ for example-bkg'
 
     assert np.all(plot.y >= 0)
 
@@ -1223,7 +1236,7 @@ def check_bkg_source(plotfunc, idval, isfit=True):
     # once we have multiple backends.
     #
     assert plot.xlabel == 'Energy (keV)'
-    assert plot.ylabel == 'f(E)  Photons/sec/cm$^2$/keV'
+    assert normalize_latex(plot.ylabel) == 'f(E)  Photons/sec/cm$^2$/keV'
     assert plot.title == 'Source Model of example-bkg'
 
     assert np.all(plot.y >= 0)

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -790,8 +790,6 @@ def test_get_source_plot_energy(idval, clean_astro_ui):
 
     assert sp.title == 'Source Model of example'
     assert sp.xlabel == 'Energy (keV)'
-
-    #y label depends on the backend
     assert normalize_latex(sp.ylabel) == 'f(E)  Photons/sec/cm$^2$/keV'
 
 

--- a/sherpa/plot/bokeh_backend.py
+++ b/sherpa/plot/bokeh_backend.py
@@ -90,7 +90,7 @@ class BokehBackend(BasicBackend):
     "current plot" or "current figure". This fits in very well with the `matplotlib.pyplot`
     model, but requires some extra work for object-oriented plotting packages.
 
-    term:`bokeh` is such an object-oriented package, which, by itself,
+    :term:`bokeh` is such an object-oriented package, which, by itself,
     does not keep a plotting state. Usually, bokeh commands act
     on an axis object that is passed in as a parameter.
     Sherpa, on the other hand, does not keep track of those objects,
@@ -98,8 +98,8 @@ class BokehBackend(BasicBackend):
 
     We solve this problem with attributes in the BokehBackend class:
 
-    - current_fig: the current figure
-    - current_axis: the current axis. This is a reference to one of the
+    - `current_fig`: the current figure
+    - `current_axis`: the current axis. This is a reference to one of the
       panels in the current figure.
 
     We follow a similar approach to default to cycling through colors
@@ -196,6 +196,24 @@ class BokehBackend(BasicBackend):
     def __exit__(self, exec_type, value, traceback):
         '''Called from the UI after an interactive plot is done.'''
         return False
+
+    def get_latex_for_string(self, txt):
+        """Convert LaTeX formula
+
+        Parameters
+        ----------
+        txt : str
+            The text component in LaTeX form (e.g. r'\alpha^2'). It
+            should not contain any non-LaTeX content.
+
+        Returns
+        -------
+        latex : str
+            The text modified as appropriate for a backend so that the LaTeX
+            will be displayed properly.
+
+        """
+        return f"$${txt}$$"
 
     def _figure(self):
         fig = figure()


### PR DESCRIPTION
## Summary
Correctly render LaTeX labels in bokeh

## Details
Previously, bokeh could only set an entire string in LaTeX, but now it can also do that for substrings in a label, so update code and docs for that.

The main motivation is to improve the docs for bokeh with instructions on LaTeX labels (which are common in astronomy), but take the opportunity to make the plots docs past doctests.