### PR TITLE
Install Miniforge for ci-conda workflow

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -22,16 +22,6 @@ else
    fi
 fi
 
-# Ensure we have set up conda
-#
-source ${CONDA}/etc/profile.d/conda.sh
-
-# update and add channels
-conda update --yes conda
-conda config --add channels conda-forge
-#Remove defaults to avoid conflicts with conda-forge
-conda config --remove channels defaults
-
 # To avoid issues with non-XSPEC builds (e.g.
 # https://github.com/sherpa/sherpa/pull/794#issuecomment-616570995 )
 # the XSPEC-related channels are only added if needed

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -17,6 +17,7 @@ concurrency:
 env:
   xspec_channel: "https://cxc.cfa.harvard.edu/conda/xspec"
   CONDA_BUILD_SYSROOT: ${{ github.workspace }}/11.0SDK/MacOSX11.0.sdk
+  conda_loc: ${{ github.workspace }}/conda_loc
 
 jobs:
   tests:
@@ -117,6 +118,9 @@ jobs:
         BOKEHVER: ${{ matrix.bokeh-version }}
         XSPECVER: ${{ matrix.xspec-version }}
       run: |
+        curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh -o conda-installer.sh
+        bash conda-installer.sh -b -p ${conda_loc}
+        source ${conda_loc}/etc/profile.d/conda.sh
         source .github/scripts/setup_conda.sh
 
     - name: Conda Setup (Xspec and DS9)
@@ -124,7 +128,7 @@ jobs:
       env:
         XSPECVER: ${{ matrix.xspec-version }}
       run: |
-        source ${CONDA}/etc/profile.d/conda.sh
+        source ${conda_loc}/etc/profile.d/conda.sh
         conda activate build
         if [ "$RUNNER_OS" != "macOS" ]; then
           source .github/scripts/setup_ds9.sh
@@ -138,7 +142,7 @@ jobs:
       env:
         PYTHON_LDFLAGS: " "
       run: |
-        source ${CONDA}/etc/profile.d/conda.sh
+        source ${conda_loc}/etc/profile.d/conda.sh
         conda activate build
         pip install .[test] --verbose
 
@@ -147,14 +151,14 @@ jobs:
       env:
         PYTHON_LDFLAGS: " "
       run: |
-        source ${CONDA}/etc/profile.d/conda.sh
+        source ${conda_loc}/etc/profile.d/conda.sh
         conda activate build
         pip install -e .[test] --verbose
 
     - name: Install the test data?
       if: matrix.test-data == 'package'
       run: |
-        source ${CONDA}/etc/profile.d/conda.sh
+        source ${conda_loc}/etc/profile.d/conda.sh
         conda activate build
         pip install ./sherpa-test-data
 
@@ -181,7 +185,7 @@ jobs:
         fi
 
         echo "** smoke test: ${smokevars}"
-        source ${CONDA}/etc/profile.d/conda.sh
+        source ${conda_loc}/etc/profile.d/conda.sh
         conda activate build
         cd /home
         sherpa_smoke ${smokevars}
@@ -215,7 +219,7 @@ jobs:
           # moment, but leave this in
           export PATH="${PATH}:/opt/X11/bin"
         fi
-        source ${CONDA}/etc/profile.d/conda.sh
+        source ${conda_loc}/etc/profile.d/conda.sh
         conda activate build
         conda install -yq pytest-cov
         pytest --pyargs sherpa --cov sherpa --cov-report xml:${{ github.workspace }}/coverage.xml
@@ -223,7 +227,7 @@ jobs:
     - name: sherpa_test Tests
       if: matrix.test-data == 'package' || matrix.test-data == 'none'
       run: |
-        source ${CONDA}/etc/profile.d/conda.sh
+        source ${conda_loc}/etc/profile.d/conda.sh
         conda activate build
         conda install -yq pytest-cov
         cd $HOME


### PR DESCRIPTION
Summary
-------------
Install Miniforge for use with ci-conda worflow.

Details
-------------
Conda has been updated on the Linux GitHub Actions image (Ubuntu 22.04.5 runner image version: 20241103.1.0). This pulls in recent Conda updates to remove the inclusion of the "defaults" channel by default (opting to let the installers like Miniconda, etc. do this themselves). Related:
- https://github.com/conda/conda/releases/tag/24.9.2
- https://github.com/conda/conda/releases/tag/24.9.0
As the default Conda installed on the GitHub Actions images is "Miniconda" anyway [(Ubuntu 22.04 software details)](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md), we want to move away from this anyway. There is more discussion to be had about whether it would be better to just use the "setup-miniconda" github action (which allows you to select Miniforge), but considering this has a small footprint and would allow us to more finely control this I am opting for installing Miniforge ourselves (like we already do in the ci-conda-deployment workflow).
We will need to get a similar (if not the same) fix for this in main for sherpa (see #2195).