### PR TITLE
Extend xspec

### DIFF
--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -49,6 +49,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
       set_xschatter
       set_xscosmo
       set_xspath_manager
+      set_xspath_model
       set_xsstate
       set_xsxsect
       set_xsxset

--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -35,6 +35,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
       get_xsabund
       get_xsabund_doc
       get_xsabundances
+      get_xsabundances_path
       get_xschatter
       get_xscosmo
       get_xspath_manager

--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -31,6 +31,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
    .. autosummary::
       :toctree: api
 
+      clear_xsxflt
       clear_xsxset
       get_xsabund
       get_xsabund_doc
@@ -38,17 +39,20 @@ for a general description of the ``sherpa.astro.xspec`` module.
       get_xsabundances_path
       get_xschatter
       get_xscosmo
+      get_xsxflt
       get_xspath_manager
       get_xspath_model
       get_xsstate
       get_xsversion
       get_xsxsect
       get_xsxset
+      load_xsxflt
       read_xstable_model
       set_xsabund
       set_xsabundances
       set_xschatter
       set_xscosmo
+      set_xsxflt
       set_xspath_manager
       set_xspath_model
       set_xsstate

--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -31,6 +31,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
    .. autosummary::
       :toctree: api
 
+      clear_xsxset
       get_xsabund
       get_xsabund_doc
       get_xsabundances

--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -31,6 +31,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
    .. autosummary::
       :toctree: api
 
+      clear_xsdb
       clear_xsxflt
       clear_xsxset
       get_xsabund
@@ -39,6 +40,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
       get_xsabundances_path
       get_xschatter
       get_xscosmo
+      get_xsdb
       get_xsxflt
       get_xspath_manager
       get_xspath_model
@@ -52,6 +54,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
       set_xsabundances
       set_xschatter
       set_xscosmo
+      set_xsdb
       set_xsxflt
       set_xspath_manager
       set_xspath_model

--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -51,6 +51,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
       set_xspath_manager
       set_xspath_model
       set_xsstate
+      set_xsversion
       set_xsxsect
       set_xsxset
 

--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -41,6 +41,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
       get_xschatter
       get_xscosmo
       get_xsdb
+      get_xsDEM
       get_xsxflt
       get_xspath_manager
       get_xspath_model

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -136,10 +136,9 @@ warning = logging.getLogger(__name__).warning
 # a structured type (e.g. a dataclass), but it's not clear how we want
 # this to evolve, so leave as a dict.
 #
-# The idea is that we do not always want to rely on the XSPEC model
-# library - since it doesn't always let you ask "what has the user
-# set", with the interface currently available to Sherpa - so we
-# record these settings manually.
+# We only want to note any changes the user has made to the paths,
+# rather than storing in the state the default settings (which may
+# change with system or version).
 #
 xsstate: dict[str, Any] = {
     "paths": {},
@@ -906,7 +905,7 @@ def get_xspath_model() -> str:
 
     See Also
     --------
-    get_xspath_manager
+    get_xspath_manager, set_xspath_model
 
     Examples
     --------
@@ -918,30 +917,64 @@ def get_xspath_model() -> str:
     return _xspec.get_xspath_model()
 
 
-def set_xspath_manager(path: str) -> None:
+def set_xspath_manager(path: Path | str) -> None:
     """Set the path to the files describing the XSPEC models.
+
+    .. versionchanged:: 4.17.1
+       The argument can now be sent in as a Path object.
 
     Parameters
     ----------
-    path : str
+    path : str or Path
         The new path.
 
     See Also
     --------
-    get_xspath_manager
+    get_xspath_manager, set_xspath_model
 
     Examples
     --------
     >>> set_xspath_manager('/data/xspec/spectral/manager')
     """
 
-    _xspec.set_xspath_manager(path)
-    spath = get_xspath_manager()
-    if spath != path:
+    spath = str(path)
+    _xspec.set_xspath_manager(spath)
+    got = get_xspath_manager()
+    if got != spath:
         raise IOError("Unable to set the XSPEC manager path "
-                      f"to '{path}'")
+                      f"to '{spath}'")
 
-    xsstate["paths"]["manager"] = path
+    # Inform the state that the manager path has been changed.
+    xsstate["paths"]["manager"] = spath
+
+
+def set_xspath_model(path: Path | str) -> None:
+    """Set the path to the XSPEC model data files.
+
+    .. versionadded:: 4.17.1
+
+    Parameters
+    ----------
+    path : str or Path
+        The new path.
+
+    See Also
+    --------
+    get_xspath_model, set_xspath_manager
+
+    Examples
+    --------
+    >>> set_xspath_model('/data/xspec/spectral/modelData/')
+    """
+
+    spath = str(path)
+    _xspec.set_xspath_model(spath)
+    got = get_xspath_model()
+    if got != spath:
+        raise IOError(f"Unable to set the XSPEC model path to '{spath}'")
+
+    # Inform the state that the model path has been changed.
+    xsstate["paths"]["model"] = spath
 
 
 # Provide XSPEC module state as a dictionary.  The "cosmo" state is
@@ -1043,6 +1076,9 @@ def set_xsstate(state: dict[str, Any]) -> None:
     paths = state.get("paths", {})
     with suppress(KeyError):
         set_xspath_manager(paths["manager"])
+
+    with suppress(KeyError):
+        set_xspath_model(paths["model"])
 
 
 def read_xstable_model(modelname: str,

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -141,6 +141,7 @@ warning = logging.getLogger(__name__).warning
 # (which may change with system or version).
 #
 xsstate: dict[str, Any] = {
+    "abundances": None,
     "paths": {},
     "versions": {}
 }
@@ -291,11 +292,6 @@ def get_xsabund_doc(name: str | None = None) -> str:
     return _xspec.get_xsabund_doc(aname).strip()
 
 
-# The current interface to the XSPEC model library makes this awkward
-# to write. Once the interface switches to using the FunctionUtility
-# interface this code will be a lot simpler internally, without
-# changing the API.
-#
 def set_xsabundances(abundances: dict[str, float]) -> None:
     """Set the abundances used by X-Spec.
 
@@ -338,22 +334,8 @@ def set_xsabundances(abundances: dict[str, float]) -> None:
 
         out[z - 1] = abund
 
-    # Write them to a file and then load them.
-    #
-    # This should set delete_on_close=False but that
-    # requires Python 3.12.
-    #
-    with tempfile.NamedTemporaryFile(encoding="ascii", mode="w",
-                                     delete=False) as fh:
-        for elem in out:
-            fh.write(f"{elem}\n")
-
-        # Make sure data is written to disk. Could this just
-        # be fh.flush() and avoid closing the file?
-        #
-        fh.close()
-
-        set_xsabund(fh.name)
+    _xspec.set_xsabund_vector(out)
+    xsstate["abundances"] = get_xsabundances()
 
 
 # This function is not added to __all__ as it is very specialized.
@@ -396,6 +378,38 @@ def get_xselements() -> dict[str, int]:
         out[elem] = idx
 
     return out
+
+
+# This function is not added to __all__ as it is very specialized.
+#
+def get_xsabundances_path() -> Path:
+    """Return the path to the abundances file used by X-Spec.
+
+    This file is used by X-Spec to determine the different
+    abundance-table settings used by set_xsabund and get_xsabund.
+
+    .. versionadded:: 4.17.1
+
+    Returns
+    -------
+    path : pathlib.Path
+        The full path to the abundances file.
+
+    See Also
+    --------
+    get_xsabund, set_xsabund
+
+    Examples
+    --------
+
+    >>> get_xsabundances_path()
+    PosixPath('/path/to/spectral/manager/abundances.dat')
+
+    """
+
+    out = Path(_xspec.get_xspath_abundance())
+    out /= Path(_xspec.get_abundance_file())
+    return out.resolve()
 
 
 def get_xschatter() -> int:
@@ -662,6 +676,13 @@ def set_xsabund(abundance: str) -> None:
     """
 
     _xspec.set_xsabund(abundance)
+
+    # Ensure the abundances state setting is created or deleted.
+    #
+    if get_xsabund() == "file":
+        xsstate["abundances"] = get_xsabundances()
+    else:
+        xsstate["abundances"] = None
 
 
 def set_xschatter(level: int) -> None:
@@ -1084,8 +1105,8 @@ def get_xsstate() -> dict[str, Any]:
         The current settings for the XSPEC module, including but not
         limited to: the abundance and cross-section settings,
         parameters for the cosmological model, any XSET parameters
-        that have been set, versions changed, and changes to the paths
-        used by the model library.
+        that have been set, abundance settings, versions changed, and
+        changes to the paths used by the model library.
 
     See Also
     --------
@@ -1094,7 +1115,12 @@ def get_xsstate() -> dict[str, Any]:
 
     """
 
+    abundances = xsstate["abundances"]
+    if abundances is not None:
+        abundances = abundances.copy()
+
     return {"abund": get_xsabund(),
+            "abundances": abundances,
             "chatter": get_xschatter(),
             "cosmo": get_xscosmo(),
             "xsect": get_xsxsect(),
@@ -1117,8 +1143,8 @@ def set_xsstate(state: dict[str, Any]) -> None:
         The current settings for the XSPEC module. This is expected to
         match the return value of ``get_xsstate``, and so uses the
         keys: 'abund', 'chatter', 'cosmo', 'xsect', 'modelstrings',
-        'versions', and 'paths'. If a keyword is missing then that
-        setting will not be changed.
+        'abundances', 'versions', and 'paths'. If a keyword is missing
+        then that setting will not be changed.
 
     See Also
     --------
@@ -1139,8 +1165,18 @@ def set_xsstate(state: dict[str, Any]) -> None:
             # Assume state is not a dictionary, so return.
             return
 
-    with suppress(KeyError):
-        set_xsabund(state["abund"])
+    # If a manually-set up table has been loaded then we use that
+    # (this is given by the "abundances" value being set), otherwise
+    # we use the abundance table (the "abund" value).
+    #
+    abundances = state.get("abundances", None)
+    if abundances is None:
+        with suppress(KeyError):
+            set_xsabund(state["abund"])
+
+    else:
+        # This is expected to be a dict of abundance names and values.
+        set_xsabundances(abundances)
 
     with suppress(KeyError):
         set_xsxsect(state["xsect"])

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1201,6 +1201,88 @@ def load_xsxflt(data: DataPHA,
         info("  %s = %g", keyname, fval)
 
 
+def clear_xsdb() -> None:
+    """Clear out the XSPEC database.
+
+    .. versionadded:: 4.17.1
+
+    See Also
+    --------
+    get_xsdb, set_xsdb
+
+    Examples
+    --------
+
+    >>> clear_xsdb()
+
+    """
+    return _xspec.clear_db()
+
+
+def get_xsdb() -> dict[str, float]:
+    """Return the XSPEC database values.
+
+    .. versionadded:: 4.17.1
+
+    Returns
+    -------
+    db : dict
+        The current keywords (strings) and values (numbers) associated
+        with the XSPEC database. It may be empty.
+
+    See Also
+    --------
+    clear_xsdb, set_xsdb
+
+    Notes
+    -----
+
+    XSPEC provides an internal database to which any model can add
+    a keyword. This is intended for models which want to save useful
+    information during a calculation.
+
+    Examples
+    --------
+
+    >>> get_xsdb()
+    {}
+
+    >>> set_db("inner", 0.2)
+    >>> set_db("outer", 2)
+    >>> get_db()
+    {'inner': 0.2, 'outer': 2.0}
+
+    """
+    return _xspec.get_db()
+
+
+def set_xsdb(key: str, value: float) -> None:
+    """Set a XSPEC database value.
+
+    .. versionadded:: 4.17.1
+
+    Parameters
+    ----------
+    key : str
+        The keyword to set (it is converted to lower case).
+    value : number
+        The number to set.
+
+    See Also
+    --------
+    clear_db, get_db
+
+    Examples
+    --------
+
+    >>> set_xsdb("inner", 0.2)
+    >>> set_xsdb("outer", 2)
+    >>> get_xsdb()
+
+    """
+    _xspec.set_db(key, value)
+
+
 def get_xspath_manager() -> str:
     """Return the path to the files describing the XSPEC models.
 
@@ -1324,8 +1406,8 @@ def get_xsstate() -> dict[str, Any]:
 
     See Also
     --------
-    get_xsabund, get_xschatter, get_xscosmo, get_xsxflt, get_xsxsect,
-    get_xsxset, set_xsstate
+    get_xsabund, get_xschatter, get_xscosmo, get_xsdb, get_xsxflt,
+    get_xsxsect, get_xsxset, set_xsstate
 
     """
 
@@ -1351,6 +1433,7 @@ def get_xsstate() -> dict[str, Any]:
             "modelstrings": get_xsxset(),
             "paths": xsstate["paths"].copy(),
             "versions": xsstate["versions"].copy(),
+            "db": get_xsdb(),
             "xflt": xflt
             }
 
@@ -1368,8 +1451,8 @@ def set_xsstate(state: dict[str, Any]) -> None:
         The current settings for the XSPEC module. This is expected to
         match the return value of ``get_xsstate``, and so uses the
         keys: 'abund', 'chatter', 'cosmo', 'xsect', 'modelstrings',
-        'xflt', 'abundances', 'versions', and 'paths'. If a keyword is
-        missing then that setting will not be changed.
+        'xflt', 'db', 'abundances', 'versions', and 'paths'. If a
+        keyword is missing then that setting will not be changed.
 
     See Also
     --------
@@ -1419,6 +1502,12 @@ def set_xsstate(state: dict[str, Any]) -> None:
         clear_xsxset()
         for name, value in modelstrings.items():
             set_xsxset(name, value)
+
+    db = state.get("db", None)
+    if db is not None:
+        clear_xsdb()
+        for name, value in db.items():
+            set_xsdb(name, value)
 
     xflt = state.get("xflt", None)
     if xflt is not None:
@@ -1598,7 +1687,8 @@ __all__ = ('get_xschatter', 'get_xsabund', 'get_xscosmo', 'get_xsxsect',
            'get_xsversion', 'set_xsversion',
            'set_xsxset', 'get_xsxset', 'clear_xsxset',
            'set_xsstate', 'get_xsstate',
-           'clear_xsxflt', 'get_xsxflt', 'set_xsxflt', 'clear_xsxflt',
+           'get_xsxflt', 'set_xsxflt', 'clear_xsxflt',
+           'clear_xsdb', 'get_xsdb', 'set_xsdb', 'clear_xsdb',
            'get_xsabundances', 'set_xsabundances')
 
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1283,6 +1283,40 @@ def set_xsdb(key: str, value: float) -> None:
     _xspec.set_db(key, value)
 
 
+# This function is not added to __all__ as it is very specialized
+# and we need more experience as to how it will be used.
+#
+def get_xsDEM() -> tuple[np.ndarray, np.ndarray]:
+    """The relative contributions of plasma at different temperatures.
+
+    Returns
+    -------
+    temp, dem
+       The distribution of plasma at different temperatures for
+       multi-temperature models (the dem array will sum to 1). These
+       arrays may be empty.
+
+    Notes
+    -----
+    The XSPEC model library provides very-limited access to this
+    data. It is only for the last plasma model calculated, so be
+    careful if the model expression contains multiple plasma models.
+
+    Examples
+    --------
+
+    Ensure the model has been evaluated and then plot the
+    distribution:
+
+    >>> plot_model()
+    >>> t, d = get_xsDEM()
+    >>> plot_scatter(t, d, name="DEM", xlabel="Temperature", ylabel="DEM")
+
+    """
+
+    return _xspec.get_xsDEM()
+
+
 def get_xspath_manager() -> str:
     """Return the path to the files describing the XSPEC models.
 

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -233,16 +233,25 @@ def get_xsabund(element: str | None = None) -> str | float:
     return _xspec.get_xsabund(element)
 
 
-def get_xsabundances() -> dict[str, float]:
+def get_xsabundances(table: str | None = None) -> dict[str, float]:
     """Return the abundance settings used by X-Spec.
 
+    .. versionchanged:: 4.17.1
+       The optional table argument was added.
+
     .. versionadded:: 4.17.0
+
+    Parameter
+    ---------
+    table : optional
+        The table to use. Leave as None to use the selected abundance
+        table.
 
     Returns
     -------
     abundances : dict
-        The current set of abundances. The keys are the element names
-        (e.g. 'Fe') and the values are the abundances.
+        The keys are the element names (e.g. 'Fe') and the values are
+        the abundances.
 
     See Also
     --------
@@ -254,9 +263,16 @@ def get_xsabundances() -> dict[str, float]:
     >>> get_xsabundances()
     {'H': 1.0, 'He': ...}
 
+    >>> set_xsabud("angr")
+    >>> get_xsabundances()["Cu"]
+    1.619999956403717e-08
+    >>> get_xsabundances("felc")["Cu"]
+    0.0
+
     """
 
-    return {name: _xspec.get_xsabund(name)
+    tbl = get_xsabund() if table is None else table
+    return {name: _xspec.get_xsabund_table(tbl, name)
             for name in get_xselements().keys()}
 
 

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -521,6 +521,96 @@ static PyObject* get_xset( PyObject *self, PyObject *args  )
 
 }
 
+
+// XFLT functions
+//
+//      static int getNumberXFLT(int ifl);
+//      // This will throw a silent YellowAlert if map corresponding to ifl doesn't exist.
+//      static const std::map<string, Real>& getAllXFLT(int ifl);
+//      static bool inXFLT(int ifl, int i);
+//      static bool inXFLT(int ifl, string skey);
+//      static double getXFLT(int ifl, int i);
+//      static double getXFLT(int ifl, string skey);
+//      static void loadXFLT(int ifl, const std::map<string, Real>& values);
+//      static void clearXFLT();
+//
+// We use a dictionary interface - that is we set and get dictionaries
+// rather than have commands work on individual keys. That is,
+// checks like inXFLT have to be done by the user on the data returned
+// by these routines.
+//
+static PyObject* clearXFLT( PyObject *self )
+{
+  FunctionUtility::clearXFLT();
+  Py_RETURN_NONE;
+}
+
+static PyObject* getAllXFLT( PyObject *self, PyObject *args )
+{
+  int spectrumNumber = 1;
+
+  if ( !PyArg_ParseTuple( args, (char*)"i", &spectrumNumber ) )
+    return NULL;
+
+  PyObject *d = PyDict_New();
+
+  // Check that we have data, to avoid a YellowAlert when calling
+  // getAllXFLT.
+  //
+  if (FunctionUtility::getNumberXFLT(spectrumNumber) > 0) {
+    const std::map<string, Real> xflt = FunctionUtility::getAllXFLT(spectrumNumber);
+
+    for (const auto& item : xflt) {
+      PyObject *value = PyFloat_FromDouble(item.second);
+      PyDict_SetItemString(d, item.first.c_str(), value);
+      Py_DECREF(value);
+    }
+  }
+
+  return d;
+}
+
+static PyObject* loadXFLT( PyObject *self, PyObject *args )
+{
+  PyObject *xflt_dict = NULL;
+  int spectrumNumber = 1;
+
+  if ( !PyArg_ParseTuple( args, (char*)"iO!",
+			  &spectrumNumber,
+			  &PyDict_Type, &xflt_dict
+			  ) )
+    return NULL;
+
+  std::map<string, Real> xflt;
+
+  PyObject *key, *value;
+  Py_ssize_t pos = 0;
+
+  while (PyDict_Next(xflt_dict, &pos, &key, &value)) {
+
+    const char *k = PyUnicode_AsUTF8(key);
+    if (k == NULL) {
+	PyErr_SetString( PyExc_ValueError,
+			 (char*)"keys must be strings" );
+	return NULL;
+    }
+
+    double v = PyFloat_AsDouble(value);
+    if (v == -1 && PyErr_Occurred()) {
+	PyErr_SetString( PyExc_ValueError,
+			 (char*)"values must be numbers" );
+	return NULL;
+    }
+
+    xflt[k] = v;
+  }
+
+  // We do not check if xflt is empty.
+  FunctionUtility::loadXFLT(spectrumNumber, xflt);
+  Py_RETURN_NONE;
+}
+
+
 template <const std::string& get()>
 static PyObject* get_xspec_string( PyObject *self ) {
   return Py_BuildValue( (char*)"s", get().c_str() );
@@ -559,6 +649,11 @@ static PyMethodDef XSpecMethods[] = {
   NOARGSPEC(clear_xsxset, clear_xset),
   FCTSPEC(set_xsxset, set_xset),
   FCTSPEC(get_xsxset, get_xset),
+
+  // XFLT commands
+  NOARGSPEC(clear_xflt, clearXFLT),
+  FCTSPEC(get_xflt, getAllXFLT),
+  FCTSPEC(set_xflt, loadXFLT),
 
   // The set commands are not wrapped yet as it's not clear how well
   // the system handles these changes (e.g. it doesn't seem to update

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -421,6 +421,12 @@ static PyMethodDef XSpecMethods[] = {
   NOARGSPEC(clear_xsxset, clear_xset),
   FCTSPEC(set_xsxset, set_xset),
   FCTSPEC(get_xsxset, get_xset),
+
+  NOARGSPEC(get_xsversion_atomdb, get_xspec_string<FunctionUtility::atomdbVersion>),
+  NOARGSPEC(get_xsversion_nei, get_xspec_string<FunctionUtility::neiVersion>),
+  FCTSPEC(set_xsversion_atomdb, set_xspec_string<FunctionUtility::atomdbVersion>),
+  FCTSPEC(set_xsversion_nei, set_xspec_string<FunctionUtility::neiVersion>),
+
   NOARGSPEC(get_xspath_manager, get_xspec_string<FunctionUtility::managerPath>),
   NOARGSPEC(get_xspath_model, get_xspec_string<FunctionUtility::modelDataPath>),
   FCTSPEC(set_xspath_manager, set_xspec_string<FunctionUtility::managerPath>),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -117,7 +117,13 @@ static PyObject* get_chatter( PyObject *self )
 }
 
 
-// TODO: we could send in an integer for the Z number (ie either name or number)
+// TODO:
+//   we could send in an integer for the Z number (ie either name
+//   or number) but that seems a bit excessive, as the user can
+//   get a dict of abundances keyed by the element name.
+//
+// See also: get_abund_from_table
+//
 static PyObject* get_abund( PyObject *self, PyObject *args )
 {
 
@@ -151,6 +157,62 @@ static PyObject* get_abund( PyObject *self, PyObject *args )
   if( tmpStream.str().size() > 0 ) {
     return PyErr_Format( PyExc_TypeError, // TODO: change from TypeError to ValueError?
 			 (char*)"could not find element '%s'", element);
+  }
+
+  return (PyObject*) Py_BuildValue( (char*)"f", abundVal );
+
+}
+
+
+// See also: get_abund
+//
+// It is simpler to have separate routines rather than to try to deal
+// with the multiple options in one routine.
+//
+static PyObject* get_abund_from_table( PyObject *self, PyObject *args )
+{
+
+  // This requires both the table and element name.
+  //
+  char* table = NULL;
+  char* element = NULL;
+  if ( !PyArg_ParseTuple( args, (char*)"ss", &table, &element ) )
+    return NULL;
+
+  // Get the specific abundance. Unfortunately getAbundance reports an
+  // error to stderr when an invalid element is used, so we need to
+  // hide this. However it does throw an error if the table is unknown.
+  //
+  std::ostream* errStream = IosHolder::errHolder();
+  std::ostringstream tmpStream;
+  IosHolder::setStreams(IosHolder::inHolder(),
+			IosHolder::outHolder(),
+			&tmpStream);
+
+  float abundVal = 0.0;
+  try {
+    abundVal = FunctionUtility::getAbundance(string(table),
+					     string(element));
+  } catch (FunctionUtility::NoInitializer&) {
+    return PyErr_Format( PyExc_ValueError,
+			 "Unknown abundance table '%s'",
+			 table );
+  }
+
+  IosHolder::setStreams(IosHolder::inHolder(),
+			IosHolder::outHolder(),
+			errStream);
+
+  // Was there an error?
+  //
+  if( tmpStream.str().size() > 0 ) {
+    // No backwards compatability to worry about, so use the sensible
+    // error type (ValueError rather than TypeError as used by
+    // get_abund).
+    //
+    return PyErr_Format( PyExc_ValueError,
+			 (char*)"could not find element '%s' in table '%s'",
+			 element, table );
   }
 
   return (PyObject*) Py_BuildValue( (char*)"f", abundVal );
@@ -485,6 +547,7 @@ static PyMethodDef XSpecMethods[] = {
   NOARGSPEC(get_xschatter, get_chatter),
   FCTSPEC(set_xschatter, set_chatter),
   FCTSPEC(get_xsabund, get_abund),
+  FCTSPEC(get_xsabund_table, get_abund_from_table),
   FCTSPEC(get_xsabund_doc, get_abund_doc),
   FCTSPEC(set_xsabund, set_abund),
   FCTSPEC(set_xsabund_vector, set_abund_vector),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -202,8 +202,6 @@ static PyObject* set_chatter( PyObject *self, PyObject *args )
 
 // Based on xsFortran::FPSOLR
 //
-// TODO: add a version where we can send in an array of numbers
-//
 static PyObject* set_abund( PyObject *self, PyObject *args )
 {
 
@@ -224,7 +222,7 @@ static PyObject* set_abund( PyObject *self, PyObject *args )
     Py_RETURN_NONE;
   }
 
-  // If we've got here then try to read the data from a file
+  // If we've got here then try to read the data from a file.
   //
   const size_t nelems = FunctionUtility::NELEMS();
   std::vector<float> vals(nelems, 0);
@@ -261,6 +259,55 @@ static PyObject* set_abund( PyObject *self, PyObject *args )
 
   Py_RETURN_NONE;
 
+}
+
+
+// Handle a vector of abundances. It must be the right size.
+// To match set_abund when given a file name we set the
+// abundances to "file". This means that a user can not
+// load up a set of abundances and *NOT* use them; they
+// would have to reset the abundance table after loading.
+//
+static PyObject* set_abund_vector( PyObject *self, PyObject *args )
+{
+  sherpa::astro::xspec::FloatArray vector;
+  if ( !PyArg_ParseTuple( args, (char*)"O&",
+			  (converter)sherpa::convert_to_contig_array< sherpa::astro::xspec::FloatArray >,
+			  &vector ) )
+    return NULL;
+
+  size_t nelem = FunctionUtility::NELEMS();
+  size_t nvector = static_cast<size_t>(vector.get_size());
+
+  // Rather than worry about what to do with either too many or too
+  // few values, just error out.
+  //
+  if ( nvector != nelem ) {
+    return PyErr_Format( PyExc_ValueError,
+			 (char*)"Array must contain %d elements, not %d",
+			 nelem, nvector );
+  }
+
+  std::vector<float> vals(nelem);
+  std::copy(&vector[0], &vector[0] + nelem, &vals[0]);
+
+  // Hide the screen output from this call.
+  //
+  std::ostream* outStream = IosHolder::outHolder();
+  std::ostringstream tmpStream;
+  IosHolder::setStreams(IosHolder::inHolder(),
+			&tmpStream,
+			IosHolder::errHolder());
+
+  FunctionUtility::ABUND("file");
+
+  IosHolder::setStreams(IosHolder::inHolder(),
+			outStream,
+			IosHolder::errHolder());
+
+  FunctionUtility::abundanceVectors("file", vals);
+
+  Py_RETURN_NONE;
 }
 
 
@@ -413,6 +460,7 @@ static PyMethodDef XSpecMethods[] = {
   FCTSPEC(get_xsabund, get_abund),
   FCTSPEC(get_xsabund_doc, get_abund_doc),
   FCTSPEC(set_xsabund, set_abund),
+  FCTSPEC(set_xsabund_vector, set_abund_vector),
   FCTSPEC(set_xscosmo, set_cosmo),
   NOARGSPEC(get_xscosmo, get_cosmo),
   NOARGSPEC(get_xsxsect, get_xspec_string<FunctionUtility::XSECT>),
@@ -421,6 +469,22 @@ static PyMethodDef XSpecMethods[] = {
   NOARGSPEC(clear_xsxset, clear_xset),
   FCTSPEC(set_xsxset, set_xset),
   FCTSPEC(get_xsxset, get_xset),
+
+  // The set commands are not wrapped yet as it's not clear how well
+  // the system handles these changes (e.g. it doesn't seem to update
+  // the stored abundances if you change one or both of the abundance
+  // settings). The cross-section file should also be accessible in a
+  // similar manner, but the XSPEC API does not provide access to this
+  // (at least for XSPEC 12.12.1).
+  //
+  // Also, abundPath is essentially managerPath, but we provide access
+  // to it as it could be changed (but not by any routine we currently
+  // provide access to).
+  //
+  NOARGSPEC(get_abundance_file, get_xspec_string<FunctionUtility::abundanceFile>),
+  NOARGSPEC(get_xspath_abundance, get_xspec_string<FunctionUtility::abundPath>),
+  // FCTSPEC(set_abundance_file, set_xspec_string<FunctionUtility::abundanceFile>),
+  // FCTSPEC(set_xspath_abundance, set_xspec_string<FunctionUtility::abundPath>),
 
   NOARGSPEC(get_xsversion_atomdb, get_xspec_string<FunctionUtility::atomdbVersion>),
   NOARGSPEC(get_xsversion_nei, get_xspec_string<FunctionUtility::neiVersion>),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -319,8 +319,12 @@ static PyObject* set_cross( PyObject *self, PyObject *args )
 }
 
 
-// TODO: We could have a seperate "reset" command
-//
+static PyObject* clear_xset( PyObject *self )
+{
+  FunctionUtility::eraseModelStringDataBase();
+  Py_RETURN_NONE;
+}
+
 static PyObject* set_xset( PyObject *self, PyObject *args )
 {
 
@@ -330,6 +334,11 @@ static PyObject* set_xset( PyObject *self, PyObject *args )
   if ( !PyArg_ParseTuple( args, (char*)"ss", &str_name, &str_value ) )
     return NULL;
 
+  // Sending in INITIALIZE will reset the database but
+  // - users can now use the clear_xsxset() routine
+  // - using INITIALIZE for this has been marked as deprecated in
+  //   4.17.1
+  //
   string name = XSutility::upperCase(string(str_name));
   if (name == "INITIALIZE") {
     FunctionUtility::eraseModelStringDataBase();
@@ -345,13 +354,31 @@ static PyObject* get_xset( PyObject *self, PyObject *args  )
 
   char* str_name = NULL;
 
-  if ( !PyArg_ParseTuple( args, (char*)"s", &str_name ) )
+  if ( !PyArg_ParseTuple( args, (char*)"|s", &str_name ) )
     return NULL;
 
+  // If no argument is given then we return a dictonary
+  // of all items.
+  //
+  if ( str_name == NULL ) {
+
+    PyObject *d = PyDict_New();
+    for (const auto& item : FunctionUtility::modelStringDataBase()) {
+      PyObject *value = PyUnicode_FromString(item.second.c_str());
+      PyDict_SetItemString(d, item.first.c_str(), value);
+      Py_DECREF(value);
+    }
+
+    return d;
+  }
+
+  // Treat an unknown key as an error.
+  //
   static string value;
   value = FunctionUtility::getModelString(string(str_name));
   if (value == FunctionUtility::NOT_A_KEY()) {
-    value.erase();
+    PyErr_SetString( PyExc_KeyError, str_name );
+    return NULL;
   }
 
   return Py_BuildValue( (char*)"s", value.c_str() );
@@ -393,6 +420,7 @@ static PyMethodDef XSpecMethods[] = {
   NOARGSPEC(get_xsxsect, get_xspec_string<FunctionUtility::XSECT>),
 
   FCTSPEC(set_xsxsect, set_cross),
+  NOARGSPEC(clear_xsxset, clear_xset),
   FCTSPEC(set_xsxset, set_xset),
   FCTSPEC(get_xsxset, get_xset),
   NOARGSPEC(get_xspath_manager, get_xspec_string<FunctionUtility::managerPath>),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -390,16 +390,14 @@ static PyObject* get_xspec_string( PyObject *self ) {
   return Py_BuildValue( (char*)"s", get().c_str() );
 }
 
-static PyObject* set_manager_data_path( PyObject *self, PyObject *args )
-{
-
+template <void set(const std::string& value)>
+static PyObject* set_xspec_string( PyObject *self, PyObject *args ) {
   char* path = NULL;
   if ( !PyArg_ParseTuple( args, (char*)"s", &path ) )
     return NULL;
 
-  FunctionUtility::managerPath(string(path));
+  set(string(path));
   Py_RETURN_NONE;
-
 }
 
 #define NOARGSPEC(name, func) \
@@ -425,7 +423,8 @@ static PyMethodDef XSpecMethods[] = {
   FCTSPEC(get_xsxset, get_xset),
   NOARGSPEC(get_xspath_manager, get_xspec_string<FunctionUtility::managerPath>),
   NOARGSPEC(get_xspath_model, get_xspec_string<FunctionUtility::modelDataPath>),
-  FCTSPEC(set_xspath_manager, set_manager_data_path),
+  FCTSPEC(set_xspath_manager, set_xspec_string<FunctionUtility::managerPath>),
+  FCTSPEC(set_xspath_model, set_xspec_string<FunctionUtility::modelDataPath>),
 
   // Start model definitions
 

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -946,7 +946,7 @@ def test_get_xsstate_keys():
     ostate = xspec.get_xsstate()
     assert isinstance(ostate, dict)
 
-    for key in ["abund", "chatter", "cosmo", "xsect",
+    for key in ["abund", "chatter", "cosmo", "xsect", "xflt",
                 "modelstrings", "paths"]:
         assert key in ostate
 
@@ -2504,3 +2504,115 @@ def test_table_mod_mul_escale_redshift(make_data_path):
     tbl.redshift = 0
     tbl.escale = 2
     assert tbl(elo, ehi) == pytest.approx(MUL_TABLE_E2, rel=2e-6)
+
+
+@requires_xspec
+def test_xflt_can_clear_all():
+    """Check clear_xsxflt() does something."""
+
+    from sherpa.astro import xspec
+
+    xspec.set_xsxflt(1, {"a": 23})
+    xspec.set_xsxflt(3, {"b": 4.9})
+    xspec.clear_xsxflt()
+
+    # We check spectrumNumber 1, 2, and 3 just to make sure.
+    for i in range(1, 4):
+        assert len(xspec.get_xsxflt(i)) == 0
+
+
+@requires_xspec
+def test_xflt_can_clear_single():
+    """We can clear a single spectrumNumber with an empty dict."""
+
+    from sherpa.astro import xspec
+
+    xspec.set_xsxflt(1, {"a": 23, "b": 4.9})
+    xspec.set_xsxflt(2, {"a": 23, "b": 4.9})
+
+    assert len(xspec.get_xsxflt(1)) == 2
+    assert len(xspec.get_xsxflt(2)) == 2
+
+    xspec.set_xsxflt(2, {})
+
+    assert len(xspec.get_xsxflt(1)) == 2
+    assert len(xspec.get_xsxflt(2)) == 0
+
+    xspec.clear_xsxflt()
+
+
+@requires_xspec
+def test_xflt_can_get():
+    """We can get the values we set.
+
+    It's not clear whether we should upper-case the keys, so check
+    that we do not change the case (this could be changed in the
+    future).
+
+    """
+
+    from sherpa.astro import xspec
+
+    xspec.clear_xsxflt()
+    xspec.set_xsxflt(1, {"CC": -1.2e-2, "aA": 23, "b": 4.9})
+
+    out = xspec.get_xsxflt(1)
+    assert len(out) == 3
+    assert out["aA"] == pytest.approx(23)
+    assert out["b"] == pytest.approx(4.9)
+    assert out["CC"] == pytest.approx(-1.2e-2)
+
+    xspec.clear_xsxflt()
+
+
+@requires_xspec
+def test_xflt_can_get_xsxstate():
+    """Check we return the XFLT data as part of the state"""
+
+    from sherpa.astro import xspec
+
+    xspec.clear_xsxflt()
+    xspec.set_xsxflt(4, {"CC": -1.2e-2, "aA": 23, "b": 4.9})
+    xspec.set_xsxflt(2, {"FOO": 200})
+    xspec.set_xsxflt(1, {})
+
+    state = xspec.get_xsstate()
+    assert "xflt" in state
+    xflt = state["xflt"]
+    assert len(xflt) == 2
+    assert sorted(xflt.keys()) == [2, 4]
+
+    assert sorted(xflt[2].keys()) == ["FOO"]
+    assert sorted(xflt[4].keys()) == ["CC", "aA", "b"]
+
+    assert xflt[2]["FOO"] == pytest.approx(200)
+    assert xflt[4]["aA"] == pytest.approx(23)
+    assert xflt[4]["b"] == pytest.approx(4.9)
+    assert xflt[4]["CC"] == pytest.approx(-1.2e-2)
+
+
+@requires_xspec
+def test_xflt_can_set_xsxstate():
+    """Check we set the XFLT data via the state."""
+
+    from sherpa.astro import xspec
+
+    xspec.clear_xsxflt()
+
+    # Set the XSFLT state to see what happens
+    xspec.set_xsxflt(9, {"TMP": 2000})
+
+    xflt = {4: {"CC": -1.2e-2, "aA": 23, "b": 4.9},
+            2: {"FOO": 200},
+            1: {}}
+    xspec.set_xsstate({"xflt": xflt})
+
+    assert xspec.get_xsxflt(1) == {}
+    assert xspec.get_xsxflt(2) == {"FOO": 200}
+    assert xspec.get_xsxflt(4) == {"b": 4.9, "aA": 23, "CC": -1.2e-2}
+
+    # What about the previous setting?
+    assert xspec.get_xsxflt(9) == {}
+
+    # And this is an unknown record
+    assert xspec.get_xsxflt(3) == {}

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -739,7 +739,86 @@ def test_abund_change_file_subset(tmp_path):
 
 
 @requires_xspec
+def test_get_xsabundances_table_name():
+    """Check we can get a different abundance table to the default."""
+
+    from sherpa.astro import xspec
+
+    oval = xspec.get_xsabund()
+    assert oval != "wilm"  # just in case
+
+    elems1 = xspec.get_xsabundances()
+    elems2 = xspec.get_xsabundances("wilm")
+    elems3 = xspec.get_xsabundances()
+
+    assert elems1 != elems2
+    assert elems1 == elems3  # just to check no change
+    check_abundances(elems2["H"],
+                     elems2["He"],
+                     elems2["Si"],
+                     elems2["Ar"],
+                     elems2["K"],
+                     elems2["Fe"])
+
+
+@requires_xspec
+def test_get_xsabundances_table_name_file():
+    """Check we can get a different abundance table to the default.
+
+    Unlike test_get_xsabundances_table_name we load our own abnudances
+    so we can definitely check they are being used.
+
+    """
+
+    from sherpa.astro import xspec
+
+    orig = xspec.get_xsabund()
+    oelems = xspec.get_xsabundances()
+    assert orig != "file"  # as restoring this would be annoying
+
+    nelems = {"H": 1.0, "He": 0.2, "Fe": 2.3, "Zn": 1.3}
+    try:
+        xspec.set_xsabundances(nelems)
+        xspec.set_xsabund(orig)
+
+        got1 = xspec.get_xsabundances()
+        got2 = xspec.get_xsabundances("file")
+    finally:
+        xspec.set_xsabund(orig)
+
+    # Check that got2 matches what we expect and isn't the same as
+    # got1.
+    #
+    assert got1 == oelems
+    assert got1 != got2
+    for k, v in got2.items():
+        if k in nelems:
+            assert v == pytest.approx(nelems[k])
+        else:
+            assert v == pytest.approx(0.0)
+
+
+@requires_xspec
+def test_get_xsabundances_table_name_unknown():
+    """Check we error out if the table name is unknown.
+
+    I don't think there is a way to query XSPEC for the known
+    abundance tables, so we just have to hope we use a name that isn't
+    going to be used.
+
+    """
+
+    from sherpa.astro import xspec
+
+    tbl = "not-an-abundance-table"
+    with pytest.raises(ValueError,
+                       match=f"^Unknown abundance table '{tbl}'$"):
+        xspec.get_xsabundances(tbl)
+
+
+@requires_xspec
 def test_xset_change():
+
     """Can we change the xset setting.
     """
 

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -100,7 +100,8 @@ def test_chatter_default():
 
 
 @requires_xspec
-def test_version():
+@pytest.mark.parametrize("name", [None, "atomdb", "nei"])
+def test_version(name):
     """Can we get at the XSPEC version?
 
     There is limited testing of the return value.
@@ -108,12 +109,68 @@ def test_version():
 
     from sherpa.astro import xspec
 
-    v = xspec.get_xsversion()
+    v = xspec.get_xsversion(name)
     assert isinstance(v, (str, ))
     assert len(v) > 0
 
-    # Could check it's of the form a.b.c[optional] but leave that for
-    # now.
+
+@requires_xspec
+@pytest.mark.parametrize("name", ["ATOMDB", "", "foo"])
+def test_version_error(name):
+    """Does this error out?
+
+    At the moment we are case sensitive when checking the name.
+
+    """
+
+    from sherpa.astro import xspec
+
+    with pytest.raises(ValueError,
+                       match=f"^name must be one of None, 'atomdb', or 'nei', not '{name}'$"):
+        xspec.get_xsversion(name)
+
+
+@requires_xspec
+@pytest.mark.parametrize("name", ["atomdb", "nei"])
+def test_set_version(name):
+    """Can we set the XSPEC version?
+
+    This is just to check we can call the routine - we don't really do
+    much with it.
+
+    """
+
+    from sherpa.astro import xspec
+
+    old = xspec.get_xsversion(name)
+
+    # pick a value that is "realistic" but old, and should not
+    # appear with any supported XSPEC version.
+    #
+    new = '3.0.0'
+    assert old != new
+
+    try:
+        xspec.set_xsversion(name, new)
+        assert xspec.get_xsversion(name) == new
+    finally:
+        xspec.set_xsversion(name, old)
+
+
+@requires_xspec
+@pytest.mark.parametrize("name", ["ATOMDB", "", "foo"])
+def test_set_version_error(name):
+    """Does this error out?
+
+    At the moment we are case sensitive when checking the name.
+
+    """
+
+    from sherpa.astro import xspec
+
+    with pytest.raises(ValueError,
+                       match=f"^name must be 'atomdb' or 'nei', not '{name}'$"):
+        xspec.set_xsversion(name, "1.2.3")
 
 
 @requires_xspec

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -946,7 +946,7 @@ def test_get_xsstate_keys():
     ostate = xspec.get_xsstate()
     assert isinstance(ostate, dict)
 
-    for key in ["abund", "chatter", "cosmo", "xsect", "xflt",
+    for key in ["abund", "chatter", "cosmo", "xsect", "xflt", "db",
                 "modelstrings", "paths"]:
         assert key in ostate
 
@@ -2616,3 +2616,53 @@ def test_xflt_can_set_xsxstate():
 
     # And this is an unknown record
     assert xspec.get_xsxflt(3) == {}
+
+
+@requires_xspec
+def test_db_can_clear_all():
+    """Check clear_db() does something."""
+
+    from sherpa.astro import xspec
+
+    xspec.set_xsdb("a", 23);
+    xspec.set_xsdb("b", 4.9);
+    xspec.clear_xsdb()
+
+    assert len(xspec.get_xsdb()) == 0
+
+
+@requires_xspec
+def test_db_can_set():
+    """We can set a single value."""
+
+    from sherpa.astro import xspec
+
+    xspec.set_xsdb("aA", -1.2e4);
+    ans = xspec.get_xsdb()
+    assert ans["aa"] == pytest.approx(-1.2e4);
+
+    xspec.clear_xsdb()
+
+
+@requires_xspec
+def test_db_can_get():
+    """We can get the values we set.
+
+    It appears that the keys are converted to lower case.
+
+    """
+
+    from sherpa.astro import xspec
+
+    xspec.clear_xsdb()
+    xspec.set_xsdb("aA", 23)
+    xspec.set_xsdb("b", 4.9)
+    xspec.set_xsdb("CC", -1.2e-2)
+
+    out = xspec.get_xsdb()
+    assert len(out) == 3
+    assert out["aa"] == pytest.approx(23)
+    assert out["b"] == pytest.approx(4.9)
+    assert out["cc"] == pytest.approx(-1.2e-2)
+
+    xspec.clear_xsdb()


### PR DESCRIPTION
The last part of #1615 and some additions

- adds support for the XFLT keywords
  - need to work on integrating in the last changes from #2106, but I want to change how the `spectrumNumber` argument is sent in; it shouldn't be a property of the model as we want the model to be usable with multiple datasets, but then how do we send it in
- adds support for the model database
  - it's not clear any model makes use of this, but it's easy to add 
- add basic support for the `plot dem` command
  - it's very limited, but that's because the XSPEC API is very limited
 
It requires

- #2215 
- #2216 
 