### PR TITLE
XSPEC: fix up error message

### DIFF
--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1433,10 +1433,16 @@ class XSModel(RegriddableModel1D, metaclass=ModelMeta):
             #   - model class
             #   - model name
             #   - parameter list
+            #   - any kwargs
             #
             msg = f"{ve}: {self.type}.{self.name}"
-            for par, val in zip(self.pars, args[0]):
+            for par, val in zip(self.pars, p):
                 msg += f" {par.name}={val}"
+
+            if kwargs:
+                msg += " KEYWORDS "
+                for k, v in kwargs.items():
+                    msg += f"{k}={v}"
 
             raise ValueError(msg) from None
 


### PR DESCRIPTION
# Summary

Correct the information provided in the unlikely case than an XSPEC model fails.

# Details

[This was found working on #2106 but it is separate from that]

The error message that happens in the rare case of the XSPEC model failing now

a) correctly lists the parameters and their values

   previously the parameters were being mapped to the low-energy axis, which is obviously garbage

b) any keyword arguments are now also included in the error message

The energy grid could be included, but this is something the caller can more-easily identify than a particular set of parameters (and keyword arguments) so it's not worth adding to the already-long line.

# Example

An example from #2106 (hence the DBG message and the keyword argument and the ability to call the smaug model):

## BEFORE

```
>>> m([0.1, 0.2, 0.3], [0.2, 0.3, 0.4])
DBG: calling smaug

***XSPEC Error:  in function XSmaug: cannot find XFLTnnnn keyword for inner annulus for spectrum 1

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/models/model.py", line 808, in __call__
    return self.calc([p.val for p in self.pars], *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/astro/xspec/__init__.py", line 1925, in calc
    super().calc(p, *args, **kwargs)
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/models/model.py", line 473, in cache_model
    vals = func(cls, pars, xlo, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/astro/xspec/__init__.py", line 1836, in calc
    raise ValueError(msg) from None
ValueError: XSPEC additive model evaluation failed: xssmaug.smaug kT_cc=0.1 kT_dt=0.2 kT_ix=0.3 KEYWORDS spectrumNumber=1
```

## AFTER

```
>>> m([0.1, 0.2, 0.3], [0.2, 0.3, 0.4])
DBG: calling smaug

***XSPEC Error:  in function XSmaug: cannot find XFLTnnnn keyword for inner annulus for spectrum 1

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/models/model.py", line 808, in __call__
    return self.calc([p.val for p in self.pars], *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/astro/xspec/__init__.py", line 1925, in calc
    super().calc(p, *args, **kwargs)
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/models/model.py", line 473, in cache_model
    vals = func(cls, pars, xlo, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dburke/sherpa/sherpa-xspec/sherpa/astro/xspec/__init__.py", line 1836, in calc
    raise ValueError(msg) from None
ValueError: XSPEC additive model evaluation failed: xssmaug.smaug kT_cc=1.0 kT_dt=1.0 kT_ix=0.0 kT_ir=0.1 kT_cx=0.5 kT_cr=0.1 kT_tx=0.0 kT_tr=0.5 nH_cc=1.0 nH_ff=1.0 nH_cx=0.5 nH_cr=0.1 nH_gx=0.0 nH_gr=0.002 Ab_cc=1.0 Ab_xx=0.0 Ab_rr=0.1 redshift=0.01 meshpts=10.0 rcutoff=2.0 mode=1.0 itype=2.0 norm=1.0 KEYWORDS spectrumNumber=1
```

For reference

```
>>> from sherpa.astro import xspec
>>> m = xspec.XSsmaug()
>>> print(m)
smaug
   Param        Type          Value          Min          Max      Units
   -----        ----          -----          ---          ---      -----
   smaug.kT_cc  thawed            1         0.08          100        keV
   smaug.kT_dt  thawed            1            0          100        keV
   smaug.kT_ix  frozen            0            0           10           
   smaug.kT_ir  frozen          0.1       0.0001            1        Mpc
   smaug.kT_cx  thawed          0.5            0           10           
   smaug.kT_cr  thawed          0.1       0.0001           20        Mpc
   smaug.kT_tx  frozen            0            0           10           
   smaug.kT_tr  frozen          0.5       0.0001            3        Mpc
   smaug.nH_cc  frozen            1        1e-06            3     cm**-3
   smaug.nH_ff  frozen            1            0            1           
   smaug.nH_cx  thawed          0.5            0           10           
   smaug.nH_cr  thawed          0.1       0.0001            2        Mpc
   smaug.nH_gx  frozen            0            0           10           
   smaug.nH_gr  frozen        0.002       0.0001           20        Mpc
   smaug.Ab_cc  frozen            1            0            5      solar
   smaug.Ab_xx  frozen            0            0           10           
   smaug.Ab_rr  frozen          0.1       0.0001            1        Mpc
   smaug.redshift frozen         0.01       0.0001           10           
   smaug.meshpts frozen           10            1        10000           
   smaug.rcutoff frozen            2            1            3        Mpc
   smaug.mode   frozen            1            0            2           
   smaug.itype  frozen            2            1            4           
   smaug.norm   thawed            1            0        1e+24           
```
