### PR TITLE
Error out if model names are not strings

### DIFF
--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016 - 2024
+#  Copyright (C) 2010, 2016-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -536,6 +536,8 @@ class Model(NoNewAttributesAfterInit):
     def __init__(self,
                  name: str,
                  pars: Sequence[Parameter] = ()) -> None:
+        if not isinstance(name, str):
+            raise TypeError("The parameter 'name' for a model must be a string but it is a " + str(type(name)) + ".")
         self.name = name
         self.type = self.__class__.__name__.lower()
         self._pars = tuple(pars)

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2016, 2017, 2020 - 2024
+#  Copyright (C) 2007, 2016-2017, 2020-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -2138,3 +2138,12 @@ def test_model_linked_par_outside_limit():
     with pytest.raises(ParameterErr,
                        match="parameter mdl.ampl has a minimum of 0"):
         mdl.thawedpars = [12, 6]
+
+
+@pytest.mark.parametrize('name',
+                         [None, 23, Box1D("23")])
+def test_name_not_string(name):
+    """Check if we can use a non-string name"""
+    with pytest.raises(TypeError,
+                       match="The parameter 'name' for a model must be a string but it is a "):
+        mdl = Box1D(name=name)


### PR DESCRIPTION
## Summary

Raise an error if a model name is not a string

## Details

It is easy (#2222) to accidentally make a model where the name of a model is not a string, but another model instance. This might look like it works, but will lead to a useless model that is hard to debug for the average user because even printing out the model will fail in some cases.

This PR raises and error on model generation if the name is not a string.

## Rejected alternatives

A little more lenient variant of this would be to allow integers as well as strings but what is implemented here is already less strict than the UI, where you can't use ints at all:
```Python
In [15]: from sherpa.astro import ui

In [16]: ui.load_arrays('data1', [1,2,3,4], [1,2,2,1.1])

In [17]: ui.set_model('data1', ui.box1d.box1)

In [18]: ui.set_model('data1', ui.box1d.1)
  Cell In[18], line 1
    ui.set_model('data1', ui.box1d.1)
                          ^
SyntaxError: invalid syntax. Perhaps you forgot a comma?
```

while in this PR the string could be "1":
```Python
In [19]: ui.box1d(name="1")
Out[19]: <Box1D model instance 'box1d.1'>
```

fixes #2222