### PR TITLE
No longer use bin_lo/hi values from PHA or ARF. Fix #1564

### DIFF
--- a/docs/data/pha.rst
+++ b/docs/data/pha.rst
@@ -66,8 +66,6 @@ PHA FITS file::
   counts         = Float64[1024]
   staterror      = None
   syserror       = None
-  bin_lo         = None
-  bin_hi         = None
   grouping       = Int16[1024]
   quality        = Int16[1024]
   exposure       = 38564.608926889
@@ -96,8 +94,6 @@ that are set in this file's FITS metadata::
   counts         = Float64[1024]
   staterror      = None
   syserror       = None
-  bin_lo         = None
-  bin_hi         = None
   grouping       = Int16[1024]
   quality        = Int16[1024]
   exposure       = 38564.608926889
@@ -115,8 +111,6 @@ that are set in this file's FITS metadata::
   energ_lo = Float64[1090]
   energ_hi = Float64[1090]
   specresp = Float64[1090]
-  bin_lo   = None
-  bin_hi   = None
   exposure = 38564.141454905
   ethresh  = 1e-10
   >>> print(pha.get_rmf())
@@ -147,8 +141,6 @@ created::
   counts         = Int64[1024]
   staterror      = None
   syserror       = None
-  bin_lo         = None
-  bin_hi         = None
   grouping       = None
   quality        = None
   exposure       = None
@@ -499,8 +491,6 @@ representing the background region.
   counts         = Float64[1024]
   staterror      = None
   syserror       = None
-  bin_lo         = None
-  bin_hi         = None
   grouping       = Int16[1024]
   quality        = Int16[1024]
   exposure       = 38564.608926889

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -1061,13 +1061,6 @@ extra checks, such as the `~sherpa.astro.data.DataPHA.grouping` and
 `~sherpa.astro.data.DataPHA.quality` columns for PHA data which
 are converted to integer values.
 
-One example of incomplete validation is that the
-`~sherpa.astro.data.DataPHA.bin_lo` and
-`~sherpa.astro.data.DataPHA.bin_hi` fields are not checked to ensure
-that both are set, or that they are in descending order, that the
-``bin_hi`` value is always larger than the correspondnig ``bin_lo``
-value, or that there are no overlapping bins.
-
 .. _data_design_errors:
 
 Error messages

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -2749,23 +2749,21 @@ will be removed. The identifiers can be integers or strings.
 
         """
 
+        # It is not clear what the filter flag is meant to do and
+        # there is no test that can be used to identify what it is
+        # meant to do. The RMF and ARF get_indep calls ignore the
+        # filter flag they are sent.
+        #
         energylist = []
         for resp_id in self.response_ids:
             arf, rmf = self.get_response(resp_id)
-            lo = None
-            hi = None
-
             if rmf is not None:
-                lo = rmf.energ_lo
-                hi = rmf.energ_hi
-                if filter:
-                    lo, hi = rmf.get_indep()
-
+                lo, hi = rmf.get_indep(filter=filter)
             elif arf is not None:
-                lo = arf.energ_lo
-                hi = arf.energ_hi
-                if filter:
-                    lo, hi = arf.get_indep()
+                lo, hi = arf.get_indep(filter=filter)
+            else:
+                lo = None
+                hi = None
 
             energylist.append((lo, hi))
 

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -53,9 +53,7 @@ reducing the number of values in a data set - and adds an extra way
 to filter the data with the quality array. The class extends
 `~sherpa.data.Data1D`, since the primary data is channels and
 counts, but it also has to act like an integrated data set
-(`~sherpa.data.Data1DInt`) in some cases. In an extension to
-OGIP support, there is limited support for the ``BIN_LO`` and
-``BIN_HI`` fields provided with Chandra grating data.
+(`~sherpa.data.Data1DInt`) in some cases.
 
 The `DataIMG` class extends 2D support for "gridded" data, with
 multiple possible coordinate systems (e.g. ``logical``, ``physical``,
@@ -67,6 +65,10 @@ Notes
 
 Some functionality depends on the presence of the region and grouping
 Sherpa modules, which are optional components of Sherpa.
+
+Prior to 4.18.0 there was limited support for the ``BIN_LO`` and
+``BIN_HI`` fields provided with Chandra grating data, but this has now
+been removed.
 
 Notebook support
 ----------------
@@ -555,7 +557,9 @@ def html_arf(arf):
     erange = _calc_erange(arf.energ_lo, arf.energ_hi)
     meta.append(('Energy range', erange))
 
-    # repeat for wavelengths (without the energy threshold)
+    # It would be nice to show the wavelength range, but how to decide
+    # when to include it? For now the presence of bin_lo/hi fields is
+    # used (this is not an OGIP standard).
     #
     if arf.bin_lo is not None and arf.bin_hi is not None:
         wrange = _calc_wrange(arf.bin_lo, arf.bin_hi)
@@ -898,6 +902,9 @@ class DataARF(DataOgipResponse):
     The ARF format is described in OGIP documents [CAL_92_002]_ and
     [CAL_92_002a]_.
 
+    .. versionchanged:: 4.18.0
+       The bin_lo and bin_hi columns are now ignored.
+
     Parameters
     ----------
     name : str
@@ -909,6 +916,7 @@ class DataARF(DataOgipResponse):
         ENERG_LO values for each bin, and the energy arrays must be
         in increasing or decreasing order.
     bin_lo, bin_hi : array or None, optional
+        These should not be set.
     exposure : number or None, optional
         The exposure time for the ARF, in seconds.
     header : dict or None, optional
@@ -1478,7 +1486,8 @@ class DataPHA(Data1D):
 
     .. versionchanged:: 4.18.0
        Validation now happens when setting the units field as well as
-       in the set_analysis routine.
+       in the set_analysis routine. The bin_lo and bin_hi columns are
+       now ignored.
 
     Parameters
     ----------
@@ -1491,8 +1500,7 @@ class DataPHA(Data1D):
         The statistical and systematic errors for the data, if
         defined.
     bin_lo, bin_hi : array or None, optional
-        The wavelength ranges for the channels. This is intended to support
-        Chandra grating spectra.
+        These should not be set.
     grouping : array of int or None, optional
     quality : array of int or None, optional
     exposure : number or None, optional
@@ -1708,10 +1716,11 @@ class DataPHA(Data1D):
             raise DataErr('bad', 'quantity', val)
 
         # Check that the units setting is valid.
-        # TODO: can we remove the bin_lo/hi check?
         #
         if units != "channel":
             arf, rmf = self.get_response()
+            if arf is None and rmf is None:
+                raise DataErr("norsp", self.name)
 
             # Does it make sense to check the ARF and RMF are compatible
             # here? Shouldn't it be done when setting the response.
@@ -1720,13 +1729,8 @@ class DataPHA(Data1D):
                 if rmf.detchans != len(self.channel):
                     raise DataErr("incompatibleresp", rmf.name, self.name)
 
-            elif arf is not None:
-                if len(arf.energ_lo) != len(self.channel):
-                    raise DataErr("incompleteresp", self.name)
-
-            elif self.bin_lo is None and self.bin_hi is None:
-                # No ARF or RMF
-                raise DataErr("norsp", self.name)
+            elif arf is not None and len(arf.energ_lo) != len(self.channel):
+                raise DataErr("incompleteresp", self.name)
 
         # Set the units for any associated background if we can.
         # Since the setting only really matters if fitting the
@@ -2639,13 +2643,6 @@ will be removed. The identifiers can be integers or strings.
         if self.units == 'channel':
             elo = self.channel
             ehi = self.channel + 1
-        elif (self.bin_lo is not None) and (self.bin_hi is not None):
-            # TODO: review whether bin_lo/hi should over-ride the response
-            elo = self.bin_lo
-            ehi = self.bin_hi
-            if (elo[0] > elo[-1]) and (ehi[0] > ehi[-1]):
-                elo = hc / self.bin_hi
-                ehi = hc / self.bin_lo
         else:
             arf, rmf = self.get_response(response_id)
             if rmf is not None:
@@ -2751,47 +2748,36 @@ will be removed. The identifiers can be integers or strings.
 
         """
 
-        if (self.bin_lo is not None) and (self.bin_hi is not None):
-            elo = self.bin_lo
-            ehi = self.bin_hi
-            if (elo[0] > elo[-1]) and (ehi[0] > ehi[-1]):
-                if self.units == 'wavelength':
-                    return (elo, ehi)
+        energylist = []
+        for resp_id in self.response_ids:
+            arf, rmf = self.get_response(resp_id)
+            lo = None
+            hi = None
 
-                elo = hc / self.bin_hi
-                ehi = hc / self.bin_lo
+            if rmf is not None:
+                lo = rmf.energ_lo
+                hi = rmf.energ_hi
+                if filter:
+                    lo, hi = rmf.get_indep()
 
+            elif arf is not None:
+                lo = arf.energ_lo
+                hi = arf.energ_hi
+                if filter:
+                    lo, hi = arf.get_indep()
+
+            energylist.append((lo, hi))
+
+        if len(energylist) > 1:
+            # TODO: This is only tested by test_eval_multi_xxx and not with
+            # actual (i.e. real world) data
+            elo, ehi, _ = compile_energy_grid(energylist)
+        elif (not energylist or
+              (len(energylist) == 1 and
+                  np.equal(energylist[0], None).any())):
+            raise DataErr('noenergybins', 'Response')
         else:
-            energylist = []
-            for resp_id in self.response_ids:
-                arf, rmf = self.get_response(resp_id)
-                lo = None
-                hi = None
-
-                if rmf is not None:
-                    lo = rmf.energ_lo
-                    hi = rmf.energ_hi
-                    if filter:
-                        lo, hi = rmf.get_indep()
-
-                elif arf is not None:
-                    lo = arf.energ_lo
-                    hi = arf.energ_hi
-                    if filter:
-                        lo, hi = arf.get_indep()
-
-                energylist.append((lo, hi))
-
-            if len(energylist) > 1:
-                # TODO: This is only tested by test_eval_multi_xxx and not with
-                # actual (i.e. real world) data
-                elo, ehi, lookuptable = compile_energy_grid(energylist)
-            elif (not energylist or
-                  (len(energylist) == 1 and
-                      np.equal(energylist[0], None).any())):
-                raise DataErr('noenergybins', 'Response')
-            else:
-                elo, ehi = energylist[0]
+            elo, ehi = energylist[0]
 
         lo, hi = elo, ehi
         if self.units == 'wavelength':

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2015 - 2025
+#  Copyright (C) 2008, 2015-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1476,6 +1476,10 @@ class DataPHA(Data1D):
     The PHA format is described in an OGIP document [OGIP_92_007]_ and
     [OGIP_92_007a]_.
 
+    .. versionchanged:: 4.18.0
+       Validation now happens when setting the units field as well as
+       in the set_analysis routine.
+
     Parameters
     ----------
     name : str
@@ -1703,11 +1707,41 @@ class DataPHA(Data1D):
         else:
             raise DataErr('bad', 'quantity', val)
 
+        # Check that the units setting is valid.
+        # TODO: can we remove the bin_lo/hi check?
+        #
+        if units != "channel":
+            arf, rmf = self.get_response()
+
+            # Does it make sense to check the ARF and RMF are compatible
+            # here? Shouldn't it be done when setting the response.
+            #
+            if rmf is not None:
+                if rmf.detchans != len(self.channel):
+                    raise DataErr("incompatibleresp", rmf.name, self.name)
+
+            elif arf is not None:
+                if len(arf.energ_lo) != len(self.channel):
+                    raise DataErr("incompleteresp", self.name)
+
+            elif self.bin_lo is None and self.bin_hi is None:
+                # No ARF or RMF
+                raise DataErr("norsp", self.name)
+
+        # Set the units for any associated background if we can.
+        # Since the setting only really matters if fitting the
+        # background then hide any errors (e.g. if there is no
+        # background response and units is not 'channel').
+        #
         for bkg_id in self.background_ids:
             bkg = self.get_background(bkg_id)
-            if bkg.get_response() != (None, None) or \
-               (bkg.bin_lo is not None and bkg.bin_hi is not None):
+            # The background dataset is guaranteed to exist but the
+            # type of bkg can technically be None so add an assert.
+            assert bkg is not None
+            try:
                 bkg.units = units
+            except DataErr:
+                pass
 
         self._units = units
 
@@ -1715,7 +1749,19 @@ class DataPHA(Data1D):
         return cast(AnalysisType, self._units)
 
     units = property(_get_units, _set_units,
-                     doc="Units of the independent axis: one of 'channel', 'energy', 'wavelength'.")
+                     doc="""Units of the independent axis.
+
+    Values are one of: 'channel', 'energy', or 'wavelength'.
+
+    .. versionchanged:: 4.18.0
+       The units can only be set to 'energy' or 'wavelength' after
+       a response has been added.
+
+    See Also
+    --------
+    set_analysis
+
+""")
 
     def _get_rate(self) -> bool:
         return self._rate
@@ -2108,12 +2154,15 @@ will be removed. The identifiers can be integers or strings.
         return html_pha(self)
 
     def __getstate__(self):
-        state = self.__dict__.copy()
-        return state
+        return self.__dict__.copy()
 
     def __setstate__(self, state):
+        # Why do this?
         self._background_ids = state['_background_ids']
         self._backgrounds = state['_backgrounds']
+        self._responses = state['_responses']
+        self._data_space = state['_data_space']
+
         self._set_units(state['_units'])
 
         if 'header' not in state:
@@ -2147,7 +2196,7 @@ will be removed. The identifiers can be integers or strings.
 
         See Also
         --------
-        get_analysis
+        get_analysis, units
 
         Examples
         --------
@@ -2172,19 +2221,6 @@ will be removed. The identifiers can be integers or strings.
 
         self.rate = type == "rate"
 
-        arf, rmf = self.get_response()
-        if rmf is not None and rmf.detchans != len(self.channel):
-            raise DataErr("incompatibleresp", rmf.name, self.name)
-
-        if (rmf is None and arf is None) and \
-           (self.bin_lo is None and self.bin_hi is None) and \
-           quantity != "channel":
-            raise DataErr("norsp", self.name)
-
-        if rmf is None and arf is not None and quantity != "channel" and \
-           len(arf.energ_lo) != len(self.channel):
-            raise DataErr("incompleteresp", self.name)
-
         self.units = quantity
 
     def get_analysis(self) -> AnalysisType:
@@ -2204,7 +2240,7 @@ will be removed. The identifiers can be integers or strings.
 
         See Also
         --------
-        set_analysis
+        set_analysis, units
 
         Examples
         --------
@@ -5102,6 +5138,11 @@ It is an integer or string.
                 # do nothing (other than display an INFO message).
                 #
                 bkg.notice(lo, hi, ignore)
+            except DataErr:
+                # If there is no response then ignore this filter.
+                # TODO: what is the best thing to do here?
+                #
+                pass
             finally:
                 bkg.units = old_bkg_units
 

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -379,7 +379,6 @@ class ARFModelPHA(ARFModel):
 
         # Create a view of original ARF
         self.arf = DataARF(arf.name, arf.energ_lo, arf.energ_hi, arf.specresp,
-                           bin_lo=arf.bin_lo, bin_hi=arf.bin_hi,
                            exposure=arf.exposure, header=arf.header)
 
         # Filter the view for current fitting session
@@ -488,7 +487,6 @@ class RSPModelPHA(RSPModel):
 
         # Create a view of original ARF
         self.arf = DataARF(arf.name, arf.energ_lo, arf.energ_hi, arf.specresp,
-                           bin_lo=arf.bin_lo, bin_hi=arf.bin_hi,
                            exposure=arf.exposure, header=arf.header)
 
         # Filter the view for current fitting session

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -266,6 +266,9 @@ class RSPModel(CompositeModel, ArithmeticModel):
 class RMFModelPHA(RMFModel):
     """RMF convolution model with associated PHA data set.
 
+    .. versionchanged:: 4.18.0
+       The bin_lo and bin_hi columns are now ignored.
+
     Notes
     -----
     Scaling by the AREASCAL setting (scalar or array) is included in
@@ -281,31 +284,6 @@ class RMFModelPHA(RMFModel):
 
         RMFModel.filter(self)
 
-        pha = self.pha
-        # If PHA is a finer grid than RMF, evaluate model on PHA and
-        # rebin down to the granularity that the RMF expects.
-        if pha.bin_lo is not None and pha.bin_hi is not None:
-            bin_lo, bin_hi = pha.bin_lo, pha.bin_hi
-
-            # If PHA grid is in angstroms then convert to keV for
-            # consistency
-            if (bin_lo[0] > bin_lo[-1]) and (bin_hi[0] > bin_hi[-1]):
-                bin_lo = hc / pha.bin_hi
-                bin_hi = hc / pha.bin_lo
-
-            # FIXME: What about filtered option?? bin_lo, bin_hi are
-            # unfiltered??
-
-            # Compare disparate grids in energy space
-            self.rmfargs = ((self.elo, self.ehi), (bin_lo, bin_hi))
-
-            # FIXME: Compute on finer energy grid?  Assumes that PHA has
-            # finer grid than RMF
-            self.elo, self.ehi = bin_lo, bin_hi
-
-            # Wavelength grid (angstroms)
-            self.lo, self.hi = hc / self.ehi, hc / self.elo
-
         # Assume energy as default spectral coordinates
         self.xlo, self.xhi = self.elo, self.ehi
         if self.pha.units == 'wavelength':
@@ -315,9 +293,11 @@ class RMFModelPHA(RMFModel):
         rmf = self._rmf  # original
 
         # Create a view of original RMF
-        self.rmf = DataRMF(rmf.name, rmf.detchans, rmf.energ_lo, rmf.energ_hi,
-                           rmf.n_grp, rmf.f_chan, rmf.n_chan, rmf.matrix,
-                           rmf.offset, rmf.e_min, rmf.e_max, rmf.header)
+        self.rmf = DataRMF(rmf.name, rmf.detchans, rmf.energ_lo,
+                           rmf.energ_hi, rmf.n_grp, rmf.f_chan,
+                           rmf.n_chan, rmf.matrix, offset=rmf.offset,
+                           e_min=rmf.e_min, e_max=rmf.e_max,
+                           header=rmf.header)
 
         # Filter the view for current fitting session
         _notice_resp(self.pha.get_noticed_channels(), None, self.rmf)
@@ -370,6 +350,9 @@ class RMFModelNoPHA(RMFModel):
 class ARFModelPHA(ARFModel):
     """ARF convolution model with associated PHA data set.
 
+    .. versionchanged:: 4.18.0
+       The bin_lo and bin_hi columns are now ignored.
+
     Notes
     -----
     Scaling by the AREASCAL setting (scalar or array) is included in
@@ -385,26 +368,6 @@ class ARFModelPHA(ARFModel):
 
         ARFModel.filter(self)
 
-        pha = self.pha
-        # If PHA is a finer grid than ARF, evaluate model on PHA and
-        # rebin down to the granularity that the ARF expects.
-        if pha.bin_lo is not None and pha.bin_hi is not None:
-            bin_lo, bin_hi = pha.bin_lo, pha.bin_hi
-
-            # If PHA grid is in angstroms then convert to keV for
-            # consistency
-            if (bin_lo[0] > bin_lo[-1]) and (bin_hi[0] > bin_hi[-1]):
-                bin_lo = hc / pha.bin_hi
-                bin_hi = hc / pha.bin_lo
-
-            # FIXME: What about filtered option?? bin_lo, bin_hi are
-            # unfiltered??
-
-            # Compare disparate grids in energy space
-            self.arfargs = ((self.elo, self.ehi), (bin_lo, bin_hi))
-
-            # FIXME: Assumes ARF grid is finest
-
         # Assume energy as default spectral coordinates
         self.xlo, self.xhi = self.elo, self.ehi
         if self.pha.units == 'wavelength':
@@ -416,7 +379,8 @@ class ARFModelPHA(ARFModel):
 
         # Create a view of original ARF
         self.arf = DataARF(arf.name, arf.energ_lo, arf.energ_hi, arf.specresp,
-                           arf.bin_lo, arf.bin_hi, arf.exposure, arf.header)
+                           bin_lo=arf.bin_lo, bin_hi=arf.bin_hi,
+                           exposure=arf.exposure, header=arf.header)
 
         # Filter the view for current fitting session
         if numpy.iterable(pha.mask):
@@ -477,6 +441,9 @@ class ARFModelNoPHA(ARFModel):
 class RSPModelPHA(RSPModel):
     """RMF + ARF convolution model with associated PHA.
 
+    .. versionchanged:: 4.18.0
+       The bin_lo and bin_hi columns are now ignored.
+
     Notes
     -----
     Scaling by the AREASCAL setting (scalar or array) is included in
@@ -493,30 +460,14 @@ class RSPModelPHA(RSPModel):
 
         RSPModel.filter(self)
 
-        pha = self.pha
-        # If PHA is a finer grid than RMF, evaluate model on PHA and
-        # rebin down to the granularity that the RMF expects.
-        if pha.bin_lo is not None and pha.bin_hi is not None:
-            bin_lo, bin_hi = pha.bin_lo, pha.bin_hi
-
-            # If PHA grid is in angstroms then convert to keV for
-            # consistency
-            if (bin_lo[0] > bin_lo[-1]) and (bin_hi[0] > bin_hi[-1]):
-                bin_lo = hc / pha.bin_hi
-                bin_hi = hc / pha.bin_lo
-
-            # FIXME: What about filtered option?? bin_lo, bin_hi are
-            # unfiltered??
-
-            # Compare disparate grids in energy space
-            self.arfargs = ((self.elo, self.ehi), (bin_lo, bin_hi))
-
-            # FIXME: Assumes ARF grid is finest
-
+        # Can this really happen? There is a test of it but it is an
+        # engineered test case rather than "actual" data.
+        #
+        # Should this check be a "or" and not "and", and really it
+        # should check the grid values.
+        #
         elo, ehi = self.rmf.get_indep()
-        # self.elo, self.ehi are from ARF
         if len(elo) != len(self.elo) and len(ehi) != len(self.ehi):
-
             self.rmfargs = ((elo, ehi), (self.elo, self.ehi))
 
         # Assume energy as default spectral coordinates
@@ -529,13 +480,16 @@ class RSPModelPHA(RSPModel):
         rmf = self._rmf
 
         # Create a view of original RMF
-        self.rmf = DataRMF(rmf.name, rmf.detchans, rmf.energ_lo, rmf.energ_hi,
-                           rmf.n_grp, rmf.f_chan, rmf.n_chan, rmf.matrix,
-                           rmf.offset, rmf.e_min, rmf.e_max, rmf.header)
+        self.rmf = DataRMF(rmf.name, rmf.detchans, rmf.energ_lo,
+                           rmf.energ_hi, rmf.n_grp, rmf.f_chan,
+                           rmf.n_chan, rmf.matrix, offset=rmf.offset,
+                           e_min=rmf.e_min, e_max=rmf.e_max,
+                           header=rmf.header)
 
         # Create a view of original ARF
         self.arf = DataARF(arf.name, arf.energ_lo, arf.energ_hi, arf.specresp,
-                           arf.bin_lo, arf.bin_hi, arf.exposure, arf.header)
+                           bin_lo=arf.bin_lo, bin_hi=arf.bin_hi,
+                           exposure=arf.exposure, header=arf.header)
 
         # Filter the view for current fitting session
         _notice_resp(self.pha.get_noticed_channels(), self.arf, self.rmf)

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -471,12 +471,6 @@ def read_arf(arg) -> DataARF:
             "header": header,
             "ethresh": ogip_emin}
 
-    blo = block.get("BIN_LO")
-    bhi = block.get("BIN_HI")
-    if blo is not None and bhi is not None:
-        data["bin_lo"] = blo.values
-        data["bin_hi"] = bhi.values
-
     return DataARF(filename, **data)
 
 
@@ -846,8 +840,6 @@ def _process_pha_block(filename: str,
     # Do we create the backgrounds directly?
     #
     kwargs = {"channel": channel,
-              "bin_lo": get("BIN_LO"),
-              "bin_hi": get("BIN_HI"),
               # "grouping": get("GROUPING", expand=True),
               # "quality": get("QUALITY", expand=True),
               "grouping": getcol("GROUPING"),
@@ -1457,10 +1449,6 @@ def _pack_pha(dataset: DataPHA) -> BlockList:
     addfield("QUALITY", dataset.quality, np.int16,
              "Quality (0 for okay)")
 
-    if dataset.bin_lo is not None and dataset.bin_hi is not None:
-        cols.extend([Column("BIN_LO", dataset.bin_lo),
-                     Column("BIN_HI", dataset.bin_hi)])
-
     def addscal(value, name, label):
         """Add the scaling value."""
 
@@ -1573,15 +1561,6 @@ def _pack_arf(dataset: ARFType) -> BlockList:
                     values=dataset.energ_hi.astype(np.float32)),
              Column("SPECRESP", unit="cm^2", desc="Effective Area",
                     values=dataset.specresp.astype(np.float32))]
-
-    # Chandra files can have BIN_LO/HI values, so copy
-    # across if both set.
-    #
-    blo = dataset.bin_lo
-    bhi = dataset.bin_hi
-    if blo is not None and bhi is not None:
-        acols.extend([Column("BIN_LO", blo),
-                      Column("BIN_HI", bhi)])
 
     pheader = _empty_header(creator=True)
 

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -575,13 +575,6 @@ def get_arf_data(arg: str | TABLECrate,
     cols = [copycol(arf, filename, name, dtype=SherpaFloat)
             for name in ["ENERG_LO", "ENERG_HI", "SPECRESP"]]
 
-    # Optional columns: either both given or none
-    #
-    with suppress(IOErr):
-        bin_lo = copycol(arf, filename, "BIN_LO", dtype=SherpaFloat)
-        bin_hi = copycol(arf, filename, "BIN_HI", dtype=SherpaFloat)
-        cols.extend([bin_lo, bin_hi])
-
     return SpecrespBlock(arf.name, header=headers, columns=cols), filename
 
 
@@ -853,8 +846,6 @@ def _read_pha(pha: TABLECrate,
                         ("RATE", SherpaFloat),
                         ("STAT_ERR", SherpaFloat),
                         ("SYS_ERR", SherpaFloat),
-                        ("BIN_LO", SherpaFloat),
-                        ("BIN_HI", SherpaFloat),
                         ("BACKGROUND_UP", SherpaFloat),
                         ("BACKGROUND_DOWN", SherpaFloat),
                         # Possible scalar values

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -608,13 +608,6 @@ def _read_arf_specresp(arf: fits.HDUList,
     cols = [copycol(hdu, filename, name, dtype=SherpaFloat)
             for name in ["ENERG_LO", "ENERG_HI", "SPECRESP"]]
 
-    # Optional columns: either both given or none
-    #
-    with suppress(IOErr):
-        bin_lo = copycol(hdu, filename, "BIN_LO", dtype=SherpaFloat)
-        bin_hi = copycol(hdu, filename, "BIN_HI", dtype=SherpaFloat)
-        cols.extend([bin_lo, bin_hi])
-
     return SpecrespBlock(hdu.name, header=headers, columns=cols)
 
 
@@ -865,8 +858,6 @@ def _read_pha(pha: fits.BinTableHDU,
                         ("RATE", SherpaFloat),
                         ("STAT_ERR", SherpaFloat),
                         ("SYS_ERR", SherpaFloat),
-                        ("BIN_LO", SherpaFloat),
-                        ("BIN_HI", SherpaFloat),
                         ("BACKGROUND_UP", SherpaFloat),
                         ("BACKGROUND_DOWN", SherpaFloat),
                         # Possible scalar values

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -98,8 +98,6 @@ def test_pha_write_basic(make_data_path, tmp_path):
 
         assert obj.staterror is None
         assert obj.syserror is None
-        assert obj.bin_lo is None
-        assert obj.bin_hi is None
 
         assert obj.exposure == pytest.approx(38564.608926889)
         assert np.log10(obj.backscal) == pytest.approx(-5.597491618115439)
@@ -236,8 +234,6 @@ def test_pha_write_basic_errors(make_data_path, tmp_path):
         assert np.argmax(obj.staterror) == 51
 
         assert obj.syserror is None
-        assert obj.bin_lo is None
-        assert obj.bin_hi is None
 
         assert obj.exposure == pytest.approx(38564.608926889)
         assert np.log10(obj.backscal) == pytest.approx(-5.597491618115439)
@@ -393,8 +389,6 @@ def test_pha_write_xmm_grating(make_data_path, tmp_path):
         assert np.argmax(obj.staterror) == 1498
 
         assert obj.syserror is None
-        assert obj.bin_lo is None
-        assert obj.bin_hi is None
 
         assert obj.exposure == pytest.approx(28965.6406250)
         assert obj.backscal == pytest.approx(1.0)
@@ -598,7 +592,7 @@ def test_write_pha_fits_basic_roundtrip(tmp_path):
     assert isinstance(inpha, DataPHA)
     assert inpha.channel == pytest.approx(chans)
     assert inpha.counts == pytest.approx(counts)
-    for field in ["staterror", "syserror", "bin_lo", "bin_hi",
+    for field in ["staterror", "syserror",
                   "grouping", "quality"]:
         assert getattr(inpha, field) is None
 
@@ -845,7 +839,7 @@ def test_write_pha_fits_with_extras_roundtrip(tmp_path, caplog):
     assert inpha.exposure == pytest.approx(etime)
     assert inpha.backscal == pytest.approx(bscal)
     assert inpha.areascal == pytest.approx(ascal)
-    for field in ["staterror", "syserror", "bin_lo", "bin_hi"]:
+    for field in ["staterror", "syserror"]:
         assert getattr(inpha, field) is None
 
     assert inpha.grouped
@@ -1208,8 +1202,6 @@ def test_csc_pha_roundtrip(make_data_path, tmp_path):
 
         assert obj.staterror is None
         assert obj.syserror is None
-        assert obj.bin_lo is None
-        assert obj.bin_hi is None
 
         assert obj.exposure == pytest.approx(37664.157219191)
         assert np.log10(obj.backscal) == pytest.approx(lbscal)

--- a/sherpa/astro/io/tests/test_io_response.py
+++ b/sherpa/astro/io/tests/test_io_response.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2023 - 2025
+#  Copyright (C) 2021, 2023-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -81,7 +81,7 @@ def test_read_arf(make_data_path):
     assert hdr["CTI_CORR"]
     assert hdr["DTCOR"] == pytest.approx(0.98318749385508,)
 
-    for field in ["energ_lo", "energ_hi", "specresp", "bin_lo", "bin_hi"]:
+    for field in ["energ_lo", "energ_hi", "specresp"]:
         attr = getattr(arf, field)
         assert len(attr) == 8192
         assert attr.dtype == np.float64
@@ -92,10 +92,6 @@ def test_read_arf(make_data_path):
 
     assert arf.specresp.sum() == pytest.approx(67517.7296)
     assert np.argmax(arf.specresp) == 7041
-
-    assert (arf.bin_lo[:-1] == arf.bin_hi[1:]).all()
-    assert arf.bin_lo[-1] == pytest.approx(1.0)
-    assert arf.bin_hi[0] == pytest.approx(41.959999084)
 
 
 @requires_data
@@ -214,9 +210,6 @@ def test_write_arf_fits(make_data_path, tmp_path):
     assert new.energ_hi.sum() == pytest.approx(TEST_ARF_EHI_SUM)
     assert new.specresp.sum() == pytest.approx(TEST_ARF_SPECRESP_SUM)
 
-    assert new.bin_lo is None
-    assert new.bin_hi is None
-
 
 @requires_data
 @requires_fits
@@ -245,14 +238,14 @@ def test_write_arf_ascii(make_data_path, tmp_path):
 @requires_data
 @requires_fits
 def test_write_arf_fits_chandra_acis_hetg(make_data_path, tmp_path):
-    """Check we can write out an ARF with BIN_LO/HI as a FITS file.
+    """Check we can write out a Chandra ACIS grating ARF as a FITS file.
+
+    This used to write out BIN_LO/HI values too, until #1564 was fixed.
     """
 
     infile = make_data_path("3c120_meg_-1.arf.gz")
     orig = io.read_arf(infile)
     assert orig.exposure > 10
-    assert orig.bin_lo is not None
-    assert orig.bin_hi.size == orig.specresp.size
 
     outpath = tmp_path / "out.arf"
     outfile = str(outpath)
@@ -283,14 +276,13 @@ def test_write_arf_fits_chandra_acis_hetg(make_data_path, tmp_path):
     assert new.energ_hi == pytest.approx(orig.energ_hi)
     assert new.specresp == pytest.approx(orig.specresp)
 
-    assert new.bin_lo == pytest.approx(orig.bin_lo)
-    assert new.bin_hi == pytest.approx(orig.bin_hi)
-
 
 @requires_data
 @requires_fits
 def test_write_arf_ascii_chandra_acis_hetg(make_data_path, tmp_path):
-    """Check we can write out an ARF with BIN_LO/HI as an ASCII file.
+    """Check we can write out a Chandra ACIS grating ARF as an ASCII file.
+
+    This used to write out BIN_LO/HI values too, until #1564 was fixed.
     """
 
     infile = make_data_path("3c120_meg_-1.arf.gz")
@@ -301,10 +293,10 @@ def test_write_arf_ascii_chandra_acis_hetg(make_data_path, tmp_path):
     io.write_arf(outfile, orig, ascii=True)
 
     new = io.read_ascii(outfile, ncols=3, dstype=Data1DInt,
-                        colkeys=["BIN_LO", "BIN_HI", "SPECRESP"])
+                        colkeys=["ENERG_LO", "ENERG_HI", "SPECRESP"])
 
-    assert new.xlo == pytest.approx(orig.bin_lo)
-    assert new.xhi == pytest.approx(orig.bin_hi)
+    assert new.xlo == pytest.approx(orig.energ_lo)
+    assert new.xhi == pytest.approx(orig.energ_hi)
     assert new.y == pytest.approx(orig.specresp)
 
 
@@ -923,9 +915,6 @@ def test_write_fake_arf(tmp_path):
     assert new.energ_lo == pytest.approx(elo)
     assert new.energ_hi == pytest.approx(ehi)
     assert new.specresp == pytest.approx(y)
-
-    assert new.bin_lo is None
-    assert new.bin_hi is None
 
 
 # Is offset=10 valid? As far as I can see there's no reason to not

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -2862,28 +2862,6 @@ def test_make_invalid_dependent_axis(data_class, args):
         data_class("wrong", *args)
 
 
-def test_pha_fails_when_bin_lo_is_invalid():
-    """What happens when bin_lo has a different size to the data?
-
-    This is to test the order of calls in the __init__ method.
-    """
-
-    with pytest.raises(DataErr,
-                       match="size mismatch between independent axis and bin_lo: 3 vs 2"):
-        DataPHA("something", CHANS, ONES, bin_lo=[1, 3])
-
-
-def test_pha_fails_when_bin_hi_is_invalid():
-    """What happens when bin_hi has a different size to the data?
-
-    This is to test the order of calls in the __init__ method.
-    """
-
-    with pytest.raises(DataErr,
-                       match="size mismatch between independent axis and bin_hi: 3 vs 2"):
-        DataPHA("something", CHANS, ONES, bin_hi=[1, 3])
-
-
 @pytest.mark.parametrize("data_args",
                          [ARF_ARGS, PHA_ARGS, IMG_ARGS, IMGINT_ARGS])
 def test_set_independent_axis_to_none(data_args):
@@ -2946,29 +2924,7 @@ def test_pha_dependent_field_can_not_be_a_scalar(related):
         setattr(data, related, 2)
 
 
-@pytest.mark.parametrize("vals", [[4], (2, 3, 4, 5)])
-def test_pha_bin_field_must_match_initialization(vals):
-    """The bin_lo/hi must match the data"""
-
-    data_class, args = PHA_ARGS
-    with pytest.raises(DataErr,
-                       match=r"^size mismatch between independent axis and bin_hi: 3 vs [14]$"):
-        data_class(*args, bin_lo=[1, 2, 3], bin_hi=vals)
-
-
-@pytest.mark.parametrize("vals", [[4], (2, 3, 4, 5)])
-def test_pha_bin_field_must_match_after(vals):
-    """The bin_lo/hi must match the data"""
-
-    data_class, args = PHA_ARGS
-    data = data_class(*args)
-    data.bin_hi = [4, 5, 6]
-    with pytest.raises(DataErr,
-                       match=r"^size mismatch between independent axis and bin_lo: 3 vs [14]$"):
-        data.bin_lo = vals
-
-
-@pytest.mark.parametrize("related", ["staterror", "syserror", "grouping", "quality", "bin_lo", "bin_hi"])
+@pytest.mark.parametrize("related", ["staterror", "syserror", "grouping", "quality"])
 @pytest.mark.parametrize("vals", [True, 0, np.asarray(1)])
 def test_pha_related_field_can_not_be_a_scalar(related, vals):
     """The related fields (staterror/syserror/grouping/quality/...) can not be a scalar."""
@@ -2980,7 +2936,7 @@ def test_pha_related_field_can_not_be_a_scalar(related, vals):
         setattr(data, related, vals)
 
 
-@pytest.mark.parametrize("label", ["staterror", "syserror", "grouping", "quality", "bin_lo", "bin_hi"])
+@pytest.mark.parametrize("label", ["staterror", "syserror", "grouping", "quality"])
 @pytest.mark.parametrize("vals", [[1, 1], np.ones(10)])
 def test_pha_related_field_can_not_be_a_sequence_wrong_size(label, vals):
     """Check we error out if column=label has the wrong size: sequence"""

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1933,8 +1933,8 @@ def test_energy_filter_ordering(make_data_path):
     assert mask1 == pytest.approx(mask2)
 
 
-@pytest.mark.parametrize('units', ['bin', 'chan', 'energy', 'wave'])
-def test_pha_get_ebins_internal_no_response(units):
+@pytest.mark.parametrize('units', ['bin', 'chan'])
+def test_pha_get_ebins_internal_no_response_chans(units):
     """Check that _get_ebins has an unlikely-used path checked.
 
     It's  not clear what we are meant to return here - i.e. no
@@ -1949,6 +1949,21 @@ def test_pha_get_ebins_internal_no_response(units):
     lo, hi = pha._get_ebins()
     assert lo == pytest.approx(chans)
     assert hi == pytest.approx(chans + 1)
+
+
+@pytest.mark.parametrize('units', ['energy', 'wave'])
+def test_pha_get_ebins_internal_no_response_not_channels(units):
+    """Check that _get_ebins has an unlikely-used path checked.
+
+    This used to succeed but in 4.17.1 was made to error out.
+    """
+
+    chans = np.arange(1, 10, dtype=np.int16)
+    counts = np.ones(9, dtype=np.int16)
+    pha = DataPHA('tst', chans, counts)
+    with pytest.raises(DataErr,
+                       match="^No instrument response found for dataset tst$"):
+        pha.units = units
 
 
 def test_get_background_scale_is_none():

--- a/sherpa/astro/tests/test_astro_data_asca_unit.py
+++ b/sherpa/astro/tests/test_astro_data_asca_unit.py
@@ -69,7 +69,7 @@ def check_pha0(pha, errors=True, responses=True):
     assert pha.counts.sum() == pytest.approx(1688.0)
     assert np.argmax(pha.counts) == 36
 
-    for field in ['staterror', 'syserror', 'bin_lo', 'bin_hi']:
+    for field in ['staterror', 'syserror']:
         assert getattr(pha, field) is None
 
     assert len(pha.grouping) == nchan
@@ -146,7 +146,6 @@ def check_pha1(pha, errors=True, responses=True):
     assert np.argmax(pha.counts) == 85
 
     for field in ['staterror', 'syserror',
-                  'bin_lo', 'bin_hi',
                   'grouping', 'quality'
                   ]:
         assert getattr(pha, field) is None
@@ -206,8 +205,7 @@ def check_arf0(arf):
     assert arf.specresp.sum() == pytest.approx(115339.06293487549)
     assert np.argmax(arf.specresp) == 193
 
-    for field in ['bin_lo', 'bin_hi', 'exposure']:
-        assert getattr(arf, field) is None
+    assert arf.exposure is None
 
 
 def check_arf1(arf):
@@ -236,8 +234,7 @@ def check_arf1(arf):
     assert arf.specresp.sum() == pytest.approx(125779.58236)
     assert np.argmax(arf.specresp) == 194
 
-    for field in ['bin_lo', 'bin_hi', 'exposure']:
-        assert getattr(arf, field) is None
+    assert arf.exposure is None
 
 
 def check_rmf0(rmf):

--- a/sherpa/astro/tests/test_astro_data_chandra_unit.py
+++ b/sherpa/astro/tests/test_astro_data_chandra_unit.py
@@ -69,8 +69,7 @@ def check_pha(pha, responses=True):
     assert pha.counts.sum() == pytest.approx(77)
     assert np.argmax(pha.counts) == 10
 
-    for field in ['staterror', 'syserror', 'quality', 'grouping',
-                  'bin_lo', 'bin_hi']:
+    for field in ['staterror', 'syserror', 'quality', 'grouping']:
         assert getattr(pha, field) is None
 
     assert pha.grouped is False
@@ -147,9 +146,6 @@ def check_arf(arf):
     assert arf.energ_hi[0] == pytest.approx(0.23)
     assert arf.energ_lo[-1] == pytest.approx(10.99)
     assert arf.energ_hi[-1] == pytest.approx(11.0)
-
-    assert arf.bin_lo is None
-    assert arf.bin_hi is None
 
     # Rather than check each element, use some simple summary
     # statistics.
@@ -242,14 +238,6 @@ def check_pha_grating(pha, errors=False, responses=True):
     assert pha.counts.max() == pytest.approx(15.0)
     assert pha.counts.sum() == pytest.approx(16298.0)
     assert np.argmax(pha.counts) == 5871
-
-    assert len(pha.bin_lo) == nchan
-    assert len(pha.bin_hi) == nchan
-    assert pha.bin_hi[1:] == pytest.approx(pha.bin_lo[:-1])
-    assert pha.bin_lo[0] == pytest.approx(21.4775)
-    assert pha.bin_hi[0] == pytest.approx(21.48)
-    assert pha.bin_lo[-1] == pytest.approx(1.0)
-    assert pha.bin_hi[-1] == pytest.approx(1.0025)
 
     for field in ['syserror', 'quality', 'grouping']:
         assert getattr(pha, field) is None
@@ -349,14 +337,6 @@ def check_arf_grating(arf):
     assert arf.energ_hi[0] == pytest.approx(0.57727474)
     assert arf.energ_lo[-1] == pytest.approx(12.36749935)
     assert arf.energ_hi[-1] == pytest.approx(12.39841843)
-
-    assert len(arf.bin_lo) == nbins
-    assert len(arf.bin_hi) == nbins
-    assert arf.bin_hi[1:] == pytest.approx(arf.bin_lo[:-1])
-    assert arf.bin_lo[0] == pytest.approx(21.4775)
-    assert arf.bin_hi[0] == pytest.approx(21.48)
-    assert arf.bin_lo[-1] == pytest.approx(1.0)
-    assert arf.bin_hi[-1] == pytest.approx(1.0025)
 
     # Rather than check each element, use some simple summary
     # statistics.

--- a/sherpa/astro/tests/test_astro_data_notebook.py
+++ b/sherpa/astro/tests/test_astro_data_notebook.py
@@ -64,12 +64,8 @@ def check(r, summary, name, label, nmeta):
 def test_arf(header, all_plot_backends):
     ebins = np.arange(0.1, 1, 0.1)
 
-    # fake wavelength conversion
-    wbins = 10 / ebins
-
     y = np.linspace(10, 80, ebins.size - 1)
     d = data.DataARF('arf 1', ebins[:-1], ebins[1:], y,
-                     bin_lo=wbins[1:], bin_hi=wbins[:-1],
                      exposure=100.1, header=header)
     r = d._repr_html_()
 
@@ -77,9 +73,7 @@ def test_arf(header, all_plot_backends):
     check(r, 'ARF', 'arf 1', 'SPECRESP', nmeta=nmeta)
 
     assert '<div class="dataname">Energy range</div>' in r
-    assert '<div class="dataname">Wavelength range</div>' in r
     assert '<div class="dataval">0.1 - 0.9 keV, bin size 0.1 keV</div>' in r
-    assert '<div class="dataval">12.5 - 50 &#8491;, bin size 1.38889 - 50 &#8491;</div>' in r
 
 
 @pytest.mark.parametrize('header', [None, {}, TEST_HEADER])

--- a/sherpa/astro/tests/test_astro_data_rosat_unit.py
+++ b/sherpa/astro/tests/test_astro_data_rosat_unit.py
@@ -162,7 +162,7 @@ def validate_pha(pha, errors=False):
 
     # TODO: check that grouping/quality is applied correctly
 
-    emptyfields = ['syserror', 'bin_lo', 'bin_hi']
+    emptyfields = ['syserror']
     if errors:
         assert len(pha.staterror) == nchan
         assert pha.staterror.min() == pytest.approx(0.0)

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -88,7 +88,7 @@ def check_pha(pha):
     assert pha.counts.sum() == pytest.approx(58.0)
     assert np.argmax(pha.counts) == 110
 
-    for field in ['staterror', 'syserror', 'bin_lo', 'bin_hi',
+    for field in ['staterror', 'syserror',
                   'grouping', 'quality']:
         assert getattr(pha, field) is None
 
@@ -154,8 +154,7 @@ def check_arf(arf):
     assert arf.specresp.sum() == pytest.approx(178696.1007297188)
     assert np.argmax(arf.specresp) == 309
 
-    for field in ['bin_lo', 'bin_hi', 'exposure']:
-        assert getattr(arf, field) is None
+    assert arf.exposure is None
 
 
 def check_rmf(rmf):

--- a/sherpa/astro/tests/test_astro_data_xmm_unit.py
+++ b/sherpa/astro/tests/test_astro_data_xmm_unit.py
@@ -81,8 +81,7 @@ def check_pha(pha, responses=True):
     assert pha.quality.sum() == 276
     assert pha.quality.argmax() == 662
 
-    for field in ['staterror', 'syserror',
-                  'bin_lo', 'bin_hi']:
+    for field in ['staterror', 'syserror']:
         assert getattr(pha, field) is None
 
     assert pha.grouped is True
@@ -153,9 +152,6 @@ def check_arf(arf):
     assert arf.energ_hi[0] == pytest.approx(0.005)
     assert arf.energ_lo[-1] == pytest.approx(11.9949998856)
     assert arf.energ_hi[-1] == pytest.approx(12.0)
-
-    assert arf.bin_lo is None
-    assert arf.bin_hi is None
 
     # Rather than check each element, use some simple summary
     # statistics.
@@ -257,8 +253,7 @@ def check_pha_grating(pha, errors=False):
     assert pha.counts.sum() == pytest.approx(2724.0)
     assert np.argmax(pha.counts) == 1498
 
-    for field in ['syserror', 'bin_lo', 'bin_hi',
-                  'grouping']:
+    for field in ['syserror', 'grouping']:
         assert getattr(pha, field) is None
 
     if errors:

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -27,7 +27,7 @@ import pytest
 from sherpa.utils.testing import requires_data, requires_fits
 
 from sherpa.astro.data import DataARF, DataPHA
-from sherpa.astro.instrument import create_delta_rmf
+from sherpa.astro.instrument import create_arf, create_delta_rmf
 from sherpa.astro.plot import SourcePlot, ComponentSourcePlot, \
     DataPHAPlot, ModelPHAHistogram, ModelHistogram, OrderPlot, \
     _check_hist_bins, \
@@ -669,6 +669,10 @@ def test_pha_data_with_gaps_977():
     "precision"). At the moment this is only done for PHA
     data and model plots, not for generic histogram plots.
     See issue #977
+
+    After dropping support for bin_lo/hi - issue #1564 - it is not
+    clear whether this is still a useful test, but keep in for now.
+
     """
 
     chans = np.arange(1, 6)
@@ -676,9 +680,17 @@ def test_pha_data_with_gaps_977():
 
     blo = np.asarray([100, 99, 98, 97, 96])
     bhi = np.asarray([101, 100.0000000001, 99, 98, 97])
+    elo = hc / bhi
+    ehi = hc / blo
 
-    d = DataPHA('x', chans, vals, bin_lo=blo, bin_hi=bhi)
-    d.set_analysis('wave')
+    d = DataPHA('x', chans, vals)
+
+    rmf = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi)
+    arf = create_arf(elo, ehi)
+    d.set_rmf(rmf)
+    d.set_arf(arf)
+
+    d.set_analysis("wave")
 
     p = aplot.DataPHAPlot()
     p.prepare(d)
@@ -713,8 +725,16 @@ def test_pha_model_with_gaps_977():
 
     blo = np.asarray([100, 99, 98, 97, 96])
     bhi = np.asarray([101, 100.0000000001, 99, 98, 97])
+    elo = hc / bhi
+    ehi = hc / blo
 
-    d = DataPHA('x', chans, vals, bin_lo=blo, bin_hi=bhi)
+    d = DataPHA('x', chans, vals)
+
+    rmf = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi)
+    arf = create_arf(elo, ehi)
+    d.set_rmf(rmf)
+    d.set_arf(arf)
+
     d.set_analysis('wave')
 
     mdl = Polynom1D()

--- a/sherpa/astro/tests/test_fake_pha.py
+++ b/sherpa/astro/tests/test_fake_pha.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2023
+#  Copyright (C) 2020 - 2021, 2023 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -547,7 +547,7 @@ def test_fake_pha_has_valid_ogip_keywords_all_fake(tmp_path):
     assert inpha.channel == pytest.approx(channels)
     assert inpha.counts == pytest.approx(data.counts)
 
-    for field in ["staterror", "syserror", "bin_lo", "bin_hi",
+    for field in ["staterror", "syserror",
                   "grouping", "quality"]:
         assert getattr(inpha, field) is None
 
@@ -622,7 +622,7 @@ def test_fake_pha_has_valid_ogip_keywords_from_real(make_data_path, tmp_path):
     assert inpha.channel == pytest.approx(np.arange(1, 1025))
     assert inpha.counts == pytest.approx(data.counts)
 
-    for field in ["staterror", "syserror", "bin_lo", "bin_hi",
+    for field in ["staterror", "syserror",
                   "grouping", "quality"]:
         assert getattr(inpha, field) is None
 

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015, 2016, 2019, 2021, 2023, 2024
+#  Copyright (C) 2015, 2016, 2019, 2021, 2023 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1271,12 +1271,6 @@ def _save_dataset_pha(out: OutType, idstr: str, pha: DataPHA) -> None:
     #
     # setarray("quality")
     # setarray("grouping")
-
-    if pha.bin_lo is not None and pha.bin_hi is not None:
-        # no use restoring only one of these
-        #
-        _output(out, f"get_data({idstr}).bin_lo = {pha.bin_lo.tolist()}")
-        _output(out, f"get_data({idstr}).bin_hi = {pha.bin_hi.tolist()}")
 
 
 def _save_dataset(out: OutType,

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -813,56 +813,55 @@ def test_show_data_datapha_no_bkg_no_response():
     s.show_data(outfile=out)
 
     toks = out.getvalue().split("\n")
-    assert toks[0] == "Data Set: 1"
-    assert toks[1] == "Filter: 1,4-5 Channel"
-    assert toks[2] == "Noticed Channels: 1,4-5"
-    assert toks[3] == "name           = "
-    assert toks[4] == "channel        = Int64[5]"
-    assert toks[5] == "counts         = Int64[5]"
-    assert toks[6] == "staterror      = None"
-    assert toks[7] == "syserror       = None"
-    assert toks[8] == "bin_lo         = None"
-    assert toks[9] == "bin_hi         = None"
-    assert toks[10] == "grouping       = None"
-    assert toks[11] == "quality        = None"
-    assert toks[12] == "exposure       = 100.0"
-    assert toks[13] == "backscal       = None"
-    assert toks[14] == "areascal       = None"
-    assert toks[15] == "grouped        = False"
-    assert toks[16] == "subtracted     = False"
-    assert toks[17] == "units          = channel"
-    assert toks[18] == "rate           = True"
-    assert toks[19] == "plot_fac       = 0"
-    assert toks[20] == "response_ids   = []"
-    assert toks[21] == "background_ids = []"
-    assert toks[22] == ""
-    assert toks[23] == "Data Set: 2"
-    assert toks[24] == "Filter: 1-5 Channel"
-    assert toks[25] == "Noticed Channels: 1-5"
-    assert toks[26] == "name           = "
-    assert toks[27] == "channel        = Int64[5]"
-    assert toks[28] == "counts         = Int64[5]"
-    assert toks[29] == "staterror      = None"
-    assert toks[30] == "syserror       = None"
-    assert toks[31] == "bin_lo         = None"
-    assert toks[32] == "bin_hi         = None"
-    assert toks[33] == "grouping       = None"
-    assert toks[34] == "quality        = None"
-    assert toks[35] == "exposure       = 200.0"
-    assert toks[36] == "backscal       = None"
-    assert toks[37] == "areascal       = None"
-    assert toks[38] == "grouped        = False"
-    assert toks[39] == "subtracted     = False"
-    assert toks[40] == "units          = channel"
-    assert toks[41] == "rate           = True"
-    assert toks[42] == "plot_fac       = 0"
-    assert toks[43] == "response_ids   = []"
-    assert toks[44] == "background_ids = []"
-    assert toks[45] == ""
-    assert toks[46] == ""
-    assert toks[47] == ""
+    def check(expected):
+        assert toks.pop(0) == expected
 
-    assert len(toks) == 48
+    check("Data Set: 1")
+    check("Filter: 1,4-5 Channel")
+    check("Noticed Channels: 1,4-5")
+    check("name           = ")
+    check("channel        = Int64[5]")
+    check("counts         = Int64[5]")
+    check("staterror      = None")
+    check("syserror       = None")
+    check("grouping       = None")
+    check("quality        = None")
+    check("exposure       = 100.0")
+    check("backscal       = None")
+    check("areascal       = None")
+    check("grouped        = False")
+    check("subtracted     = False")
+    check("units          = channel")
+    check("rate           = True")
+    check("plot_fac       = 0")
+    check("response_ids   = []")
+    check("background_ids = []")
+    check("")
+    check("Data Set: 2")
+    check("Filter: 1-5 Channel")
+    check("Noticed Channels: 1-5")
+    check("name           = ")
+    check("channel        = Int64[5]")
+    check("counts         = Int64[5]")
+    check("staterror      = None")
+    check("syserror       = None")
+    check("grouping       = None")
+    check("quality        = None")
+    check("exposure       = 200.0")
+    check("backscal       = None")
+    check("areascal       = None")
+    check("grouped        = False")
+    check("subtracted     = False")
+    check("units          = channel")
+    check("rate           = True")
+    check("plot_fac       = 0")
+    check("response_ids   = []")
+    check("background_ids = []")
+    check("")
+    check("")
+    check("")
+
+    assert len(toks) == 0
 
 
 def test_show_data_datapha_bkg_no_response():
@@ -891,80 +890,78 @@ def test_show_data_datapha_bkg_no_response():
     s.show_data(outfile=out)
 
     toks = out.getvalue().split("\n")
-    assert toks[0] == "Data Set: 1"
-    assert toks[1] == "Filter: 1-5 Channel"
-    assert toks[2] == "Bkg Scale 1: 1"  # TODO: what are these meant to be?
-    assert toks[3] == "Bkg Scale 2: 2"  # TODO: what are these meant to be?
-    assert toks[4] == "Noticed Channels: 1-5"
-    assert toks[5] == "name           = src"
-    assert toks[6] == "channel        = Int64[5]"
-    assert toks[7] == "counts         = Int64[5]"
-    assert toks[8] == "staterror      = None"
-    assert toks[9] == "syserror       = None"
-    assert toks[10] == "bin_lo         = None"
-    assert toks[11] == "bin_hi         = None"
-    assert toks[12] == "grouping       = None"
-    assert toks[13] == "quality        = None"
-    assert toks[14] == "exposure       = 400.0"
-    assert toks[15] == "backscal       = None"
-    assert toks[16] == "areascal       = None"
-    assert toks[17] == "grouped        = False"
-    assert toks[18] == "subtracted     = False"
-    assert toks[19] == "units          = channel"
-    assert toks[20] == "rate           = True"
-    assert toks[21] == "plot_fac       = 0"
-    assert toks[22] == "response_ids   = []"
-    assert toks[23] == "background_ids = [1, 2]"
-    assert toks[24] == ""
-    assert toks[25] == "Background Data Set: 1:1"
-    assert toks[26] == "Filter: 1,4-5 Channel"
-    assert toks[27] == "Noticed Channels: 1,4-5"
-    assert toks[28] == "name           = down"
-    assert toks[29] == "channel        = Int64[5]"
-    assert toks[30] == "counts         = Int64[5]"
-    assert toks[31] == "staterror      = None"
-    assert toks[32] == "syserror       = None"
-    assert toks[33] == "bin_lo         = None"
-    assert toks[34] == "bin_hi         = None"
-    assert toks[35] == "grouping       = None"
-    assert toks[36] == "quality        = None"
-    assert toks[37] == "exposure       = 200.0"
-    assert toks[38] == "backscal       = None"
-    assert toks[39] == "areascal       = None"
-    assert toks[40] == "grouped        = False"
-    assert toks[41] == "subtracted     = False"
-    assert toks[42] == "units          = channel"
-    assert toks[43] == "rate           = True"
-    assert toks[44] == "plot_fac       = 0"
-    assert toks[45] == "response_ids   = []"
-    assert toks[46] == "background_ids = []"
-    assert toks[47] == ""
-    assert toks[48] == "Background Data Set: 1:2"
-    assert toks[49] == "Filter: 1-5 Channel"
-    assert toks[50] == "Noticed Channels: 1-5"
-    assert toks[51] == "name           = up"
-    assert toks[52] == "channel        = Int64[5]"
-    assert toks[53] == "counts         = Int64[5]"
-    assert toks[54] == "staterror      = None"
-    assert toks[55] == "syserror       = None"
-    assert toks[56] == "bin_lo         = None"
-    assert toks[57] == "bin_hi         = None"
-    assert toks[58] == "grouping       = None"
-    assert toks[59] == "quality        = None"
-    assert toks[60] == "exposure       = 100.0"
-    assert toks[61] == "backscal       = None"
-    assert toks[62] == "areascal       = None"
-    assert toks[63] == "grouped        = False"
-    assert toks[64] == "subtracted     = False"
-    assert toks[65] == "units          = channel"
-    assert toks[66] == "rate           = True"
-    assert toks[67] == "plot_fac       = 0"
-    assert toks[68] == "response_ids   = []"
-    assert toks[69] == "background_ids = []"
-    assert toks[70] == ""
-    assert toks[71] == ""
-    assert toks[72] == ""
-    assert len(toks) == 73
+    def check(expected):
+        assert toks.pop(0) == expected
+
+    check("Data Set: 1")
+    check("Filter: 1-5 Channel")
+    check("Bkg Scale 1: 1")  # TODO: what are these meant to be?
+    check("Bkg Scale 2: 2")  # TODO: what are these meant to be?
+    check("Noticed Channels: 1-5")
+    check("name           = src")
+    check("channel        = Int64[5]")
+    check("counts         = Int64[5]")
+    check("staterror      = None")
+    check("syserror       = None")
+    check("grouping       = None")
+    check("quality        = None")
+    check("exposure       = 400.0")
+    check("backscal       = None")
+    check("areascal       = None")
+    check("grouped        = False")
+    check("subtracted     = False")
+    check("units          = channel")
+    check("rate           = True")
+    check("plot_fac       = 0")
+    check("response_ids   = []")
+    check("background_ids = [1, 2]")
+    check("")
+    check("Background Data Set: 1:1")
+    check("Filter: 1,4-5 Channel")
+    check("Noticed Channels: 1,4-5")
+    check("name           = down")
+    check("channel        = Int64[5]")
+    check("counts         = Int64[5]")
+    check("staterror      = None")
+    check("syserror       = None")
+    check("grouping       = None")
+    check("quality        = None")
+    check("exposure       = 200.0")
+    check("backscal       = None")
+    check("areascal       = None")
+    check("grouped        = False")
+    check("subtracted     = False")
+    check("units          = channel")
+    check("rate           = True")
+    check("plot_fac       = 0")
+    check("response_ids   = []")
+    check("background_ids = []")
+    check("")
+    check("Background Data Set: 1:2")
+    check("Filter: 1-5 Channel")
+    check("Noticed Channels: 1-5")
+    check("name           = up")
+    check("channel        = Int64[5]")
+    check("counts         = Int64[5]")
+    check("staterror      = None")
+    check("syserror       = None")
+    check("grouping       = None")
+    check("quality        = None")
+    check("exposure       = 100.0")
+    check("backscal       = None")
+    check("areascal       = None")
+    check("grouped        = False")
+    check("subtracted     = False")
+    check("units          = channel")
+    check("rate           = True")
+    check("plot_fac       = 0")
+    check("response_ids   = []")
+    check("background_ids = []")
+    check("")
+    check("")
+    check("")
+
+    assert len(toks) == 0
 
 
 def test_show_bkg_datapha_no_response():
@@ -990,33 +987,34 @@ def test_show_bkg_datapha_no_response():
     s.show_bkg(outfile=out)
 
     toks = out.getvalue().split("\n")
-    assert toks[0] == "Background Data Set: 1:1"
-    assert toks[1] == "Filter: 1,4-5 Channel"
-    assert toks[2] == "Noticed Channels: 1,4-5"
-    assert toks[3] == "name           = down"
-    assert toks[4] == "channel        = Int64[5]"
-    assert toks[5] == "counts         = Int64[5]"
-    assert toks[6] == "staterror      = None"
-    assert toks[7] == "syserror       = None"
-    assert toks[8] == "bin_lo         = None"
-    assert toks[9] == "bin_hi         = None"
-    assert toks[10] == "grouping       = None"
-    assert toks[11] == "quality        = None"
-    assert toks[12] == "exposure       = 200.0"
-    assert toks[13] == "backscal       = None"
-    assert toks[14] == "areascal       = None"
-    assert toks[15] == "grouped        = False"
-    assert toks[16] == "subtracted     = False"
-    assert toks[17] == "units          = channel"
-    assert toks[18] == "rate           = True"
-    assert toks[19] == "plot_fac       = 0"
-    assert toks[20] == "response_ids   = []"
-    assert toks[21] == "background_ids = []"
-    assert toks[22] == ""
-    assert toks[23] == ""
-    assert toks[24] == ""
+    def check(expected):
+        assert toks.pop(0) == expected
 
-    assert len(toks) == 25
+    check("Background Data Set: 1:1")
+    check("Filter: 1,4-5 Channel")
+    check("Noticed Channels: 1,4-5")
+    check("name           = down")
+    check("channel        = Int64[5]")
+    check("counts         = Int64[5]")
+    check("staterror      = None")
+    check("syserror       = None")
+    check("grouping       = None")
+    check("quality        = None")
+    check("exposure       = 200.0")
+    check("backscal       = None")
+    check("areascal       = None")
+    check("grouped        = False")
+    check("subtracted     = False")
+    check("units          = channel")
+    check("rate           = True")
+    check("plot_fac       = 0")
+    check("response_ids   = []")
+    check("background_ids = []")
+    check("")
+    check("")
+    check("")
+
+    assert len(toks) == 0
 
 
 def test_show_data_datapha_bkg():
@@ -1050,85 +1048,84 @@ def test_show_data_datapha_bkg():
     s.show_data(outfile=out)
 
     toks = out.getvalue().split("\n")
-    assert toks[0] == "Data Set: 1"
-    assert toks[1] == "Filter: 0.1000-1.5000 Energy (keV)"
-    assert toks[2] == "Bkg Scale: 2"
-    assert toks[3] == "Noticed Channels: 1-5"
-    assert toks[4] == "name           = src"
-    assert toks[5] == "channel        = Int64[5]"
-    assert toks[6] == "counts         = Int64[5]"
-    assert toks[7] == "staterror      = None"
-    assert toks[8] == "syserror       = None"
-    assert toks[9] == "bin_lo         = None"
-    assert toks[10] == "bin_hi         = None"
-    assert toks[11] == "grouping       = None"
-    assert toks[12] == "quality        = None"
-    assert toks[13] == "exposure       = 400.0"
-    assert toks[14] == "backscal       = None"
-    assert toks[15] == "areascal       = None"
-    assert toks[16] == "grouped        = False"
-    assert toks[17] == "subtracted     = False"
-    assert toks[18] == "units          = energy"
-    assert toks[19] == "rate           = True"
-    assert toks[20] == "plot_fac       = 0"
-    assert toks[21] == "response_ids   = [1]"
-    assert toks[22] == "background_ids = [1]"
-    assert toks[23] == ""
-    assert toks[24] == "RMF Data Set: 1:1"
-    assert toks[25] == "name     = srmf"
-    assert toks[26] == "energ_lo = Float64[5]"
-    assert toks[27] == "energ_hi = Float64[5]"
-    assert toks[28] == "n_grp    = Int16[5]"
-    assert toks[29] == "f_chan   = Int16[5]"
-    assert toks[30] == "n_chan   = Int16[5]"
-    assert toks[31] == "matrix   = Float32[5]"
-    assert toks[32] == "e_min    = Float64[5]"
-    assert toks[33] == "e_max    = Float64[5]"
-    assert toks[34] == "detchans = 5"
-    assert toks[35] == "offset   = 1"
-    assert toks[36] == "ethresh  = None"
-    assert toks[37] == ""
-    assert toks[38] == "Background Data Set: 1:1"
-    assert toks[39] == "Filter: 0.1000-1.5000 Energy (keV)"
-    assert toks[40] == "Noticed Channels: 1-5"
-    assert toks[41] == "name           = bkg"
-    assert toks[42] == "channel        = Int64[5]"
-    assert toks[43] == "counts         = Int64[5]"
-    assert toks[44] == "staterror      = None"
-    assert toks[45] == "syserror       = None"
-    assert toks[46] == "bin_lo         = None"
-    assert toks[47] == "bin_hi         = None"
-    assert toks[48] == "grouping       = None"
-    assert toks[49] == "quality        = None"
-    assert toks[50] == "exposure       = 200.0"
-    assert toks[51] == "backscal       = None"
-    assert toks[52] == "areascal       = None"
-    assert toks[53] == "grouped        = False"
-    assert toks[54] == "subtracted     = False"
-    assert toks[55] == "units          = energy"
-    assert toks[56] == "rate           = True"
-    assert toks[57] == "plot_fac       = 0"
-    assert toks[58] == "response_ids   = [1]"
-    assert toks[59] == "background_ids = []"
-    assert toks[60] == ""
-    assert toks[61] == "Background RMF Data Set: 1:1"
-    assert toks[62] == "name     = brmf"
-    assert toks[63] == "energ_lo = Float64[5]"
-    assert toks[64] == "energ_hi = Float64[5]"
-    assert toks[65] == "n_grp    = Int16[5]"
-    assert toks[66] == "f_chan   = Int16[5]"
-    assert toks[67] == "n_chan   = Int16[5]"
-    assert toks[68] == "matrix   = Float32[5]"
-    assert toks[69] == "e_min    = Float64[5]"
-    assert toks[70] == "e_max    = Float64[5]"
-    assert toks[71] == "detchans = 5"
-    assert toks[72] == "offset   = 1"
-    assert toks[73] == "ethresh  = None"
-    assert toks[74] == ""
-    assert toks[75] == ""
-    assert toks[76] == ""
+    def check(expected):
+        assert toks.pop(0) == expected
 
-    assert len(toks) == 77
+    check("Data Set: 1")
+    check("Filter: 0.1000-1.5000 Energy (keV)")
+    check("Bkg Scale: 2")
+    check("Noticed Channels: 1-5")
+    check("name           = src")
+    check("channel        = Int64[5]")
+    check("counts         = Int64[5]")
+    check("staterror      = None")
+    check("syserror       = None")
+    check("grouping       = None")
+    check("quality        = None")
+    check("exposure       = 400.0")
+    check("backscal       = None")
+    check("areascal       = None")
+    check("grouped        = False")
+    check("subtracted     = False")
+    check("units          = energy")
+    check("rate           = True")
+    check("plot_fac       = 0")
+    check("response_ids   = [1]")
+    check("background_ids = [1]")
+    check("")
+    check("RMF Data Set: 1:1")
+    check("name     = srmf")
+    check("energ_lo = Float64[5]")
+    check("energ_hi = Float64[5]")
+    check("n_grp    = Int16[5]")
+    check("f_chan   = Int16[5]")
+    check("n_chan   = Int16[5]")
+    check("matrix   = Float32[5]")
+    check("e_min    = Float64[5]")
+    check("e_max    = Float64[5]")
+    check("detchans = 5")
+    check("offset   = 1")
+    check("ethresh  = None")
+    check("")
+    check("Background Data Set: 1:1")
+    check("Filter: 0.1000-1.5000 Energy (keV)")
+    check("Noticed Channels: 1-5")
+    check("name           = bkg")
+    check("channel        = Int64[5]")
+    check("counts         = Int64[5]")
+    check("staterror      = None")
+    check("syserror       = None")
+    check("grouping       = None")
+    check("quality        = None")
+    check("exposure       = 200.0")
+    check("backscal       = None")
+    check("areascal       = None")
+    check("grouped        = False")
+    check("subtracted     = False")
+    check("units          = energy")
+    check("rate           = True")
+    check("plot_fac       = 0")
+    check("response_ids   = [1]")
+    check("background_ids = []")
+    check("")
+    check("Background RMF Data Set: 1:1")
+    check("name     = brmf")
+    check("energ_lo = Float64[5]")
+    check("energ_hi = Float64[5]")
+    check("n_grp    = Int16[5]")
+    check("f_chan   = Int16[5]")
+    check("n_chan   = Int16[5]")
+    check("matrix   = Float32[5]")
+    check("e_min    = Float64[5]")
+    check("e_max    = Float64[5]")
+    check("detchans = 5")
+    check("offset   = 1")
+    check("ethresh  = None")
+    check("")
+    check("")
+    check("")
+
+    assert len(toks) == 0
 
 
 def test_show_bkg_source_output():

--- a/sherpa/astro/ui/tests/test_astro_supports_pha2.py
+++ b/sherpa/astro/ui/tests/test_astro_supports_pha2.py
@@ -66,17 +66,6 @@ def validate_pha(d, bkg=True):
     assert d.channel.max() == pytest.approx(8192.0)
     assert d.channel.sum() == pytest.approx(8193.0 * 8192.0 / 2.0)
 
-    assert len(d.bin_lo) == 8192
-    assert len(d.bin_hi) == 8192
-
-    # check the bins are increasing (so bin_lo[i] < bin_hi[i])
-    # but in descending order
-    assert (d.bin_lo < d.bin_hi).all()
-    assert (d.bin_lo[:-1] > d.bin_lo[1:]).all()
-
-    # are they consecutive?
-    assert (d.bin_lo[:-1] == d.bin_hi[1:]).all()
-
     assert d.counts.sum() > 0
     assert (d.counts >= 0).all()
 

--- a/sherpa/astro/ui/tests/test_astro_supports_pha2.py
+++ b/sherpa/astro/ui/tests/test_astro_supports_pha2.py
@@ -418,8 +418,8 @@ def test_746(make_data_path, clean_astro_ui):
     # group the data
     ui.group_width(id=10, num=2)
 
-    ui.set_analysis('wave')
-    ui.notice(21.4, 21.7)
+    ui.set_analysis(10, 'wave')
+    ui.notice_id(10, 21.4, 21.7)
 
     # internal check that getting the expected data
     expected = np.zeros(30)

--- a/sherpa/astro/ui/tests/test_astro_ui_io.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_io.py
@@ -230,9 +230,13 @@ def test_pha3_roundtrip_check(make_data_path, clean_astro_ui, tmp_path):
     ui.clean()
 
     ui.load_pha(src)
-    ui.load_bkg(bkg)
     ui.load_rmf(rmf)
     ui.load_arf(arf)
+
+    # Load the background after the responses so that they are
+    # associated with it.
+    #
+    ui.load_bkg(bkg)
 
     check_fit_stats()
 

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1905,11 +1905,11 @@ set_analysis(1, quantity="wavelength", type="rate", factor=0)
 
 ######### Filter Data
 
-notice_id(1, "2.000000000000:12.000000000000")
+notice_id(1, "2.000000050569:11.999999841898")
 notice_id(1, bkg_id=1)
-notice_id(1, "2.000000000000:12.000000000000", bkg_id=1)
+notice_id(1, "2.000000050569:11.999999841898", bkg_id=1)
 notice_id(1, bkg_id=2)
-notice_id(1, "2.000000000000:12.000000000000", bkg_id=2)
+notice_id(1, "2.000000050569:11.999999841898", bkg_id=2)
 
 
 ######### Set Statistic
@@ -1946,15 +1946,15 @@ load_bkg(1, "@@/3c120_pha2", bkg_id=2)
 
 ######### Set Energy or Wave Units
 
-set_analysis(1, quantity="wavelength", type="rate", factor=0)
+set_analysis(1, quantity="channel", type="rate", factor=0)
 
 ######### Filter Data
 
-notice_id(1, "2.000000000000:4.000000000000")
+notice_id(1, "3793:6192")
 notice_id(1, bkg_id=1)
-notice_id(1, "2.000000000000:4.000000000000", bkg_id=1)
+notice_id(1, "3793:6192", bkg_id=1)
 notice_id(1, bkg_id=2)
-notice_id(1, "2.000000000000:4.000000000000", bkg_id=2)
+notice_id(1, "3793:6192", bkg_id=2)
 load_pha(10, "@@/3c120_pha2")
 
 ######### Load Background Data Sets
@@ -1964,15 +1964,15 @@ load_bkg(10, "@@/3c120_pha2", bkg_id=2)
 
 ######### Set Energy or Wave Units
 
-set_analysis(10, quantity="wavelength", type="rate", factor=0)
+set_analysis(10, quantity="channel", type="rate", factor=0)
 
 ######### Filter Data
 
-notice_id(10, "2.000000000000:4.000000000000")
+notice_id(10, "7593:7992")
 notice_id(10, bkg_id=1)
-notice_id(10, "2.000000000000:4.000000000000", bkg_id=1)
+notice_id(10, "7593:7992", bkg_id=1)
 notice_id(10, bkg_id=2)
-notice_id(10, "2.000000000000:4.000000000000", bkg_id=2)
+notice_id(10, "7593:7992", bkg_id=2)
 load_pha(11, "@@/3c120_pha2")
 
 ######### Load Background Data Sets
@@ -1982,15 +1982,15 @@ load_bkg(11, "@@/3c120_pha2", bkg_id=2)
 
 ######### Set Energy or Wave Units
 
-set_analysis(11, quantity="wavelength", type="rate", factor=0)
+set_analysis(11, quantity="channel", type="rate", factor=0)
 
 ######### Filter Data
 
-notice_id(11, "2.000000000000:4.000000000000")
+notice_id(11, "6793:7592")
 notice_id(11, bkg_id=1)
-notice_id(11, "2.000000000000:4.000000000000", bkg_id=1)
+notice_id(11, "6793:7592", bkg_id=1)
 notice_id(11, bkg_id=2)
-notice_id(11, "2.000000000000:4.000000000000", bkg_id=2)
+notice_id(11, "6793:7592", bkg_id=2)
 load_pha(12, "@@/3c120_pha2")
 
 ######### Load Background Data Sets
@@ -2000,15 +2000,15 @@ load_bkg(12, "@@/3c120_pha2", bkg_id=2)
 
 ######### Set Energy or Wave Units
 
-set_analysis(12, quantity="wavelength", type="rate", factor=0)
+set_analysis(12, quantity="channel", type="rate", factor=0)
 
 ######### Filter Data
 
-notice_id(12, "2.000000000000:4.000000000000")
+notice_id(12, "5993:7192")
 notice_id(12, bkg_id=1)
-notice_id(12, "2.000000000000:4.000000000000", bkg_id=1)
+notice_id(12, "5993:7192", bkg_id=1)
 notice_id(12, bkg_id=2)
-notice_id(12, "2.000000000000:4.000000000000", bkg_id=2)
+notice_id(12, "5993:7192", bkg_id=2)
 load_pha(2, "@@/3c120_pha2")
 
 ######### Load Background Data Sets
@@ -2018,15 +2018,15 @@ load_bkg(2, "@@/3c120_pha2", bkg_id=2)
 
 ######### Set Energy or Wave Units
 
-set_analysis(2, quantity="wavelength", type="rate", factor=0)
+set_analysis(2, quantity="channel", type="rate", factor=0)
 
 ######### Filter Data
 
-notice_id(2, "2.000000000000:4.000000000000")
+notice_id(2, "5393:6992")
 notice_id(2, bkg_id=1)
-notice_id(2, "2.000000000000:4.000000000000", bkg_id=1)
+notice_id(2, "5393:6992", bkg_id=1)
 notice_id(2, bkg_id=2)
-notice_id(2, "2.000000000000:4.000000000000", bkg_id=2)
+notice_id(2, "5393:6992", bkg_id=2)
 load_pha(3, "@@/3c120_pha2")
 
 ######### Load Background Data Sets
@@ -2036,15 +2036,15 @@ load_bkg(3, "@@/3c120_pha2", bkg_id=2)
 
 ######### Set Energy or Wave Units
 
-set_analysis(3, quantity="wavelength", type="rate", factor=0)
+set_analysis(3, quantity="channel", type="rate", factor=0)
 
 ######### Filter Data
 
-notice_id(3, "2.000000000000:4.000000000000")
+notice_id(3, "6993:7792")
 notice_id(3, bkg_id=1)
-notice_id(3, "2.000000000000:4.000000000000", bkg_id=1)
+notice_id(3, "6993:7792", bkg_id=1)
 notice_id(3, bkg_id=2)
-notice_id(3, "2.000000000000:4.000000000000", bkg_id=2)
+notice_id(3, "6993:7792", bkg_id=2)
 load_pha(4, "@@/3c120_pha2")
 
 ######### Load Background Data Sets
@@ -2054,15 +2054,15 @@ load_bkg(4, "@@/3c120_pha2", bkg_id=2)
 
 ######### Set Energy or Wave Units
 
-set_analysis(4, quantity="wavelength", type="rate", factor=0)
+set_analysis(4, quantity="channel", type="rate", factor=0)
 
 ######### Filter Data
 
-notice_id(4, "2.000000000000:4.000000000000")
+notice_id(4, "6993:7792")
 notice_id(4, bkg_id=1)
-notice_id(4, "2.000000000000:4.000000000000", bkg_id=1)
+notice_id(4, "6993:7792", bkg_id=1)
 notice_id(4, bkg_id=2)
-notice_id(4, "2.000000000000:4.000000000000", bkg_id=2)
+notice_id(4, "6993:7792", bkg_id=2)
 load_pha(5, "@@/3c120_pha2")
 
 ######### Load Background Data Sets
@@ -2072,15 +2072,15 @@ load_bkg(5, "@@/3c120_pha2", bkg_id=2)
 
 ######### Set Energy or Wave Units
 
-set_analysis(5, quantity="wavelength", type="rate", factor=0)
+set_analysis(5, quantity="channel", type="rate", factor=0)
 
 ######### Filter Data
 
-notice_id(5, "2.000000000000:4.000000000000")
+notice_id(5, "5393:6992")
 notice_id(5, bkg_id=1)
-notice_id(5, "2.000000000000:4.000000000000", bkg_id=1)
+notice_id(5, "5393:6992", bkg_id=1)
 notice_id(5, bkg_id=2)
-notice_id(5, "2.000000000000:4.000000000000", bkg_id=2)
+notice_id(5, "5393:6992", bkg_id=2)
 load_pha(6, "@@/3c120_pha2")
 
 ######### Load Background Data Sets
@@ -2090,15 +2090,15 @@ load_bkg(6, "@@/3c120_pha2", bkg_id=2)
 
 ######### Set Energy or Wave Units
 
-set_analysis(6, quantity="wavelength", type="rate", factor=0)
+set_analysis(6, quantity="channel", type="rate", factor=0)
 
 ######### Filter Data
 
-notice_id(6, "2.000000000000:4.000000000000")
+notice_id(6, "3793:6192")
 notice_id(6, bkg_id=1)
-notice_id(6, "2.000000000000:4.000000000000", bkg_id=1)
+notice_id(6, "3793:6192", bkg_id=1)
 notice_id(6, bkg_id=2)
-notice_id(6, "2.000000000000:4.000000000000", bkg_id=2)
+notice_id(6, "3793:6192", bkg_id=2)
 load_pha(7, "@@/3c120_pha2")
 
 ######### Load Background Data Sets
@@ -2108,15 +2108,15 @@ load_bkg(7, "@@/3c120_pha2", bkg_id=2)
 
 ######### Set Energy or Wave Units
 
-set_analysis(7, quantity="wavelength", type="rate", factor=0)
+set_analysis(7, quantity="channel", type="rate", factor=0)
 
 ######### Filter Data
 
-notice_id(7, "2.000000000000:4.000000000000")
+notice_id(7, "5993:7192")
 notice_id(7, bkg_id=1)
-notice_id(7, "2.000000000000:4.000000000000", bkg_id=1)
+notice_id(7, "5993:7192", bkg_id=1)
 notice_id(7, bkg_id=2)
-notice_id(7, "2.000000000000:4.000000000000", bkg_id=2)
+notice_id(7, "5993:7192", bkg_id=2)
 load_pha(8, "@@/3c120_pha2")
 
 ######### Load Background Data Sets
@@ -2126,15 +2126,15 @@ load_bkg(8, "@@/3c120_pha2", bkg_id=2)
 
 ######### Set Energy or Wave Units
 
-set_analysis(8, quantity="wavelength", type="rate", factor=0)
+set_analysis(8, quantity="channel", type="rate", factor=0)
 
 ######### Filter Data
 
-notice_id(8, "2.000000000000:4.000000000000")
+notice_id(8, "6793:7592")
 notice_id(8, bkg_id=1)
-notice_id(8, "2.000000000000:4.000000000000", bkg_id=1)
+notice_id(8, "6793:7592", bkg_id=1)
 notice_id(8, bkg_id=2)
-notice_id(8, "2.000000000000:4.000000000000", bkg_id=2)
+notice_id(8, "6793:7592", bkg_id=2)
 load_pha(9, "@@/3c120_pha2")
 
 ######### Load Background Data Sets
@@ -2144,15 +2144,15 @@ load_bkg(9, "@@/3c120_pha2", bkg_id=2)
 
 ######### Set Energy or Wave Units
 
-set_analysis(9, quantity="wavelength", type="rate", factor=0)
+set_analysis(9, quantity="channel", type="rate", factor=0)
 
 ######### Filter Data
 
-notice_id(9, "2.000000000000:4.000000000000")
+notice_id(9, "7593:7992")
 notice_id(9, bkg_id=1)
-notice_id(9, "2.000000000000:4.000000000000", bkg_id=1)
+notice_id(9, "7593:7992", bkg_id=1)
 notice_id(9, bkg_id=2)
-notice_id(9, "2.000000000000:4.000000000000", bkg_id=2)
+notice_id(9, "7593:7992", bkg_id=2)
 
 
 ######### Set Statistic
@@ -3541,8 +3541,29 @@ def test_restore_pha2(make_data_path):
 
     # Note: not including .gz for the file name
     ui.load_pha(make_data_path("3c120_pha2"))
-    ui.set_analysis("wave")
-    ui.notice(2, 4)
+
+    # Before #1564 we could say
+    #
+    #    ui.set_analysis("wave")
+    #    ui.notice(2, 4)
+    #
+    for idval in [1, 6]:
+        ui.notice_id(idval, 3793, 6192)
+
+    for idval in [2, 5]:
+        ui.notice_id(idval, 5393, 6992)
+
+    for idval in [3, 4]:
+        ui.notice_id(idval, 6993, 7792)
+
+    for idval in [7, 12]:
+        ui.notice_id(idval, 5993, 7192)
+
+    for idval in [8, 11]:
+        ui.notice_id(idval, 6793, 7592)
+
+    for idval in [9, 10]:
+        ui.notice_id(idval, 7593, 7992)
 
     def check_data():
         assert ui.list_data_ids() == pytest.approx([1, 10, 11, 12, 2, 3, 4, 5, 6, 7, 8, 9])

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1326,7 +1326,6 @@ class Session(sherpa.ui.utils.Session):
         +------------+-----------------+--------------------+
         | DataPHA    | channel, counts | statistical error, |
         |            |                 | systematic error,  |
-        |            |                 | bin_lo, bin_hi,    |
         |            |                 | grouping, quality  |
         +------------+-----------------+--------------------+
         | DataIMG    | x0, x1, y       | shape,             |

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -1029,14 +1029,14 @@ def calc_kcorr(data, model, z, obslo, obshi, restlo=None, resthi=None):
 
     if hasattr(data, 'get_response'):
         arf, rmf = data.get_response()
-        elo = data.bin_lo
-        ehi = data.bin_hi
-        if arf is not None:
-            elo = arf.energ_lo
-            ehi = arf.energ_hi
-        elif rmf is not None:
+        if rmf is not None:
             elo = rmf.energ_lo
             ehi = rmf.energ_hi
+        elif arf is not None:
+            elo = arf.energ_lo
+            ehi = arf.energ_hi
+        else:
+            raise DataErr('norsp', data.name)
     else:
         elo, ehi = data.get_indep()
 

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -24,7 +24,7 @@
 
 """
 
-from typing import Optional
+from typing import Optional, Sequence
 
 import numpy as np
 
@@ -99,7 +99,11 @@ def get_xspec_norm(y: np.ndarray, mdl: np.ndarray) -> ValueAndRange:
             'max': r * guess._guess_ampl_scale}
 
 
-def compile_energy_grid(arglist):
+def compile_energy_grid(arglist: Sequence[tuple[np.ndarray, np.ndarray]]
+                        ) -> list[np.ndarray,
+                                  np.ndarray,
+                                  list[tuple[np.ndarray, np.ndarray]]
+                                  ]:
     '''Combine several grids (energy, channel, wavelength) into one.
 
     This function combines several grids into one, such that the model

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -6736,7 +6736,10 @@ class Session(NoNewAttributesAfterInit):
     # Source models
     #
 
-    def _eval_model_expression(self, expr, typestr='model'):
+    def _eval_model_expression(self,
+                               expr: str,
+                               typestr: str = 'model'
+                               ) -> Model:
         try:
             return eval(expr, self._model_globals, self._model_components)
         except Exception as exc:


### PR DESCRIPTION
# Summary

Do not use the BIN_LO/HI columns from Chandra grating PHA/ARF files. Fix #1564.

# Details

As noted on #1564 and #1871 the BIN_LO/HI settings just complicate the code and do not add much (CXC never pushed this as a standard and I do not think any other mission uses these columns). The aim is to

- simplify the code
- make it easier to use a public interface to get at the independent axis values (see #2189, which relies on this PR)

This relies on (a tick indicates that it has been merged **and** removed from this PR)

- [X] #2188
- [X] #2191
- [ ]  #2190

The changes are relatively easy, but a bit annoying, in part because there are a number of tests that set the `bin_lo/hi` fields as they provided an easy way set up things (i.e. without creating a RMF) and so some effort is needed to work out if the test is still relevant.

The `DataPHA` and `DataARF` classes retain `bin_lo` and `bin_hi` fields but they are not used (and, in the `DataPHA` case, are always set to `None`, no-matter what the code tries).  This si to try and reduce the impact this change will have (but it's probably not going to save people who affected by the change). There is a `FutureWarning` the first time that the `DataPHA.bin_lo` field is set to a non-zero value, but I don't know how useful that will be (there is no warning for the `DataARF` case as I don't see that as being that useful to warn about).

The PR finishes off with some internal clean ups in the instrument code

- `pylint` suggestions
- adding some types (where I understand the code)
- some amalgamation and simplification
- some code style changes

More changes here probably require properly tackling #1871 as there is some interesting code here left over from some of the `bin_lo/hi` removals.

# Notes

Before this change you could say

```python
ui.load_pha("3c120_pha2")
ui.set_analysis("wave")
ui.plot_data(4)
```

and see something like

```
dataset 1: 0.333333:7.16 Wavelength (Angstrom)
dataset 10: 1:41.96 Wavelength (Angstrom)
dataset 11: 0.5:20.98 Wavelength (Angstrom)
dataset 12: 0.333333:13.9867 Wavelength (Angstrom)
dataset 2: 0.5:10.74 Wavelength (Angstrom)
dataset 3: 1:21.48 Wavelength (Angstrom)
dataset 4: 1:21.48 Wavelength (Angstrom)
dataset 5: 0.5:10.74 Wavelength (Angstrom)
dataset 6: 0.333333:7.16 Wavelength (Angstrom)
dataset 7: 0.333333:13.9867 Wavelength (Angstrom)
dataset 8: 0.5:20.98 Wavelength (Angstrom)
dataset 9: 1:41.96 Wavelength (Angstrom)
```

![sherpa](https://github.com/user-attachments/assets/b7724b3e-bfe4-47ea-95a2-84e29456c9ce)


Now the call will error out with the message

```
DataErr: No instrument response found for dataset 3c120_pha2
```

There's no real easy way to get this to say "Create a diagonal response" to let people know what to do (and, to be honest, they are better off just loading in the actual response at this point anyway, my $0.02).