### PR TITLE
Allow both Intel and ARM macOS GitHub runners for the conda builds

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -37,12 +37,7 @@ fi
 # the XSPEC-related channels are only added if needed
 #
 if [ -n "${XSPECVER}" ]; then
-  if [[ "`uname -s`" == "Darwin" && "`uname -m`" != "x86_64" ]] ; then
-    # we need to use the CXC conda channel to get the ARM XSPEC build for now
-    conda config --add channels https://cxc.harvard.edu/conda/ciao
-  else
-    conda config --add channels ${xspec_channel}
-  fi
+  conda config --add channels ${xspec_channel}
 fi
 
 # Figure out requested dependencies

--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash -e
 
+# Occasionally useful to know what these values are
+echo "** uname -s: `uname -s`"
+echo "** uname -m: `uname -m`"
+
 if [ "`uname -s`" == "Darwin" ] ; then
-    compilers="clang_osx-64 clangxx_osx-64 gfortran_osx-64"
+
+    if [ "`uname -m`" == "x86_64" ]; then
+	sys="64"
+    else
+	sys="arm64"
+    fi
+    compilers="clang_osx-${sys} clangxx_osx-${sys} gfortran_osx-${sys}"
 
     #Download the macOS 11.0 SDK to the CONDA_BUILD_SYSROOT location for the Conda Compilers to work
     mkdir -p ${GITHUB_WORKSPACE}/11.0SDK
@@ -10,7 +20,7 @@ if [ "`uname -s`" == "Darwin" ] ; then
       echo "macOS 11.0 SDK download failed"
     fi
     tar -C ${GITHUB_WORKSPACE}/11.0SDK -xf MacOSX11.0.sdk.tar.xz
-    #End of Conda compilers section
+
 else
     compilers="gcc_linux-64 gxx_linux-64 gfortran_linux-64"
 
@@ -27,7 +37,12 @@ fi
 # the XSPEC-related channels are only added if needed
 #
 if [ -n "${XSPECVER}" ]; then
- conda config --add channels ${xspec_channel}
+  if [[ "`uname -s`" == "Darwin" && "`uname -m`" != "x86_64" ]] ; then
+    # we need to use the CXC conda channel to get the ARM XSPEC build for now
+    conda config --add channels https://cxc.harvard.edu/conda/ciao
+  else
+    conda config --add channels ${xspec_channel}
+  fi
 fi
 
 # Figure out requested dependencies
@@ -39,7 +54,8 @@ if [ -n "${XSPECVER}" ];
  then export XSPEC="xspec-modelsonly=${XSPECVER}";
 fi
 
-echo "dependencies: ${MATPLOTLIB} ${BOKEH} ${NUMPY} ${FITS} ${XSPEC}"
+echo "dependencies: ${MATPLOTLIB} ${BOKEH} ${NUMPY} ${XSPEC} ${FITSBUILD}"
+echo "compilers:    ${compilers}"
 
 # Create and activate conda build environment
 conda create --yes -n build python"=${PYTHONVER}.*=*cpython*" pip ${MATPLOTLIB} ${BOKEH} ${NUMPY} ${XSPEC} ${FITSBUILD} ${compilers}

--- a/.github/scripts/setup_ds9.sh
+++ b/.github/scripts/setup_ds9.sh
@@ -2,7 +2,6 @@
 
 ds9_base_url=https://ds9.si.edu/download/
 
-# variable $CONDA_PREFIX should be defined by conda by using conda activate (in setup_conda.sh)
 if [[ "x${CONDA_PREFIX}" == "x" ]];
 then
     echo "Error: CONDA_PREFIX not set. This should be set for active Conda environments."
@@ -40,7 +39,7 @@ xpa_tar=xpa.${ds9_os}.2.1.20.tar.gz
 download $ds9_base_url/$ds9_os/$ds9_tar
 download $ds9_base_url/$ds9_os/$xpa_tar
 
-# untar them
+# untar them; assume $CONDA_PREFIX/bin is in the path
 echo "* unpacking ds9/XPA"
 start_dir=$(pwd)
 cd ${CONDA_PREFIX}/bin

--- a/.github/scripts/setup_xspec.sh
+++ b/.github/scripts/setup_xspec.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash -e
 
-# variable $CONDA_PREFIX should be defined by conda by using conda activate (in setup_conda.sh)
 if [[ "x${CONDA_PREFIX}" == "x" ]];
 then
     echo "Error: CONDA_PREFIX not set. This should be set for active Conda environments."

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -123,18 +123,29 @@ jobs:
         source ${conda_loc}/etc/profile.d/conda.sh
         source .github/scripts/setup_conda.sh
 
-    - name: Conda Setup (Xspec and DS9)
+    # The decision on whether to install DS9 or not has historically
+    # been tied to XSPEC, which is why this rule checks for XSPEC
+    # support.
+    #
+    # The DS9 tests have been shown to be problematic on macOS/GitHub
+    # so we do not install DS9 on this platform.
+    #
+    - name: Conda Setup (DS9)
+      if: matrix.xspec-version != '' && runner.os != 'macOS'
+      run: |
+        source ${conda_loc}/etc/profile.d/conda.sh
+        conda activate build
+        source .github/scripts/setup_ds9.sh
+        # We need xvfb to run the tests so ensure it's installed
+        pip install pytest-xvfb
+
+    - name: Conda Setup (Xspec)
       if: matrix.xspec-version != ''
       env:
         XSPECVER: ${{ matrix.xspec-version }}
       run: |
         source ${conda_loc}/etc/profile.d/conda.sh
         conda activate build
-        if [ "$RUNNER_OS" != "macOS" ]; then
-          source .github/scripts/setup_ds9.sh
-          # We need xvfb to run the tests so ensure it's installed
-          pip install pytest-xvfb
-        fi
         source .github/scripts/setup_xspec.sh
 
     - name: Build Sherpa (install)

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -30,14 +30,25 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: MacOS Full Build
-            os: macos-12
-            python-version: "3.10"
+          - name: MacOS Intel Full Build (Python 3.11)
+            os: macos-13
+            python-version: "3.11"
             install-type: develop
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
+            bokeh-version: 3
             xspec-version: 12.14.0i
+
+          - name: MacOS ARM Full Build (Python 3.11)
+            os: macos-14
+            python-version: "3.11"
+            install-type: develop
+            fits: astropy
+            test-data: submodule
+            matplotlib-version: 3
+            bokeh-version: 3
+            xspec-version: 12.13.1e
 
           - name: Linux Minimum Setup (Python 3.10)
             os: ubuntu-latest


### PR DESCRIPTION
# Summary

Add a macOS ARM build, and update the macOS Intel build to use the macOS-13 runner.

# Details

This is a rework of #1958 and #2009 (#2009 also used the `setup-miniconda` action but #2195 installed it directly so this part was removed).

There's three parts

a) update the scripts to support ARM builds
b) a minor clean up of the workflow actions by splitting up the DS9 and XSPEC installation steps as they are technically separate (this is not technically needed but there are macOS specific rules for the DS9 part which is nice to clean up as part of this)
c) add a macOS ARM build and update the Intel build to `macos-13` since `macos-12` is about to be removed.

As part of this we have

- select the CIAO `conda` channel for macOS ARM since there's no ARM build of `xspec-modelsonly` in the `xspec` channel
- use version `12.13.1` rather than `12.14.0` of XSPEC for macOS ARM to match the CIAO `conda` channel
- tweaked the macOS conda install to use Python 3.11 and install bokeh (for both architectures)

I have **not** checked to see how this interacts with 

- #2156
