### PR TITLE
ptcat-3768 - reverting the enforcement of the min/max for linked parameters 

### DIFF
--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1374,6 +1374,7 @@ def test_ismabs_parameter_name_clashes():
 @requires_data
 @requires_fits
 @requires_xspec
+@pytest.mark.xfail
 def test_xstbl_link_parameter_evaluation(make_data_path):
     """See also sherpa/models/test_parameter::test_link_parameter_setting
 

--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -368,25 +368,14 @@ hard_min
 
     # 'val' property
     #
-    # Note that _get_val has to check the parameter value when it
-    # is a link, to ensure that it isn't outside the parameter's
-    # min/max range. See issue #742.
-    #
     _val: SherpaFloat  # needed for typing
 
     def _get_val(self) -> SherpaFloat:
         if hasattr(self, 'eval'):
             return self.eval()
-        if self.link is None:
-            return self._val
-
-        val = self.link.val
-        if val < self.min:
-            raise ParameterErr('edge', self.fullname, 'minimum', self.min)
-        if val > self.max:
-            raise ParameterErr('edge', self.fullname, 'maximum', self.max)
-
-        return val
+        if self.link is not None:
+            return self.link.val
+        return self._val
 
     def _set_val(self, val: Union[Parameter, SupportsFloat]) -> None:
         if isinstance(val, Parameter):

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -2100,6 +2100,7 @@ def test_model_can_not_change_pars():
         mdl.pars = [Parameter("x", "y", 2)]
 
 
+@pytest.mark.xfail
 def test_model_linked_par_outside_limit():
     """What happens if a linked par is outside it's limits"""
 

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -495,6 +495,7 @@ def test_link_unlink_val_ui():
     tst_unlink(src1, src2)
 
 
+@pytest.mark.xfail
 def test_link_parameter_setting():
     """See https://github.com/sherpa/sherpa/issues/742
 
@@ -539,6 +540,7 @@ def test_link_parameter_setting():
     assert mdl.gamma.val == pytest.approx(-2)
 
 
+@pytest.mark.xfail
 def test_link_parameter_evaluation():
     """See also test_link_parameter_setting
 


### PR DESCRIPTION
aperture photometry exceeds the bounds in some link cases. We're reverting this change for CSC 2.2 until aperture photometry gets fixed.