### PR TITLE
specify DS9 region format used in pytest

### DIFF
--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -216,6 +216,7 @@ def test_image_getregion(coordsys):
 
     # Use XPA to set a region in the imager
     imshape = 'image; circle 8.5 7.0 0.8'
+    im.xpaset('regions format ds9')
     im.xpaset('regions', data=imshape)
 
     rval = ds9_backend.get_region(coordsys)


### PR DESCRIPTION
DS9 pytests fails since `xpaset regions` failed to execute if you have a DS9 preference file to default the region file formatting as something other than 'ds9' (e.g. 'ciao').  

By specifying the test's region format [and coordinate system, which is already being done in these tests] being used will supersede whatever setting is found in the user's preference file by doing a `xpaset('regions format ds9')` before the `xpaset('regions', data=imshape)`.