### PR TITLE
Tests: compare Response1D and MultipleResponse1D behavior

### DIFF
--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -1356,8 +1356,8 @@ def test_rsp_multi_1_label(arfexp, phaexp):
 
     assert isinstance(wrapped, ArithmeticModel)
 
-    # The labelling of the model differes from the Response1D case, so
-    # re-do the analysis.
+    # The labelling of the model differs from the Response1D case, so
+    # redo the analysis.
     #
     # TODO:
     #   - what happens to the ARF exposure time?
@@ -1451,7 +1451,7 @@ def test_rsp_multi_2_label(analysis, arfexp, phaexp):
 
     assert isinstance(wrapped, ArithmeticModel)
 
-    # The labelling of the model differes from the Response1D case, so
+    # The labelling of the model differs from the Response1D case, so
     # re-do the analysis.
     #
     # TODO:


### PR DESCRIPTION
# Summary

Improve testing of the multi-response code. There is no change in behaviour here.

# Details

I had written this for some multi-response changes I have been working on, but this code is currently in limbo but we may as well take the tests. As noted below, the `MultipleResponse1D` code behaves in "interesting" ways, so all these tests are really regression tests, so we will note if we ever change the code behaviour. I will note that the basics tested here do seem to suggest the code is "okay" for the normal use case, but there are some interesting issues we could dig into, **but not in this PR**.

Add basic tests like

- Response1D and MultipleResponse1D are the same for a single-response PHA
- adding the same response twice for MultipleResponse1D does double the signal sen by Response1D

In doing so I have re-worked some existing Response1D routines so they all call setup_resp() rather than repeating this code in each test.

I will note that the MultiResponse1D tests are currently meant as regression tests since I have not had time to really understand what the code is meant to be doing, and understand why it appears to behave differently to the Response1D case when we have the expoure time coming from the ARF and not the PHA (which is post-OGIP behaviour, as noted in issue #1871). That is, I would not be surprised if we decide to change some of the behaviour. I will note that the string name for the multi-response case is definitely wrong here.