### PR TITLE
Allow pytest 8.3.4 to be used

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -30,13 +30,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: MacOS Full Build
-            os: macos-12
-            python-version: "3.10"
+          - name: MacOS Intel Full Build
+            os: macos-13
+            python-version: "3.11"
             install-type: develop
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
+            bokeh-version: 3
             xspec-version: 12.14.0i
 
           - name: Linux Minimum Setup (Python 3.10)

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -1504,7 +1504,7 @@ def test_write_pha_with_bad_quality(tmp_path):
     counts = chans * 2
     group = [1, -1, -1, 1, -1, 1, 1, 1, -1]
     quality = [0, 5, 0, 0, 0, 0, 0, 2, 2]
-    qfilt = [True, False] + [True] * 5 + [False] * 2
+    qfilt = np.asarray([True, False] + [True] * 5 + [False] * 2)
 
     pha0 = DataPHA("qual", chans, counts, grouping=group,
                    quality=quality)

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -2367,7 +2367,7 @@ def test_pha_check_limit(ignore, lo, hi, evals):
     pha.units = 'energy'
 
     assert pha.mask is True
-    assert pha.get_mask() == pytest.approx([True] * 10)
+    assert pha.get_mask() == pytest.approx(np.ones(10, dtype=bool))
 
     func = pha.ignore if ignore else pha.notice
     func(lo, hi)
@@ -2380,7 +2380,7 @@ def test_pha_check_limit(ignore, lo, hi, evals):
         vin = True
 
     c1, c2, c3 = evals
-    expected = [vout] * c1 + [vin] * c2 + [vout] * c3
+    expected = np.asarray([vout] * c1 + [vin] * c2 + [vout] * c3)
     assert pha.mask == pytest.approx(pha.get_mask())
     assert pha.mask == pytest.approx(expected)
 
@@ -2449,7 +2449,7 @@ def test_pha_check_limit_channel(ignore, lo, hi, evals):
     pha.units = 'channel'
 
     assert pha.mask is True
-    assert pha.get_mask() == pytest.approx([True] * 10)
+    assert pha.get_mask() == pytest.approx(np.ones(10, dtype=bool))
 
     func = pha.ignore if ignore else pha.notice
     func(lo, hi)
@@ -2462,7 +2462,7 @@ def test_pha_check_limit_channel(ignore, lo, hi, evals):
         vin = True
 
     c1, c2, c3 = evals
-    expected = [vout] * c1 + [vin] * c2 + [vout] * c3
+    expected = np.asarray([vout] * c1 + [vin] * c2 + [vout] * c3)
     assert pha.mask == pytest.approx(pha.get_mask())
     assert pha.mask == pytest.approx(expected)
 
@@ -2672,7 +2672,9 @@ def test_is_mask_reset_pha(caplog):
     # Pick a value somewhere within the independent axis
     assert data.mask is True
     data.ignore(None, 2)
-    assert data.mask == pytest.approx([False, False, True])
+
+    mask = np.asarray([False, False, True])
+    assert data.mask == pytest.approx(mask)
 
     # Change the independent axis, but to something of the same
     # length.
@@ -2683,7 +2685,7 @@ def test_is_mask_reset_pha(caplog):
     assert len(caplog.records) == 0
 
     # The mask has *not* been cleared
-    assert data.mask == pytest.approx([False, False, True])
+    assert data.mask == pytest.approx(mask)
 
 
 def test_is_mask_reset_pha_channel(caplog):
@@ -2703,7 +2705,8 @@ def test_is_mask_reset_pha_channel(caplog):
     assert len(caplog.records) == 0
 
     # The mask has not been cleared
-    assert data.mask == pytest.approx([False, False, True])
+    mask = np.asarray([False, False, True])
+    assert data.mask == pytest.approx(mask)
 
 
 @requires_region
@@ -3376,9 +3379,11 @@ def test_pha_notice_bkg_id_none():
 
     pha.notice(lo=2, bkg_id=None)  # the default
 
-    assert pha.mask == pytest.approx([False, True])
-    assert b1.mask == pytest.approx([False, True])
-    assert bup.mask == pytest.approx([False, True])
+    bfilt = np.asarray([False, True])
+
+    assert pha.mask == pytest.approx(bfilt)
+    assert b1.mask == pytest.approx(bfilt)
+    assert bup.mask == pytest.approx(bfilt)
 
 
 @pytest.mark.parametrize("bkg_id", [1, "up"])
@@ -3394,13 +3399,15 @@ def test_pha_notice_bkg_id_scalar(bkg_id):
 
     pha.notice(lo=2, bkg_id=bkg_id)
 
+    bfilt = np.asarray([False, True])
+
     assert pha.mask is True
     if bkg_id == 1:
-        assert b1.mask == pytest.approx([False, True])
+        assert b1.mask == pytest.approx(bfilt)
         assert bup.mask is True
     else:
         assert b1.mask is True
-        assert bup.mask == pytest.approx([False, True])
+        assert bup.mask == pytest.approx(bfilt)
 
 
 def test_pha_notice_bkg_id_array_all():
@@ -3415,9 +3422,11 @@ def test_pha_notice_bkg_id_array_all():
 
     pha.notice(lo=2, bkg_id=["up", 1])
 
+    bfilt = np.asarray([False, True])
+
     assert pha.mask is True
-    assert b1.mask == pytest.approx([False, True])
-    assert bup.mask == pytest.approx([False, True])
+    assert b1.mask == pytest.approx(bfilt)
+    assert bup.mask == pytest.approx(bfilt)
 
 
 @pytest.mark.parametrize("bkg_id", [1, "up"])
@@ -3433,13 +3442,15 @@ def test_pha_notice_bkg_id_array_subset(bkg_id):
 
     pha.notice(lo=2, bkg_id=[bkg_id])
 
+    bfilt = np.asarray([False, True])
+
     assert pha.mask is True
     if bkg_id == 1:
-        assert b1.mask == pytest.approx([False, True])
+        assert b1.mask == pytest.approx(bfilt)
         assert bup.mask is True
     else:
         assert b1.mask is True
-        assert bup.mask == pytest.approx([False, True])
+        assert bup.mask == pytest.approx(bfilt)
 
 
 def get_img_spatial_mask():

--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -712,7 +712,8 @@ def test_rmfmodelpha_delta_no_ebounds(analysis, caplog):
 
     assert len(caplog.records) == 0
     if analysis == "energy":
-        assert pha.mask == pytest.approx([False, True, True, True, False])
+        expected = np.asarray([False, True, True, True, False])
+        assert pha.mask == pytest.approx(expected)
     else:
         assert not pha.mask.any()
 

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -227,8 +227,8 @@ def test_sourceplot_filtered(caplog, make_basic_datapha):
     # The filtering should probably be this, but let's test the
     # current behavior:
     #
-    # expected = [False] * 2 + [True] * 6 + [False] * 2
-    expected = [False] * 3 + [True] * 5 + [False] * 2
+    # expected = np.asarray([False] * 2 + [True] * 6 + [False] * 2)
+    expected = np.asarray([False] * 3 + [True] * 5 + [False] * 2)
     assert sp.mask == pytest.approx(expected)
     assert len(caplog.records) == 0
     check_sourceplot_energy(sp)
@@ -365,7 +365,7 @@ def test_sourceplot_wavelength_filtered(caplog, make_basic_datapha):
     # Given the filtering for energy didn't quite match, DJB is
     # slightly surprised this works.
     #
-    expected = [False] * 2 + [True] * 6 + [False] * 2
+    expected = np.asarray([False] * 2 + [True] * 6 + [False] * 2)
     assert sp.mask == pytest.approx(expected)
     assert len(caplog.records) == 0
     check_sourceplot_wavelength(sp)

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -1962,7 +1962,8 @@ def check_pha_offset(specresp, matrix, energ_lo, energ_hi,
     ui.notice(0.5, 0.8)
 
     data = ui.get_data()
-    assert data.mask == pytest.approx([False] * 3 + [True] * 3 + [False] * 3)
+    expected = np.asarray([False] * 3 + [True] * 3 + [False] * 3)
+    assert data.mask == pytest.approx(expected)
 
     assert ui.get_filter(format="%.2f", delim="-") == "0.45-0.85"
 

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -2957,7 +2957,7 @@ def test_pha_set_filter_unmasked(simple_pha):
     expected = [True, True, False, True, False]
     ui.set_filter(expected)
 
-    assert data.mask == pytest.approx(expected)
+    assert data.mask == pytest.approx(np.asarray(expected))
 
 
 def test_pha_set_filter_unmasked_wrong(simple_pha):
@@ -2973,11 +2973,14 @@ def test_pha_set_filter_masked(simple_pha):
 
     data = ui.get_data()
 
+    mask = np.asarray([True, False, False, False, True])
+    mask2 = np.asarray([True, False, True, False, True])
+
     ui.ignore(4, 8)
-    assert data.mask == pytest.approx([True, False, False, False, True])
+    assert data.mask == pytest.approx(mask)
 
     ui.set_filter(np.asarray([True, False, True, False, False]))
-    assert data.mask == pytest.approx([True, False, True, False, True])
+    assert data.mask == pytest.approx(mask2)
 
 
 def test_pha_set_filter_masked_wrong(simple_pha):

--- a/sherpa/astro/ui/tests/test_filtering.py
+++ b/sherpa/astro/ui/tests/test_filtering.py
@@ -709,7 +709,7 @@ def test_ignore_bad_simple_comparison(caplog):
 
         d = s.get_data(idval)
         assert d.mask is True
-        assert d.get_mask() == pytest.approx([True] * 5)
+        assert d.get_mask() == pytest.approx(np.ones(5, dtype=bool))
 
     assert len(caplog.records) == 2
     s.ignore_bad(1)
@@ -733,7 +733,7 @@ def test_ignore_bad_simple_comparison(caplog):
     assert s.get_filter(1) == "1,3:5"
     assert s.get_filter(2) == "1:5"
 
-    mask = [True] + [False] + [True] * 3
+    mask = np.asarray([True] + [False] + [True] * 3)
     d1 = s.get_data(1)
     assert d1.mask == pytest.approx(mask)
     assert d1.get_mask() == pytest.approx(mask)
@@ -762,12 +762,12 @@ def test_ignore_bad_simple_comparison(caplog):
     assert s.get_filter(1) == "1,3"
     assert s.get_filter(2) == "1:3"
 
-    mask = [True] + [False] + [True] + [False] * 2
+    mask = np.asarray([True] + [False] + [True] + [False] * 2)
     d1 = s.get_data(1)
     assert d1.mask == pytest.approx(mask)
     assert d1.get_mask() == pytest.approx(mask)
 
-    mask = [True] * 2 + [False] * 2
+    mask = np.asarray([True] * 2 + [False] * 2)
     d2 = s.get_data(2)
     assert d2.mask == pytest.approx(mask)
     assert d2.get_mask() == pytest.approx(mask)

--- a/sherpa/astro/utils/tests/test_astro_utils_unit.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_unit.py
@@ -194,7 +194,7 @@ def test_filter_resp_basics(offset, selected, ng, fch, nch, mat, msk):
     assert f_chan2 == pytest.approx(np.asarray(fch) + delta)
     assert n_chan2 == pytest.approx(nch)
     assert matrix2 == pytest.approx(mat)
-    assert mask2 == pytest.approx(msk)
+    assert mask2 == pytest.approx(np.asarray(msk))
 
 
 @pytest.mark.parametrize("lo, hi, expected",
@@ -414,7 +414,8 @@ def test_qual_setting():
     """Regression test."""
 
     pha = make_data("qual")
-    assert pha.quality_filter == pytest.approx([True, True, False, True])
+    expected = np.asarray([True, True, False, True])
+    assert pha.quality_filter == pytest.approx(expected)
 
 
 @pytest.mark.parametrize("data_class", ["1d", "1dint", "pha", "grp", "qual"])
@@ -869,4 +870,5 @@ def test_expand_grouped_mask_ingalid_group():
 def test_expand_grouped_mask(mask, group, expected):
     """Check how test_expand_grouped_mask works."""
 
-    assert expand_grouped_mask(mask, group) == pytest.approx(expected)
+    evals = np.asarray(expected)
+    assert expand_grouped_mask(mask, group) == pytest.approx(evals)

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1321,7 +1321,7 @@ def test_data_filter_invalid_size_scalar():
     x = numpy.asarray([1, 2, 5])
     d = Data1D('x', x, x)
     d.ignore(None, 2)
-    assert d.mask == pytest.approx([False, False, True])
+    assert d.mask == pytest.approx(numpy.asarray([False, False, True]))
 
     with pytest.raises(DataErr,
                        match="Array must be a sequence or None"):
@@ -1567,7 +1567,7 @@ def test_data1dint_check_limit(ignore, lo, hi, evals):
 
     c1, c2, c3 = evals
     expected = [vout] * c1 + [vin] * c2 + [vout] * c3
-    assert d.mask == pytest.approx(expected)
+    assert d.mask == pytest.approx(numpy.asarray(expected))
 
 
 def test_filter_apply_none():
@@ -1993,7 +1993,7 @@ def test_mask_sent_array_non_bool():
     expected = [True, False, True, False, True, True, False, True, False, True]
 
     data.mask = mask
-    assert data.mask == pytest.approx(expected)
+    assert data.mask == pytest.approx(numpy.asarray(expected))
 
 
 @pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -1408,7 +1408,8 @@ def test_load_filter_simple(idval, tmp_path):
     else:
         s.load_filter(idval, str(infile), ncols=1, ignore=True)
 
-    assert s.get_data().mask == pytest.approx([True, True, False])
+    expected = np.asarray([True, True, False])
+    assert s.get_data().mask == pytest.approx(expected)
 
 
 @pytest.mark.parametrize("idval", [None, 1])

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -1209,7 +1209,7 @@ def test_set_filter_unmasked(ignore, clean_ui):
     ui.load_arrays(1, x, y)
 
     data = ui.get_data()
-    assert data.mask
+    assert data.mask is True
 
     if ignore:
         expected = [False, True, False]
@@ -1217,7 +1217,7 @@ def test_set_filter_unmasked(ignore, clean_ui):
         expected = [True, False, True]
 
     ui.set_filter(np.asarray([True, False, True]), ignore=ignore)
-    assert data.mask == pytest.approx(expected)
+    assert data.mask == pytest.approx(np.asarray(expected))
 
 
 def test_set_filter_unmasked_wrong(clean_ui):
@@ -1245,7 +1245,9 @@ def test_set_filter_masked(ignore, clean_ui):
     ui.ignore(lo=15, hi=45)
 
     data = ui.get_data()
-    assert data.mask == pytest.approx([True, False, False, False, True])
+
+    orig = np.asarray([True, False, False, False, True])
+    assert data.mask == pytest.approx(orig)
 
     # Unlike test_set_filter_masked the two expected values are not
     # logical inverses, since we need to consider the existing mask.
@@ -1256,7 +1258,7 @@ def test_set_filter_masked(ignore, clean_ui):
         expected = [True, False, True, False, True]
 
     ui.set_filter(np.asarray([True, False, True, False, False]), ignore=ignore)
-    assert data.mask == pytest.approx(expected)
+    assert data.mask == pytest.approx(np.asarray(expected))
 
 
 def test_set_filter_masked_wrong(clean_ui):

--- a/sherpa/utils/tests/test_utils.py
+++ b/sherpa/utils/tests/test_utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2010, 2016, 2018 - 2024
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -374,9 +374,11 @@ def test_filter_bins_one(lo, hi, res):
     lo>hi.
     """
 
+    expected = numpy.asarray(res)
+
     dvals = numpy.asarray([1, 2, 3, 4, 5])
     flags = utils.filter_bins([lo], [hi], [dvals])
-    assert flags == pytest.approx(res)
+    assert flags == pytest.approx(expected)
 
     # We can also check an identity: that
     #    a <= x <= b
@@ -385,7 +387,7 @@ def test_filter_bins_one(lo, hi, res):
     #    x <= b
     #
     flags = utils.filter_bins([lo, None], [None, hi], [dvals, dvals])
-    assert flags == pytest.approx(res)
+    assert flags == pytest.approx(expected)
 
 
 
@@ -418,7 +420,7 @@ def test_filter_bins_one_int(lo, hi, res):
     hivals = lovals + 1
     flags = utils.filter_bins([None, lo], [hi, None], [lovals, hivals],
                               integrated=True)
-    assert flags == pytest.approx(res)
+    assert flags == pytest.approx(numpy.asarray(res))
 
 
 


### PR DESCRIPTION
# Summary

Allow the tests to pass with pytest version 8.3.4 by changing the test code. The GitHub macOS conda action is updated to macos-13 (for the Intel build). There is no functional change here.

# Details

Fix #2202.

In pytest 8.3.3 and earlier
    
        >>> import numpy as np; import pytest
        >>> pytest.__version__
        '8.3.3'
        >>> np.ones(2, dtype=bool) == pytest.approx([True, True])
        True
    
However, pytest 8.3.4 now causes this to fail
    
        >>> import numpy as np; import pytest
        >>> pytest.__version__
        '8.3.4'
        >>> np.ones(2, dtype=bool) == pytest.approx([True, True])
        False
    
This is because of "pytest.approx considers boolean numeric types"

- https://github.com/pytest-dev/pytest/issues/9353
    
The solution is to make the "expected" value be a ndarray, and so
    
        >>> np.ones(2, dtype=bool) == pytest.approx(np.asarray([True, True]))
        True
    
holds with both pytest 8.3.3 and 8.3.4.
    
So this commit basically goes through and updates the tests so that we use a ndarray for boolean arrays.
    
An alternative would be to change from
    
        assert got == pytest.approx(expected)
    
to something like
    
        assert np.all(got == expected)
    
However, the error message when the array lengths are different or an element is different are a **lot less** useful, and the change would be even-more invasive than this change.

I have also added a commit based on the work in #2198 to allow the macOS Intel runner to pass the tests (and bump the python version up to something more up to date).