### PR TITLE
Drop support for Python 3.9 and add 3.12

### DIFF
--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -70,7 +70,7 @@ jobs:
         image: ["redhat/ubi8"]
         conda-os: ["Linux-x86_64"]
         os-dir: ["linux-64"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - name: Install git and diff
@@ -128,7 +128,7 @@ jobs:
         os-type: ["macos-12"]
         conda-os: ["MacOSX-x86_64"]
         os-dir: ["osx-64"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     env:
       CONDA_BUILD_SYSROOT: /opt/MacOSX11.0.sdk
 
@@ -234,12 +234,6 @@ jobs:
       run: |
         source ${conda_loc}/etc/profile.d/conda.sh
         curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/main.zip 
-        echo "conda create -n test39 --yes -q -c file://$(pwd)/packages python=3.9 astropy sherpa matplotlib"
-        conda create -n test39 --yes -q -c file://$(pwd)/packages python=3.9 astropy sherpa matplotlib
-        conda activate test39
-        pip install main.zip
-        sherpa_smoke -f astropy
-        sherpa_test
         echo "conda create -n test310 --yes -q -c file://$(pwd)/packages python=3.10 astropy sherpa matplotlib"
         conda create -n test310 --yes -q -c file://$(pwd)/packages python=3.10 astropy sherpa matplotlib
         conda activate test310
@@ -249,6 +243,12 @@ jobs:
         echo "conda create -n test311 --yes -q -c file://$(pwd)/packages python=3.11 astropy sherpa matplotlib"
         conda create -n test311 --yes -q -c file://$(pwd)/packages python=3.11 astropy sherpa matplotlib
         conda activate test311
+        pip install main.zip
+        sherpa_smoke -f astropy
+        sherpa_test
+        echo "conda create -n test312 --yes -q -c file://$(pwd)/packages python=3.12 astropy sherpa matplotlib"
+        conda create -n test312 --yes -q -c file://$(pwd)/packages python=3.12 astropy sherpa matplotlib
+        conda activate test312
         pip install main.zip
         sherpa_smoke -f astropy
         sherpa_test

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -38,17 +38,17 @@ jobs:
             matplotlib-version: 3
             xspec-version: 12.14.0i
 
-          - name: Linux Minimum Setup (Python 3.9)
+          - name: Linux Minimum Setup (Python 3.10)
             os: ubuntu-latest
-            python-version: "3.9"
-            numpy-version: "1.21"
+            python-version: "3.10"
+            numpy-version: "1.24"
             install-type: develop
             test-data: none
 
           - name: Linux Minimum Setup (Python 3.11)
             os: ubuntu-latest
             python-version: "3.11"
-            numpy-version: "1.23"
+            numpy-version: "1.24"
             install-type: develop
             test-data: none
 

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -27,8 +27,8 @@ jobs:
         include:
           - name: Linux Minimum Setup
             os: ubuntu-latest
-            python-version: "3.9"
-            numpy-pkg: 'numpy>=1.21,<1.22'
+            python-version: "3.10"
+            numpy-pkg: 'numpy>=1.24,<1.25'
             install-type: develop
             test-data: none
 
@@ -44,7 +44,7 @@ jobs:
 
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
-            python-version: "3.9"
+            python-version: "3.11"
             numpy-pkg: 'numpy'
             install-type: install
             test-data: package

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,9 +96,9 @@ Example: new functionality, such as
 
 **Software versions**
 
-Development should use Python 3.9 or later.
+Development should use Python 3.10 or later.
 
-Ideally, NumPy support should be 1.21 or greater, but please include a comment
+Ideally, NumPy support should be 1.24 or greater, but please include a comment
 if you need to restrict (or relax) this further.
 
 Sherpa requires a C compiler, along with related tools, to build. Additional

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/sherpa/badge/)](https://sherpa.readthedocs.io/)
 [![DOI](https://zenodo.org/badge/683/sherpa/sherpa.svg)](https://zenodo.org/badge/latestdoi/683/sherpa/sherpa)
 [![GPLv3+ License](https://img.shields.io/badge/license-GPLv3+-blue.svg)](https://www.gnu.org/copyleft/gpl.html)
-![Python version](https://img.shields.io/badge/Python-3.9,3.10,3.11,3.12-green.svg?style=flat)
+![Python version](https://img.shields.io/badge/Python-3.10,3.11,3.12-green.svg?style=flat)
 
 <!-- TOC *generated with [DocToc](https://github.com/thlorenz/doctoc)* -->
 **Table of Contents**
@@ -71,7 +71,7 @@ documentation, and should be read if the following is not sufficient.
 It is strongly recommended that some form of *virtual environment* is
 used with Sherpa.
 
-Sherpa is tested against Python versions 3.9, 3.10, and 3.11.
+Sherpa is tested against Python versions 3.10 and 3.11 with experimental support for Python 3.12.
 
 The last version of Sherpa which supported Python 2.7 is
 [Sherpa 4.11.1](https://doi.org/10.5281/zenodo.3358134).
@@ -80,7 +80,7 @@ Using Conda
 --------------
 
 Sherpa is provided for both Linux and macOS operating systems running
-Python 3.9, 3.10, and 3.11. It can be installed with the `conda`
+Python 3.10, 3.11, and (experimental) 3.12. It can be installed with the `conda`
 package manager by saying
 
     $ conda install -c https://cxc.cfa.harvard.edu/conda/sherpa -c conda-forge sherpa

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ range of statistics and robust optimisers.
 Sherpa is released under the
 `GNU General Public License v3.0
 <https://github.com/sherpa/sherpa/blob/master/LICENSE>`_,
-and is compatible with Python versions 3.9 to 3.12.
+and is compatible with Python versions 3.10 to 3.12.
 Information on recent releases and citation information for
 Sherpa is available using the Digital Object Identifier (DOI)
 `10.5281/zenodo.593753 <https://doi.org/10.5281/zenodo.593753>`_.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,7 +33,7 @@ Requirements
 
 Sherpa has the following requirements:
 
-* Python 3.9 to 3.12
+* Python 3.10 to 3.12
 * NumPy (version 2.0 should work but there has been limited testing)
 * Linux or OS-X (patches to add Windows support are welcome)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
   "Programming Language :: C",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -31,7 +30,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics"
 ]
 
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 dependencies = [
   "numpy"
 ]

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ import sys
 # This is done before we load in any non-core modules to avoid people
 # installing software that they can not use.
 #
-if sys.version_info < (3, 9):
-    sys.stderr.write("Sherpa 4.15.1 (and later) requires Python 3.9 or later.\n\n")
-    sys.stderr.write("Please use Sherpa 4.15.0 if you need to use Python 3.8\n")
+if sys.version_info < (3, 10):
+    sys.stderr.write("Sherpa 4.17.0 (and later) requires Python 3.10 or later.\n\n")
+    sys.stderr.write("Please use Sherpa 4.16.1 if you need to use Python 3.9\n")
     sys.exit(1)
 
 # We need to import setuptools so that 'python setup.py develop'


### PR DESCRIPTION
Summary
========
Drop support for Python 3.9 and numpy < 1.24 and note Python 3.12 experimental support.

Details
======
This PR:
- Drops support for Python 3.9 and numpy < 1.24
- Adds Python 3.12 conda packages and notes that it is experimental
