### PR TITLE
Allow tests to pass with Python 3.13.0

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -1405,10 +1405,23 @@ def test_show_fit(session):
     assert toks[11] == "Statistic: LeastSq"
     assert toks[12] == "Least Squared Statistic."
     assert toks[13] == ""
-    assert toks[14] == "    The least-square statistic is equivalent to a chi-square"
-    assert toks[15] == "    statistic where the error on each point - sigma(i) - is 1."
+
+    # Python 3.13 has changed the way that leading spaces are handled in docstrings
+    msg1 = "The least-square statistic is equivalent to a chi-square"
+    msg2 = "statistic where the error on each point - sigma(i) - is 1."
+    if sys.version_info >= (3, 13, 0):
+        assert toks[14] == msg1
+        assert toks[15] == msg2
+    else:
+        assert toks[14] == f"    {msg1}"
+        assert toks[15] == f"    {msg2}"
+
     assert toks[16] == ""
-    assert toks[17] == "    "
+    if sys.version_info >= (3, 13, 0):
+        assert toks[17] == ""
+    else:
+        assert toks[17] == "    "
+
     assert toks[18] == ""
     assert toks[19] == "Fit:Dataset               = 2"
     assert toks[20] == "Method                = neldermead"

--- a/sherpa/astro/xspec/tests/test_xspec_regrid.py
+++ b/sherpa/astro/xspec/tests/test_xspec_regrid.py
@@ -30,7 +30,10 @@ is to check sepcialized behavior with the XSPEC models.
 
 """
 
+import re
+
 import numpy as np
+
 import pytest
 
 from sherpa.models.basic import Const1D, Gauss1D
@@ -45,7 +48,10 @@ from sherpa.utils.testing import requires_data, requires_fits, \
 # miss). It also lets us check why a test fails (in case the failure
 # mode changes due to other parts of Sherpa).
 #
-IntegrateError = "'integrate' is an invalid keyword argument for this function"
+# The error message changed in Python 3.13, hence the check for
+# either message.
+#
+IntegrateError = "('integrate' is an invalid keyword argument for this function)|(this function got an unexpected keyword argument 'integrate')"
 
 
 @requires_xspec
@@ -96,7 +102,7 @@ def test_regrid_does_not_require_bins(mname, xsmodel):
 
     # assert str(exc.value) == 'calc() requires pars,lo,hi arguments, sent 2 arguments'
     # assert str(exc.value).endswith('() takes no keyword arguments')
-    assert str(exc.value) == IntegrateError
+    assert re.match(IntegrateError, str(exc.value))
 
 
 @requires_data

--- a/sherpa/plot/tests/test_backend_utils.py
+++ b/sherpa/plot/tests/test_backend_utils.py
@@ -1,6 +1,6 @@
 #
-#  Copyright (C) 2022
-#      MIT
+#  Copyright (C) 2022, 2024
+#  MIT
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,6 +17,9 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+
+import sys
+
 from sherpa.plot.backend_utils import (translate_args,
                                        add_kwargs_to_doc,
                                        get_keyword_defaults)
@@ -99,8 +102,31 @@ class A():
 
 def test_modify_doctring():
     '''Check that kwarg descriptions are properly inserted into the docstring.'''
-    a = A()
-    expected = '''Method that does nothing
+
+    # Python 3.13 has changed how strings are indented.
+    #
+    if sys.version_info >= (3, 13, 0):
+        expected = '''Method that does nothing
+
+more text here
+
+Parameters
+----------
+a : int
+    Our stuff
+title : string, default=None
+    Title of figure (only use if `overplot=False`)
+color : string or number, default=None
+    any matplotlib color with a really long text attached to it that will not fit in the one line of text in the docstring
+kwargs : dict, optional
+    All other keyword parameters are passed to the plotting library.
+
+Returns
+-------
+something
+'''
+    else:
+        expected = '''Method that does nothing
 
         more text here
 
@@ -119,5 +145,7 @@ def test_modify_doctring():
         -------
         something
         '''
+
+    a = A()
     assert a.func.__doc__ == expected
  

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -26,6 +26,7 @@ to be kept up to date.
 from io import StringIO
 import logging
 import pickle
+import sys
 from unittest.mock import patch
 
 import numpy as np
@@ -1142,7 +1143,21 @@ def test_modelwrapper_str_with_doc():
 
     s = Session()
     wrap = ModelWrapper(s, ModelWithDoc)
-    assert str(wrap) == "This has a doc string\n\n    This line is not included in the model-wrapped doc string.\n    "
+
+    # Python 3.13 has changed how it handles indentation
+    lwrap = str(wrap).split("\n")
+    assert lwrap[0] == "This has a doc string"
+    assert lwrap[1] == ""
+
+    msg = "This line is not included in the model-wrapped doc string."
+    if sys.version_info >= (3, 13, 0):
+        assert lwrap[2] == msg
+        assert lwrap[3] == ""
+    else:
+        assert lwrap[2] == f"    {msg}"
+        assert lwrap[3] == "    "
+
+    assert len(lwrap) == 4
 
 
 def test_modelwrapper_str_no_doc():


### PR DESCRIPTION
# Summary

Allow the tests to pass with Python 3.13.0.

# Details

Python 3.13 has changed how docstrings are indented (in that it automatically removes leading indentation).

This affects a few of our tests, so update them to allow for the old and new behaviour. I felt it simpler to just gate on the Python version (sys.version_info) rather than try to write tests that could handle both. The downside to my approach is that the tests repeat themselves. The upside is that it's much easier and cleaner to update them once Python 3.13 becomes our minimum supported version.

There is also a change in a `TypeError` which affects a few of our XSPEC tests: these tests are written to catch the current behaviour, since the code is known to fail, and so we just want to know when anything has changed. So we can easily tweak the message check to work with both pre-3.13 and 3.13 messages.

I have run this test with as extensive a check as I can make it (Linux only) checking

- matplotlib plus bokeh
- DS9 and xpa
- `runslow` tests
- `runzenodo` tests