### PR TITLE
Note that we need the file program to build Sherpa

### DIFF
--- a/.github/workflows/ci-pip-arch.yml
+++ b/.github/workflows/ci-pip-arch.yml
@@ -44,21 +44,21 @@ jobs:
       uses: uraimo/run-on-arch-action@v2
       with:
         arch: ${{ matrix.arch }}
-        # distro: ubuntu_rolling
-        # ubuntu 22.04 uses Python 3.10
-        distro: ubuntu22.04
+        # use the latest LTS version
+        distro: ubuntu_latest
 
         shell: /bin/bash
 
         # Based on AstroPy
         install: |
           apt-get update -q -y
-          apt-get install -q -y git \
+          apt-get install -q -y \
                                 g++ \
                                 gfortran \
                                 flex \
                                 bison \
                                 make \
+                                file \
                                 pkg-config \
                                 python3 \
                                 python3-dev \

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -138,7 +138,7 @@ The prerequisites for building from source are:
 * Python packages: ``setuptools``, ``numpy`` (these should be
   automatically installed by ``pip``)
 * System: ``gcc`` and ``g++`` or ``clang`` and ``clang++``, ``make``, ``flex``,
-  ``bison``, ``ar`` (which may be provided by the ``binutils`` package)
+  ``bison``, ``ar`` (which may be provided by the ``binutils`` package), ``file``.
 
 The aim is to support recent versions of these tools and libraries;
 please report problems to the


### PR DESCRIPTION
# Summary

Note that the file command is needed to build Sherpa (it is used by extern/configure).

# Details

I was trying to build Sherpa in a docker container to try and work out what's going on in #2220 and in reviewing the output of `extern/configure` realized it wanted the `file` command. So

a) add a note of this to the documentation
b) bump the one GH action that install stuff to include `file` just to make sure
  - as part of this, remove the installation of `git` since this isn't needed to build Sherpa
  - bump the Ubuntu version from `22.04` to `latest` (aka the latest LTS)

It is not really clear what problem not having `file` leads to, if any (since you'd need to track what `configure` was doing with the information), but we may as well note the requirement. Also, most users will already have it.