### PR TITLE
TESTS: mark more that require the group module

### DIFF
--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020 - 2024
+#  Copyright (C) 2020 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -275,6 +275,7 @@ def test_pha_channel_empty_remains_empty():
     assert empty.channel is None
 
 
+@requires_group
 @pytest.mark.parametrize("chans", [None, [1, 2, 3]])
 def test_pha_group_when_empty(chans):
     """A regression test."""
@@ -2472,6 +2473,7 @@ def test_pha_change_quality_values(caplog):
     assert pha.get_filter() == '1:7'
 
 
+@requires_group
 def test_pha_group_adapt_check():
     """Regression test.
 
@@ -2540,6 +2542,7 @@ def test_pha_group_ignore_bad_then_filter(caplog):
     assert pha.get_dep(filter=True) == pytest.approx([6, 6])
 
 
+@requires_group
 def test_pha_group_ignore_bad_then_group(caplog):
     """Regression test."""
 
@@ -2585,6 +2588,7 @@ def test_pha_group_ignore_bad_then_group(caplog):
     assert pha.get_dep(filter=True) == pytest.approx([4, 3, 6, 6, 7])
 
 
+@requires_group
 def test_pha_filter_ignore_bad_filter(caplog):
     """A regression test.
 

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2020 - 2024
+#  Copyright (C) 2017, 2018, 2020 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -44,7 +44,7 @@ from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.random import poisson_noise
 from sherpa.utils.testing import requires_data, requires_fits, \
-    requires_region, requires_wcs, requires_xspec
+    requires_group, requires_region, requires_wcs, requires_xspec
 
 
 def backend_is(name: str) -> bool:
@@ -3367,6 +3367,7 @@ def test_pha_group_filter_ignore_bad(caplog, clean_astro_ui):
     assert r.getMessage() == "dataset 1: 1:4 -> 1:5 Channel"
 
 
+@requires_group
 def test_pha_group_ignore_bad_group(caplog, clean_astro_ui):
     """Regression test.
 


### PR DESCRIPTION
# Summary

Mark several recently-added tests with the requires_group decorator. There is no functional change.

# Details

It would be nice to track these - either by some automated means or with a CI build - but this build configuration is rare so I don't think it's worth it.

An alternative would be to drop the "can build Sherpa without the group module/library" but that is a much bigger issue so we may as well take this simple change anyway.

I found this when working on 
- #1948
but it is completely separate from that work (other than the fact that reworking the build system gets you into places where we don't  have the group module, so you can't run the tests!).