### PR TITLE
updating Sherpa citations

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -5,7 +5,7 @@ release:
 
    >>> import sherpa
    >>> sherpa.citation()
-   >>> sherpa.citation('4.12.1')
+   >>> sherpa.citation('4.16.1')
 
 The output can be saved to a file by setting the filename argument.
 
@@ -19,6 +19,23 @@ provides advice on how to cite the correct version.
 If you want a general-purpose citation then please use either of the
 following, kindly provided by the SAO/NASA Astrophysics Data System
 service:
+
+@ARTICLE{2024arXiv240910400S,
+       author = {{Siemiginowska}, Aneta and {Burke}, Douglas and {G{\"u}nther}, Hans Moritz and {Lee}, Nicholas P. and {McLaughlin}, Warren and {Principe}, David A. and {Cheer}, Harlan and {Fruscione}, Antonella and {Laurino}, Omar and {McDowell}, Jonathan and {Terrell}, Marie},
+        title = "{Sherpa: An Open Source Python Fitting Package}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - High Energy Astrophysical Phenomena},
+         year = 2024,
+        month = sep,
+          eid = {arXiv:2409.10400},
+        pages = {arXiv:2409.10400},
+          doi = {10.48550/arXiv.2409.10400},
+archivePrefix = {arXiv},
+       eprint = {2409.10400},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240910400S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @INPROCEEDINGS{2001SPIE.4477...76F,
        author = {{Freeman}, Peter and {Doe}, Stephen and {Siemiginowska}, Aneta},

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -81,6 +81,27 @@ If you want a general-purpose citation then please use either of the
 following, kindly provided by the SAO/NASA Astrophysics Data System
 service:
 
+The most recent article will appear in the Astrophysical Journal Supplement Series and it is
+available on the archives:
+
+@ARTICLE{2024arXiv240910400S,
+       author = {{Siemiginowska}, Aneta and {Burke}, Douglas and {G{\"u}nther}, Hans Moritz and {Lee}, Nicholas P. and {McLaughlin}, Warren and {Principe}, David A. and {Cheer}, Harlan and {Fruscione}, Antonella and {Laurino}, Omar and {McDowell}, Jonathan and {Terrell}, Marie},
+        title = "{Sherpa: An Open Source Python Fitting Package}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - High Energy Astrophysical Phenomena},
+         year = 2024,
+        month = sep,
+          eid = {arXiv:2409.10400},
+        pages = {arXiv:2409.10400},
+          doi = {10.48550/arXiv.2409.10400},
+archivePrefix = {arXiv},
+       eprint = {2409.10400},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240910400S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
 @INPROCEEDINGS{2001SPIE.4477...76F,
        author = {{Freeman}, Peter and {Doe}, Stephen and {Siemiginowska}, Aneta},
         title = "{Sherpa: a mission-independent data analysis application}",

--- a/sherpa/tests/test_sherpa.py
+++ b/sherpa/tests/test_sherpa.py
@@ -78,7 +78,7 @@ def test_citation_hardcoded(tmp_path):
     assert cts[2] == 'Sherpa 4.8.0 was released on January 27, 2016.'
     assert cts[3] == ''
     assert cts[4] == '@software{sherpa_2016_45243,'
-    assert len(cts) == 65
+    assert len(cts) == 86
 
 
 @pytest.mark.zenodo


### PR DESCRIPTION
I added the citation to the most recent paper accepted and posted to astro-ph. I included the citation to astro-ph and plan to update when we have the paper published in ApJ Supp.

`sherpa.citation('latest')` now includes the following, after the Zenodo reference:

```
The most recent article to appear in the Astrophysical Journal Supplement Series:

@ARTICLE{2024arXiv240910400S,
       author = {{Siemiginowska}, Aneta and {Burke}, Douglas and {G{"u}nther}, Hans Moritz and {Lee}, Nicholas P. and {McLaughlin}, Warren and {Principe}, David A. and {Cheer}, Harlan and {Fruscione}, Antonella and {Laurino}, Omar and {McDowell}, Jonathan and {Terrell}, Marie},
        title = "{Sherpa: An Open Source Python Fitting Package}",
      journal = {arXiv e-prints},
     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - High Energy Astrophysical Phenomena},
         year = 2024,
        month = sep,
          eid = {arXiv:2409.10400},
        pages = {arXiv:2409.10400},
          doi = {10.48550/arXiv.2409.10400},
archivePrefix = {arXiv},
       eprint = {2409.10400},
 primaryClass = {astro-ph.IM},
       adsurl = {https://ui.adsabs.harvard.edu/abs/2024arXiv240910400S},
      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
}

```