### PR TITLE
DOC: Use "Examples" rather than "Example"

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -3983,8 +3983,8 @@ It is an integer or string.
         by the source exposure time (if set). The final step is
         to divide by the number of background files used.
 
-        Example
-        -------
+        Examples
+        --------
 
         Calculate the background counts, per channel, scaled to match
         the source:
@@ -5885,8 +5885,8 @@ class DataIMGInt(DataIMG):
     header : dict
         The FITS header associated with the data to store meta data.
 
-    Example
-    -------
+    Examples
+    --------
     In this example, we first generate a 1000 (x,y) points from a 2D Gaussian.
     This could be, e.g., photons observed from a star. In x direction, the center
     of the Gaussian is at 1.2 and in y direction at 0.0. We then use

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -243,8 +243,8 @@ def _get_file_contents(arg: DatasetType,
     The returned fits.HDUList should be used as a context manager,
     since that will then close the value **if needed**.
 
-    Example
-    -------
+    Examples
+    --------
 
     The file will be closed after the with loop if arg is a
     string, but not if it's a astropy.io.fits object:

--- a/sherpa/astro/io/xstable.py
+++ b/sherpa/astro/io/xstable.py
@@ -35,8 +35,8 @@ obvious that the interface is as usable as it could be.
    TableBlock, are now defined in the sherpa.astro.io.types module.
    Some types have been changed as part of this work.
 
-Example
--------
+Examples
+--------
 
 The following example creates an additive table model
 that represents a gaussian model where the only parameters are

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -294,8 +294,8 @@ The `cache_clear` and `cache_status` methods of the `ArithmeticModel`
 and `CompositeModel` classes allow you to clear the cache and display
 to the standard output the cache status of each model component.
 
-Example
-=======
+Examples
+========
 
 The following class implements a simple scale model which has a single
 parameter (``scale``) which defaults to 1. It can be used for both
@@ -400,8 +400,8 @@ def modelCacher1d(func: Callable) -> Callable:
     not relevant for the model (as there's no easy way to find this
     out).
 
-    Example
-    -------
+    Examples
+    --------
 
     Allow `MyModel` model evaluations to be cached::
 
@@ -1174,8 +1174,8 @@ class CompositeModel(Model):
         Information on the cache - the number of "hits", "misses", and
         "requests" - is displayed at the INFO logging level.
 
-        Example
-        -------
+        Examples
+        --------
 
         >>> mdl.cache_status()
          xsphabs.gal                size:    5  hits:   715  misses:   158  check=  873
@@ -1402,8 +1402,8 @@ class ArithmeticModel(Model):
         Information on the cache - the number of "hits", "misses", and
         "requests" - is displayed at the INFO logging level.
 
-        Example
-        -------
+        Examples
+        --------
 
         >>> pl.cache_status()
          powlaw1d.pl                size:    5  hits:   633  misses:   240  check=  873

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -194,8 +194,8 @@ def set_backend(new_backend: Union[str, BaseBackend, type[BaseBackend]]) -> None
         Set a sherpa plotting backend. The backend can be passed in as an
         object, or as a convenience, as a simple string
 
-    Example
-    -------
+    Examples
+    --------
     Set the backend to use Pylab from matplotlib for plotting. This is
     probably what most users need:
 
@@ -256,8 +256,8 @@ class TemporaryPlottingBackend(contextlib.AbstractContextManager):
         also pass in a string naming a loaded backend class or the class
         itself; calling this context manager will then create an instance.
 
-    Example
-    -------
+    Examples
+    --------
 
     >>> from sherpa.plot import TemporaryPlottingBackend, DataPlot
     >>> from sherpa.data import Data1D

--- a/sherpa/plot/backend_utils.py
+++ b/sherpa/plot/backend_utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2022, 2023
+#  Copyright (C) 2022 - 2024
 #  MIT
 #
 #
@@ -49,8 +49,8 @@ def translate_args(func):
     syntax for the same option, e.g. one backend might call a color
     "red", while another uses the tuple (1, 0, 0) to describe the same color.
 
-    Example
-    -------
+    Examples
+    --------
     In this example, the input 'r' or 'b' will be translated into an rgb tuple
     before the ``plot`` function is called. Other values (e.g. ``color=(0, 0, 0)``)
     will be passed through unchanged so that the user can also make use of any other

--- a/sherpa/sim/__init__.py
+++ b/sherpa/sim/__init__.py
@@ -796,8 +796,8 @@ class ReSampleData(NoNewAttributesAfterInit):
     to 1000 and the seed is set to `None`. The `call` method should
     be used instead if the values need changing.
 
-    Example
-    -------
+    Examples
+    --------
 
     >>> from sherpa.astro import ui
     >>> from sherpa.models.basic import PowLaw1D


### PR DESCRIPTION
# Summary

Consistent use of "Examples" to indicate one or more examples in the documentation.

# Details

Depending on exactly what you are doing you may [*] see a warning about using "Example", so just go ahead and use "Examples" througout, even in places where it's likely not an issue.

[*] I forget how to trigger this