### PR TITLE
Fix xspec missing doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,10 +113,7 @@ extern/region-*/src/reglexer.c.tmp
 # Sphinx documentation
 docs/_build
 docs/**/api
-docs/SherpaQuickStart.ipynb
-docs/NotebookSupport.ipynb
-docs/ExamplePlots.ipynb
-docs/ViewingPHAResponses.ipynb
+docs/*.ipynb
 
 #generated from python setup.py test
 .pytest_cache

--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -32,6 +32,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
       :toctree: api
 
       get_xsabund
+      get_xsabund_doc
       get_xsabundances
       get_xschatter
       get_xscosmo


### PR DESCRIPTION
# Summary

Add get_xsabund_doc to the list of functions in the documentation. There is no functional change.

# Details

Two changes

- add the symbol to the documentation
- clean up the .gitignore file
