### PR TITLE
Better handle dataspace1d for DataPHA use cases when offset is not 1

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2020 - 2024
+#  Copyright (C) 2016, 2018, 2020 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -27,7 +27,7 @@ import os
 import re
 import sys
 
-import numpy
+import numpy as np
 
 import pytest
 
@@ -264,8 +264,8 @@ def clc_filter(caplog, msg, astro=False, pos=-1):
 @requires_group
 def test_zero_division_calc_stat(caplog):
     ui = AstroSession()
-    x = numpy.arange(100)
-    y = numpy.zeros(100)
+    x = np.arange(100)
+    y = np.zeros(100)
     ui.load_arrays(1, x, y, DataPHA)
 
     assert len(caplog.record_tuples) == 0
@@ -286,7 +286,7 @@ def test_zero_division_calc_stat(caplog):
     # Then, since calc_stat_info only logs something and doesn't return anything, we use
     # a white box approach to get the result from _get_stat_info.
     ui.calc_stat_info()
-    assert ui._get_stat_info()[0].rstat is numpy.nan
+    assert ui._get_stat_info()[0].rstat is np.nan
 
 
 @pytest.mark.parametrize("session", [Session, AstroSession])
@@ -479,7 +479,7 @@ def test_astro_plot_bkgxxx(label):
     data = DataPHA("data", [1, 2, 3], [5, 2, 3])
     bkg = DataPHA("bkg", [1, 2, 3], [2, 1, 2])
 
-    egrid = numpy.asarray([0.1, 0.2, 0.3, 0.4])
+    egrid = np.asarray([0.1, 0.2, 0.3, 0.4])
     arf = create_arf(egrid[:-1], egrid[1:])
 
     s.set_data(data)
@@ -511,7 +511,7 @@ def test_astro_plot_bkg_xxx(label):
     data = DataPHA("data", [1, 2, 3], [5, 2, 3])
     bkg = DataPHA("bkg", [1, 2, 3], [2, 1, 2])
 
-    egrid = numpy.asarray([0.1, 0.2, 0.3, 0.4])
+    egrid = np.asarray([0.1, 0.2, 0.3, 0.4])
     arf = create_arf(egrid[:-1], egrid[1:])
 
     s.set_data(data)
@@ -870,8 +870,8 @@ def test_show_data_datapha_bkg_no_response():
 
     s = AstroSession()
 
-    chans = numpy.arange(1, 6, dtype=int)
-    counts = numpy.asarray([10, 20, 15, 12, 10], dtype=int)
+    chans = np.arange(1, 6, dtype=int)
+    counts = np.asarray([10, 20, 15, 12, 10], dtype=int)
     data = DataPHA("src", chans, counts)
     bkg1 = DataPHA("down", chans, counts)
     bkg2 = DataPHA("up", chans, counts)
@@ -972,8 +972,8 @@ def test_show_bkg_datapha_no_response():
 
     s = AstroSession()
 
-    chans = numpy.arange(1, 6, dtype=int)
-    counts = numpy.asarray([10, 20, 15, 12, 10], dtype=int)
+    chans = np.arange(1, 6, dtype=int)
+    counts = np.asarray([10, 20, 15, 12, 10], dtype=int)
     data = DataPHA("src", chans, counts)
     bkg = DataPHA("down", chans, counts)
 
@@ -1024,14 +1024,14 @@ def test_show_data_datapha_bkg():
 
     s = AstroSession()
 
-    chans = numpy.arange(1, 6, dtype=int)
-    counts = numpy.asarray([10, 20, 15, 12, 10], dtype=int)
+    chans = np.arange(1, 6, dtype=int)
+    counts = np.asarray([10, 20, 15, 12, 10], dtype=int)
     data = DataPHA("src", chans, counts)
     bkg = DataPHA("bkg", chans, counts)
 
     # Pick a variety of bin edges. Just pick a RMF-only example.
     #
-    edges = numpy.asarray([0.1, 0.2, 0.4, 0.7, 1.0, 1.5])
+    edges = np.asarray([0.1, 0.2, 0.4, 0.7, 1.0, 1.5])
     src_rmf = create_delta_rmf(edges[:-1], edges[1:], name="srmf",
                                e_min=edges[:-1], e_max=edges[1:])
     bkg_rmf = create_delta_rmf(edges[:-1], edges[1:], name="brmf",
@@ -1138,8 +1138,8 @@ def test_show_bkg_source_output():
     s._add_model_types(sherpa.models.basic)
     s._add_model_types(sherpa.astro.models)
 
-    chans = numpy.arange(1, 6, dtype=int)
-    counts = numpy.asarray([10, 20, 15, 12, 10], dtype=int)
+    chans = np.arange(1, 6, dtype=int)
+    counts = np.asarray([10, 20, 15, 12, 10], dtype=int)
     data = DataPHA("src", chans, counts)
     bkg = DataPHA("bkg", chans, counts)
 
@@ -1148,7 +1148,7 @@ def test_show_bkg_source_output():
 
     # Pick a variety of bin edges. Just pick a RMF-only example.
     #
-    edges = numpy.asarray([0.1, 0.2, 0.4, 0.7, 1.0, 1.5])
+    edges = np.asarray([0.1, 0.2, 0.4, 0.7, 1.0, 1.5])
     src_rmf = create_delta_rmf(edges[:-1], edges[1:], name="srmf",
                                e_min=edges[:-1], e_max=edges[1:])
     bkg_rmf = create_delta_rmf(edges[:-1], edges[1:], name="brmf",
@@ -1689,7 +1689,7 @@ def test_get_xxx_component_plot_with_templates_data1d(session, label, make_data_
     # not check the actual values.
     #
     assert mplot.y == pytest.approx(cplot.y * ynorm)
-    assert numpy.all(mplot.y > 0)
+    assert np.all(mplot.y > 0)
 
 
 @requires_data
@@ -1737,7 +1737,7 @@ def test_get_xxx_component_plot_with_templates_data1d_no_interp(session, label, 
     # not check the actual values.
     #
     assert mplot.y == pytest.approx(cplot.y * ynorm)
-    assert numpy.all(mplot.y > 0)
+    assert np.all(mplot.y > 0)
 
 
 @requires_data
@@ -1751,7 +1751,7 @@ def test_get_xxx_component_plot_with_templates_data1dint(session, label, make_da
     # The actual data isn't too relevant, but pick similar x range
     # to load_template_with_interpolation-bb_data.dat
     #
-    edges = numpy.arange(1, 3, 0.1) * 1e14
+    edges = np.arange(1, 3, 0.1) * 1e14
     s.load_arrays(1, edges[:-1], edges[1:], edges[1:] * 0, Data1DInt)
 
     bbtemp, ynorm = setup_template_model(s, make_data_path)
@@ -1778,7 +1778,7 @@ def test_get_xxx_component_plot_with_templates_data1dint(session, label, make_da
     # not check the actual values.
     #
     assert mplot.y == pytest.approx(cplot.y * ynorm)
-    assert numpy.all(mplot.y > 0)
+    assert np.all(mplot.y > 0)
 
 
 @requires_data
@@ -1792,7 +1792,7 @@ def test_get_xxx_component_plot_with_templates_data1dint_no_interp(session, labe
     # The actual data isn't too relevant, but pick similar x range
     # to load_template_with_interpolation-bb_data.dat
     #
-    edges = numpy.arange(1, 3, 0.1) * 1e14
+    edges = np.arange(1, 3, 0.1) * 1e14
     s.load_arrays(1, edges[:-1], edges[1:], edges[1:] * 0, Data1DInt)
 
     bbtemp, ynorm = setup_template_model(s, make_data_path, interp=None)
@@ -1822,8 +1822,8 @@ def test_get_xxx_component_plot_with_templates_data1dint_no_interp(session, labe
         assert len(cplot.y) == 100
 
         assert mplot.y[0] == pytest.approx(cplot.y[0] * ynorm)
-        assert numpy.all(mplot.y > 0)
-        assert numpy.all(cplot.y > 0)
+        assert np.all(mplot.y > 0)
+        assert np.all(cplot.y > 0)
 
     else:
 
@@ -1837,7 +1837,7 @@ def test_get_xxx_component_plot_with_templates_data1dint_no_interp(session, labe
         # not check the actual values.
         #
         assert mplot.y == pytest.approx(cplot.y * ynorm)
-        assert numpy.all(mplot.y > 0)
+        assert np.all(mplot.y > 0)
 
 
 @requires_data
@@ -1857,10 +1857,10 @@ def test_get_source_component_plot_with_templates_datapha(interp, make_data_path
     # The actual data isn't too relevant, but pick similar x range
     # to load_template_with_interpolation-bb_data.dat
     #
-    chans = numpy.arange(1, 100, dtype=numpy.int16)
+    chans = np.arange(1, 100, dtype=np.int16)
     s.load_arrays(1, chans, chans * 0, DataPHA)
 
-    edges = numpy.linspace(1, 3, num=len(chans) + 1) * 1e4
+    edges = np.linspace(1, 3, num=len(chans) + 1) * 1e4
     arf = create_arf(edges[:-1], edges[1:])
     s.set_arf(arf)
 
@@ -1880,7 +1880,7 @@ def test_get_source_component_plot_with_templates_datapha(interp, make_data_path
     # not check the actual values.
     #
     assert mplot.y == pytest.approx(cplot.y * ynorm)
-    assert numpy.all(mplot.y > 0)
+    assert np.all(mplot.y > 0)
 
 
 @requires_data
@@ -1900,10 +1900,10 @@ def test_get_model_component_plot_with_templates_datapha(interp, make_data_path)
     # The actual data isn't too relevant, but pick similar x range
     # to load_template_with_interpolation-bb_data.dat
     #
-    chans = numpy.arange(1, 100, dtype=numpy.int16)
+    chans = np.arange(1, 100, dtype=np.int16)
     s.load_arrays(1, chans, chans * 0, DataPHA)
 
-    edges = numpy.linspace(1, 3, num=len(chans) + 1) * 1e4
+    edges = np.linspace(1, 3, num=len(chans) + 1) * 1e4
     arf = create_arf(edges[:-1], edges[1:])
     s.set_arf(arf)
 
@@ -1923,7 +1923,7 @@ def test_get_model_component_plot_with_templates_datapha(interp, make_data_path)
     # not check the actual values.
     #
     assert mplot.y == pytest.approx(cplot.y * ynorm)
-    assert numpy.all(mplot.y > 0)
+    assert np.all(mplot.y > 0)
 
 
 @requires_data
@@ -1947,18 +1947,18 @@ def test_compare_get_model_component_plot_with_templates(interp, make_data_path)
     # array is normally used for 1D non-integrated) we can try
     # and get the same values used.
     #
-    chans = numpy.arange(1, NBINS + 1, dtype=numpy.int16)
+    chans = np.arange(1, NBINS + 1, dtype=np.int16)
     s.load_arrays("pha", chans, chans * 0, DataPHA)
 
     # Give the ARF a non-unit response so we can see if it has been
     # applied (or, can infer it has been applied since the model
     # component will apply it).
     #
-    edges = numpy.arange(10000, 30001, BIN_WIDTH)
-    arf = create_arf(edges[:-1], edges[1:], numpy.ones(NBINS) * SPECRESP)
+    edges = np.arange(10000, 30001, BIN_WIDTH)
+    arf = create_arf(edges[:-1], edges[1:], np.ones(NBINS) * SPECRESP)
     s.set_arf("pha", arf)
 
-    ones = numpy.ones(NBINS)
+    ones = np.ones(NBINS)
     s.load_arrays("int", edges[:-1], edges[1:], ones, Data1DInt)
     s.load_arrays("1d", edges[:-1], ones, Data1D)
 
@@ -1979,9 +1979,9 @@ def test_compare_get_model_component_plot_with_templates(interp, make_data_path)
     # In case the pathway is different from using the default dataset
     # identifier, check some basic things about the response.
     #
-    assert numpy.all(cplot_pha.y > 0)
-    assert numpy.all(cplot_int.y > 0)
-    assert numpy.all(cplot_1d.y > 0)
+    assert np.all(cplot_pha.y > 0)
+    assert np.all(cplot_int.y > 0)
+    assert np.all(cplot_1d.y > 0)
 
     assert cplot_int.xlo == pytest.approx(cplot_pha.xlo)
     assert cplot_1d.x == pytest.approx(cplot_pha.xlo)
@@ -2013,7 +2013,7 @@ def test_get_source_component_plot_with_templates_datapha_no_response(make_data_
 
     s = AstroSession()
 
-    chans = numpy.arange(1, 100, dtype=numpy.int16)
+    chans = np.arange(1, 100, dtype=np.int16)
     s.load_arrays(1, chans, chans * 0, DataPHA)
 
     bbtemp, ynorm = setup_template_model(s, make_data_path)
@@ -2041,7 +2041,7 @@ def test_get_model_component_plot_with_templates_datapha_no_response(make_data_p
 
     s = AstroSession()
 
-    chans = numpy.arange(1, 100, dtype=numpy.int16)
+    chans = np.arange(1, 100, dtype=np.int16)
     s.load_arrays(1, chans, chans * 0, DataPHA)
 
     bbtemp, ynorm = setup_template_model(s, make_data_path)
@@ -2053,7 +2053,7 @@ def test_get_model_component_plot_with_templates_datapha_no_response(make_data_p
 
     cplot = s.get_model_component_plot(bbtemp)
     assert cplot.title == "Model component: template.bbtemp"
-    assert numpy.all(cplot.y > 0)
+    assert np.all(cplot.y > 0)
 
 
 def check_stat_info_basic(sinfo, name, ids, numpoints, statval):
@@ -2128,7 +2128,7 @@ def test_get_stat_info_astro_one(caplog):
     data = DataPHA("example", [1, 2, 3], [3, 7, 6])
     bkg = DataPHA("background", [1, 2, 3], [1, 1, 2])
 
-    egrid = numpy.asarray([0.1, 0.2, 0.4, 0.8])
+    egrid = np.asarray([0.1, 0.2, 0.4, 0.8])
     arf = create_arf(egrid[:-1], egrid[1:])
     data.set_arf(arf)
     bkg.set_arf(arf)
@@ -2161,7 +2161,7 @@ def test_get_stat_info_astro_two(caplog):
 
     bkg2 = DataPHA("background2", [1, 2, 3], [1, 1, 2])
 
-    egrid = numpy.asarray([0.1, 0.2, 0.4, 0.8])
+    egrid = np.asarray([0.1, 0.2, 0.4, 0.8])
     arf = create_arf(egrid[:-1], egrid[1:])
     data1.set_arf(arf)
     data2.set_arf(arf)
@@ -2286,7 +2286,7 @@ def test_set_full_model_pha_warning_response(caplog):
 
     s.load_arrays(1, [1, 2], [2, 4], DataPHA)
 
-    egrid = numpy.asarray([0.1, 0.2, 0.3])
+    egrid = np.asarray([0.1, 0.2, 0.3])
     s.set_arf(create_arf(egrid[:-1], egrid[1:], [10, 20]))
 
     gmdl = s.create_model_component("gauss1d", "gmdl")
@@ -2316,7 +2316,7 @@ def test_set_full_model_pha_warning_response_bkg():
     s.load_arrays(1, [1, 2], [2, 4], DataPHA)
     s.set_bkg(1, DataPHA("b", [1, 2], [1, 2]))
 
-    egrid = numpy.asarray([0.1, 0.2, 0.3])
+    egrid = np.asarray([0.1, 0.2, 0.3])
     s.set_arf(create_arf(egrid[:-1], egrid[1:], [10, 20]))
     s.set_arf(create_arf(egrid[:-1], egrid[1:], [5, 10]), bkg_id=1)
 
@@ -2454,7 +2454,7 @@ def test_notice_warning(caplog):
     s.load_arrays(1, [1, 2, 3], [1, 2, 3], DataPHA)
     s.load_arrays(2, [1, 2, 3], [1, 2, 3], DataPHA)
 
-    egrid = numpy.asarray([0.5, 0.7, 1.0, 2.0])
+    egrid = np.asarray([0.5, 0.7, 1.0, 2.0])
     elo = egrid[:-1]
     ehi = egrid[1:]
     rmf = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi)
@@ -2489,7 +2489,7 @@ def test_ignore_warning(caplog):
     s.load_arrays(1, [1, 2, 3], [1, 2, 3], DataPHA)
     s.load_arrays(2, [1, 2, 3], [1, 2, 3], DataPHA)
 
-    egrid = numpy.asarray([0.5, 0.7, 1.0, 2.0])
+    egrid = np.asarray([0.5, 0.7, 1.0, 2.0])
     elo = egrid[:-1]
     ehi = egrid[1:]
     rmf = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi)
@@ -2527,7 +2527,7 @@ def test_set_analysis_messages(caplog):
     s.load_arrays(2, [1, 2, 3], [1, 2, 3], DataPHA)
     s.load_arrays("foo", [1, 2, 3], [1, 2, 3], DataPHA)
 
-    egrid = numpy.asarray([0.5, 0.7, 1.0, 2.0])
+    egrid = np.asarray([0.5, 0.7, 1.0, 2.0])
     elo = egrid[:-1]
     ehi = egrid[1:]
     rmf = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi)
@@ -2947,7 +2947,7 @@ def test_fake_random(session, idval):
 
     s = session()
     s._add_model_types(sherpa.models.basic)
-    s.set_rng(numpy.random.RandomState(735))
+    s.set_rng(np.random.RandomState(735))
 
     s.load_arrays(idval, [2, 5, 9], [12, 13, 14])
     mdl = s.create_model_component("polynom1d", "mdl")
@@ -3384,7 +3384,7 @@ def test_check_get_source_and_model_with_background():
     s.set_backscal(2)
     s.set_backscal(8, bkg_id=1)
 
-    egrid = numpy.asarray([0.1, 0.2, 0.4, 0.8])
+    egrid = np.asarray([0.1, 0.2, 0.4, 0.8])
     elo = egrid[:-1]
     ehi = egrid[1:]
     rmf = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi)
@@ -3427,7 +3427,7 @@ def test_calc_model_sum_of_bkg():
     s.load_arrays(1, [1, 2, 3], [4, 5, 6], DataPHA)
     s.set_bkg(DataPHA("x", [1, 2, 3], [9, 2, 1]))
 
-    egrid = numpy.asarray([0.1, 0.2, 0.4, 0.8])
+    egrid = np.asarray([0.1, 0.2, 0.4, 0.8])
     elo = egrid[:-1]
     ehi = egrid[1:]
     rmf = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi)
@@ -3470,7 +3470,7 @@ def test_calc_source_sum_of_bkg():
     s.load_arrays(1, [1, 2, 3], [4, 5, 6], DataPHA)
     s.set_bkg(DataPHA("x", [1, 2, 3], [9, 2, 1]))
 
-    egrid = numpy.asarray([0.1, 0.2, 0.4, 0.8])
+    egrid = np.asarray([0.1, 0.2, 0.4, 0.8])
     elo = egrid[:-1]
     ehi = egrid[1:]
     rmf = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi)
@@ -3527,7 +3527,7 @@ def test_bkg_fit_data_with_no_model():
     s.set_bkg(DataPHA("ex", [1, 2, 3], [2, 0, 1]))
     s.set_bkg(DataPHA("ex", [1, 2, 3], [2, 0, 1]), bkg_id=2)
 
-    egrid = numpy.asarray([0.1, 0.2, 0.4, 0.8])
+    egrid = np.asarray([0.1, 0.2, 0.4, 0.8])
     elo = egrid[:-1]
     ehi = egrid[1:]
     rmf = create_delta_rmf(elo, ehi, e_min=elo, e_max=ehi)
@@ -4001,7 +4001,7 @@ def test_fit_datapha_mix_data(id1):
     # We allow ARF-only analysis, so test it. The fit seems to ignore
     # the bin widths in this case.
     #
-    egrid = numpy.asarray([0.2, 0.5, 0.9])
+    egrid = np.asarray([0.2, 0.5, 0.9])
     arf = create_arf(egrid[:-1], egrid[1:])
     s.set_arf(1, arf)
     s.set_arf(2, arf)
@@ -4040,7 +4040,7 @@ def test_fit_datapha_mix_data_with_bkg(id1):
     # We allow ARF-only analysis, so test it. The fit seems to ignore
     # the bin widths in this case.
     #
-    egrid = numpy.asarray([0.2, 0.5, 0.9])
+    egrid = np.asarray([0.2, 0.5, 0.9])
     arf = create_arf(egrid[:-1], egrid[1:])
     s.set_arf(1, arf)
     s.set_arf(2, arf)
@@ -4084,7 +4084,7 @@ def test_fit_datapha_mix_data_only_bkg(id1):
     # We allow ARF-only analysis, so test it. The fit seems to ignore
     # the bin widths in this case.
     #
-    egrid = numpy.asarray([0.2, 0.5, 0.9])
+    egrid = np.asarray([0.2, 0.5, 0.9])
     arf = create_arf(egrid[:-1], egrid[1:])
     s.set_arf(1, arf)
     s.set_arf(2, arf)
@@ -4137,7 +4137,7 @@ def test_fit_datapha_mix_data_only_bkg_no_response(id1):
     # We allow ARF-only analysis, so test it. The fit seems to ignore
     # the bin widths in this case.
     #
-    egrid = numpy.asarray([0.2, 0.5, 0.9])
+    egrid = np.asarray([0.2, 0.5, 0.9])
     arf = create_arf(egrid[:-1], egrid[1:])
     s.set_arf(1, arf)
     s.set_arf(2, arf)
@@ -4178,7 +4178,7 @@ def test_fit_datapha_mix_data_with_bkg_sensible():
     # We allow ARF-only analysis, so test it. The fit seems to ignore
     # the bin widths in this case.
     #
-    egrid = numpy.asarray([0.2, 0.5, 0.9])
+    egrid = np.asarray([0.2, 0.5, 0.9])
     arf = create_arf(egrid[:-1], egrid[1:])
     s.set_arf(1, arf)
     s.set_arf(2, arf)
@@ -4216,10 +4216,10 @@ def test_set_fit_works(session):
 
     s = session()
 
-    rng = numpy.random.RandomState()
+    rng = np.random.RandomState()
     s.set_rng(rng)
     got = s.get_rng()
-    assert isinstance(got, numpy.random.RandomState)
+    assert isinstance(got, np.random.RandomState)
 
     s.set_rng(None)
     got = s.get_rng()

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -4236,7 +4236,7 @@ def test_set_fit_checks_arg(session):
         s.set_rng(1234)
 
 
-@pytest.mark.parametrize("offset", [pytest.param(0, marks=pytest.mark.xfail), 1, pytest.param(5, marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("offset", [0, 1, 5])
 def test_dataspace1d_datapha_offset(offset):
     """Ensure we can create the correct channel numbers for DataPHA"""
 
@@ -4251,7 +4251,7 @@ def test_dataspace1d_datapha_offset(offset):
     assert d.channel == pytest.approx(chans)
 
 
-@pytest.mark.parametrize("offset", [pytest.param(0, marks=pytest.mark.xfail), 1, pytest.param(5, marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("offset", [0, 1, 5])
 def test_dataspace1d_datapha_offset_bkg(offset):
     """Can we set the background correctly"""
 
@@ -4293,7 +4293,6 @@ def test_dataspace1d_datapha_invalid_args(start, stop, step, numbins):
                       dstype=DataPHA)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("start,stop,step,numbins",
                          [[1, 5, 0.5, None],
                           [1, 5, 1.1, None],

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -170,8 +170,7 @@ def test_dataspace1d_datapha(clean_astro_ui):
 
     assert ui.list_data_ids() == []
 
-    # Note the grid is ignored, other than the number of bins
-    ui.dataspace1d(20, 30, step=2.5, id='x', dstype=ui.DataPHA)
+    ui.dataspace1d(1, 5, id='x', dstype=ui.DataPHA)
 
     assert ui.list_data_ids() == ['x']
     assert ui.get_data('x').name == 'dataspace1d'
@@ -199,7 +198,7 @@ def test_dataspace1d_datapha_bkg_nopha(clean_astro_ui):
     """We need a PHA to create a background dataset"""
 
     with pytest.raises(IdentifierErr) as exc:
-        ui.dataspace1d(20, 30, step=2.5, id='x', bkg_id=2, dstype=ui.DataPHA)
+        ui.dataspace1d(1, 5, id='x', bkg_id=2, dstype=ui.DataPHA)
 
     assert str(exc.value) == 'data set x has not been set'
 
@@ -212,13 +211,12 @@ def test_dataspace1d_datapha_bkg(clean_astro_ui):
 
     # We don't use the grid range or step size since numbins has been
     # given.
-    ui.dataspace1d(20, 30, step=2.5, numbins=10, id='x', dstype=ui.DataPHA)
+    ui.dataspace1d(1, 10, numbins=10, id='x', dstype=ui.DataPHA)
 
     assert ui.list_data_ids() == ['x']
     assert ui.list_bkg_ids('x') == []
 
-    ui.dataspace1d(20, 30, step=2.5, numbins=10, id='x', bkg_id=2,
-                   dstype=ui.DataPHA)
+    ui.dataspace1d(1, 10, step=1, id='x', bkg_id=2, dstype=ui.DataPHA)
 
     assert ui.list_data_ids() == ['x']
     assert ui.list_bkg_ids('x') == [2]

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015 - 2024
+#  Copyright (C) 2010, 2015 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1007,7 +1007,13 @@ class Session(sherpa.ui.utils.Session):
 
         Create an "empty" one-dimensional data set by defining the
         grid on which the points are defined (the independent axis).
-        The values are set to 0.
+        The values on the dependent axis are set to 0.
+
+        .. versionchanged:: 4.17.1
+           When creating a DataPHA data set, the start and stop values
+           are now used, and the step and numbins arguments must be
+           meaningful (if set). Previously it always started the
+           channel values at 1.
 
         Parameters
         ----------
@@ -1027,7 +1033,7 @@ class Session(sherpa.ui.utils.Session):
            `get_default_id`.
         bkg_id : int, str, or None, optional
            If set, the grid is for the background component of the
-           data set.
+           data set. This is only used when dstype is set to `DataPHA`.
         dstype : data class to use, optional
            What type of data is to be used. Supported values include
            `Data1DInt` (the default), `Data1D`, and `DataPHA`.
@@ -1041,9 +1047,14 @@ class Session(sherpa.ui.utils.Session):
 
         Notes
         -----
-        The meaning of the ``stop`` parameter depends on whether it is a
-        binned or unbinned data set (as set by the ``dstype``
+
+        The meaning of the ``stop`` parameter depends on whether it is
+        a binned or unbinned data set (as set by the ``dstype``
         parameter).
+
+        For DataPHA values, ``step`` and ``numbins`` should be left at
+        their default values, and only the ``start`` and ``stop``
+        values changed.
 
         Examples
         --------
@@ -1103,10 +1114,24 @@ class Session(sherpa.ui.utils.Session):
 
         is_pha = issubclass(dstype, DataPHA)
         if is_pha:
-            channel = np.arange(1, len(xlo) + 1, dtype=float)
-            args = [channel, y]
-            # kwargs['bin_lo'] = xlo
-            # kwargs['bin_hi'] = xhi
+            # Check that xlo is "sensible"
+            # - not empty (this has been checked for already)
+            # - values are consecutive
+            #   (could check step and numbins arguments above, but
+            #    easier to do this here)
+            # - values are integers
+            #
+            if not float(xlo[0]).is_integer():
+                raise DataErr("start must be an integer")
+
+            # Expect integer spacing; should this allow for numerical
+            # tolerances?
+            #
+            dx = np.diff(xlo, n=1)
+            if dx[0] != 1:
+                raise DataErr("channel spacing is not 1")
+
+            args = [xlo, y]
         elif dstype is not sherpa.data.Data1DInt:
             args = [xlo, y]
 


### PR DESCRIPTION
# Summary

The sherpa.astro.ui.utils.dataspace1d call can now be used to generate a channel grid that does not start at 1 for DataPHA data. The arguments are now checked to ensure they are sensible in this case (consecutive integer values).

# Details

I noticed this when coming up with a work-around for #2212.

We can now say

```python
from sherpa.astro import ui
ui.dataspace1d(0, 1023, dstype=ui.DataPHA)
```

to create a zero-count spectrum with channels 0 to 1023.

Previously I could say

```python
ui.dataspace1d(23, 30, dstype=ui.DataPHA)
```

and that would create a channel grid of `[1, 2, 3, 4, 5, 6, 7, 8]` and this now creates channels of `[23, 24, ..., 30]`. This could cause confusion, but I'm not sure we ever promised the old behaviour.

A more-interesting case is that

```python
ui.dataspace1d(23, 30, step=2, dstype=ui.DataPHA)
```

would create a channel range of `[1, 2, 3, 4, 5]`. It now is an error:

```
>>> ui.dataspace1d(23, 30, step=2, dstype=ui.DataPHA)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in dataspace1d
  File "/lagado.real/sherpa/sherpa-xspec/sherpa/astro/ui/utils.py", line 1127, in dataspace1d
    raise DataErr("channel spacing is not 1")
sherpa.utils.err.DataErr: channel spacing is not 1
```

The code will complain if you say

```python
ui.dataspace1d(1.1, 1024, dstype=ui.DataPHA)
```

complaining that the start value is not an integer, but it will allow

```python
ui.dataspace1d(1, 1024.1, dstype=ui.DataPHA)
```

and will treat this as channels=[1, 2, ..., 1025]. I am not sure it's worth catching this particular case.
