### PR TITLE
Two small astropy-related doc changes

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -14,7 +14,7 @@ problems or feature requests on github
 At present we do not have any explicit documentation on how
 to contribute to Sherpa, but it is similar to other open-source
 packages such as
-`AstroPy <https://docs.astropy.org/en/stable/index.html#contributing>`_.
+`AstroPy <https://docs.astropy.org/en/stable/index_dev.html>`_.
 
 The developer documentation is also currently lacking.
 

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -162,12 +162,13 @@ Conda can be used to install all the dependencies for Sherpa, including
 
 ::
 
-    conda create -n sherpaciao -c https://cxc.cfa.harvard.edu/conda/ciao -c conda-forge ds9 astropy ciao
+    conda create -n sherpaciao -c https://cxc.cfa.harvard.edu/conda/ciao -c conda-forge ds9 ciao
     conda install -n sherpaciao --only-deps -c https://cxc.cfa.harvard.edu/conda/ciao -c conda-forge sherpa
     conda activate sherpaciao
+    pip install astropy
 
 The first line installs the full `CIAO release
-<https://cxc.harvard.edu/ciao/>`_ and astropy, required for building
+<https://cxc.harvard.edu/ciao/>`_, required for building
 and running tests locally.
 
 If you want to also build the documentation then add (after you have


### PR DESCRIPTION
## Summary

- Update linke to astropy dev docs (that we link to in lieu of writing our own dev docs)
- Recommend to install astropy via pip, not conda

## Details

I find that the conda dependency resolver fails (or at least takes > 2 h) to resolve `conda create -n sherpaciao -c https://cxc.cfa.harvard.edu/conda/ciao -c conda-forge ds9 ciao astropy`, while it takes only seconds without astropy (This is specifically on MacOS X with Python 3.11, but even if other combinations are faster, this change doesn't hurt). So, install astropy with pip instead, once the conda environment is set up.