### PR TITLE
Fix bug in cache code that limited cache size to 1.

### DIFF
--- a/docs/evaluation/cache.rst
+++ b/docs/evaluation/cache.rst
@@ -56,9 +56,9 @@ to look up a value in the `_cache` dictionary. If it exists then the
 stored value is returned, otherwise the model is evaluated and added
 to the `_cache` dictionary. In order to keep the cache size small, the
 `_queue` array is used to remove an existing value from the store when
-a new value is added. The default size for the `_queue` array is
-a single value, but it can be changed by
-:ref:`the startup method <startup-modelcacher1d>`.
+a new value is added. The size for the `_queue` array is set to
+:py:attr:`~sherpa.models.model.ArithmeticModel.cache` elements (the
+default value for this attribute is 5).
 
 .. _startup-modelcacher1d:
 
@@ -68,9 +68,8 @@ The startup method
 The model :py:meth:`~sherpa.models.model.ArithmeticModel.startup`
 method is automatically called by the :py:meth:`~sherpa.fit.Fit.fit`
 method, but can also be called manually. It sets the `_use_caching`
-attribute and sets the `_queue` array to have
-:py:attr:`~sherpa.models.model.ArithmeticModel.cache` elements (the
-default value for this attribute is 5).
+attribute.
+
 
 Although the default value for the `cache` argument to `startup` is
 set to `False`, the `sherpa.fit.evaluates_model` decorator - which

--- a/docs/evaluation/cache.rst
+++ b/docs/evaluation/cache.rst
@@ -44,6 +44,17 @@ This may be useful if you are evaluating models over a large grid,
 to save memory. For a composite model (e.g. a sum of models) you need
 to set the cache for each component.
 
+When we use the fit method of the UI or the fit method of an optimizer, it is possible to
+turn off caching for all models with the ``cache`` parameter, e.g.
+``ui.fit(..., cache=False)``.
+This works by iterating over all the model components and setting the
+``cache`` attribute to zero. Note that the opposite is not true: setting
+``cache=True`` does not turn on the cache for all model components, it simply
+leaves it at the previous setting. This is because some models may not work with
+caching at all and need to stay at ``cache=0`` at all times.
+The cache has to be manually set to a positive number for all models that should use the cache
+to allow caching again.
+
 How does the cache work?
 ========================
 

--- a/docs/evaluation/cache.rst
+++ b/docs/evaluation/cache.rst
@@ -50,13 +50,12 @@ How does the cache work?
 ========================
 
 The parameter values, integrate setting, and grid values are used to
-create an unique token - the SHA256 hash of the values - which is used
+create a unique token - the SHA256 hash of the values - which is used
 to look up a value in the `_cache` dictionary. If it exists then the
 stored value is returned, otherwise the model is evaluated and added
 to the `_cache` dictionary. In order to keep the cache size small, the
-`_queue` array is used to remove an existing value from the store when
-a new value is added. The size for the `_queue` array is set to
-:py:attr:`~sherpa.models.model.ArithmeticModel.cache` elements (the
+oldest element in the cache is removed when the number of entries becomes
+larger than :py:attr:`~sherpa.models.model.ArithmeticModel.cache` elements (the
 default value for this attribute is 5).
 
 .. _startup-modelcacher1d:
@@ -110,8 +109,7 @@ True
 [0. 1. 1. 1. 0. 0.]
 >>> print(m._cache)  # doctest: +SKIP
 {b'<random byte string>': array([0., 1., 1., 1., 0., 0.])}
->>> print(m._queue)  # doctest: +SKIP
-[b'<random byte string>']
+
 
 Fit and the startup method
 --------------------------

--- a/docs/evaluation/cache.rst
+++ b/docs/evaluation/cache.rst
@@ -29,23 +29,22 @@ When is the cache useful?
 =========================
 
 At present most 1D models use the cache by default when evaluated
-normally, but not during a fit. It is intended to improve fit
-performance - that is, reduce the time taken to fit a dataset - but
-there has been limited effort to evaluate its efficiency.
+during a fit, but not when evaluated separately (e.g. on the command
+line by hand). It is intended to improve fit performance, but the actual
+time saved depends on the model and the data being fit.
 
 Can I turn off this behavior?
 =============================
 
-The `_use_caching` attribute of a model can be set to `False` to stop
-the cache behavior. This may be useful if you are evaluating models
-over a large grid, to save memory, or the model calculation is not
-expensive, and so the extra time used to store the result is not
-beneficial.
+The size of the cache for a specific model component called ``mdl`` can
+be set to zero (``mdl.cache=0``) to turn off the cache behavior.
+This may be useful if you are evaluating models over a large grid,
+to save memory. For a composite model (e.g. a sum of models) you need
+to set the cache for each component.
 
-Note that the :ref:`the startup method <startup-modelcacher1d>` can
-change this value, but it depends if you are calling `startup`
-directly or indirectly, via the ``fit`` and ``est_errors`` methods of
-a fit object.
+Alternatively, caching can be switched off for a specific
+fit call: ``f.fit(cache=False)``.
+
 
 How does the cache work?
 ========================
@@ -63,7 +62,7 @@ default value for this attribute is 5).
 .. _startup-modelcacher1d:
 
 The startup method
-==================
+------------------
 
 The model :py:meth:`~sherpa.models.model.ArithmeticModel.startup`
 method is automatically called by the :py:meth:`~sherpa.fit.Fit.fit`
@@ -82,7 +81,7 @@ have to explicitly pass ``cache=False`` to the fit method::
     f.fit(cache=False)
 
 The teardown method
-===================
+-------------------
 
 The model :py:meth:`~sherpa.models.model.ArithmeticModel.teardown`
 method is run after the fit is done - to match `startup` - and

--- a/docs/evaluation/cache.rst
+++ b/docs/evaluation/cache.rst
@@ -28,10 +28,12 @@ by running a test as shown below,
 When is the cache useful?
 =========================
 
-At present most 1D models use the cache by default when evaluated
-during a fit, but not when evaluated separately (e.g. on the command
-line by hand). It is intended to improve fit performance, but the actual
+At present most 1D models use the cache by default.
+It is intended to improve fit performance, but the actual
 time saved depends on the model and the data being fit.
+Compared to most built-in sherpa models, models in the optional XSPEC model
+library (:py:mod:`sherpa.astro.xspec`) tend to be more complex and
+thus benefit more from caching.
 
 Can I turn off this behavior?
 =============================
@@ -41,10 +43,6 @@ be set to zero (``mdl.cache=0``) to turn off the cache behavior.
 This may be useful if you are evaluating models over a large grid,
 to save memory. For a composite model (e.g. a sum of models) you need
 to set the cache for each component.
-
-Alternatively, caching can be switched off for a specific
-fit call: ``f.fit(cache=False)``.
-
 
 How does the cache work?
 ========================
@@ -58,33 +56,6 @@ oldest element in the cache is removed when the number of entries becomes
 larger than :py:attr:`~sherpa.models.model.ArithmeticModel.cache` elements (the
 default value for this attribute is 5).
 
-.. _startup-modelcacher1d:
-
-The startup method
-------------------
-
-The model :py:meth:`~sherpa.models.model.ArithmeticModel.startup`
-method is automatically called by the :py:meth:`~sherpa.fit.Fit.fit`
-method, but can also be called manually. It sets the `_use_caching`
-attribute.
-
-
-Although the default value for the `cache` argument to `startup` is
-set to `False`, the `sherpa.fit.evaluates_model` decorator - which
-is used to wrap the :py:meth:`~sherpa.fit.Fit.fit`,
-:py:meth:`~sherpa.fit.Fit.simulfit`, and
-:py:meth:`~sherpa.fit.Fit.est_errors` methods - over-rides this value
-and uses a value of `True`. Therefore, to turn off the cache you
-have to explicitly pass ``cache=False`` to the fit method::
-
-    f.fit(cache=False)
-
-The teardown method
--------------------
-
-The model :py:meth:`~sherpa.models.model.ArithmeticModel.teardown`
-method is run after the fit is done - to match `startup` - and
-currently sets the `_use_caching` setting to `False`.
 
 Examples
 ========
@@ -101,8 +72,6 @@ attribute, and see that it has been updated by the model evaluation.
 >>> m = Box1D()
 >>> m.xlow = 1.5
 >>> m.xhi = 4.5
->>> print(m._use_caching)
-True
 >>> print(m._cache)
 {}
 >>> print(m([1, 2, 3, 4, 5, 6]))
@@ -165,9 +134,3 @@ The cache contains 4 elements which we can display::
     [3.39944171 3.39944171 3.39944171]
     [3.40061543 3.40061543 3.40061543]
 
-Note that if we had called::
-
-    f.fit(cache=False)
-
-then the cache would not have been used (e.g. `mdl._cache` would
-have remained empty).

--- a/sherpa/astro/models/tests/test_astro_model.py
+++ b/sherpa/astro/models/tests/test_astro_model.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2016, 2018, 2020, 2021, 2022, 2023
+#  Copyright (C) 2007, 2016, 2018, 2020-2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -95,7 +95,6 @@ def test_send_keyword_1d(cls):
     """What happens if we use an un-supported keyword?"""
 
     mdl = cls()
-    mdl._use_caching = False
 
     if cls == models.LineBroad:
         mdl.vsini = 1e6
@@ -118,7 +117,6 @@ def test_send_keyword_2d(cls):
     """What happens if we use an un-supported keyword?"""
 
     mdl = cls()
-    mdl._use_caching = False
 
     # Not guaranteed to produce interesting results
     x0 =  [10, 12, 13, 15]

--- a/sherpa/astro/models/tests/test_astro_model.py
+++ b/sherpa/astro/models/tests/test_astro_model.py
@@ -91,8 +91,8 @@ def test_create_and_evaluate(name, cls):
                                  models.PseudoVoigt1D,
                                  models.Schechter,
                                  models.Voigt1D])
-def test_send_keyword_1d(cls):
-    """What happens if we use an un-supported keyword?"""
+def test_send_keyword_1d_with_cache(cls):
+    """What happens if we use an un-supported keyword and use caching?"""
 
     mdl = cls()
 
@@ -101,6 +101,35 @@ def test_send_keyword_1d(cls):
 
     # Not guaranteed to produce interesting results
     x = [10, 12, 13, 15]
+    y1 = mdl(x)
+    assert len(mdl._cache) == 1
+    y2 = mdl(x, not_an_argument=True)
+    assert len(mdl._cache) == 2
+    assert y2 == pytest.approx(y1)
+
+
+@pytest.mark.parametrize("cls", [models.Atten,
+                                 models.BBody,
+                                 models.BBodyFreq,
+                                 models.BPL1D,
+                                 models.Beta1D,
+                                 models.Edge,
+                                 models.LineBroad,
+                                 models.Lorentz1D,
+                                 models.NormBeta1D,
+                                 models.PseudoVoigt1D,
+                                 models.Schechter,
+                                 models.Voigt1D])
+def test_send_keyword_1d_no_cache(cls):
+    """What happens if we use an un-supported keyword and disable caching?"""
+
+    mdl = cls()
+    mdl.cache = 0
+    if cls == models.LineBroad:
+        mdl.vsini = 1e6
+
+    # Not guaranteed to produce interesting results
+    x = [10, 11.3, 13, 15]
     y1 = mdl(x)
     y2 = mdl(x, not_an_argument=True)
     assert y2 == pytest.approx(y1)

--- a/sherpa/astro/utils/tests/test_astro_utils_xspec.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_xspec.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2023, 2024
+#  Copyright (C) 2021, 2023-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -647,7 +647,7 @@ class XSabcd(XSAdditiveModel):
         # norm parameter is automatically added by XSAdditiveModel
         pars = (self.xs,)
         XSAdditiveModel.__init__(self, name, pars)
-        self._use_caching = False
+        self.cache = 0
         warnings.warn('support for models like xsabcd (recalculated per spectrum) is untested.')
 
 '''

--- a/sherpa/astro/utils/xspec.py
+++ b/sherpa/astro/utils/xspec.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2012 - 2016, 2020 - 2024
+#  Copyright (C) 2012-2016, 2020-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -526,7 +526,7 @@ def read_model_definition(fh, namefunc: Callable[[str], str]) -> Optional[ModelD
 
 def mpop(array: list[str]) -> Optional[float]:
     """Pop first element from array (converting to float),
-    returning defval if empty.
+    returning None if empty.
     """
 
     try:

--- a/sherpa/astro/utils/xspec.py
+++ b/sherpa/astro/utils/xspec.py
@@ -876,8 +876,7 @@ def simple_wrap(modelname: str, mdl: ModelDefinition) -> str:
     # initialized.
     #
     if nflags > 1 and mdl.flags[1] == 1:
-        out += f"{t2}self._use_caching = False\n"
-
+        out += f"{t2}self.cache = 0\n"
         # Still warn the user that this is not tested.
         out += f"{t2}warnings.warn('support for models like xs{mdl.name.lower()} "
         out += "(recalculated per spectrum) is untested.')\n"

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016 - 2021, 2023 - 2025
+#  Copyright (C) 2016-2021, 2023-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1826,9 +1826,9 @@ def test_model_can_send_spectrumnumber_combine():
     # As we evaluate the models multiple times with the same
     # arguments we need to ensure the models are not cached.
     #
-    m1._use_caching = False
-    m2._use_caching = False
-    # comb._use_caching = False  no cache for composite models
+    m1.cache = 0
+    m2.cache = 0
+    # comb.cache = 0  no cache for composite models
 
     egrid = np.arange(1, 4)
     elo = egrid[:-1]
@@ -1915,8 +1915,8 @@ def test_model_can_send_spectrumnumber_combine_non_xspec():
     m2 = Scale1D("m2")
     m2.c0 = 1.5
 
-    m1._use_caching = False
-    m2._use_caching = False
+    m1.cache = 0
+    m2.cache = 0
 
     # These should evaluate to the same thing.
     #

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -921,7 +921,7 @@ def test_deprecated_use_caching():
 def test_evaluate_no_cache1d_use_caching():
     """Check we can turn off caching: 1d"""
 
-    xgrid = numpy.arange(2, 10, 1.5)
+    xgrid = np.arange(2, 10, 1.5)
 
     mdl = Polynom1D()
     mdl.integrate = False
@@ -930,7 +930,7 @@ def test_evaluate_no_cache1d_use_caching():
     assert len(mdl._cache) == 0
 
     # Check the default values
-    expected = numpy.ones(6)
+    expected = np.ones(6)
     assert mdl(xgrid) == pytest.approx(expected)
     assert len(mdl._cache) == 0
 
@@ -997,13 +997,13 @@ def test_cache_is_actually_used():
     Here, we manipulte the cached value and then call the model
     to check that the cached value is used.
     """
-    xgrid = numpy.arange(2, 10, 1.5)
+    xgrid = np.arange(2, 10, 1.5)
 
     mdl = Polynom1D()
     assert len(mdl._cache) == 0
 
     # Check the default values
-    expected = numpy.ones(6)
+    expected = np.ones(6)
     assert mdl(xgrid) == pytest.approx(expected)
 
     # Manipulate the values in the cache
@@ -1162,7 +1162,6 @@ class DoNotUseModel(Model):
 
     def __init__(self, *args, **kwargs) -> None:
         # Model caching ability
-        self.cache = 2
         self.cache_clear()
         Model.__init__(self, *args, **kwargs)
 
@@ -1224,7 +1223,7 @@ def test_cache_reset_when_size_changes():
     mdl = Polynom1D()
     mdl.cache = 2
 
-    x = numpy.arange(2, 10, 1.5)
+    x = np.arange(2, 10, 1.5)
     mdl(x)
 
     assert len(mdl._cache) == 1
@@ -1261,7 +1260,7 @@ def test_cache_not_used_in_fit():
     """
     mdl = Const1D('con1')
     mdl.c0 = 1
-    dat = Data1D('data', numpy.arange(4), 2 * numpy.ones(4), numpy.ones(4))
+    dat = Data1D('data', np.arange(4), 2 * np.ones(4), np.ones(4))
     fit = Fit(dat, mdl)
     res = fit.fit()
     assert mdl.c0.val == pytest.approx(2)

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1125,7 +1125,6 @@ class DoNotUseModel(Model):
 
     def cache_clear(self) -> None:
         """Clear the cache."""
-        self._queue = []
 
         self._cache: dict[bytes, np.ndarray] = {}
         self._cache_ctr: dict[str, int] = {'hits': 0, 'misses': 0, 'check': 0}
@@ -1142,7 +1141,7 @@ class DoNotUseModel(Model):
 def get_cache_classes():
     """This is a function because we want to conditionally
     include an XSPEC model. Within a function, we can simply
-    pass that if XSEPC is not available.
+    pass that if XSPEC is not available.
     """
     cls_list = [DoNotUseModel, Polynom1D]
 

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -949,6 +949,23 @@ def test_evaluate_cache1d():
     check_cache(mdl, expected, xgrid)
 
 
+def test_cache_is_actually_used():
+    """Most other test check that the cache has values in it,
+    but not that those values are actually returned."""
+    xgrid = numpy.arange(2, 10, 1.5)
+
+    mdl = Polynom1D()
+    assert len(mdl._cache) == 0
+
+    # Check the default values
+    expected = numpy.ones(6)
+    assert mdl(xgrid) == pytest.approx(expected)
+
+    # Manipulate the values in the cache
+    mdl._cache[list(mdl._cache.keys())[0]] = 2 * expected
+    assert mdl(xgrid) == pytest.approx(2 * expected)
+
+
 def test_evaluate_no_cache1dint():
     """Check we can turn off caching: 1dint"""
 

--- a/sherpa/ui/tests/test_ui.py
+++ b/sherpa/ui/tests/test_ui.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2012, 2015, 2016, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2012, 2015-2016, 2018-2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -594,9 +594,9 @@ class MyCacheTestModel(ArithmeticModel):
         b = par[2]
         fvec = A * np.exp(- mylambda * x) + b
         if self.counter == 0:
-            assert self._use_caching
+            assert self.cache > 0
         else:
-            assert not self._use_caching
+            assert self.cache == 0
         self.counter += 1
         return fvec
 


### PR DESCRIPTION
## Summary
Fix bug that limited cache size to 1.

## Details
While working on #2080, I discovered that the caching code does not do what the docs promise it would. The size of the cache is fixed to 1, although the docs and default setting put it at 5. Given how little memory caches need (for a typical X-ray spectrum with 1024 channels and a float64 data type returned from the model it's about 2kB) but how long many XSPEC models take to evaluate there is no justification to restrict it to size one nor was that intended (from reading docs and code).

I looked at the logs for our fitters at typical X-ray fits, and setting it to 1 actually captures most of the calls, but going slightly higher will be better in some cases at little cost.

So, this PR fixes that bug.