### PR TITLE
Bad

### DIFF
--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -3024,7 +3024,7 @@ def test_pha_mask_size_must_match_ungrouped():
     assert not data.grouped
 
     with pytest.raises(DataErr,
-                       match="size mismatch between independent axis and mask: 8 vs 3"):
+                       match="size mismatch between data and mask: 8 vs 3"):
         data.mask = [1, 0, 1]
 
 

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -3220,6 +3220,10 @@ def setup_pha_quality_example():
     # "severity" of the quality setting.
     #
     pha.set_analysis("energy")
+
+    # For some reason this has not actually been grouped
+    assert not pha.grouped
+
     return pha, elo, ehi
 
 
@@ -3347,6 +3351,8 @@ def test_pha_eval_model_to_fit_grouped_quality():
     # change the result.
     #
     pha.ignore(0.6, 0.8)
+
+    assert not pha.grouped
 
     m1 = pha.eval_model(full_mdl)
     m2 = pha.eval_model_to_fit(full_mdl)

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1711,7 +1711,7 @@ def test_pha_quality_all_bad_basic_checks():
     assert pha.get_filter() == ""
     assert pha.get_x() == pytest.approx([1, 2, 3, 4])
     assert pha.apply_filter(fvals) == pytest.approx([])
-    assert pha.apply_grouping(fvals) == pytest.approx(fvals)
+    assert pha.apply_grouping(fvals) == pytest.approx([])
 
 
 @pytest.mark.parametrize("qual,fexpr,mask,counts",
@@ -1740,7 +1740,7 @@ def test_pha_quality_change_mask(make_quality_pha):
 
     pha = make_quality_pha
     pha.ignore_bad()
-    assert pha.mask is True
+    assert pha.mask == pytest.approx([True] * 3)
     pha.mask = [1, 1, 0]
     assert pha.mask == pytest.approx([True, True, False])
 
@@ -3088,8 +3088,7 @@ def test_quality_pha_get_indep(make_quality_pha):
 def test_grouped_pha_mask(make_grouped_pha):
     """What is the default mask setting?"""
     pha = make_grouped_pha
-    assert np.isscalar(pha.mask)
-    assert pha.mask is True
+    assert pha.mask == pytest.approx([True, True])
 
 
 def test_grouped_pha_get_mask(make_grouped_pha):

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -2008,13 +2008,12 @@ def test_pha_quality_ignore_bad_clear_filter(make_quality_pha):
     assert pha.get_mask() == pytest.approx([False] * 2 + [True] * 2)
     assert pha.quality_filter == pytest.approx(qflags)
 
-    # This removes the quality filter!
     pha.notice()
 
     assert pha.get_filter() == "1:9"
     assert pha.mask is True
-    assert pha.get_mask() == pytest.approx([True] * 9)
-    assert pha.quality_filter is None
+    assert pha.get_mask() == pytest.approx(qflags)
+    assert pha.quality_filter == pytest.approx(qflags)
 
 
 def test_pha_grouping_changed_no_filter_1160(make_test_pha):
@@ -2455,9 +2454,8 @@ def test_pha_change_quality_values(caplog):
 
     assert pha.quality == pytest.approx([0, 0, 0, 2, 2, 0, 0])
 
-    # Should quality filter be reset?
-    assert pha.quality_filter == pytest.approx([True] * 5 + [False] * 2)
-    assert pha.get_dep(filter=True) == pytest.approx([4, 2])
+    assert pha.quality_filter == pytest.approx([True] * 3 + [False] * 2 + [True] * 2)
+    assert pha.get_dep(filter=True) == pytest.approx([4, 2, 1])
     assert pha.get_filter() == '1:7'
 
 
@@ -2547,22 +2545,21 @@ def test_pha_group_ignore_bad_then_group(caplog):
     pha.group_counts(4)
     assert len(caplog.records) == 0
 
+    qual_mask = [True] + [False] + [True] * 5
+
     assert pha.mask is True
     assert pha.get_mask() == pytest.approx(qual_mask)
     assert pha.get_filter() == '1:7'
     assert pha.quality_filter == pytest.approx(qual_mask)
     assert pha.quality == pytest.approx([0, 2, 0, 0, 0, 0, 0])
     assert pha.get_dep(filter=False) == pytest.approx(counts)
-    assert pha.get_dep(filter=True) == pytest.approx([4, 2, 6, 6])
+    assert pha.get_dep(filter=True) == pytest.approx([4, 3, 6, 6, 7])
 
-    # Shouldn't this be a no-op. It isn't because the group call
-    # didn't change the quality_filter array, so it now changes what
-    # are the good/bad channels.
+    # This is a no-op call.
     #
     pha.ignore_bad()
     assert len(caplog.records) == 0
 
-    qual_mask = [True] + [False] + [True] * 5
     assert pha.mask is True
     assert pha.get_mask() == pytest.approx(qual_mask)
     assert pha.get_filter() == '1:7'

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -218,7 +218,7 @@ def test_set_filter_mismatch(f, bid, clean_astro_ui):
     bkg = ui.DataPHA("bkg", np.asarray([1, 2, 3]), [1, 1, 0])
     ui.set_bkg(bkg)
     with pytest.raises(DataErr,
-                       match="size mismatch between independent axis and mask: 3 vs 2"):
+                       match="size mismatch between data and mask: 3 vs 2"):
         ui.set_filter(f, bkg_id=bid)
 
 

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -3383,8 +3383,8 @@ def test_pha_group_ignore_bad_group(caplog, clean_astro_ui):
     ui.group_counts(3)
     assert len(caplog.records) == 4
 
-    assert ui.get_dep(filter=False) == pytest.approx([5, 2, 4])
-    assert ui.get_dep(filter=True) == pytest.approx([5, 2, 4])
+    assert ui.get_dep(filter=False) == pytest.approx([5, 3, 4, 55])
+    assert ui.get_dep(filter=True) == pytest.approx([5, 3, 4, 55])
 
     r = caplog.records[3]
     assert r.name == "sherpa.ui.utils"
@@ -3417,8 +3417,8 @@ def test_pha_group_filter_ignore_bad_group(caplog, clean_astro_ui):
     ui.notice()
     assert len(caplog.records) == 5
 
-    assert ui.get_dep(filter=False) == pytest.approx([3.5, 3, 4, 55])
-    assert ui.get_dep(filter=True) == pytest.approx([3.5, 3, 4, 55])
+    assert ui.get_dep(filter=False) == pytest.approx([3.5, 4])
+    assert ui.get_dep(filter=True) == pytest.approx([3.5, 4])
 
     r = caplog.records[4]
     assert r.name == "sherpa.ui.utils"

--- a/sherpa/astro/ui/tests/test_filtering.py
+++ b/sherpa/astro/ui/tests/test_filtering.py
@@ -99,9 +99,12 @@ def test_filter_basic(make_data_path):
     s2 = ui.calc_stat()
     assert s2 == pytest.approx(stats['bad'])
 
+    # Prior to 4.17.0 this removed the quality filter
     ui.notice(None, None)
+
     s3 = ui.calc_stat()
-    assert s3 == pytest.approx(stats['all'])
+    # assert s3 == pytest.approx(stats['all'])
+    assert s3 == pytest.approx(stats['bad'])
 
     ui.notice(0.5, 8.0)
     s4 = ui.calc_stat()
@@ -204,10 +207,10 @@ def test_filter_bad_ungrouped(make_data_path, clean_astro_ui, caplog):
     clc_filter(caplog, "dataset 1: 0.0073:14.9504 -> 0.0073:14.5416 Energy (keV)")
 
     assert ui.get_dep().shape == (1024, )
-    assert pha.quality_filter is None
 
     expected = np.ones(1024, dtype=bool)
     expected[996:1025] = False
+    assert pha.quality_filter == pytest.approx(expected)
     assert pha.mask == pytest.approx(expected)
 
     # At this point we've changed the mask array so Sherpa thinks

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -449,6 +449,8 @@ def _counts(data, lo, hi, func, *args):
     if data.ndim != 1:
         raise DataErr("wrongdim", data.name, 1)
 
+    # Should this routine drop or include "bad quality" values?
+    #
     lo, hi = bounds_check(lo, hi)
     old_mask = data.mask
     old_quality_filter = getattr(data, 'quality_filter', None)


### PR DESCRIPTION
# Summary

Nope. The more I look at this the more I just don't understand the original design ...

# Details

I've been rushing to get improvements for `ignore_bad` in, as I suddenly realised it could be done. Then it couldn't. Then it could. Then maybe.

So this is the minimal-usable-output of #2142 and attempts to better integrate the quality filtering in with the existing data, rather than just randomly  inserted into some of the code paths. Now, the two big issues with handling "quality-filtered" data are

1. do we treat this just as we do the existing `ignore/notice/mask` case, since no-matter how you do it you have the possibility of a mis-match between data and a filter
2. how do we differentiate the "definitely" bad versus "operationally" bad values (1/5 versus 2)

It really gets hard when we come to working with an interactive environment, since what happens if you do

    ignore_bad()

 which filters out bad data, and then

    group_counts(15) 

which hopefully makes use of the quality filter. Well, one of the results of the group_xxx calls is that they change the quality array (although to maybe the same values), and hence should we now be using the new quality filters or should it require the user to call `ignore_bad` explicitly. Either way is confusing...

There's also fun when filtered-out data lies within a valid group, or you try to filter out a set of channels that are marked as bad quality. Well, fun if you enjoy making no progress.

So, for now we are punting on most of these and just trying to make the existing code "work better".

It should not change any code that doesn't call `ignore_bad`. Anuy code that does use `ignore_bad` is likely to be very finickity so worth a re-look with this new code.

# Examples

Some fun stuff: in 4.16 we have

```
sherpa-4.16.0> load_arrays(1, [1, 2, 3], [2, 3, 0], DataPHA)

sherpa-4.16.0> set_quality([0, 0, 2])

sherpa-4.16.0> get_dep(filter=True)
array([2., 3., 0.])

sherpa-4.16.0> ignore_bad()
dataset 1: 1:3 -> 1:2 Channel

sherpa-4.16.0> get_dep(filter=True)
array([2., 3.])

sherpa-4.16.0> notice()
dataset 1: 1:2 -> 1:3 Channel

sherpa-4.16.0> get_dep(filter=True)
array([2., 3., 0.])
```

Note that the call `notice()` has removed the quality filter. I can understand it, but it's also very annoying for it to clear out the quality array. We should have a separate way to restore the "bad" filter. In this branch we get

```
TO BE CHECKED
```