### PR TITLE
UI: note when a 1D filter command has failed

### DIFF
--- a/sherpa/astro/ui/tests/test_filtering.py
+++ b/sherpa/astro/ui/tests/test_filtering.py
@@ -278,12 +278,10 @@ def test_filter_bad_grouped(make_data_path, clean_astro_ui, caplog):
     # What happens when we filter the data? Unlike #1169
     # we do change the noticed range.
     #
-    # This should create a filter message, but thanks to ignore_bad we
-    # get an IndexError, which has been caught and that causes the
-    # filter message to not be displayed.
-    #
     ui.notice(0.5, 7)
-    assert len(caplog.records) == 1
+    assert len(caplog.records) == 2
+    check_last_caplog(caplog, "sherpa.ui.utils",
+                      logging.ERROR, "dataset 1: 1D filter has failed")
 
     assert pha.quality_filter == pytest.approx(expected)
 
@@ -597,22 +595,36 @@ def test_notice_reporting_data2d(session, caplog):
     assert s.get_filter() == ""
 
     # At the moment it's not obvious what the arguments mean, so just
-    # act as a regression test. In particular, we get no caplog output.
+    # act as a regression test.
     #
     s.notice(lo=13)
-    assert len(caplog.record_tuples) == 0
+    assert len(caplog.record_tuples) == 1
+    check_last_caplog(caplog, "sherpa.ui.utils",
+                      logging.ERROR, "dataset 1: 1D filter has failed")
+
     assert s.get_filter() == ""
 
     s.ignore(6, 15)
-    assert len(caplog.record_tuples) == 0
+    assert len(caplog.record_tuples) == 2
+    check_last_caplog(caplog, "sherpa.ui.utils",
+                      logging.ERROR, "dataset 1: 1D filter has failed")
+
     assert s.get_filter() == ""
 
     s.notice_id(1, 13, 15)
-    assert len(caplog.record_tuples) == 0
+    assert len(caplog.record_tuples) == 3
+    check_last_caplog(caplog, "sherpa.ui.utils",
+                      logging.ERROR, "dataset 1: 1D filter has failed")
+
     assert s.get_filter() == ""
 
+    # It's not clear this filter message is correct, but it's not
+    # really obvious what we want to happen here anyway.
+    #
     s.ignore_id(1)
-    assert len(caplog.record_tuples) == 0
+    assert len(caplog.record_tuples) == 4
+    clc_filter(caplog, "dataset 1: <broken> -> no data")
+
     assert s.get_filter() == ""
 
 


### PR DESCRIPTION
# Summary

Provide more information for the UI user if a filter command has failed.

# Details

[This is based on work I was hoping to fix by finally resolving `ignore_bad` / #2142 but I have not got to that, so let's try and improve things for the user until I can get back to working on this]

[This does not fix anything, as that is too hard to do now, but just lets the user know something is screwy]

When I originally added the "notice/ignore reports the filter via the log" feature I explicitly hid the error case. I feared that it would be confusing for the user. Well, this turns out to be annoying when there is an error, such as in #1936, as it is very easy to miss the fact "I should have got a message but did not".

So now we

- handle the case when we've gone from "broken" to "okay" (although to be honest the user should still be very wary about this case); this is primarily just to separate out the behaviour from the next change

- raise a WARNING message if there is a broken filter

I hope this is a reasonable balance between telling the user something has gone wrong and not over-loading them with information that doesn't help them.

I also note that this is ONLY at the UI layer; users of the OO code have to work this out themselves (but that's been the standard approach).

Really we should not have these problems but

1. ignore_bad has been a hard nut to crack

2. what do we want to happen when applying a 1D filter to 2D data

so I think it better to at least warn the users.

# Example

If we take the example from #1936 we now get the following - note that the last two commands

a) tell the user something has gone wrong with an `ERROR` line
b) the follow on `nocice()` call has indicated that we've gone from a "broken" state, although users should still worry

```
>>> from sherpa.astro.ui import *
WARNING: failed to import sherpa.astro.xspec; XSPEC models will not be available
>>> load_pha("sherpa-test-data/sherpatest/9774.pi")
read ARF file sherpa-test-data/sherpatest/9774.arf
read RMF file sherpa-test-data/sherpatest/9774.rmf
read background file sherpa-test-data/sherpatest/9774_bg.pi
>>> notice(0.4, 8)
dataset 1: 0.00146:14.9504 -> 0.3942:8.0008 Energy (keV)
>>> group_counts(20)
dataset 1: 0.3942:8.0008 Energy (keV) (unchanged)
>>> (get_quality() > 0).any()
True
>>> ignore_bad()
ERROR: filtering grouped data with quality flags, previous filters deleted
dataset 1: 0.3942:8.0008 -> 0.00146:14.9504 Energy (keV)
>>> notice(0.4, 8)
WARNING: dataset 1: 1D filter has failed
>>> notice()
dataset 1: <broken> -> 0.00146:14.9504 Energy (keV)
```

You can compare the behavior to CIAO 4.16 where you can see there's no output from the last two `notice` calls:

```
sherpa-4.16.0> load_pha("/lagado.real/sherpa/sherpa-1/sherpa-test-data/sherpatest/9774.pi")
read ARF file /lagado.real/sherpa/sherpa-1/sherpa-test-data/sherpatest/9774.arf
read RMF file /lagado.real/sherpa/sherpa-1/sherpa-test-data/sherpatest/9774.rmf
read background file /lagado.real/sherpa/sherpa-1/sherpa-test-data/sherpatest/9774_bg.pi

sherpa-4.16.0> notice(0.4, 8)
dataset 1: 0.00146:14.9504 -> 0.3942:8.0008 Energy (keV)

sherpa-4.16.0> group_counts(20)
dataset 1: 0.3942:8.0008 Energy (keV) (unchanged)

sherpa-4.16.0> (get_quality() > 0).any()
True

sherpa-4.16.0> ignore_bad()
WARNING: filtering grouped data with quality flags, previous filters deleted
dataset 1: 0.3942:8.0008 -> 0.00146:14.9504 Energy (keV)

sherpa-4.16.0> notice(0.4, 8)

sherpa-4.16.0> notice()

sherpa-4.16.0> 
```