### PR TITLE
Allow user-statistics to be referenced by name to match the documentation.

### DIFF
--- a/sherpa/stats/tests/test_user_stat.py
+++ b/sherpa/stats/tests/test_user_stat.py
@@ -158,8 +158,7 @@ def test_get_stat_name_user_stat(use_string, clean_astro_ui):
     else:
         ui.set_stat(eval(statname))
 
-    # This response is not ideal
-    assert ui.get_stat_name() == "userstat"
+    assert ui.get_stat_name() == statname.lower()
 
 
 @pytest.mark.parametrize("use_string", [False, True])

--- a/sherpa/stats/tests/test_user_stat.py
+++ b/sherpa/stats/tests/test_user_stat.py
@@ -61,7 +61,7 @@ def test_user_stat_unit(clean_astro_ui):
 @pytest.mark.parametrize("use_string", [False, True])
 def test_user_model_stat_docs(use_string, clean_astro_ui):
     """This test reproduces the documentation shown at:
-    http://cxc.harvard.edu/sherpa4.4/statistics/#userstat
+    https://cxc.cfa.harvard.edu/sherpa/statistics/#userstat
 
     and:
     http://cxc.harvard.edu/sherpa/threads/user_model/

--- a/sherpa/stats/tests/test_user_stat.py
+++ b/sherpa/stats/tests/test_user_stat.py
@@ -26,7 +26,7 @@ from pytest import approx
 from sherpa.astro import ui
 from sherpa.data import Data1D
 from sherpa.stats import UserStat
-from sherpa.utils.err import StatErr
+from sherpa.utils.err import IdentifierErr, StatErr
 
 
 def test_user_stat_unit(clean_astro_ui):
@@ -58,7 +58,7 @@ def test_user_stat_unit(clean_astro_ui):
     assert 3.235 == ui.get_fit_results().statval
 
 
-@pytest.mark.parametrize("use_string", [False, pytest.param(True, marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("use_string", [False, True])
 def test_user_model_stat_docs(use_string, clean_astro_ui):
     """This test reproduces the documentation shown at:
     http://cxc.harvard.edu/sherpa4.4/statistics/#userstat
@@ -116,7 +116,6 @@ def test_user_model_stat_docs(use_string, clean_astro_ui):
     assert ui.get_par("myl.b").val == approx(3, abs=0.01)
 
 
-@pytest.mark.xfail  # issue #2225
 def test_list_stats(clean_astro_ui):
     """Can we list the stats after adding a new one?"""
 
@@ -144,7 +143,7 @@ def test_list_stats(clean_astro_ui):
     assert set(nstats).difference(set(ostats)) == set([statname.lower()])
 
 
-@pytest.mark.parametrize("use_string", [False, pytest.param(True, marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("use_string", [False, True])
 def test_get_stat_name_user_stat(use_string, clean_astro_ui):
     """What does get_stat_name return?"""
 
@@ -163,7 +162,7 @@ def test_get_stat_name_user_stat(use_string, clean_astro_ui):
     assert ui.get_stat_name() == "userstat"
 
 
-@pytest.mark.parametrize("use_string", [False, pytest.param(True, marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("use_string", [False, True])
 def test_get_stat_user_stat(use_string, clean_astro_ui):
     """What does get_stat return?"""
 
@@ -184,6 +183,15 @@ def test_get_stat_user_stat(use_string, clean_astro_ui):
     assert s.name == statname
     assert s.statfunc == delme
     assert s.errfunc is None
+
+
+@pytest.mark.parametrize("name", ["map", "Map"])
+def test_load_user_stat_invalid_name(name, clean_astro_ui):
+    """Check we error out"""
+
+    with pytest.raises(IdentifierErr,
+                       match=f"^'{name}' is reserved for the native Python function$"):
+        ui.load_user_stat(name, None)
 
 
 def test_341(clean_astro_ui):

--- a/sherpa/stats/tests/test_user_stat.py
+++ b/sherpa/stats/tests/test_user_stat.py
@@ -106,7 +106,9 @@ def test_user_model_stat_docs(use_string, clean_astro_ui):
     if use_string:
         ui.set_stat("mystat")
     else:
-        ui.set_stat(eval("mystat"))
+        evalout = eval("mystat")
+        assert isinstance(evalout, UserStat)
+        ui.set_stat(evalout)
 
     ui.set_model(eval("myl"))
 
@@ -120,7 +122,7 @@ def test_list_stats(clean_astro_ui):
     """Can we list the stats after adding a new one?"""
 
     # We do not hard code the statistic names here, in case we ever
-    # add (or remove) any frmo the defaut set.
+    # add (or remove) any from the default set.
     #
 
     ostats = ui.list_stats()

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -8061,7 +8061,7 @@ class Session(NoNewAttributesAfterInit):
             kwargs = dict(pars)
             userstat = sherpa.logposterior.Prior(calc_stat_func, priors, kwargs)
 
-        # Ideally we wuold not add this to the global symbol table,
+        # Ideally we would not add this to the global symbol table,
         # but existing code may rely on this behaviour.
         #
         _assign_obj_to_main(statname, userstat)

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -2952,6 +2952,10 @@ class Session(NoNewAttributesAfterInit):
     def get_stat_name(self) -> str:
         """Return the name of the current fit statistic.
 
+        .. versionchanged:: 4.17.1
+           User statistics now return their name, in lower-case,
+           rather than the string "userstat".
+
         Returns
         -------
         name : str
@@ -2974,7 +2978,7 @@ class Session(NoNewAttributesAfterInit):
         'cash'
 
         """
-        return type(self.get_stat()).__name__.lower()
+        return self.get_stat().name.lower()
 
     def set_stat(self,
                  stat: str | Stat


### PR DESCRIPTION
# Summary

Allow user-statistics to be set by name. The get_stat_name routine now returns the actual name of the user statistic, rather than the generic value "userstat". Fix #2225.

# Details

We now ensure that any user statistic that is loaded is registered with the stats store (aka, added to the `_stats` dict). As part of this we ensure that the name is not "deeply wrong" (aka a Python symbol name) based on the check made in `load_user_model`.

The `get_stat_name` change is a small one, but I think it makes sense and I do not understand why it was written this way when all the stats objects have a `name` field. We do convert to lower-case just to fit into the "lower-case" behaviour the stats routines seem to want. 