### PR TITLE
Better handle fake_pha when offset is not 1

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_simulation.py
@@ -443,7 +443,7 @@ def test_fake_pha_add_background(method, expected, idval, clean_astro_ui):
                          [(None, [189, 382, 400]),
                           (identity, [200, 400, 400])
                           ])
-@pytest.mark.parametrize("offset", [pytest.param(0, marks=pytest.mark.xfail), 1, pytest.param(5, marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("offset", [0, 1, 5])
 @pytest.mark.parametrize("idval", [None, 1, "faked"])
 def test_fake_pha_no_data(method, expected, offset, idval, clean_astro_ui):
     """What happens if there is no data loaded at the id?

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015 - 2024
+#  Copyright (C) 2010, 2015 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -9663,6 +9663,10 @@ class Session(sherpa.ui.utils.Session):
         time, along with a Poisson noise term. A background component can
         be included.
 
+        .. versionchanged:: 4.17.1
+           Improvements for faking data when the channel range does
+           not start at 1.
+
         .. versionchanged:: 4.16.1
            Several bugs have been addressed when simulating data with
            a background: the background model contribution would be
@@ -9859,7 +9863,8 @@ class Session(sherpa.ui.utils.Session):
             rmf0 = rmf
 
         if pha.channel is None:
-            pha.channel = sao_arange(1, rmf0.detchans)
+            pha.channel = sao_arange(rmf0.offset,
+                                     rmf0.detchans + rmf0.offset - 1)
 
         elif len(pha.channel) != rmf0.detchans:
             raise DataErr('incompatibleresp', rmf.name, str(idval))


### PR DESCRIPTION
# Summary

Allow fake_pha to work with missions where the first channel is not 1. Fix #2212.

# Details

This is a very simple fix. I forget how we try and include backgrounds here (this is related to #2122, which is an annoyingly-similar number) but I'm going to assume it's just magically correct.