### PR TITLE
Group rework WIP

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -140,6 +140,8 @@ The prerequisites for building from source are:
 * System: ``gcc`` and ``g++`` or ``clang`` and ``clang++``, ``make``, ``flex``,
   ``bison``, ``ar`` (which may be provided by the ``binutils`` package)
 
+   * the C++ compiler must support C++11.
+
 The aim is to support recent versions of these tools and libraries;
 please report problems to the
 `Sherpa issue tracker <https://github.com/sherpa/sherpa/issues/>`_.

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -24,6 +24,8 @@
 
 """
 
+import itertools
+from operator import itemgetter
 from typing import Callable, Optional
 
 import numpy as np
@@ -1206,5 +1208,285 @@ def do_group(data: ArrayType,
     for start_idx, end_idx in ranges:
         vals = dvals[start_idx:end_idx]
         out.append(combine(vals))
+
+    return np.asarray(out)
+
+
+def do_group2(data: ArrayType,
+              group: ArrayType,
+              name: Callable | str
+              ) -> np.ndarray:
+    """Group the array using OGIP standards.
+
+    Parameters
+    ----------
+    data : array_like
+        The data to group.
+    group : array_like
+        The OGIP grouping data: 1 indicates the start of a group and
+        -1 continues the group.
+    name : {'sum', '_sum_sq', '_max', '_min', '_middle', '_make_groups'}
+        The grouping scheme to combine values within a group.
+
+    Returns
+    -------
+    grouped : array
+        The grouped data. It will be smaller than data unless group only
+        contains 1's.
+
+    Examples
+    --------
+
+    Group the array [1, 2, 3, 4, 5, 6] into groups of length 2, 1, and 3,
+    using different grouping schemes:
+
+    >>> data = [1, 2, 3, 4, 5, 6]
+    >>> group = [1, -1, 1, 1, -1, -1]
+    >>> do_group(data, group, '_make_groups')
+    [1, 2, 3]
+    >>> do_group(data, group, 'sum')
+    [3, 3, 15]
+    >>> do_group(data, group, '_min')
+    [1, 3, 4]
+    >>> do_group(data, group, '_max')
+    [2, 3, 6]
+    >>> do_group(data, group, '_middle')
+    [1.5, 3. , 5. ]
+
+    """
+
+    # Match the 4.17.0 error message behaviour:
+    # - check length
+    # - check name is valid
+    # - return [] if empty
+    #
+    if len(data) != len(group):
+        raise TypeError(f"input array sizes do not match, data: {len(data)} vs group: {len(group)}")
+
+    # How do we combine the data.
+    #
+    if isinstance(name, str):
+        if name == "sum":
+            combine = np.sum
+        elif name == "_sum_sq":
+            combine = lambda x: np.sqrt(np.sum(x * x))
+        elif name == "_max":
+            combine = np.max
+        elif name == "_min":
+            combine = np.min
+        elif name == "_middle":
+            combine = lambda x: (np.min(x) + np.max(x)) / 2.0
+        elif name == "_make_groups":
+            _counter = {"n": data[0]}
+            def combine(x):
+                out = _counter["n"]
+                _counter["n"] += 1
+                return out
+
+        else:
+            # match 4.17.0 error
+            raise ValueError(f"unsupported group function: {name}")
+
+    elif callable(name):
+        # Assume it has the correct signature so if it doesn't it's
+        # the caller's problem to deal with.
+        #
+        combine = name
+
+    else:
+        raise ArgumentTypeErr("name must be a string or a callable")
+
+    # If there's no data it's easy.
+    #
+    if len(data) == 0:
+        return np.asarray([])
+
+    # The grouping array has three states:
+    #
+    #     > 0, < 0, and 0
+    #
+    # We could treat it as >= 0 and < 0 but then this hides the issue
+    # of getting a 0 followed by a -1, which in 4.17.0 and earlier was
+    # treated as an error. There is also the fact that starting with a
+    # negative value is also technically an error. It is not clear
+    # what XSPEC does in these cases.
+    #
+    # The state value is used to decide if
+    #   state=0   no data has been processed
+    #   state=1   group value is 0
+    #   state=2   we are in a group
+    #
+    group_data = []
+    state = 0
+    out = []
+    for idx, (grpval, dataval) in enumerate(zip(group, data)):
+
+        if grpval < 0:
+            if state != 2:
+                # What did 4.17.0 do here?
+                raise DataErr(f"{grpval} is not valid at index {idx}")
+
+            state = 2
+            group_data.append(dataval)
+            continue
+
+        # This is a new "group", so we need to add the previous group,
+        # unless we are in the "start" state.
+        #
+        if state != 0:
+            out.append(combine(group_data))
+            group_data = []
+
+        if grpval == 0:
+            # This is just to identify a possible error situation
+            state = 1
+        else:
+            state = 2
+
+        group_data.append(dataval)
+
+    # Handle the last group
+    #
+    out.append(combine(group_data))
+    return np.asarray(out)
+
+
+def do_group3(data: ArrayType,
+              group: ArrayType,
+              name: Callable | str
+              ) -> np.ndarray:
+    """Group the array using OGIP standards.
+
+    Parameters
+    ----------
+    data : array_like
+        The data to group.
+    group : array_like
+        The OGIP grouping data: 1 indicates the start of a group and
+        -1 continues the group.
+    name : {'sum', '_sum_sq', '_max', '_min', '_middle', '_make_groups'}
+        The grouping scheme to combine values within a group.
+
+    Returns
+    -------
+    grouped : array
+        The grouped data. It will be smaller than data unless group only
+        contains 1's.
+
+    Examples
+    --------
+
+    Group the array [1, 2, 3, 4, 5, 6] into groups of length 2, 1, and 3,
+    using different grouping schemes:
+
+    >>> data = [1, 2, 3, 4, 5, 6]
+    >>> group = [1, -1, 1, 1, -1, -1]
+    >>> do_group(data, group, '_make_groups')
+    [1, 2, 3]
+    >>> do_group(data, group, 'sum')
+    [3, 3, 15]
+    >>> do_group(data, group, '_min')
+    [1, 3, 4]
+    >>> do_group(data, group, '_max')
+    [2, 3, 6]
+    >>> do_group(data, group, '_middle')
+    [1.5, 3. , 5. ]
+
+    """
+
+    # Match the 4.17.0 error message behaviour:
+    # - check length
+    # - check name is valid
+    # - return [] if empty
+    #
+    if len(data) != len(group):
+        raise TypeError(f"input array sizes do not match, data: {len(data)} vs group: {len(group)}")
+
+    # How do we combine the data.
+    #
+    if isinstance(name, str):
+        if name == "sum":
+            combine = np.sum
+        elif name == "_sum_sq":
+            combine = lambda x: np.sqrt(np.sum(x * x))
+        elif name == "_max":
+            combine = np.max
+        elif name == "_min":
+            combine = np.min
+        elif name == "_middle":
+            combine = lambda x: (np.min(x) + np.max(x)) / 2.0
+        elif name == "_make_groups":
+            _counter = {"n": data[0]}
+            def combine(x):
+                out = _counter["n"]
+                _counter["n"] += 1
+                return out
+
+        else:
+            # match 4.17.0 error
+            raise ValueError(f"unsupported group function: {name}")
+
+    elif callable(name):
+        # Assume it has the correct signature so if it doesn't it's
+        # the caller's problem to deal with.
+        #
+        combine = name
+
+    else:
+        raise ArgumentTypeErr("name must be a string or a callable")
+
+    # If there's no data it's easy.
+    #
+    if len(data) == 0:
+        return np.asarray([])
+
+    # Map the grouping column into a set of groups (so all elements
+    # of group 1 is labelled with 1). This can then be passed to
+    # itertools.groupby to do the actual grouping.
+    #
+    # The grouping array has three states:
+    #
+    #     > 0, < 0, and 0
+    #
+    # We could treat it as >= 0 and < 0 but then this hides the issue
+    # of getting a 0 followed by a -1, which in 4.17.0 and earlier was
+    # treated as an error. There is also the fact that starting with a
+    # negative value is also technically an error. It is not clear
+    # what XSPEC does in these cases.
+    #
+    # The state value is used to decide if
+    #   state=0   no data has been processed
+    #   state=1   group value is 0
+    #   state=2   we are in a group
+    #
+    group_nums = []
+    state = 0
+    group_num = 0
+    for idx, (grpval, dataval) in enumerate(zip(group, data)):
+
+        if grpval < 0:
+            if state != 2:
+                # What did 4.17.0 do here?
+                raise DataErr(f"{grpval} is not valid at index {idx}")
+
+            state = 2
+            group_nums.append((group_num, dataval))
+            continue
+
+        group_num += 1
+        group_nums.append((group_num, dataval))
+
+        if grpval == 0:
+            # This is just to identify a possible error situation
+            state = 1
+        else:
+            state = 2
+
+    # It would be faster to create the array and then fill it up but
+    # we do not know what the data type should be.
+    #
+    out = []
+    for _, grp in itertools.groupby(group_nums, key=itemgetter(0)):
+        out.append(combine([g[1] for g in grp]))
 
     return np.asarray(out)

--- a/sherpa/astro/utils/src/_utils.cc
+++ b/sherpa/astro/utils/src/_utils.cc
@@ -149,8 +149,7 @@ namespace sherpa { namespace astro { namespace utils {
     }
 
     try {
-      if( EXIT_SUCCESS != _do_group(data.get_size(), data,
-				    group.get_size(), group,
+      if( EXIT_SUCCESS != _do_group(data.get_size(), data, group,
 				    grouped, type) ) {
 	PyErr_SetString( PyExc_ValueError,
 			 (char*)"group data is invalid or inconsistent" );

--- a/sherpa/astro/utils/src/_utils.cc
+++ b/sherpa/astro/utils/src/_utils.cc
@@ -49,7 +49,7 @@ namespace sherpa { namespace astro { namespace utils {
     npy_intp nelem = source.get_size();
 
     if ( effarea.get_size() != nelem ) {
-      ostringstream err;
+      std::ostringstream err;
       err << "input array sizes do not match, "
 	  << "source: " << nelem << " vs effarea: " << effarea.get_size();
       PyErr_SetString( PyExc_TypeError, err.str().c_str() );
@@ -141,7 +141,7 @@ namespace sherpa { namespace astro { namespace utils {
     return NULL;
 
     if ( data.get_size() != group.get_size() ) {
-      ostringstream err;
+      std::ostringstream err;
       err << "input array sizes do not match, "
 	  << "data: " << data.get_size() << " vs group: " << group.get_size();
       PyErr_SetString( PyExc_TypeError, err.str().c_str() );
@@ -157,7 +157,7 @@ namespace sherpa { namespace astro { namespace utils {
 	return NULL;
       }
     } catch ( std::out_of_range& ) {
-      ostringstream err;
+      std::ostringstream err;
       err << "unsupported group function: " << type;
       PyErr_SetString( PyExc_ValueError, err.str().c_str() );
       return NULL;
@@ -188,7 +188,7 @@ namespace sherpa { namespace astro { namespace utils {
     return NULL;
 
     if ( specresp.get_size() != arf_lo.get_size() ) {
-      ostringstream err;
+      std::ostringstream err;
       err << "input array sizes do not match, "
 	  << "specresp: " << specresp.get_size()
 	  << " vs arf_lo: " << arf_lo.get_size();
@@ -232,10 +232,10 @@ namespace sherpa { namespace astro { namespace utils {
     FloatArrayType matrix;
 
     BoolArray mask;
-    vector<FloatType> resp_buf;
-    vector<IntType> f_buf;
-    vector<IntType> n_buf;
-    vector<IntType> grp_buf;
+    std::vector<FloatType> resp_buf;
+    std::vector<IntType> f_buf;
+    std::vector<IntType> n_buf;
+    std::vector<IntType> grp_buf;
 
     FloatArrayType resp;
     IntArrayType grp;

--- a/sherpa/astro/utils/tests/test_astro_utils_unit.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_unit.py
@@ -310,6 +310,22 @@ def test_do_group_check_func(func, expected):
     assert ans == pytest.approx(expected)
 
 
+def test_do_group_callable():
+    """Check we can send in our own grouping function."""
+
+    def func(xs):
+        dx2 = (xs - np.mean(xs))**2
+        return np.sum(dx2)
+
+    # The groups are
+    #    1, 2
+    #    3, 4, 5
+    #    6
+    #
+    ans = do_group([1, 2, 3, 4, 5, 6], [1, -1, 1, -1, -1, 1], func)
+    assert ans == pytest.approx([0.5, 2, 0])
+
+
 # Note that the grouping code expects the data to be >= 0 so
 # support for -1 in the following is basically "an extra" (i.e. we
 # could decide to error out if values < 0 are included, which

--- a/sherpa/include/sherpa/array.hh
+++ b/sherpa/include/sherpa/array.hh
@@ -1,5 +1,6 @@
-// 
-//  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+//
+//  Copyright (C) 2007, 2015, 2024
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -34,6 +35,9 @@ namespace sherpa {
 
   public:
 
+    // Provide access to the template data type.
+    using value_type = CType;
+
     ~Array() { Py_XDECREF( array ); }
 
     Array()
@@ -58,7 +62,7 @@ namespace sherpa {
     int zeros( int ndim, const npy_intp* dims )
     {
       return init( PyArray_Zeros( ndim, const_cast< npy_intp* >( dims ),
-				  PyArray_DescrFromType( ArrayType ), 0 ) ); 
+				  PyArray_DescrFromType( ArrayType ), 0 ) );
     }
 
     PyObject* borrowed_ref()

--- a/sherpa/include/sherpa/astro/utils.hh
+++ b/sherpa/include/sherpa/astro/utils.hh
@@ -30,12 +30,7 @@
 #include <vector>
 #include <algorithm>
 
-#ifndef MID
-#define MID( a, b ) (( a + b ) / 2.0 )
-#endif
-
 namespace sherpa { namespace astro { namespace utils {
-
 
   template <typename ArrayType, typename ConstArrayType, typename IndexType>
   void arf_fold( IndexType num,
@@ -47,7 +42,6 @@ namespace sherpa { namespace astro { namespace utils {
       out[ ii ] = in1[ ii ] * in2[ ii ];
 
   }
-
 
   //
   // Function to perform XSPEC-style convolution, using an RMF
@@ -345,7 +339,7 @@ namespace sherpa { namespace astro { namespace utils {
       min = std::min( min, data[ ii + 1 ] );
       max = std::max( max, data[ ii + 1 ] );
     }
-    val = MID( min, max );
+    val = (min + max) / 2.0;
   }
 
   template <typename ConstFloatArrayType, typename FloatArrayType,

--- a/sherpa/include/sherpa/astro/utils.hh
+++ b/sherpa/include/sherpa/astro/utils.hh
@@ -342,14 +342,19 @@ namespace sherpa { namespace astro { namespace utils {
     val = (min + max) / 2.0;
   }
 
-  template <typename ConstFloatArrayType, typename FloatArrayType,
-	    typename ConstIntArrayType, typename IndexType>
-  int _do_group( IndexType len_data, const ConstFloatArrayType& data,
-		 IndexType len_group, const ConstIntArrayType& group,
-		 FloatArrayType& grouped, const char *type )
+  // The data and group arrays have the same size, nelem.
+  //
+  template <typename FloatArrayType,
+	    typename IntArrayType,
+	    typename IndexType>
+  int _do_group( IndexType nelem,
+		 const FloatArrayType& data,
+		 const IntArrayType& group,
+		 FloatArrayType& grouped,
+		 const char *type )
   {
 
-    typedef void (*fptr)( const ConstFloatArrayType&, IndexType, IndexType,
+    typedef void (*fptr)( const FloatArrayType&, IndexType, IndexType,
 			  SherpaFloat&);
     std::string funcname(type);
     std::map<std::string, fptr> funcs;
@@ -369,13 +374,13 @@ namespace sherpa { namespace astro { namespace utils {
 
     std::vector< IndexType > pick_pts;
 
-    for( IndexType ii = 0; ii < len_group; ii++ )
+    for( IndexType ii = 0; ii < nelem; ii++ )
       //if( group[ ii ] == 1 )
       // include channels where grouping == 0 so the filter will catch large
       // energy bins
       if( group[ ii ] >= 0 )
 	pick_pts.push_back( ii );
-    pick_pts.push_back( len_group );
+    pick_pts.push_back( nelem );
 
     npy_intp dim = npy_intp( pick_pts.size( ) - 1 );
     if ( EXIT_SUCCESS != grouped.create( 1, &dim ) )
@@ -385,7 +390,7 @@ namespace sherpa { namespace astro { namespace utils {
       IndexType start = pick_pts[ ii ];
       IndexType stop = pick_pts[ ii + 1 ];
 
-      if ( stop > len_data )
+      if ( stop > nelem )
 	return EXIT_FAILURE;
 
       if ( funcname == "_make_groups" ) {

--- a/sherpa/include/sherpa/astro/utils.hh
+++ b/sherpa/include/sherpa/astro/utils.hh
@@ -29,7 +29,6 @@
 #include <string>
 #include <vector>
 #include <algorithm>
-using namespace std;
 
 #ifndef MID
 #define MID( a, b ) (( a + b ) / 2.0 )
@@ -186,10 +185,10 @@ namespace sherpa { namespace astro { namespace utils {
     if( lo < lochan && hi > hichan )
       return true;
 
-    if( binary_search( noticed_chans, noticed_chans + size, lo ) )
+    if( std::binary_search( noticed_chans, noticed_chans + size, lo ) )
       return true;
 
-    if( binary_search( noticed_chans, noticed_chans + size, hi ) )
+    if( std::binary_search( noticed_chans, noticed_chans + size, hi ) )
       return true;
 
     // consider the case of fragmented channels
@@ -203,8 +202,9 @@ namespace sherpa { namespace astro { namespace utils {
     // noticed_chans = 1-249, 400-500, 601-1024
     // lo=250 hi=600
     if( lochan < lo && lo < hichan && lochan < hi && hi < hichan ) {
-      const ConstIntType *idx = upper_bound( noticed_chans,
-					  noticed_chans + size, lo );
+      const ConstIntType *idx = std::upper_bound( noticed_chans,
+						  noticed_chans + size,
+						  lo );
       if( idx == (noticed_chans + size) )
 	return false;
 
@@ -233,10 +233,10 @@ namespace sherpa { namespace astro { namespace utils {
 		   const ConstIntType *n_chan,
 		   const ConstFloatType *matrix, IndexType len_response,
 		   unsigned int offset,
-		   vector<IntType>& grp,
-		   vector<IntType>& fch,
-		   vector<IntType>& nch,
-		   vector<FloatType>& rsp,
+		   std::vector<IntType>& grp,
+		   std::vector<IntType>& fch,
+		   std::vector<IntType>& nch,
+		   std::vector<FloatType>& rsp,
 		   BoolType *mask) {
 
     IndexType response_counter = 0, group_counter = 0;
@@ -357,8 +357,8 @@ namespace sherpa { namespace astro { namespace utils {
 
     typedef void (*fptr)( const ConstFloatArrayType&, IndexType, IndexType,
 			  SherpaFloat&);
-    string funcname(type);
-    map<string, fptr> funcs;
+    std::string funcname(type);
+    std::map<std::string, fptr> funcs;
     SherpaFloat val;
     fptr func = _sum;
 
@@ -373,7 +373,7 @@ namespace sherpa { namespace astro { namespace utils {
       func = funcs.at(funcname);
     }
 
-    vector< IndexType > pick_pts;
+    std::vector< IndexType > pick_pts;
 
     for( IndexType ii = 0; ii < len_group; ii++ )
       //if( group[ ii ] == 1 )

--- a/sherpa/include/sherpa/astro/utils.hh
+++ b/sherpa/include/sherpa/astro/utils.hh
@@ -371,7 +371,7 @@ namespace sherpa { namespace astro { namespace utils {
     std::string funcname(type);
     std::map<std::string, fptr> funcs;
     SherpaFloat val;
-    fptr func = _sum;
+    fptr func = NULL;
 
     funcs["sum"] = _sum;
     funcs["_sum_sq"] = _sum_sq;
@@ -404,7 +404,7 @@ namespace sherpa { namespace astro { namespace utils {
       if ( stop > nelem )
 	return EXIT_FAILURE;
 
-      if ( funcname == "_make_groups" ) {
+      if ( func == NULL ) {
 	grouped[ ii ] = data[0] + (SherpaFloat) ii;
       } else {
 	func( data, start, stop, val );

--- a/sherpa/include/sherpa/astro/utils.hh
+++ b/sherpa/include/sherpa/astro/utils.hh
@@ -384,25 +384,35 @@ namespace sherpa { namespace astro { namespace utils {
       func = funcs.at(funcname);
     }
 
+    // Identify the start of each "group", with each "0" value being
+    // treated as a new group. There is limited validation here (e.g.
+    // if group starts with a sequence of values < 0 then they will be
+    // ignored). Each group can then be identified as
+    //
+    //     pick_pts[i] <= idx < pick_pts[i + 1]
+    //
     std::vector< IndexType > pick_pts;
-
     for( IndexType ii = 0; ii < nelem; ii++ )
-      //if( group[ ii ] == 1 )
-      // include channels where grouping == 0 so the filter will catch large
-      // energy bins
       if( group[ ii ] >= 0 )
 	pick_pts.push_back( ii );
+
+    // End the last group.
     pick_pts.push_back( nelem );
 
-    npy_intp dim = npy_intp( pick_pts.size( ) - 1 );
+    // Number of groups.
+    const size_t ngrp = pick_pts.size() - 1;
+
+    // It is assumed that this is only ever called with an array type
+    // that can store SherpaFloat values.
+    //
+    npy_intp dim = npy_intp( ngrp );
     if ( EXIT_SUCCESS != grouped.create( 1, &dim ) )
       return EXIT_FAILURE;
 
-    for( size_t ii = 0; ii < pick_pts.size( ) - 1; ii++ ) {
+    // Apply the group function to each group.
+    for( size_t ii = 0; ii < ngrp; ii++ ) {
       IndexType start = pick_pts[ ii ];
       IndexType stop = pick_pts[ ii + 1 ];
-      if ( stop > nelem )
-	return EXIT_FAILURE;
 
       if ( func == NULL ) {
 	grouped[ ii ] = data[0] + (SherpaFloat) ii;

--- a/sherpa/include/sherpa/astro/utils.hh
+++ b/sherpa/include/sherpa/astro/utils.hh
@@ -291,59 +291,61 @@ namespace sherpa { namespace astro { namespace utils {
   // group, where a single group covers the given [start, stop) range
   // for the data array.
   //
-  // The input data is provided as a template but the output value is
-  // always a SherpaFloat.
-  //
   // The Sherpa array type does not support C++11 style iterators,
   // hence the direct array access via the for loop.
   //
   template <typename FloatArrayType, typename IndexType>
-  void _sum(const FloatArrayType& data, IndexType start,
-	    IndexType stop, SherpaFloat& val) {
+  void _sum(const FloatArrayType& data,
+	    IndexType start, IndexType stop,
+	    typename FloatArrayType::value_type& val) {
 
     val = 0.0;
-    for( IndexType ii = start; ii < stop; ii++ )
+    for( auto ii = start; ii < stop; ii++ )
       val += data[ii];
   }
 
   template <typename FloatArrayType, typename IndexType>
-  void _sum_sq(const FloatArrayType& data, IndexType start,
-	       IndexType stop, SherpaFloat& val) {
+  void _sum_sq(const FloatArrayType& data,
+	       IndexType start, IndexType stop,
+	       typename FloatArrayType::value_type& val) {
 
     val = 0.0;
-    for( IndexType ii = start; ii < stop; ii++ )
+    for( auto ii = start; ii < stop; ii++ )
       val += ( data[ii] * data[ii] );
 
     val = sqrt( val );
   }
 
   template <typename FloatArrayType, typename IndexType>
-  void _max(const FloatArrayType& data, IndexType start,
-		 IndexType stop, SherpaFloat& val) {
+  void _max(const FloatArrayType& data,
+	    IndexType start, IndexType stop,
+	    typename FloatArrayType::value_type& val) {
 
     val = data[start];
-    for( IndexType ii = start + 1; ii < stop; ii++ )
+    for( auto ii = start + 1; ii < stop; ii++ )
       val = std::max( val, data[ii] );
 
   }
 
   template <typename FloatArrayType, typename IndexType>
-  void _min(const FloatArrayType& data, IndexType start,
-		 IndexType stop, SherpaFloat& val) {
+  void _min(const FloatArrayType& data,
+	    IndexType start, IndexType stop,
+	    typename FloatArrayType::value_type& val) {
 
     val = data[start];
-    for( IndexType ii = start + 1; ii < stop; ii++ )
+    for( auto ii = start + 1; ii < stop; ii++ )
       val = std::min( val, data[ii] );
 
   }
 
   template <typename FloatArrayType, typename IndexType>
-  void _middle(const FloatArrayType& data, IndexType start,
-	       IndexType stop, SherpaFloat& val) {
+  void _middle(const FloatArrayType& data,
+	       IndexType start, IndexType stop,
+	       typename FloatArrayType::value_type& val) {
 
-    SherpaFloat min = data[start];
-    SherpaFloat max = data[start];
-    for( IndexType ii = start + 1; ii < stop; ii++ ) {
+    auto min = data[start];
+    auto max = data[start];
+    for( auto ii = start + 1; ii < stop; ii++ ) {
       min = std::min( min, data[ii] );
       max = std::max( max, data[ii] );
     }
@@ -367,10 +369,9 @@ namespace sherpa { namespace astro { namespace utils {
   {
 
     typedef void (*fptr)( const FloatArrayType&, IndexType, IndexType,
-			  SherpaFloat&);
+			  typename FloatArrayType::value_type&);
     std::string funcname(type);
     std::map<std::string, fptr> funcs;
-    SherpaFloat val;
     fptr func = NULL;
 
     funcs["sum"] = _sum;
@@ -392,7 +393,7 @@ namespace sherpa { namespace astro { namespace utils {
     //     pick_pts[i] <= idx < pick_pts[i + 1]
     //
     std::vector< IndexType > pick_pts;
-    for( IndexType ii = 0; ii < nelem; ii++ )
+    for( auto ii = 0; ii < nelem; ii++ )
       if( group[ ii ] >= 0 )
 	pick_pts.push_back( ii );
 
@@ -402,20 +403,19 @@ namespace sherpa { namespace astro { namespace utils {
     // Number of groups.
     const size_t ngrp = pick_pts.size() - 1;
 
-    // It is assumed that this is only ever called with an array type
-    // that can store SherpaFloat values.
-    //
     npy_intp dim = npy_intp( ngrp );
     if ( EXIT_SUCCESS != grouped.create( 1, &dim ) )
       return EXIT_FAILURE;
 
     // Apply the group function to each group.
+    auto val = static_cast<typename FloatArrayType::value_type>(0.0);
     for( size_t ii = 0; ii < ngrp; ii++ ) {
-      IndexType start = pick_pts[ ii ];
-      IndexType stop = pick_pts[ ii + 1 ];
+      auto start = pick_pts[ ii ];
+      auto stop = pick_pts[ ii + 1 ];
 
       if ( func == NULL ) {
-	grouped[ ii ] = data[0] + (SherpaFloat) ii;
+	grouped[ ii ] = data[0] +
+	  static_cast<typename FloatArrayType::value_type>(ii);
       } else {
 	func( data, start, stop, val );
 	grouped[ ii ] = val;


### PR DESCRIPTION
This starts with some C++ clean ups (not strictly necessary but potentially an improvement), and could be taken anyway. They do end up with requiring C++11 support in the compiler, which I am happy with [python development is fast enough that I am not sure any platform we have the energy to support does not have a valid C++-11 compiler] but is potentially a sticking point.

Then I allows the grouping function to be sent in, as a function defined in Python, rather than hard-coded from a lost - a la #1157 

There is some attempt to improve the speed, since it is significantly slower than the all-C++ version (unsurprisingly), but it doesn't make a big difference. There may be ways of speeding this up.

I then implement the grouping code in Python, rather than C++. This is generally even slower (although for grating-style data it begins to get close to the C++ calling back to Python speed). This is also discussed in #1157 

The reason I mention speed is that unfortunately it does make a difference in fitting. I had assumed that we essentially cached the grouped data in a fit, so we only did the grouping once, but that is not true - for each iteration we end up calling the grouping code multiple times (to get both the grouped data and possibly error values and maybe bin edges [not looked into this too much]). I noticed this because the time taken to run the test suite increased noticeably during development of this code.

Now, there are ways we can look at re-working how we access data - e.g. caching it either internally in the object, which has a lot of issues about cache coherence [given all the work I've done on the filtering and grouping code I can tell you know it's "not easy to do" and "leads to a bunch of errors just like all the fixes I've made recently], or maybe within the fit/error/... code [which also has disadvantages].

I wanted to make sure this didn't get forgotten as I have to work on other things for the moment.

 