### PR TITLE
Fix typo in return value

### DIFF
--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -12533,7 +12533,7 @@ class Session(NoNewAttributesAfterInit):
 
     def get_source_components_plot(self,
                                    id: Optional[IdType] = None
-                                   ) -> Multiplot:
+                                   ) -> MultiPlot:
         """Return the data used by plot_source_components.
 
         .. versionadded:: 4.16.1


### PR DESCRIPTION
# Summary

Correctly identify the return value of get_source_components_plot. This does not change the behaviour of the code.

# Details

It should have been MultiPlot, not Multiplot.