### PR TITLE
Improve the XSPEC interface

### DIFF
--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -53,6 +53,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
       set_xspath_manager
       set_xspath_model
       set_xsstate
+      set_xsversion
       set_xsxsect
       set_xsxset
 

--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -51,6 +51,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
       set_xschatter
       set_xscosmo
       set_xspath_manager
+      set_xspath_model
       set_xsstate
       set_xsxsect
       set_xsxset

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015 - 2025
+#  Copyright (C) 2010, 2015-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -109,7 +109,8 @@ import functools
 import logging
 from pathlib import Path
 import string
-from typing import Any, overload
+import tempfile
+from typing import Any, Literal, overload
 import warnings
 
 import numpy as np
@@ -137,13 +138,14 @@ warning = logging.getLogger(__name__).warning
 # a structured type (e.g. a dataclass), but it's not clear how we want
 # this to evolve, so leave as a dict.
 #
-# We only want to note any changes the user has made to the paths,
-# rather than storing in the state the default settings (which may
-# change with system or version).
+# We only want to note any changes the user has made to the paths or
+# versions, rather than storing in the state the default settings
+# (which may change with system or version).
 #
 xsstate: dict[str, Any] = {
     "abundances": None,
     "paths": {},
+    "versions": {}
 }
 
 
@@ -473,27 +475,106 @@ def get_xscosmo() -> tuple[float, float, float]:
     return _xspec.get_xscosmo()
 
 
-def get_xsversion() -> str:
+VersionType = Literal["atomdb"] | Literal["nei"]
+
+
+def get_xsversion(name: VersionType | None = None) -> str:
     """Return the version of the X-Spec model library in use.
+
+    .. versionchanged:: 4.18.0
+       The routine can now return the atomdb or nei versions in use
+       when given the optional name argument.
+
+    Parameters
+    ----------
+    name : {"atomdb", "nei"}, optional
+       If not set, the XSPEC version is returned, otherwise it must be
+       one of "atomdb" or "nei", in which case the version in use for
+       the given database is returned.
 
     Returns
     -------
     version : str
-       The version of the X-Spec model library used by Sherpa [1]_.
+       The version of the X-Spec model library or database.
 
-    References
-    ----------
-
-    .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/
+    See Also
+    --------
+    set_xsversion
 
     Examples
     --------
 
     >>> get_xsversion()
-    '12.11.0m'
+    '12.14.0i'
+
+    >>> get_xsversion("atomdb")
+    '3.0.9'
+
+    >>> get_xsversion("nei")
+    '3.0.4'
+
     """
 
-    return _xspec.get_xsversion()
+    match name:
+        case None:
+            return _xspec.get_xsversion()
+
+        case "atomdb":
+            return _xspec.get_xsversion_atomdb()
+
+        case "nei":
+            return _xspec.get_xsversion_nei()
+
+        case _:
+            raise ValueError("name must be one of None, 'atomdb', or 'nei', "
+                             f"not '{name}'")
+
+
+def set_xsversion(name: VersionType,
+                  version: str) -> None:
+    """Set the version of the libraries library used by X-Spec.
+
+    .. versionadded:: 4.18.0
+
+    Parameters
+    ----------
+    name : {"atomdb", "nei"}
+       The library version to set.
+    version : str
+       The version of the library to use.
+
+    See Also
+    --------
+    get_xsversion
+
+    Examples
+    --------
+
+    >>> set_xsversion('atomdb', '3.0.9')
+
+    >>> set_xsversion('nei', '3.0.4')
+
+    """
+
+    match name:
+        case "atomdb":
+            setfn = _xspec.set_xsversion_atomdb
+            getfn = _xspec.get_xsversion_atomdb
+
+        case "nei":
+            setfn = _xspec.set_xsversion_nei
+            getfn = _xspec.get_xsversion_nei
+
+        case _:
+            raise ValueError("name must be 'atomdb' or 'nei', "
+                             f"not '{name}'")
+
+    # We store whatever XSPEC converts the version to, rather than the
+    # version the user sent in, just in case there is any validation
+    # done by the XSPEC code.
+    #
+    setfn(version)
+    xsstate["versions"][name] = getfn()
 
 
 def get_xsxsect() -> str:
@@ -1033,18 +1114,23 @@ def set_xspath_model(path: Path | str) -> None:
 def get_xsstate() -> dict[str, Any]:
     """Return the state of the XSPEC module.
 
+    .. versionchanged:: 4.18.0
+       More XSPEC settings are now saved.
+
     Returns
     -------
     state : dict
         The current settings for the XSPEC module, including but not
-        limited to: the abundance and cross-section settings, parameters
-        for the cosmological model, any XSET parameters that have been
-        set, and changes to the paths used by the model library.
+        limited to: the abundance and cross-section settings,
+        parameters for the cosmological model, any XSET parameters
+        that have been set, versions changed, and changes to the paths
+        used by the model library.
 
     See Also
     --------
     get_xsabund, get_xschatter, get_xscosmo, get_xsxsect, get_xsxset,
     set_xsstate
+
     """
 
     abundances = xsstate["abundances"]
@@ -1057,12 +1143,16 @@ def get_xsstate() -> dict[str, Any]:
             "cosmo": get_xscosmo(),
             "xsect": get_xsxsect(),
             "modelstrings": get_xsxset(),
-            "paths": xsstate["paths"].copy()
+            "paths": xsstate["paths"].copy(),
+            "versions": xsstate["versions"].copy(),
             }
 
 
 def set_xsstate(state: dict[str, Any]) -> None:
     """Restore the state of the XSPEC module.
+
+    .. versionchanged:: 4.18.0
+       More XSPEC settings are restored, if set.
 
     .. versionchanged:: 4.17.1
        The input state no-longer requires all the keys to be
@@ -1074,7 +1164,7 @@ def set_xsstate(state: dict[str, Any]) -> None:
         The current settings for the XSPEC module. This is expected to
         match the return value of ``get_xsstate``, and so uses the
         keys: 'abund', 'chatter', 'cosmo', 'xsect', 'modelstrings',
-        'abundances', and 'paths'. If a keyword is missing
+        'abundances', 'versions', and 'paths'. If a keyword is missing
         then that setting will not be changed.
 
     See Also
@@ -1132,6 +1222,13 @@ def set_xsstate(state: dict[str, Any]) -> None:
 
     with suppress(KeyError):
         set_xspath_model(paths["model"])
+
+    versions = state.get("versions", {})
+    with suppress(KeyError):
+        set_xsversion("atomdb", versions["atomdb"])
+
+    with suppress(KeyError):
+        set_xsversion("nei", versions["nei"])
 
 
 def read_xstable_model(modelname: str,
@@ -1288,7 +1385,7 @@ def read_xstable_model(modelname: str,
 __all__ : tuple[str, ...]
 __all__ = ('get_xschatter', 'get_xsabund', 'get_xscosmo', 'get_xsxsect',
            'set_xschatter', 'set_xsabund', 'set_xscosmo', 'set_xsxsect',
-           'get_xsversion',
+           'get_xsversion', 'set_xsversion',
            'set_xsxset', 'get_xsxset', 'clear_xsxset',
            'set_xsstate', 'get_xsstate',
            'get_xsabundances', 'set_xsabundances')

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -581,6 +581,11 @@ static PyMethodDef XSpecMethods[] = {
   // FCTSPEC(set_abundance_file, set_xspec_string<FunctionUtility::abundanceFile>),
   // FCTSPEC(set_xspath_abundance, set_xspec_string<FunctionUtility::abundPath>),
 
+  NOARGSPEC(get_xsversion_atomdb, get_xspec_string<FunctionUtility::atomdbVersion>),
+  NOARGSPEC(get_xsversion_nei, get_xspec_string<FunctionUtility::neiVersion>),
+  FCTSPEC(set_xsversion_atomdb, set_xspec_string<FunctionUtility::atomdbVersion>),
+  FCTSPEC(set_xsversion_nei, set_xspec_string<FunctionUtility::neiVersion>),
+
   NOARGSPEC(get_xspath_manager, get_xspec_string<FunctionUtility::managerPath>),
   NOARGSPEC(get_xspath_model, get_xspec_string<FunctionUtility::modelDataPath>),
   FCTSPEC(set_xspath_manager, set_xspec_string<FunctionUtility::managerPath>),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -531,16 +531,14 @@ static PyObject* get_xspec_string( PyObject *self ) {
   return Py_BuildValue( (char*)"s", get().c_str() );
 }
 
-static PyObject* set_manager_data_path( PyObject *self, PyObject *args )
-{
-
+template <void set(const std::string& value)>
+static PyObject* set_xspec_string( PyObject *self, PyObject *args ) {
   char* path = NULL;
   if ( !PyArg_ParseTuple( args, (char*)"s", &path ) )
     return NULL;
 
-  FunctionUtility::managerPath(string(path));
+  set(string(path));
   Py_RETURN_NONE;
-
 }
 
 #define NOARGSPEC(name, func) \
@@ -585,7 +583,8 @@ static PyMethodDef XSpecMethods[] = {
 
   NOARGSPEC(get_xspath_manager, get_xspec_string<FunctionUtility::managerPath>),
   NOARGSPEC(get_xspath_model, get_xspec_string<FunctionUtility::modelDataPath>),
-  FCTSPEC(set_xspath_manager, set_manager_data_path),
+  FCTSPEC(set_xspath_manager, set_xspec_string<FunctionUtility::managerPath>),
+  FCTSPEC(set_xspath_model, set_xspec_string<FunctionUtility::modelDataPath>),
 
   // Start model definitions
 

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -100,7 +100,8 @@ def test_chatter_default():
 
 
 @requires_xspec
-def test_version():
+@pytest.mark.parametrize("name", [None, "atomdb", "nei"])
+def test_version(name):
     """Can we get at the XSPEC version?
 
     There is limited testing of the return value.
@@ -108,12 +109,68 @@ def test_version():
 
     from sherpa.astro import xspec
 
-    v = xspec.get_xsversion()
+    v = xspec.get_xsversion(name)
     assert isinstance(v, (str, ))
     assert len(v) > 0
 
-    # Could check it's of the form a.b.c[optional] but leave that for
-    # now.
+
+@requires_xspec
+@pytest.mark.parametrize("name", ["ATOMDB", "", "foo"])
+def test_version_error(name):
+    """Does this error out?
+
+    At the moment we are case sensitive when checking the name.
+
+    """
+
+    from sherpa.astro import xspec
+
+    with pytest.raises(ValueError,
+                       match=f"^name must be one of None, 'atomdb', or 'nei', not '{name}'$"):
+        xspec.get_xsversion(name)
+
+
+@requires_xspec
+@pytest.mark.parametrize("name", ["atomdb", "nei"])
+def test_set_version(name):
+    """Can we set the XSPEC version?
+
+    This is just to check we can call the routine - we don't really do
+    much with it.
+
+    """
+
+    from sherpa.astro import xspec
+
+    old = xspec.get_xsversion(name)
+
+    # pick a value that is "realistic" but old, and should not
+    # appear with any supported XSPEC version.
+    #
+    new = '3.0.0'
+    assert old != new
+
+    try:
+        xspec.set_xsversion(name, new)
+        assert xspec.get_xsversion(name) == new
+    finally:
+        xspec.set_xsversion(name, old)
+
+
+@requires_xspec
+@pytest.mark.parametrize("name", ["ATOMDB", "", "foo"])
+def test_set_version_error(name):
+    """Does this error out?
+
+    At the moment we are case sensitive when checking the name.
+
+    """
+
+    from sherpa.astro import xspec
+
+    with pytest.raises(ValueError,
+                       match=f"^name must be 'atomdb' or 'nei', not '{name}'$"):
+        xspec.set_xsversion(name, "1.2.3")
 
 
 @requires_xspec

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -569,7 +569,13 @@ def validate_xspec_setting(getfunc, setfunc, newval, altval):
     finally:
         setfunc(oval)
 
-    assert xval == nval
+    # If nval is a Path we need to convert it to a str since we
+    # (currently) do not return a Path but a str.
+    #
+    if isinstance(nval, Path):
+        assert xval == str(nval)
+    else:
+        assert xval == nval
 
     # As a sanity check ensure we are back at the starting point
     assert getfunc() == oval
@@ -853,16 +859,30 @@ def test_cosmo_change():
 
 
 @requires_xspec
-def test_path_manager_change(tmp_path):
-    """Can we change the manager-path setting?
+@pytest.mark.parametrize("name", ["manager", "model"])
+@pytest.mark.parametrize("usepath", [True, False])
+def test_path_change(name, usepath, tmp_path):
+    """Can we change the path setting?
+
+    We allow string or Path objects to be sent in, which is what the
+    usepath boolean checks. It would be nice to send in the actual
+    arguments, but that would be very complicated to set up, as it
+    involves the tmp_path setting).
+
     """
 
     from sherpa.astro import xspec
 
-    validate_xspec_setting(xspec.get_xspath_manager,
-                           xspec.set_xspath_manager,
-                           '/dev/null',
-                           str(tmp_path))
+    if usepath:
+        newval = Path('/dev/null')
+        altval = tmp_path
+    else:
+        newval = '/dev/null'
+        altval = str(tmp_path)
+
+    getfn = getattr(xspec, f"get_xspath_{name}")
+    setfn = getattr(xspec, f"set_xspath_{name}")
+    validate_xspec_setting(getfn, setfn, newval, altval)
 
 
 # Note that the XSPEC state is used in test_xspec.py, but only
@@ -936,7 +956,7 @@ def test_set_xsstate_missing_key(miss_key):
             'chatter': 10,
             'cosmo': (50, 0.1, 0.4),
             'modelstrings': {'foo': '2'},
-            'paths': {'manager': '/dev/null'}}
+            'paths': {'manager': '/dev/null', 'model': '/dev/null'}}
 
     del fake[miss_key]
 


### PR DESCRIPTION
Most of this has been moved into (and merged) with 

- #2281.

The remaining changes are atomdb/nei version set/get, and this ends up being "interesting" as the XSPEC model library doesn't appear to handle changes particularly reliably (e.g. running `pytest sherpa/astro/xspec` will cause a segfault when `pytest-doctestplus` is installed because some setting has been changed internally within XSPEC).

# Summary

Add and extend routines in sherpa.astro.xspec: get_xsabundances now takes an optional table name, get_xsxset can be called with no argument, set_xsversion has been added to allow the nei and atomdb versions to be changed, get_xsversion can return the nei and atomdb versions, and clear_xsxset will clear the XSET database.

# Details

This PR builds on 

- #2215

The replacement for #1615 (what's left of it). I will note that in working on this code I have simplified some of the choices, so the exact functionality doesn't match #1615, but I believe we have what we need and the extra options provided in the earlier PRs are not actually needed.

Some of these code changes require C++11. They could be rewritten to not use C++11 features, but it does not seem worth it as our expected compilers have long-supported these capabilities.

A number of routines have been added or changed in `sherpa.astro.xspec._xspec` as this is treated as an "internal" module (i.e. if users are calling this directly then they have to expect changes). The user-level changes in `sherpa.astro.xspec` are intended to be more backwards-compatible, as normally we have just added routines or added optional arguments. There is one breaking change however, noted below.

Changes are:

- added `clear_xsxset` as an "obvious" way to clear the XSXSET database (there was a hidden way to do this but you had to know XSPEC internals to do so, by setting the `"INITIALIZE"` key)
- `get_xsxset` can now be called with no name, in which case it returns a dict containing all the settings
- `get_xsxset` now raises a `KeyError` if given an invalid name (to make the dict-like behaviour cleaner) rather than returning an empty string
  - this is an explicit breaking change
- `set_xspath_manager` can now be sent a `Path` or a `str`
- added `set_xspath_model` (which can be sent `Path` or `str`)
- `get_xsversion` can now return the `nei` and `atomdb` versions instead of the library version
- `set_xsversion` has been added to allow the `nei` and `atomdb` versions to be changed
- there have been internal changes to make `set_xsabundances` nicer, but it's not visible to the user, but it does mean that if you have set abundances from a file (or adjusted the values) then they will be recorded in the "xspec state"
- added `get_xsabundances_path` as a way to get the `Path` to the abundances file used by XSPEC
  - this is not exported by default as it is expected to be rarely used
- ensure you can't accidentally crash XSPEC by trying to set the abundances to "file" if you haven't actually loaded in any data (either from a file or by manual edits)
- the `set_xsabund` C++ implementation has added comments to explain why we don't use `FunctionUtility::readNewAbnudances()` but still keep the code from when we only were able to use the xsFORTRAN interface (which does not have a "read abundances from a file" routine); basically the error handling and behaviour of `readNewAbundances` mean it's not worth changing our existing code
- easy access to all the abundance tables, not just the currently loaded one, via `get_xsabundances("lodd")` etc
  - in earlier versions of this work I had many more ways to get this information, but for Sherpa users I think being able to just get all the abundances as a dict, labelled by element name, is all that we really need

This leaves out three future changes that are being worked on (and were in #1615, apart from, the DEM change)

- support for XFLT keywords
- support for the model database
- access to DEM data
