### PR TITLE
Add doc build option

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -259,9 +259,8 @@ autosummary_generate = True
 templates_path = ['_templates']
 
 # The suffix(es) of source filenames.
-# You can specify multiple suffix as a list of string:
 #
-source_suffix = '.rst'
+source_suffix = {'.rst': 'restructuredtext'}
 
 # The encoding of source files.
 #

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - astropy
   - pip
   - graphviz
-  - sphinx<8.0
+  - sphinx>=5.0,<8.0
   - pip:
     - ipykernel
     - nbsphinx

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -458,19 +458,26 @@ additional packages:
   for including Jupyter notebooks
 * `Graphviz <https://www.graphviz.org/>`_ (for the inheritance diagrams)
 
-With these installed, the documentation can be built by saying::
+The easiset way to install the Python packages is to install the ``doc``
+option with::
 
-    cd docs
-    make html
+  pip install .[doc]
 
-Note that this uses the installed version of sherpa, so if you want to make
-sure the current repository version is used, you will need to install it with e.g.::
+This also ensures that Sherpa has been built, as this is needed to
+build the documentation.
 
-    pip install -e .
+If conda is being used then the other packages can be installed with::
 
-before changing to the docs directory. Only very specific modules are mocked out
-because they are hard to build and are not needed for the documentation build
-(currently ds9 and XSPEC).
+  conda install -c conda-forge pandoc graphviz
+
+With these installed, the documentation can be built::
+
+  cd docs
+  make html
+
+Only very specific modules are mocked out because they are hard to
+build and are not needed for the documentation build (currently ds9
+and XSPEC).
 
 The documentation should be placed in ``docs/_build/html/index.html``.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,21 @@ test = [
   "pytest>=8.0"
 ]
 
+# This is not a complete list, but that's because the doc build
+# needs non-python packages such as pandoc and graphviz
+doc = [
+  # code needed for the documentation
+  "sphinx>=5,<8",
+  "sphinx_rtd_theme>=3.0.0",
+  "sphinx-astropy",
+  "nbsphinx",
+  "ipykernel",
+  # code needed to run the documentation tests
+  "astropy",
+  "matplotlib",
+  "bokeh"
+]
+
 [project.urls]
 Homepage = "https://cxc.harvard.edu/sherpa/"
 Documentation = "https://sherpa.readthedocs.io/"


### PR DESCRIPTION
# Summary

Provide the doc installation option which will install the python packages needed to build the documentation along with Sherpa.

# Details

I have long thought about adding the equivalent of `test_requirements.txt` but for documentation, but there's never been a good name for this. Then I realized that we can make in an optional build feature, as we did for `test`, so we can make it easy for people (and by people, I mean me) to install the necessary packages to build the documentation [having a separate file a la `test_requirements.txt` would mean we can install things without having to build Sherpa, but as of 4.16.0 we need to build Sherpa to build the docs so there's less benefit now].

As discussed in #2177 we actually have some constraints on `sphinx` and `sphinx_rtd_theme`, so update `docs/environment.yml` to these [these are the same constraints as used in the `doc` option, which is annoying to repeat but I don't think it's worth trying to re-architect things to avoid this].

There is a small change to `docs/conf.py` just to avoid a "warning" message that recent sphinx code has started to generate.

Then I update the documentation to show how to use this - it's basically

```
% pip install .[doc]
% conda install -c conda-forge pandoc graphviz   # for the conda users
% cd docs
% make html
```