### PR TITLE
Read the Docs build failures with newer sphinx versions and sphinx_rtd_theme deprecation warning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -372,7 +372,6 @@ edit_on_github_doc_root = 'docs'
 html_theme = 'sphinx_rtd_theme'
 
 # html_theme_options = {}
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,5 +18,5 @@ dependencies:
     - ipykernel
     - nbsphinx
     - sphinx-astropy
-    - sphinx_rtd_theme>=1.0.0
+    - sphinx_rtd_theme>=3.0.0
     - bokeh

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - astropy
   - pip
   - graphviz
+  - sphinx<8.0
   - pip:
     - ipykernel
     - nbsphinx


### PR DESCRIPTION
Summary
=======
Specify sphinx < 8 for the read the doc environment and remove the call to get_html_theme_path no longer needed.

Details
======
With the recent sphinx_rtd_theme release (3.0.0) released yesterday, we now pick up sphinx > 8.0 and encounter a new deprecation warning for get_html_theme_path noting that it is no longer needed. 

Double slash issue with newer sphinx versions
-----------------------------------------------
The sphinx pin here: https://github.com/readthedocs/sphinx_rtd_theme/blob/master/setup.cfg was updated from
```
sphinx >=5,<8
```
to:
```
sphinx >=6,<9
```
With the previous pinning, this forced the use of sphinx <8 in the RTD builds. With the new pinning, we are encountering an issue similar to this: https://github.com/sphinx-doc/sphinx/issues/12782
Which is not released yet (currently targeted for sphinx 8.1.0). This warning is triggering sphinx failures.

get_html_theme_path deprecation warning
--------------------------------------------
With sphinx_rtd_theme 3.0.0 we are also now seeing failures due to the following warning
```
WARNING: Calling get_html_theme_path is deprecated. If you are calling it to define html_theme_path, you are safe to remove that code.
```
So, the html_theme_path setting in the conf.py has also been removed.

