### PR TITLE
Minor xspec additions

### DIFF
--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015 - 2024
+#  Copyright (C) 2010, 2015 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -106,7 +106,7 @@ from contextlib import suppress
 import logging
 import string
 import tempfile
-from typing import Any, Optional, Union
+from typing import Any, overload
 import warnings
 
 import numpy as np
@@ -136,12 +136,24 @@ warning = logging.getLogger(__name__).warning
 # when the compiled code has not been compiled (e.g. for a Sphinx
 # documentation run).
 #
-def get_xsabund(element: Optional[str] = None) -> Union[str, float]:
+@overload
+def get_xsabund() -> str:
+    ...
+
+@overload
+def get_xsabund(element: None) -> str:
+    ...
+
+@overload
+def get_xsabund(element: str) -> float:
+    ...
+
+def get_xsabund(element: str | None = None) -> str | float:
     """Return the X-Spec abundance setting or elemental abundance.
 
     Parameters
     ----------
-    element : str, optional
+    element : str or None, optional
        When not given, the abundance table name is returned.
        If a string, then it must be an element name from:
        'H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne',
@@ -165,8 +177,8 @@ def get_xsabund(element: Optional[str] = None) -> Union[str, float]:
     Examples
     --------
 
-    Return the current abundance setting, which in this case
-    is 'angr', the default value for X-Spec:
+    Return the current abundance setting, which in this case is
+    'angr', the default value for X-Spec:
 
     >>> get_xsabund()
     'angr'
@@ -176,11 +188,23 @@ def get_xsabund(element: Optional[str] = None) -> Union[str, float]:
     >>> get_xsabund('He')
     0.09769999980926514
 
-    The `set_xsabund` function has been used to read in the
-    abundances from a file, so the routine now returns the
-    string 'file':
+    The `set_xsabund` function has been used to read in the abundances
+    from a file, so the routine now returns the string 'file':
 
     >>> set_xsabund('abund.dat')
+    >>> get_xsabund()
+    'file'
+
+    Use the Lodders 2003 abundances but replace the Oxygen abundance
+    value with 0. In this case the abundance table is labelled as
+    'file':
+
+    >>> set_xsabund("lodd")
+    >>> get_xsabund()
+    'lodd'
+    >>> tbl = get_xsabundances()
+    >>> tbl['O'] = 0
+    >>> set_xsabundances(tbl)
     >>> get_xsabund()
     'file'
 
@@ -219,7 +243,7 @@ def get_xsabundances() -> dict[str, float]:
             for name in get_xselements().keys()}
 
 
-def get_xsabund_doc(name: Optional[str] = None) -> str:
+def get_xsabund_doc(name: str | None = None) -> str:
     """Return the documentation for the abundance table.
 
     Parameters
@@ -470,17 +494,18 @@ def set_xsabund(abundance: str) -> None:
     -----
     The pre-defined abundance tables are:
 
-     - 'angr', from [2]_
-     - 'aspl', from [3]_
-     - 'feld', from [4]_, except for elements not listed which
+     - 'aneb', from [2]_
+     - 'angr', from [3]_
+     - 'aspl', from [4]_
+     - 'felc', from [5]_ (coronal)
+     - 'feld', from [6]_, except for elements not listed which
        are given 'grsa' abundances
-     - 'aneb', from [5]_
-     - 'grsa', from [6]_
-     - 'wilm', from [7]_, except for elements not listed which
-       are given zero abundance
+     - 'grsa', from [7]_
      - 'lodd', from [8]_
      - 'lpgp', from [9]_ (photospheric)
      - 'lpgs', from [9]_ (proto-solar)
+     - 'wilm', from [10]_, except for elements not listed which
+       are given zero abundance
 
     The values for these tables are given at [1]_.
 
@@ -498,27 +523,27 @@ def set_xsabund(abundance: str) -> None:
            compiled version used by Sherpa; use `get_xsversion` to
            check.
 
-    .. [2] Anders E. & Grevesse N. (1989, Geochimica et
-           Cosmochimica Acta 53, 197)
-           https://adsabs.harvard.edu/abs/1989GeCoA..53..197A
-
-    .. [3] Asplund M., Grevesse N., Sauval A.J. & Scott P.
-           (2009, ARAA, 47, 481)
-           https://adsabs.harvard.edu/abs/2009ARA%26A..47..481A
-
-    .. [4] Feldman U.(1992, Physica Scripta 46, 202)
-           https://adsabs.harvard.edu/abs/1992PhyS...46..202F
-
-    .. [5] Anders E. & Ebihara (1982, Geochimica et Cosmochimica
+    .. [2] Anders E. & Ebihara (1982, Geochimica et Cosmochimica
            Acta 46, 2363)
            https://adsabs.harvard.edu/abs/1982GeCoA..46.2363A
 
-    .. [6] Grevesse, N. & Sauval, A.J. (1998, Space Science
+    .. [3] Anders E. & Grevesse N. (1989, Geochimica et
+           Cosmochimica Acta 53, 197)
+           https://adsabs.harvard.edu/abs/1989GeCoA..53..197A
+
+    .. [4] Asplund M., Grevesse N., Sauval A.J. & Scott P.
+           (2009, ARAA, 47, 481)
+           https://adsabs.harvard.edu/abs/2009ARA%26A..47..481A
+
+    .. [5] Feldman, U., Mandelbaum, P., Seely, J.L., Doschek, G.A., Gursky H.
+           (1992, ApJSS, 81, 387)
+
+    .. [6] Feldman U.(1992, Physica Scripta 46, 202)
+           https://adsabs.harvard.edu/abs/1992PhyS...46..202F
+
+    .. [7] Grevesse, N. & Sauval, A.J. (1998, Space Science
            Reviews 85, 161)
            https://adsabs.harvard.edu/abs/1998SSRv...85..161G
-
-    .. [7] Wilms, Allen & McCray (2000, ApJ 542, 914)
-           https://adsabs.harvard.edu/abs/2000ApJ...542..914W
 
     .. [8] Lodders, K (2003, ApJ 591, 1220)
            https://adsabs.harvard.edu/abs/2003ApJ...591.1220L
@@ -526,6 +551,9 @@ def set_xsabund(abundance: str) -> None:
     .. [9] Lodders K., Palme H., Gail H.P., Landolt-Börnstein,
            New Series, vol VI/4B, pp 560–630 (2009)
            https://ui.adsabs.harvard.edu/abs/2009LanB...4B..712L/abstract
+
+    .. [10] Wilms, Allen & McCray (2000, ApJ 542, 914)
+            https://adsabs.harvard.edu/abs/2000ApJ...542..914W
 
     Examples
     --------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -101,9 +101,11 @@ References
 
 """
 
+from __future__ import annotations
 
 from contextlib import suppress
 import logging
+from pathlib import Path
 import string
 import tempfile
 from typing import Any, overload
@@ -977,11 +979,17 @@ def set_xsstate(state: dict[str, Any]) -> None:
             set_xspath_manager(managerpath)
 
 
-def read_xstable_model(modelname, filename, etable=False):
+def read_xstable_model(modelname: str,
+                       filename: Path | str,
+                       etable: bool = False
+                       ) -> XSTableModel:
     """Create a XSPEC table model.
 
     XSPEC additive (atable, [1]_), multiplicative (mtable, [2]_), and
     exponential (etable, [3]_) table models are supported.
+
+    .. versionchanged:: 4.17.1
+       The filename argument can now be sent a Path object.
 
     .. versionchanged:: 4.16.0
        Parameters with negative DELTA values are now made frozen, to
@@ -999,7 +1007,7 @@ def read_xstable_model(modelname, filename, etable=False):
     ----------
     modelname : str
        The identifier for this model component.
-    filename : str
+    filename : str or Path
        The name of the FITS file containing the data, which should
        match the XSPEC table model definition [4]_.
     etable : bool, optional
@@ -1042,6 +1050,8 @@ def read_xstable_model(modelname, filename, etable=False):
 
     """
 
+    fname = str(filename) if isinstance(filename, Path) else filename
+
     # TODO: how to avoid loading this if no backend is available
     import sherpa.astro.io
     read_hdr = sherpa.astro.io.backend.get_header_data
@@ -1050,7 +1060,7 @@ def read_xstable_model(modelname, filename, etable=False):
     # What sort of a XSPEC table model is this?
     #
     try:
-        hdr1 = read_hdr(filename, blockname="PRIMARY")
+        hdr1 = read_hdr(fname, blockname="PRIMARY")
     except IOErr as ie:
         # The error message will be generic, so add some more
         # information.
@@ -1059,7 +1069,7 @@ def read_xstable_model(modelname, filename, etable=False):
 
     hduclas1 = hdr1.get("HDUCLAS1")
     if hduclas1 is None:
-        raise IOErr("nokeyword", filename, "HDUCLAS1")
+        raise IOErr("nokeyword", fname, "HDUCLAS1")
 
     if hduclas1.value != 'XSPEC TABLE MODEL':
         # TODO: change Exception to something more useful
@@ -1072,9 +1082,9 @@ def read_xstable_model(modelname, filename, etable=False):
     escale = hdr1.get("ESCALE")
     nxflt = hdr1.get("NXFLTEXP")
     if redshift is None:
-        raise IOErr("nokeyword", filename, "REDSHIFT")
+        raise IOErr("nokeyword", fname, "REDSHIFT")
     if model is None:
-        raise IOErr("nokeyword", filename, "ADDMODEL")
+        raise IOErr("nokeyword", fname, "ADDMODEL")
 
     addredshift = bool_cast(redshift.value)
     addmodel = bool_cast(model.value)
@@ -1085,32 +1095,34 @@ def read_xstable_model(modelname, filename, etable=False):
     #
     nxfltexp = 1 if nxflt is None else int(nxflt.value)
     if nxfltexp > 1:
-        raise IOErr(f"No support for NXFLTEXP={nxfltexp} in {filename}")
+        raise IOErr(f"No support for NXFLTEXP={nxfltexp} in {fname}")
 
-    colkeys = ['NAME', 'INITIAL', 'DELTA', 'BOTTOM', 'TOP',
-               'MINIMUM', 'MAXIMUM']
-
-    hdu2, name2 = read_tbl(filename, colkeys=colkeys,
+    colkeys = ['NAME', 'INITIAL', 'DELTA', 'BOTTOM', 'TOP', 'MINIMUM',
+               'MAXIMUM']
+    hdu2, name2 = read_tbl(fname, colkeys=colkeys,
                            blockname="PARAMETERS", fix_type=False)
     hdr2 = hdu2.header
-    cols2 = [col.values for col in hdu2.columns]
+    cols2 = {col.name: col.values for col in hdu2.columns}
 
     nintkey = hdr2.get("NINTPARM")
     if nintkey is None:
-        raise IOErr("nokeyword", filename, "NINTPARM")
+        raise IOErr("nokeyword", fname, "NINTPARM")
 
     # The constructor does not need this but the XSPEC model library
     # has historically been very poor at reporting missing or invalid
-    # information, often preferrnig to crash, so ensure this required
+    # information, often preferring to crash, so ensure this required
     # keyword is present.
     #
     if hdr2.get("NADDPARM") is None:
-        raise IOErr("nokeyword", filename, "NADDPARM")
+        raise IOErr("nokeyword", fname, "NADDPARM")
 
     nint = int(nintkey.value)
-    return XSTableModel(filename, modelname, *cols2,
-                        nint=nint, addmodel=addmodel,
-                        addredshift=addredshift,
+    return XSTableModel(fname, name=modelname, parnames=cols2["NAME"],
+                        initvals=cols2["INITIAL"],
+                        delta=cols2["DELTA"], mins=cols2["BOTTOM"],
+                        maxes=cols2["TOP"], hardmins=cols2["MINIMUM"],
+                        hardmaxes=cols2["MAXIMUM"], nint=nint,
+                        addmodel=addmodel, addredshift=addredshift,
                         addescale=addescale, etable=etable)
 
 

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015 - 2024
+#  Copyright (C) 2007, 2015 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -392,9 +392,10 @@ def test_checks_input_length():
 @requires_xspec
 @requires_data
 @requires_fits
-@pytest.mark.parametrize('loadfunc', [ui.load_xstable_model, ui.load_table_model])
-def test_xstablemodel_checks_input_length(loadfunc, clean_astro_ui, make_data_path):
+@pytest.mark.parametrize('loadname', ["xstable", "table"])
+def test_xstablemodel_checks_input_length(loadname, clean_astro_ui, make_data_path):
 
+    loadfunc = getattr(ui, f"load_{loadname}_model")
     loadfunc('mdl', make_data_path('xspec-tablemodel-RCS.mod'))
     mdl = ui.get_model_component('mdl')
 
@@ -423,8 +424,11 @@ def test_xstablemodel_checks_input_length(loadfunc, clean_astro_ui, make_data_pa
 @requires_xspec
 @requires_data
 @requires_fits
-@pytest.mark.parametrize('loadfunc', [ui.load_xstable_model, ui.load_table_model])
-def test_xspec_xstablemodel(loadfunc, clean_astro_ui, make_data_path):
+@pytest.mark.parametrize('loadname', ["xstable", "table"])
+def test_xspec_xstablemodel(loadname, clean_astro_ui, make_data_path):
+
+    loadfunc = getattr(ui, f"load_{loadname}_model")
+
     # Just test one table model; use the same scheme as
     # test_xspec_models_noncontiguous().
     #
@@ -452,8 +456,10 @@ def test_xspec_xstablemodel(loadfunc, clean_astro_ui, make_data_path):
 @requires_xspec
 @requires_data
 @requires_fits
-@pytest.mark.parametrize('loadfunc', [ui.load_xstable_model, ui.load_table_model])
-def test_xspec_xstablemodel_noncontiguous2(loadfunc, clean_astro_ui, make_data_path):
+@pytest.mark.parametrize('loadname', ["xstable", "table"])
+def test_xspec_xstablemodel_noncontiguous2(loadname, clean_astro_ui, make_data_path):
+
+    loadfunc = getattr(ui, f"load_{loadname}_model")
     loadfunc('tmod', make_data_path('xspec-tablemodel-RCS.mod'))
     tmod = ui.get_model_component('tmod')
 

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -846,7 +846,7 @@ def test_set_xsstate_missing_key(key):
         """Pick the first item in vals that is not value"""
         return [v for v in vals if v != value][0]
 
-    # We need valid arguments as the values will get set woth the
+    # We need valid arguments as the values will get set with the
     # set_xsstate(fake) call below.
     #
     fake = {'abund': not_elem(ostate['abund'], ["angr", "aspl", "grsa"]),

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -827,10 +827,10 @@ def test_get_xsstate_keys():
 
 
 @requires_xspec
-@pytest.mark.parametrize("key",
+@pytest.mark.parametrize("miss_key",
                          ["abund", "chatter", "cosmo", "xsect",
                           "modelstrings"])  # paths is not a required key
-def test_set_xsstate_missing_key(key):
+def test_set_xsstate_missing_key(miss_key):
     """Check set_xsstate handles a missing key.
 
     """
@@ -838,7 +838,7 @@ def test_set_xsstate_missing_key(key):
     from sherpa.astro import xspec
 
     ostate = xspec.get_xsstate()
-    assert key in ostate
+    assert miss_key in ostate
     for val in ostate.values():
         assert val is not None
 
@@ -856,19 +856,19 @@ def test_set_xsstate_missing_key(key):
             'modelstrings': {'foo': '2'},
             'paths': {'manager': '/dev/null'}}
 
-    del fake[key]
+    del fake[miss_key]
 
     try:
         xspec.set_xsstate(fake)
 
         nstate = xspec.get_xsstate()
         ncopy = nstate.copy()
-        del ncopy[key]
+        del ncopy[miss_key]
 
         # The key should be unchanged; the others set to those in
         # fake. Checking the latter is a bit annoying.
         #
-        assert nstate[key] == ostate[key]
+        assert nstate[miss_key] == ostate[miss_key]
         for key, value in fake.items():
             match key:
                 case "cosmo":

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016 - 2021, 2023, 2024
+#  Copyright (C) 2016 - 2021, 2023 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -24,6 +24,7 @@
 import copy
 import logging
 import os
+from pathlib import Path
 import re
 
 import pytest
@@ -981,7 +982,8 @@ def test_set_xsstate_path_manager():
 @requires_data
 @requires_fits
 @requires_xspec
-def test_read_xstable_model(make_data_path):
+@pytest.mark.parametrize("usepath", [True, False])
+def test_read_xstable_model(usepath, make_data_path):
     """Limited test (only one file).
 
     Evaluation tests using this model are in
@@ -991,7 +993,8 @@ def test_read_xstable_model(make_data_path):
     from sherpa.astro import xspec
 
     path = make_data_path('xspec-tablemodel-RCS.mod')
-    tbl = xspec.read_xstable_model('bar', path)
+    filename = Path(path) if usepath else path
+    tbl = xspec.read_xstable_model('bar', filename)
 
     assert tbl.name == 'bar'
     assert isinstance(tbl, xspec.XSTableModel)


### PR DESCRIPTION
# Summary

Minor changes to the XSPEC module, including added documentation to the set_xsabund routine to note the availability of the "felc" table, and set_xsstate no-longer requires all fields to be present.

# Details

This is a small subset of the changes from #1615 that do  not require changing the C++ interface. The changes are (not in order, and not per commit):

- an internal change to the tests so that mypy is less picky
- the read_xstable_model routine can now be sent a filename as a `Path` object as well as a string; this is an "internal" routine so it is not going to change most people's lives
- set_xsabund documentation is updated to mention the "felc" table
- get_xsabund has an extra example in its docstring
- updated the typing in `sherpa/astro/xspec/__init.py` to use Python 10 syntax (can avoid `Union` and `Optional`)
  - as part of this, use an overload for `get_xsabund`
  - which means should we annotate the non-overload version; previously we have not done this because why should we, but
    - I am reading proposed new documentation  https://github.com/python/typing/pull/1839 which doesn't exactly spell it out
    - however, by annotating all versions we do guarantee that `help(set_xsabund)` will see the types
    - it also stops a pyright complaint
    - and seems to mesh with this discussion (that it makes sense to add the types): https://discuss.python.org/t/conflict-between-python-typing-library-docs-and-mypy-docs-regarding-function-overload-usage/75087
 - set_xsstate used to require all settings are present before it would run, which can be useful, but it also means that if we add a new field (as I plan to) , or delete an old field, then old states can not be restored because it wouldn't know about the new settings. So we now allow each setting to be optional.