### PR TITLE
BUILD: pin conda-build (and therefore liblief) to last known working version

### DIFF
--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -80,7 +80,7 @@ jobs:
         curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh -o conda-installer.sh
         bash conda-installer.sh -b -p ${conda_loc}
         source ${conda_loc}/etc/profile.d/conda.sh
-        conda create -yq -n builder conda-build conda-verify
+        conda create -yq -n builder "conda-build==25.1.2=*_0" conda-verify
 
     #Checkout the code with a depth of 0 to grab the tags/branches as well
     - name: Checkout Code


### PR DESCRIPTION
There's a bug between `conda-build` and `lief` that's causing a package build failure. This pins to `"conda-build==25.1.2=*_0"`, which we've also pinned to in CIAO for this same issue.

related Conda-build issue:
https://github.com/conda/conda-build/issues/5626