### PR TITLE
Change how invalid limits are checked for within the MCMC code

### DIFF
--- a/sherpa/sim/__init__.py
+++ b/sherpa/sim/__init__.py
@@ -218,8 +218,6 @@ from sherpa.utils import random
 
 info = logging.getLogger("sherpa").info
 
-_tol = np.finfo(float).eps
-
 string_types = (str, )
 
 
@@ -721,10 +719,12 @@ class MCMC(NoNewAttributesAfterInit):
 
         def calc_stat(proposed_params):
 
-            # automatic rejection outside hard limits
-            mins = sao_fcmp(proposed_params, thawedparmins, _tol)
-            maxes = sao_fcmp(thawedparmaxes, proposed_params, _tol)
-            if -1 in mins or -1 in maxes:
+            # This used to use sao_fcmp to compare these limits with
+            # a tolerance of np.finfo(float).eps, but it has since
+            # been changed to the easier check thanks to a request
+            # from the Chandra Source Catalog team.
+            if np.any(proposed_params < thawedparmins) or \
+               np.any(proposed_params > thawedparmaxes):
                 raise LimitError('Sherpa parameter hard limit exception')
 
             with SherpaVerbosity(logging.CRITICAL):


### PR DESCRIPTION
# Summary

Simplify a safety check within the MCMC proposed-parameter code.

# Details

This has been part of the specfit est_method_arg update used for the Chandra Source Catalog build - e.g. https://github.com/sherpa/sherpa/pull/2186 - but it is a seperate change from the est_method_arg. There was no documentation to say why this was useful.

It is not obvious why this was done, but there may be cases where the tolerance check for limits lead to problems - e.g.

    np.any(proposed < minvals) or np.any(proposed > maxvals)

is a better check than allowing through a proposed value which is minvals[idx] - delta or maxvals[idx] + delta where

    delta < np.finfo(float).eps

(and given that these values are double, this could happen).