### PR TITLE
Update the GitHub Actions badge for Conda and Pip workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![Build Status: Conda](https://github.com/sherpa/sherpa/workflows/Conda%20CI/badge.svg)
-![Build Status: Pip](https://github.com/sherpa/sherpa/workflows/Pip%20CI/badge.svg)
+![Build Status: Conda](https://github.com/sherpa/sherpa/actions/workflows/ci-conda-workflow.yml/badge.svg)
+![Build Status: Pip](https://github.com/sherpa/sherpa/actions/workflows/ci-pip-workflow.yml/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/sherpa/badge/)](https://sherpa.readthedocs.io/)
 [![DOI](https://zenodo.org/badge/683/sherpa/sherpa.svg)](https://zenodo.org/badge/latestdoi/683/sherpa/sherpa)
 [![GPLv3+ License](https://img.shields.io/badge/license-GPLv3+-blue.svg)](https://www.gnu.org/copyleft/gpl.html)


### PR DESCRIPTION
Summary
========
Update the GitHub Actions badge in the README.md for the Conda and Pip workflows.

Details
=====
This updates the url for the GitHub Actions status badge to point to the correct location. This fixes #2149.