### PR TITLE
update to change .bz2 references to .conda to account for changes in …

### DIFF
--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -111,7 +111,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.os-dir }}-${{ matrix.python-version }}
-        path: ${{ github.workspace }}/packages/*/sherpa*bz2
+        path: ${{ github.workspace }}/packages/*/sherpa*conda
         if-no-files-found: error
         retention-days: 3
 
@@ -199,7 +199,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.os-dir }}-${{ matrix.python-version }}
-        path: ${{ github.workspace }}/packages/*/sherpa*bz2
+        path: ${{ github.workspace }}/packages/*/sherpa*conda
         if-no-files-found: error
         retention-days: 3
 
@@ -247,8 +247,8 @@ jobs:
         source ${conda_loc}/etc/profile.d/conda.sh
         conda install conda-build
         echo "Packages downloaded here: ${{steps.download.outputs.download-path}}"
-        echo "ls packages/*/sherpa*.bz2"
-        ls packages/*/sherpa*.bz2
+        echo "ls packages/*/sherpa*.conda"
+        ls packages/*/sherpa*.conda
         echo "conda index packages"
         conda index packages
 


### PR DESCRIPTION
summary
=== 
Modify workflows to use .conda instead of .bz2 

description
===
Update the conda ci deployment .yaml to replace bz2 references with .conda to fix issues with new builds in the ci.