### PR TITLE
Fixup test failures from #2118

### DIFF
--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1191,10 +1191,10 @@ def _create_table_hdu(hdu: TableBlock) -> fits.BinTableHDU:
             out.columns[col.name].unit = col.unit
 
         if col.minval is not None:
-            out.header.append((f"TLMIN{idx}", col.minval))
+            out.header[f"TLMIN{idx}"] = col.minval
 
         if col.maxval is not None:
-            out.header.append((f"TLMAX{idx}", col.maxval))
+            out.header[f"TLMAX{idx}"] = col.maxval
 
         if col.desc is None:
             continue

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -640,8 +640,13 @@ def check_write_pha_fits_with_extras_roundtrip_crates(path, etime, bscal):
     c0 = cr.get_column(0)
     assert c0.name == "CHANNEL"
     assert c0.values.dtype == np.int64
+
+    # The CHANNEL data range is 1-4 but the header contains
+    # DETCHANS=10, so the data does not really make sense. What should
+    # be written out?
+    #
     assert c0.get_tlmin() == 1
-    assert c0.get_tlmax() == 10
+    assert c0.get_tlmax() == 4
 
     c1 = cr.get_column(1)
     assert c1.name == "COUNTS"
@@ -758,8 +763,12 @@ def check_write_pha_fits_with_extras_roundtrip_pyfits(path, etime, bscal):
         for key in ["AREASCAL", "QUALITY", "GROUPING"]:
             assert key not in hdu.header
 
+        # The CHANNEL data range is 1-4 but the header contains
+        # DETCHANS=10, so the data does not really make sense. What
+        # should be written out?
+        #
         assert hdu.header["TLMIN1"] == 1
-        assert hdu.header["TLMAX1"] == 10
+        assert hdu.header["TLMAX1"] == 4
 
     finally:
         hdus.close()
@@ -784,7 +793,8 @@ def test_write_pha_fits_with_extras_roundtrip(tmp_path, caplog):
 
     hdr = {"TELESCOP": "CHANDRA", "INSTRUME": "ACIS", "FILTER": "NONE",
            "CHANTYPE": "PI",
-           "DETCHANS": 10,  # This intentionally does not match the data
+           # DETCHANS intentionally does not match the data, so what gets written out?
+           "DETCHANS": 10,
            "OBJECT": "Made up source",
            "CORRFILE": "None",
            # This will cause a warning when reading in the file


### PR DESCRIPTION
# Summary

Fix up a test case when writing out the range of a column for a FITS column.

# Details

So, we have two issues here

1. I had only run the changes from #2118 with the AstroPy backend and the crates test needed to be changed (the TLMAX1 value was 10 but is now 4, and this was an explicit change in this PR)

2. the reason why I hadn't noted it was that the AstroPy backend, which has the same test, wasn't changed because of an "issue" with how the header elements are set. The code I wrote did not error out but did not do what I expected for TLMINn and TLMAXn **ONLY**, so they were not updated. Which meant that the corresponding change for the AstroPy backend had not had to be made, so I hadn't looked at the Crates version.

So there's a simple fix to the AstroPy FITS writing to make sure that TLMIN/MAX are written out, and updates to the test to pick up the new values.