### PR TITLE
Deal with OGIP products that do not follow the standards

### DIFF
--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -18,11 +18,12 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from collections.abc import Sequence
 from collections import defaultdict
 from contextlib import suppress
 import logging
 import os
-from typing import Any, Optional, Sequence, Union
+from typing import Any
 
 import numpy as np
 
@@ -62,8 +63,8 @@ name: str = "crates"
 """The name of the I/O backend."""
 
 
-CrateType = Union[TABLECrate, IMAGECrate]
-DatasetType = Union[str, CrateDataset]
+CrateType = TABLECrate | IMAGECrate
+DatasetType = str | CrateDataset
 
 
 def open_crate(filename: str) -> CrateType:
@@ -160,7 +161,7 @@ def get_filename_from_dmsyntax(filename: str) -> str:
 
 def _try_key(crate: CrateType,
              name: str,
-             dtype: type = str) -> Optional[KeyType]:
+             dtype: type = str) -> KeyType | None:
     """Access the key from the crate returning None if it does not exist.
 
     There's no way to differentiate between a key that does not exist
@@ -201,7 +202,7 @@ def _try_key(crate: CrateType,
 
     # byte strings are to be decoded to strings
     #
-    if dtype == str and isinstance(value, bytes):
+    if dtype is str and isinstance(value, bytes):
         return dtype(value, "utf-8")
 
     return dtype(value)
@@ -258,7 +259,7 @@ def _require_image(crate: IMAGECrate,
 
 
 def _get_crate_by_blockname(dataset: CrateDataset,
-                            blkname: str) -> Optional[CrateType]:
+                            blkname: str) -> CrateType | None:
     """Select the given block name.
 
     Parameters
@@ -292,7 +293,7 @@ def _get_crate_by_blockname(dataset: CrateDataset,
 
 # This should be added to the official backend API.
 #
-def read_table_blocks(arg: Union[str, CrateDataset, TABLECrate],
+def read_table_blocks(arg: str | CrateDataset | TABLECrate,
                       make_copy: bool = False
                       ) -> tuple[BlockList, str]:
     """Read in tabular data with no restrictions on the columns."""
@@ -327,9 +328,9 @@ def read_table_blocks(arg: Union[str, CrateDataset, TABLECrate],
     return BlockList(blocks=blocks, header=header), filename
 
 
-def get_header_data(arg: Union[str, TABLECrate],
-                    blockname: Optional[str] = None,
-                    hdrkeys: Optional[NamesType] = None
+def get_header_data(arg: str | TABLECrate,
+                    blockname: str | None = None,
+                    hdrkeys: NamesType | None = None
                     ) -> Header:
     """Read the metadata."""
 
@@ -390,7 +391,7 @@ def get_column_data(*args) -> list[np.ndarray]:
 
 def get_ascii_data(filename: str,
                    ncols: int = 2,
-                   colkeys: Optional[NamesType] = None,
+                   colkeys: NamesType | None = None,
                    **kwargs
                    ) -> tuple[TableBlock, str]:
     """Read columns from an ASCII file"""
@@ -398,13 +399,13 @@ def get_ascii_data(filename: str,
     return get_table_data(filename, ncols, colkeys)
 
 
-def get_table_data(arg: Union[str, TABLECrate],
+def get_table_data(arg: str | TABLECrate,
                    ncols: int = 1,
-                   colkeys: Optional[NamesType] = None,
-                   make_copy: bool = True,
+                   colkeys: NamesType | None = None,
+                   make_copy: bool = True,  # unused
                    fix_type: bool = True,
-                   blockname: Optional[str] = None,
-                   hdrkeys: Optional[NamesType] = None
+                   blockname: str | None = None,
+                   hdrkeys: NamesType | None = None
                    ) -> tuple[TableBlock, str]:
     """Read columns from a file or crate."""
 
@@ -416,7 +417,7 @@ def get_table_data(arg: Union[str, TABLECrate],
 
     elif isinstance(arg, TABLECrate):
         tbl = arg
-        make_copy = False
+
     else:
         raise IOErr('badfile', arg, 'TABLECrate obj')
 
@@ -485,7 +486,7 @@ def get_table_data(arg: Union[str, TABLECrate],
     return TableBlock("TABLE", header=headers, columns=cols), filename
 
 
-def get_image_data(arg: Union[str, IMAGECrate],
+def get_image_data(arg: str | IMAGECrate,
                    make_copy: bool = True,
                    fix_type: bool = True
                    ) -> tuple[ImageBlock, str]:
@@ -553,8 +554,8 @@ def get_image_data(arg: Union[str, IMAGECrate],
     return block, filename
 
 
-def get_arf_data(arg: Union[str, TABLECrate],
-                 make_copy: bool = True
+def get_arf_data(arg: str | TABLECrate,
+                 make_copy: bool = True  # unused
                  ) -> tuple[SpecrespBlock, str]:
     """Read an ARF from a file or crate"""
 
@@ -566,7 +567,6 @@ def get_arf_data(arg: Union[str, TABLECrate],
     elif isinstance(arg, TABLECrate):
         arf = arg
         filename = arg.get_filename()
-        make_copy = False
 
     else:
         raise IOErr('badfile', arg, "ARFCrate obj")
@@ -644,7 +644,8 @@ def _find_matrix_blocks(filename: str,
 def copycol(cr: TABLECrate,
             filename: str,
             name: str,
-            dtype: Optional[type] = None) -> Column:
+            dtype: type | None = None
+            ) -> Column:
     """Copy the column data (which must exist).
 
     Parameters
@@ -794,8 +795,8 @@ def _read_rmf_ebounds(rmfdataset: pycrates.RMFCrateDataset,
     return EboundsBlock("EBOUNDS", header=eheaders, columns=ecols)
 
 
-def get_rmf_data(arg: Union[str, pycrates.RMFCrateDataset],
-                 make_copy: bool = True
+def get_rmf_data(arg: str | pycrates.RMFCrateDataset,
+                 make_copy: bool = True  # unused
                  ) -> tuple[list[MatrixBlock], EboundsBlock, str]:
     """Read a RMF from a file or crate.
 
@@ -817,7 +818,6 @@ def get_rmf_data(arg: Union[str, pycrates.RMFCrateDataset],
     elif pycrates.is_rmf(arg) == 1:
         rmfdataset = arg
         filename = arg.get_filename()
-        make_copy = False
 
     else:
         raise IOErr('badfile', arg, "RMFCrateDataset obj")
@@ -876,8 +876,8 @@ def _read_pha(pha: TABLECrate,
     return SpectrumBlock(pha.name, header=headers, columns=cols)
 
 
-def get_pha_data(arg: Union[str, pycrates.PHACrateDataset],
-                 make_copy: bool = True,
+def get_pha_data(arg: str | pycrates.PHACrateDataset,
+                 make_copy: bool = True,  # unused
                  use_background: bool = False
                  ) -> tuple[SpectrumBlock, str]:
     """Read PHA data from a file or crate.
@@ -899,7 +899,6 @@ def get_pha_data(arg: Union[str, pycrates.PHACrateDataset],
     elif pycrates.is_pha(arg) == 1:
         phadataset = arg
         filename = arg.get_filename()
-        make_copy = False
 
     else:
         raise IOErr('badfile', arg, "PHACrateDataset obj")
@@ -934,7 +933,7 @@ def get_pha_data(arg: Union[str, pycrates.PHACrateDataset],
 # Write/Pack Functions #
 #
 
-def write_dataset(dataset: Union[TABLECrate, IMAGECrate, CrateDataset],
+def write_dataset(dataset: TABLECrate | IMAGECrate | CrateDataset,
                   filename: str,
                   *,
                   ascii: bool,
@@ -1144,7 +1143,7 @@ def set_rmf_data(filename: str,
 
 def set_arrays(filename: str,
                args: Sequence[np.ndarray],
-               fields: Optional[NamesType] = None,
+               fields: NamesType | None = None,
                ascii: bool = True,
                clobber: bool = False) -> None:
     """Write out the columns."""

--- a/sherpa/astro/io/crates_backend.py
+++ b/sherpa/astro/io/crates_backend.py
@@ -680,8 +680,8 @@ def copycol(cr: TABLECrate,
     behaviour.
 
     NICER has created QUALITY columns with TFORM=B which crates reads
-    in as a 2D array, but of shape (ncols, 1). So special case this,
-    as we assume there are not many csaes where we are reading in this
+    in as a 2D array, with a shape of (ncols, 1). So special case this,
+    as we assume there are not many cases where we are reading in this
     data (unfortunately it's not easy to check for exactly this
     condition as crates does not provide direct access to the TFORMn
     header value).
@@ -699,7 +699,7 @@ def copycol(cr: TABLECrate,
     elif vals.dtype == np.uint8 and vals.ndim == 2 and \
          vals.shape[1] == 1:
         # Convert boolean (nrows, 1) 2D array, created by the CIAO
-        # data model in CIAO 3.17, to 1D. Fortunately there is no
+        # data model in CIAO 4.17 (and earlier), to 1D. Fortunately there is no
         # native FITS TFORM that maps to np.uint8 other than
         # boolean/bit values, so this should be a relatively safe
         # expansion.

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021 - 2024
+#  Copyright (C) 2021 - 2025
 #  MIT
 #
 #
@@ -27,17 +27,16 @@ available.
 
 '''
 
+from collections.abc import Sequence
 import logging
-from typing import Any, Optional, Sequence
+from typing import Any
 
 import numpy as np
 
 from ..data import Data1D
 
-from .types import NamesType, HdrTypeArg, HdrType, \
-    ColumnsType, ColumnsTypeArg, DataTypeArg, DataType, \
-    Header, BlockList, TableBlock, ImageBlock, \
-    SpectrumBlock, SpecrespBlock, MatrixBlock, EboundsBlock
+from .types import NamesType, Header, BlockList, TableBlock, \
+    ImageBlock, SpectrumBlock, SpecrespBlock, MatrixBlock, EboundsBlock
 
 
 __all__ = ('get_table_data', 'get_header_data', 'get_image_data',
@@ -63,11 +62,11 @@ warning("""Cannot import usable I/O backend.
 
 def get_table_data(arg,
                    ncols: int = 1,
-                   colkeys: Optional[NamesType] = None,
+                   colkeys: NamesType | None = None,
                    make_copy: bool = True,
                    fix_type: bool = True,
-                   blockname: Optional[str] = None,
-                   hdrkeys: Optional[NamesType] = None
+                   blockname: str | None = None,
+                   hdrkeys: NamesType | None = None
                    ) -> tuple[TableBlock, str]:
     """Read columns from a file or object.
 
@@ -121,8 +120,8 @@ def get_table_data(arg,
 
 
 def get_header_data(arg,
-                    blockname: Optional[str] = None,
-                    hdrkeys: Optional[NamesType] = None
+                    blockname: str | None = None,
+                    hdrkeys: NamesType | None = None
                     ) -> Header:
     """Read the metadata.
 
@@ -228,7 +227,7 @@ def get_column_data(*args) -> list[np.ndarray]:
 #
 def get_ascii_data(filename: str,
                    ncols: int = 2,
-                   colkeys: Optional[NamesType] = None,
+                   colkeys: NamesType | None = None,
                    sep: str = ' ',
                    dstype: type = Data1D,
                    comment: str = '#',
@@ -694,7 +693,7 @@ def read_table_blocks(arg,
 
 def set_arrays(filename: str,
                args: Sequence[np.ndarray],
-               fields: Optional[NamesType] = None,
+               fields: NamesType | None = None,
                ascii: bool = True,
                clobber: bool = False) -> None:
     """Write out columns.

--- a/sherpa/astro/io/pyfits_backend.py
+++ b/sherpa/astro/io/pyfits_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015 - 2024
+#  Copyright (C) 2011, 2015 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -748,6 +748,22 @@ def copycol(hdu: fits.BinTableHDU,
 
     with suppress(KeyError):
         out.maxval = hdu.header[f"TLMAX{pos}"]
+
+    # Deal with the possibility of the TLMIN/MAX values
+    # being encoded as a string. See
+    # https://github.com/sherpa/sherpa/issues/2185
+    #
+    if isinstance(out.minval, str) or isinstance(out.maxval, str):
+        # Handle VLF data
+        dtype = vals.dtype
+        if dtype == object:
+            dtype = vals[0].dtype
+
+        if isinstance(out.minval, str):
+            out.minval = dtype.type(out.minval)
+
+        if isinstance(out.maxval, str):
+            out.maxval = dtype.type(out.maxval)
 
     return out
 

--- a/sherpa/astro/io/tests/test_io.py
+++ b/sherpa/astro/io/tests/test_io.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016 - 2018, 2020 - 2021, 2023 - 2024
+#  Copyright (C) 2016 - 2018, 2020 - 2021, 2023 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -49,7 +49,7 @@ def test_mod_fits(make_data_path, clean_astro_ui, caplog):
 
     msg = "Use load_xstable_model to load XSPEC table models"
     assert len(warn) == 1
-    assert warn[0].category == DeprecationWarning
+    assert warn[0].category is DeprecationWarning
     assert str(warn[0].message) == msg
 
     tmod = ui.get_model_component("tmod")

--- a/sherpa/astro/io/tests/test_io_img.py
+++ b/sherpa/astro/io/tests/test_io_img.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2023, 2024
+#  Copyright (C) 2021, 2023 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -346,7 +346,8 @@ def test_read_image_object(make_data_path):
 
     try:
         from sherpa.astro.io import wcs
-        # Technically the following depends on WCS support
+        # Technically the following depends on WCS support, even
+        # though we do not use the wcs symbol.
         assert img.sky.crval == pytest.approx([4083.7, 4083.7])
         assert img.eqpos.crval == pytest.approx([112.71019, 40.82296])
 

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020 - 2024
+#  Copyright (C) 2020 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -38,7 +38,7 @@ import pytest
 
 from sherpa.astro.data import DataPHA
 from sherpa.astro import io
-from sherpa.utils.err import DataErr, IOErr
+from sherpa.utils.err import DataErr
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, requires_fits
 
@@ -984,7 +984,7 @@ def test_chandra_phaII_roundtrip(make_data_path, tmp_path):
         if roundtrip:
             assert hdr["SYS_ERR"] == 0
         else:
-            assert not "SYS_ERR" in hdr
+            assert "SYS_ERR" not in hdr
 
         assert hdr["QUALITY"] == 0
         assert hdr["GROUPING"] == 0

--- a/sherpa/astro/io/tests/test_io_response.py
+++ b/sherpa/astro/io/tests/test_io_response.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2023, 2024
+#  Copyright (C) 2021, 2023 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -31,9 +31,8 @@ import pytest
 
 from sherpa.astro.data import DataARF, DataPHA, DataRMF
 from sherpa.astro.instrument import RMF1D, create_arf, create_delta_rmf
-from sherpa.astro.instrument import create_delta_rmf
 from sherpa.astro import io
-from sherpa.astro.io.types import HeaderItem, Header, Column, TableBlock, BlockList
+from sherpa.astro.io.types import HeaderItem, Header, BlockList
 from sherpa.data import Data1DInt
 from sherpa.models.basic import Gauss1D
 from sherpa.utils.err import ArgumentErr, IOErr
@@ -1177,7 +1176,7 @@ def test_read_multi_matrix_rmf(tmp_path, caplog):
     for idx, fchan in enumerate([2, 4, 6, 8, 10]):
         blurry_matrix[idx, fchan - 1:fchan + 3] = blur
 
-    expected_blurry = mdl(e4lo, e4hi) @ blurry_matrix
+    # expected_blurry = mdl(e4lo, e4hi) @ blurry_matrix
 
     assert y == pytest.approx(expected_perfect)
 

--- a/sherpa/astro/io/tests/test_io_xspec_table_model.py
+++ b/sherpa/astro/io/tests/test_io_xspec_table_model.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2023
+#  Copyright (C) 2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -226,7 +226,6 @@ def test_check_nxfp_match():
     """When NXFP is set we need more spectra"""
 
     p0 = xstable.Param("nop", 1, -1, 0, 1, values=[0, 1])
-    ap0 = xstable.BaseParam("bob", 1, -1, 0, 1)
     model1 = [1, 2, 3]
     model2 = [2, 5, 6]
     with pytest.raises(ValueError, match="^Expected 4 spectra, found 2$"):

--- a/sherpa/astro/io/types.py
+++ b/sherpa/astro/io/types.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2024
+#  Copyright (C) 2024 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -30,8 +30,9 @@ to FITS-like data structures.
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -55,7 +56,7 @@ __all__ = ("KeyType", "HeaderItem", "Header", "Column", "Block",
 # NumPy types - e.g. np.bool_, np.integer, np.floating - in some of
 # these types.
 #
-KeyType = Union[str, bool, int, float]
+KeyType = str | bool | int | float
 NamesType = Sequence[str]
 HdrTypeArg = Mapping[str, KeyType]
 HdrType = dict[str, KeyType]
@@ -63,7 +64,7 @@ HdrType = dict[str, KeyType]
 # Note that ColumnsTypeArg allows more for the values than does
 # ColumnsType.
 #
-ColumnsTypeArg = Mapping[str, Union[np.ndarray, list, tuple]]
+ColumnsTypeArg = Mapping[str, np.ndarray | list | tuple]
 ColumnsType = dict[str, np.ndarray]
 
 # It's hard to type the arguments to the Data constructors
@@ -87,10 +88,10 @@ class HeaderItem:
     value: KeyType
     """The keyword value"""
 
-    desc: Optional[str] = None
+    desc: str | None = None
     """The description for the keyword"""
 
-    unit: Optional[str] = None
+    unit: str | None = None
     """The units of the value"""
 
     def __post_init__(self) -> None:
@@ -121,7 +122,7 @@ class Header:
         """Add the item (not checking for duplicates)."""
         self.values.append(item)
 
-    def get(self, name: str) -> Optional[HeaderItem]:
+    def get(self, name: str) -> HeaderItem | None:
         """Return the first occurrence of the key (case insensitive)."""
 
         uname = name.upper()
@@ -131,7 +132,7 @@ class Header:
 
         return None
 
-    def delete(self, name: str) -> Optional[HeaderItem]:
+    def delete(self, name: str) -> HeaderItem | None:
         """Remove the first occurrence of the key, if it exists (case insensitive)."""
 
         store = []
@@ -166,16 +167,16 @@ class Column:
     type.
     """
 
-    desc: Optional[str] = None
+    desc: str | None = None
     """The column description"""
 
-    unit: Optional[str] = None
+    unit: str | None = None
     """The units of the column"""
 
-    minval: Optional[Union[int, float]] = None
+    minval: int | float | None = None
     """The minimum value (corresponds to FITS TLMIN setting)."""
 
-    maxval: Optional[Union[int, float]] = None
+    maxval: int | float | None = None
     """The maximum value (corresponds to FITS TLMAX setting)."""
 
     def __post_init__(self) -> None:
@@ -236,7 +237,7 @@ class TableBlock(Block):
             if not isinstance(col, Column):
                 raise ValueError(f"Column {idx} is not a Column object in {self.name}")
 
-    def get(self, colname: str) -> Optional[Column]:
+    def get(self, colname: str) -> Column | None:
         """Return the column (case insensitive) if it exists."""
 
         uname = colname.upper()
@@ -361,14 +362,14 @@ class ImageBlock(Block):
     image: np.ndarray
     """The image data."""
 
-    sky: Optional[WCS] = None
+    sky: WCS | None = None
     """The WCS for the physical/sky coordinate system."""
 
-    eqpos: Optional[WCS] = None
+    eqpos: WCS | None = None
     """The WCS for the WCS coordinate system."""
 
 
-BlockType = Union[TableBlock, ImageBlock]
+BlockType = TableBlock | ImageBlock
 
 
 @dataclass
@@ -383,7 +384,7 @@ class BlockList:
     blocks: list[BlockType]
     """The data for the blocks."""
 
-    header: Optional[Header] = None
+    header: Header | None = None
     """An optional header.
 
     If set this is used to create the first block with no data.

--- a/sherpa/astro/io/xstable.py
+++ b/sherpa/astro/io/xstable.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2023, 2024
+#  Copyright (C) 2023 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -136,8 +136,6 @@ import time
 from typing import Optional, Sequence, Union
 
 import numpy as np
-
-import sherpa
 
 from .types import HeaderItem, Header, Column, TableBlock, BlockList
 

--- a/sherpa/astro/tests/test_astro.py
+++ b/sherpa/astro/tests/test_astro.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015 - 2021, 2023, 2024
+#  Copyright (C) 2007, 2015 - 2021, 2023 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -137,7 +137,7 @@ def test_pha_intro(parallel, run_thread, fix_xspec):
 @requires_fits
 def test_pha_read(run_thread):
     run_thread('pha_read')
-    assert type(ui.get_data()) == DataPHA
+    assert isinstance(ui.get_data(), DataPHA)
 
 
 @requires_data
@@ -619,7 +619,7 @@ def test_xmm2(run_thread, fix_xspec):
     # changed. We filter this out as it's not at all clear what is going
     # on and we have filters in conftest to remove similar warnings
     #
-    ws = [w for w in ws if not (w.category == RuntimeWarning and
+    ws = [w for w in ws if not (w.category is RuntimeWarning and
                                 str(w.message).startswith('numpy.ndarray size changed, may indicate binary incompatibility.'))]
     assert len(ws) == 2
     cats = set([w.category for w in ws])

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2017, 2018, 2020 - 2024
+#  Copyright (C) 2007, 2015, 2017, 2018, 2020 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -4213,8 +4213,8 @@ def test_get_ylabel_img(make_data_path, coord, axis):
 @requires_fits
 @pytest.mark.parametrize("coord", ["logical", "physical", "world"])
 @pytest.mark.parametrize("label", ["not a label", "", "Energy (keV)"])
-def test_set_xlabel_img(make_data_path, coord, label):
-    """get_xlabel for DataIMG"""
+def test_set_ylabel_img(make_data_path, coord, label):
+    """get_ylabel for DataIMG"""
 
     import sherpa.astro.io
     infile = make_data_path("acisf08478_000N001_r0043_regevt3_srcimg.fits")

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -6507,7 +6507,6 @@ def make_problem_rmf(filename: Path,
 
 
 @requires_fits
-@pytest.mark.xfail(is_crates_io, reason="tests known to fail with crates")
 @pytest.mark.parametrize("offset", [0, 1, 5])
 def test_problem_pha(tmp_path, offset):
     """Check we can read in the 'problem' FITS file"""

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -48,10 +48,8 @@ from sherpa.utils.testing import requires_data, requires_fits, \
 try:
     from sherpa.astro.io import backend
     is_crates_io = backend.name == "crates"
-    is_astropy_io = backend.name == "pyfits"
 except ImportError:
     is_crates_io = False
-    is_astropy_io = False
 
 
 def test_can_not_group_ungrouped():
@@ -6540,7 +6538,6 @@ def test_problem_pha(tmp_path, offset):
 
 
 @requires_fits
-@pytest.mark.xfail(is_astropy_io, reason="tests known to fail with AstroPy")
 # The test only passes with crates for offset=0 by "luck" (as the
 # string TLMIN value gets interpreted as 0 for whatever value is in
 # the string).  This really needs DM/Crates fixes and not something

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -6505,7 +6505,7 @@ def test_problem_pha(tmp_path, offset):
 
     assert pha.channel == pytest.approx(chans)
     assert pha.counts == pytest.approx(counts)
-    # convert bools to nitegers to please pytest 8.3.4
+    # convert bools to integers to please pytest 8.3.4
     assert pha.quality == pytest.approx(quals * 1)
     assert pha.staterror is None
     assert pha.syserror is None

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -62,7 +62,7 @@ def test_can_not_group_ungrouped():
         pha.grouped = True
 
 
-def test_pha_get_indep_when_all_filtered():
+def test_pha_get_indep_when_all_filtered_ignore():
     """Regression test."""
 
     pha = DataPHA("pha", [1, 2, 3], [9, 7, 8])
@@ -75,7 +75,7 @@ def test_pha_get_indep_when_all_filtered():
     assert indep[0] == pytest.approx([])
 
 
-def test_pha_get_indep_when_all_filtered():
+def test_pha_get_indep_when_all_filtered_manual():
     """Regression test."""
 
     pha = DataPHA("pha", [1, 2, 3], [9, 7, 8])
@@ -3010,26 +3010,8 @@ def test_361():
     assert pha.get_noticed_channels() == pytest.approx([3, 4, 7, 8])
 
 
-def test_grouped_pha_get_dep(make_grouped_pha):
-    """Quality filtering and grouping is applied: get_dep
-
-    As noted in issue #1438 it's not obvious what get_y is meant to
-    return. It is not the same as get_dep as there's post-processing.
-    So just test the current behavior.
-
-    """
-    pha = make_grouped_pha
-
-    # grouped counts are [3, 3, 12]
-    # channel widths are [3, 1, 1]
-    # which gives [1, 3, 12]
-    # but the last group is marked bad by quality,
-    # so we expect [1, 3]
-    #
-    assert pha.get_dep() == pytest.approx([1, 3])
-
-
-def test_grouped_pha_get_y(make_grouped_pha):
+@pytest.mark.parametrize("filter", [False, True])
+def test_grouped_pha_get_y(filter, make_grouped_pha):
     """Quality filtering and grouping is applied: get_y
 
     As noted in issue #1438 it's not obvious what get_y is meant to
@@ -3045,7 +3027,7 @@ def test_grouped_pha_get_y(make_grouped_pha):
     # but the last group is marked bad by quality,
     # so we expect [1, 3]
     #
-    assert pha.get_y() == pytest.approx([1, 3])
+    assert pha.get_y(filter=filter) == pytest.approx([1, 3])
 
 
 def test_quality_pha_get_dep(make_quality_pha):
@@ -5872,7 +5854,7 @@ def test_pha_delete_unknown_background(bkg_id):
     b2 = DataPHA("b2", [1, 2, 3], [1, 1, 1])
 
     pha.set_background(b1, id="up")
-    pha.set_background(b1, id="down")
+    pha.set_background(b2, id="down")
 
     # This is treated as a no-op
     pha.delete_background(bkg_id)

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -21,7 +21,10 @@
 """Continued testing of sherpa.astro.data."""
 
 import logging
+from pathlib import Path
 import pickle
+import struct
+from typing import Any
 import re
 import warnings
 
@@ -41,6 +44,14 @@ from sherpa.utils.err import DataErr
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, requires_fits, \
     requires_group, requires_region, requires_wcs
+
+try:
+    from sherpa.astro.io import backend
+    is_crates_io = backend.name == "crates"
+    is_astropy_io = backend.name == "pyfits"
+except ImportError:
+    is_crates_io = False
+    is_astropy_io = False
 
 
 def test_can_not_group_ungrouped():
@@ -6158,3 +6169,412 @@ def test_rmf_get_dep_complex():
     #
     y = rmf.get_dep()
     assert y == pytest.approx([0, 0.4, 1.8, 2.8, 0])
+
+
+# Some problems are "ephemeral" as a tool that creates the file gets
+# updated. So it is hard to add problematic files to the sherpa test
+# data area. Instead we can create them on the fly, which is not ideal
+# (hard-code the FITS creation) but does at least mean we can test
+# specfic problems.
+#
+def add_spacer(fh, size: int, binary=True) -> None:
+    "Fill up the header with blank characters"
+
+    chunksize = 2880
+    rem = size % chunksize
+    if rem == 0:
+        return
+
+    spacer = chunksize - rem
+    if binary:
+        out = b"\x00" * spacer
+        fh.write(out)
+    else:
+        out = " " * spacer
+        fh.write(out.encode())
+
+
+def add_header(fh,
+               header: list[tuple[str, Any]]
+               ) -> None:
+    chars = 0
+    for key, val in header:
+        assert len(key) < 9
+        out = f"{key.upper():8s}= "
+        # This is incomplete (e.g. no time value encoding)
+        if isinstance(val, str):
+            out += f"'{val:8s}'"
+        elif isinstance(val, bool):
+            # check before integer
+            val = 'T' if val else 'F'
+            out += f"{val:>20s}"
+        elif isinstance(val, (int, np.integer)):
+            out += f"{val:20d}"
+        elif isinstance(val, (float, np.floating)):
+            out += f"{val:20.13E}"
+        else:
+            raise RuntimeError(f"missing support for {type(val)}")
+
+        # note: no support for CONTINUE lines
+        fh.write(f"{out:80s}".encode())
+        chars += 80
+
+    fh.write(f"{'END':80s}".encode())
+    chars += 80
+
+    add_spacer(fh, chars, binary=False)
+
+
+def make_problem_pha(filename: Path,
+                     minchan: int
+                     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Create a basic PHA file with issues.
+
+    - issue #2185, TLMIN/MAX are strings
+    - QUALITY is a bool column (CIAO helpdesk)
+
+    Unfortunately the TLMIN check for DataPHA doesn't quite match the
+    RMF case that caused #2185, since the current code does not
+    actually do anything with the PHA TLMIN values.
+
+    """
+
+    primary = [("SIMPLE", True),
+               ("BITPIX", 16),
+               ("NAXIS", 0),
+               ("EXTEND", True),
+               ("HDUNAME", "PRIMARY")]
+
+    nrows = 5
+
+    chans = np.arange(nrows, dtype=np.int16) + minchan
+    counts = np.arange(nrows, dtype=np.int16)
+    quals = np.zeros(nrows, dtype=bool)
+    quals[-1] = True
+
+    # Use big-endian for data.
+    spectrum_fmt = ">ii?"
+    spectrum_size = struct.calcsize(spectrum_fmt)
+
+    spectrum = [("XTENSION", "BINTABLE"),
+                ("BITPIX", 8),
+                ("NAXIS", 2),
+                ("NAXIS1", spectrum_size),
+                ("NAXIS2", nrows),
+                ("PCOUNT", 0),
+                ("GCOUNT", 1),
+                ("TFIELDS", 3),
+                ("EXTNAME", "SPECTRUM"),
+                ("CONTENT", "PHA"),
+                ("HDUCLASS", "OGIP"),
+                ("HDUCLAS1", "SPECTRUM"),
+                ("HDUCLAS2", "TOTAL"),
+                ("HDUCLAS3", "TYPE:1"),
+                ("HDUCLAS4", "COUNT"),
+                ("CHANTYPE", "PI"),
+                ("DETCHANS", nrows),
+                ("MISSION", "MADEUP"),
+                ("TELESCOP", "NOTHING"),
+                ("INSTRUME", "SPECIAL"),
+                ("FILTER", "NONE"),
+                ("OBJECT", "Simulated data"),
+                ("EXPOSURE", 1000.0),
+                ("AREASCAL", 1.0),
+                ("CORRSCAL", 1.0),
+                ("BACKSCAL", 1.2e-5),
+                ("TOTCTS", counts.sum()),
+                ("POISSERR", True),
+                ("STAT_ERR", 0),
+                ("BACKFILE", "none"),
+                ("CORRFILE", "none"),
+                ("ANCRFILE", "none"),
+                ("RESPFILE", "none"),
+                ("TTYPE1", "CHANNEL"),
+                ("TFORM1", "1J"),
+                ("TLMIN1", str(minchan)),
+                ("TLMAX1", str(minchan + nrows - 1)),
+                ("TTYPE2", "COUNTS"),
+                ("TFORM2", "1J"),
+                ("TLMIN2", counts.min()),
+                ("TLMAX2", counts.max()),
+                ("TUNIT2", "count"),
+                ("TTYPE3", "QUALITY"),
+                ("TFORM3", "1B")
+                ]
+
+    with open(filename, mode="w+b") as fh:
+        add_header(fh, primary)
+        add_header(fh, spectrum)
+
+        size = 0
+        for chan, count, qual in zip(chans, counts, quals):
+            fh.write(struct.pack(spectrum_fmt, chan, count, qual))
+            size += spectrum_size
+
+        add_spacer(fh, size)
+
+    return chans, counts, quals
+
+
+def make_problem_rmf(filename: Path,
+                     minchan: int
+                     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Create a basic RMF file with issues.
+
+    - issue #2185, TLMIN/MAX are strings
+      ideally with a VLF array since make_problem_pha tests
+      the case of a normal column
+
+    Using a VLF column (actually, three, since we need the TLMIN check
+    on F_CHAN but N_CHAN needs to match it and this means that the
+    MATRIX column is also a VLF) means understanding how the FITS heap
+    works (an area after the normal data that is referenced for each
+    VLF column to store the actual data).
+
+    """
+
+    primary = [("SIMPLE", True),
+               ("BITPIX", 16),
+               ("NAXIS", 0),
+               ("EXTEND", True)]
+
+    nrows = 4
+
+    chans = np.arange(nrows, dtype=np.int16) + minchan
+    energ = np.linspace(0.1, 1.5, nrows + 1)
+    energ_lo = energ[:-1]
+    energ_hi = energ[1:]
+
+    # What are the f_chan, n_chan, and matrix values?
+    #
+    # This is simplified by having N_CHAN=1 for each element, which
+    # means the MATRIX matches F_CHAN/N_CHAN.
+    #
+    f_chans = [ [chans[0]],
+                [chans[1], chans[1] + 2],
+                [chans[2]],
+                [chans[3]]
+              ]
+    n_chans = [ [1], [1, 1], [1], [1] ]
+    matrixs = [ [1], [0.7, 0.3], [1], [1] ]
+
+    n_grps = [ len(nc) for nc in n_chans ]
+
+    # Columns 4 to 6 are two int 32 elements each (pointers into the
+    # heap).
+    matrix_fmt = ">ffhiiiiii"
+    matrix_size = struct.calcsize(matrix_fmt)
+
+    # We have three rows the same and one row with double the amount
+    # of data.
+    #
+    matrix_heap_fmt1 = ">hhf"
+    matrix_heap_fmt2 = ">hhhhff"
+    matrix_heap_size1 = struct.calcsize(matrix_heap_fmt1)
+    matrix_heap_size2 = struct.calcsize(matrix_heap_fmt2)
+    matrix_heap_size = 3 * matrix_heap_size1 + matrix_heap_size2
+
+    matrix = [("XTENSION", "BINTABLE"),
+              ("BITPIX", 8),
+              ("NAXIS", 2),
+              ("NAXIS1", matrix_size),
+              ("NAXIS2", nrows),
+              ("PCOUNT", matrix_heap_size),
+              ("GCOUNT", 1),
+              ("TFIELDS", 6),
+              ("EXTNAME", "MATRIX"),
+              ("HDUNAME", "MATRIX"),
+              ("HDUCLASS", "OGIP"),
+              ("HDUCLAS1", "RESPONSE"),
+              ("HDUCLAS2", "RSP_MATRIX"),
+              ("HDUCLAS3", "REDIST"),
+              ("HDUVERS", "1.3.0"),
+              ("CHANTYPE", "PI"),
+              ("DETCHANS", nrows),
+              ("MISSION", "MADEUP"),
+              ("TELESCOP", "NOTHING"),
+              ("INSTRUME", "SPECIAL"),
+              ("FILTER", "NONE"),
+              ("TTYPE1", "ENERG_LO"),
+              ("TFORM1", "1E"),
+              ("TUNIT1", "keV"),
+              ("TTYPE2", "ENERG_HI"),
+              ("TFORM2", "1E"),
+              ("TUNIT2", "keV"),
+              ("TTYPE3", "N_GRP"),
+              ("TFORM3", "1I"),
+              ("TTYPE4", "F_CHAN"),
+              ("TFORM4", "1PI(2)"),  # important that it thinks there may be multiple
+              ("TLMIN4", str(minchan)),
+              ("TLMAX4", str(minchan + nrows - 1)),
+              ("TTYPE5", "N_CHAN"),
+              ("TFORM5", "1PI(2)"),  # match F_CHAN
+              ("TTYPE6", "MATRIX"),
+              ("TFORM6", "1PE(2)")
+              ]
+
+    ebounds_fmt = ">hff"
+    ebounds_size = struct.calcsize(ebounds_fmt)
+
+    ebounds = [("XTENSION", "BINTABLE"),
+               ("BITPIX", 8),
+               ("NAXIS", 2),
+               ("NAXIS1", ebounds_size),
+               ("NAXIS2", nrows),
+               ("PCOUNT", 0),
+               ("GCOUNT", 1),
+               ("TFIELDS", 3),
+               ("EXTNAME", "EBOUNDS"),
+               ("HDUNAME", "EBOUNDS"),
+               ("HDUCLASS", "OGIP"),
+               ("HDUCLAS1", "RESPONSE"),
+               ("HDUCLAS2", "EBOUNDS"),
+               ("HDUCLAS3", "REDIST"),
+               ("HDUVERS", "1.3.0"),
+               ("CHANTYPE", "PI"),
+               ("DETCHANS", nrows),
+               ("MISSION", "MADEUP"),
+               ("TELESCOP", "NOTHING"),
+               ("INSTRUME", "SPECIAL"),
+               ("FILTER", "NONE"),
+               ("TTYPE1", "CHANNEL"),
+               ("TUNIT1", "channel"),
+               ("TFORM1", "1I"),
+               ("TLMIN1", str(minchan)),
+               ("TLMAX1", str(minchan + nrows - 1)),
+               ("TTYPE2", "E_MIN"),
+               ("TFORM2", "1E"),
+               ("TUNIT2", "keV"),
+               ("TTYPE3", "E_MAX"),
+               ("TFORM3", "1E"),
+               ("TUNIT3", "keV"),
+              ]
+
+    with open(filename, mode="w+b") as fh:
+        add_header(fh, primary)
+        add_header(fh, matrix)
+
+        # The heap is organized as
+        # - f_chan[0], n_chan[0], matrix[0]
+        # - f_chan[1][0], f_chan[1][1], n_chan[1][0], n_chan[1][1],
+        #   matrix[1][0], matrix[1][1]
+        # - f_chan[2], n_chan[2], matrix[2]
+        # - f_chan[3], n_chan[3], matrix[3]
+        #
+        size = 0
+        heap_size = 0
+        heap_int = struct.calcsize(">h")
+        for elo, ehi, ngrp in zip(energ_lo, energ_hi, n_grps):
+            if ngrp == 1:
+                fh.write(struct.pack(matrix_fmt, elo, ehi, 1,
+                                     1, heap_size,
+                                     1, heap_size + heap_int,
+                                     1, heap_size + 2 * heap_int))
+                heap_size += matrix_heap_size1
+
+            elif ngrp == 2:
+                fh.write(struct.pack(matrix_fmt, elo, ehi, 2,
+                                     2, heap_size,
+                                     2, heap_size + 2 * heap_int,
+                                     2, heap_size + 4 * heap_int))
+                heap_size += matrix_heap_size2
+
+            else:
+                raise RuntimeError("internal error")
+
+            size += matrix_size
+
+        # Add in the heap.
+        #
+        for fc, nc, mz in zip(f_chans, n_chans, matrixs):
+            for v in fc:
+                fh.write(struct.pack(">h", v))
+            for v in nc:
+                fh.write(struct.pack(">h", v))
+            for v in mz:
+                fh.write(struct.pack(">f", v))
+
+        size += matrix_heap_size
+        add_spacer(fh, size)
+        add_header(fh, ebounds)
+
+        size = 0
+        for elo, ehi, chan in zip(energ_lo, energ_hi, chans):
+            fh.write(struct.pack(ebounds_fmt, chan, elo, ehi))
+            size += ebounds_size
+
+        add_spacer(fh, size)
+
+    return chans, energ_lo, energ_hi
+
+
+@requires_fits
+@pytest.mark.xfail(is_crates_io, reason="tests known to fail with crates")
+@pytest.mark.parametrize("offset", [0, 1, 5])
+def test_problem_pha(tmp_path, offset):
+    """Check we can read in the 'problem' FITS file"""
+
+    from sherpa.astro.io import read_pha
+
+    outpath = tmp_path / 'tmp.pha'
+    chans, counts, quals = make_problem_pha(outpath, offset)
+
+    pha = read_pha(str(outpath))
+    assert isinstance(pha, DataPHA)
+
+    assert pha.channel[0] == offset
+
+    assert pha.channel == pytest.approx(chans)
+    assert pha.counts == pytest.approx(counts)
+    # convert bools to nitegers to please pytest 8.3.4
+    assert pha.quality == pytest.approx(quals * 1)
+    assert pha.staterror is None
+    assert pha.syserror is None
+
+    # It is not entirely clear how the channel offset and DETCHANS
+    # values are meant to interact, so just use this as a test of the
+    # current behaviour.
+    #
+    assert pha.exposure == pytest.approx(1000.0)
+    assert pha.header["DETCHANS"] == 5
+
+
+@requires_fits
+@pytest.mark.xfail(is_astropy_io, reason="tests known to fail with AstroPy")
+# The test only passes with crates for offset=0 by "luck" (as the
+# string TLMIN value gets interpreted as 0 for whatever value is in
+# the string).  This really needs DM/Crates fixes and not something
+# that can be handled by Sherpa.
+@pytest.mark.parametrize("offset", [0,
+                                    pytest.param(1, marks=pytest.mark.xfail(is_crates_io, reason="test known to fail with crates")),
+                                    pytest.param(5, marks=pytest.mark.xfail(is_crates_io, reason="test known to fail with crates"))
+                                    ])
+def test_problem_rmf(tmp_path, offset):
+    """Check we can read in the 'problem' FITS file"""
+
+    from sherpa.astro.io import read_rmf
+
+    outpath = tmp_path / 'tmp.rmf'
+    chans, energ_lo, energ_hi = make_problem_rmf(outpath, offset)
+
+    rmf = read_rmf(str(outpath))
+    assert isinstance(rmf, DataRMF)
+
+    # Ensure that the data respects the offset.
+    assert rmf.offset == offset
+    assert rmf.f_chan[0] == offset
+
+    assert rmf.detchans == 4
+
+    assert rmf.energ_lo == pytest.approx(energ_lo)
+    assert rmf.energ_hi == pytest.approx(energ_hi)
+    assert rmf.e_min == pytest.approx(energ_lo)
+    assert rmf.e_max == pytest.approx(energ_hi)
+
+    assert rmf.n_grp == pytest.approx([1, 2, 1, 1])
+    assert rmf.f_chan == pytest.approx([chans[0],
+                                        chans[1], chans[1] + 2,
+                                        chans[2],
+                                        chans[3]])
+    assert rmf.n_chan == pytest.approx([1, 1, 1, 1, 1])
+    assert rmf.matrix == pytest.approx([1, 0.7, 0.3, 1, 1])

--- a/sherpa/astro/tests/test_astro_data_asca_unit.py
+++ b/sherpa/astro/tests/test_astro_data_asca_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2024
+#  Copyright (C) 2024, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -34,7 +34,7 @@ import pytest
 from sherpa.astro.data import DataARF, DataPHA, DataRMF
 from sherpa.astro import io
 from sherpa.astro import ui
-from sherpa.utils.err import IdentifierErr, IOErr
+from sherpa.utils.err import IdentifierErr
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, requires_fits, requires_xspec
 

--- a/sherpa/astro/tests/test_astro_data_chandra_unit.py
+++ b/sherpa/astro/tests/test_astro_data_chandra_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2024
+#  Copyright (C) 2024, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -30,8 +30,6 @@ import pytest
 
 from sherpa.astro.data import DataARF, DataPHA, DataRMF
 from sherpa.astro import io
-from sherpa.astro import ui
-from sherpa.utils.err import IOErr
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, requires_fits
 

--- a/sherpa/astro/tests/test_astro_data_notebook.py
+++ b/sherpa/astro/tests/test_astro_data_notebook.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 - 2024
+# Copyright (C) 2020 - 2025
 # Smithsonian Astrophysical Observatory
 #
 #
@@ -29,7 +29,6 @@ import numpy as np
 import pytest
 
 from sherpa.astro import data
-from sherpa import plot
 from sherpa.astro.instrument import create_delta_rmf
 from sherpa.utils.testing import requires_data, requires_fits, \
     requires_region, requires_wcs
@@ -204,7 +203,7 @@ def test_rmf_real_bad_energy(make_data_path, all_plot_backends):
 
     expected = f"The minimum ENERG_LO in the RMF '{infile}' was 0 and has been replaced by 1e-10"
     assert len(ws) == 1
-    assert ws[0].category == UserWarning
+    assert ws[0].category is UserWarning
     assert str(ws[0].message) == expected
 
     d.name = 'test.rmf'

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -287,7 +287,7 @@ def validate_replacement_warning(ws, rtype, label):
 
     assert len(ws) == 1
     w = ws[0]
-    assert w.category == UserWarning
+    assert w.category is UserWarning
 
     emsg = f"The minimum ENERG_LO in the {rtype} '{label}' " + \
            f"was 0 and has been replaced by {EMIN}"

--- a/sherpa/astro/tests/test_astro_data_swift_unit.py
+++ b/sherpa/astro/tests/test_astro_data_swift_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2021, 2023, 2024
+#  Copyright (C) 2017, 2018, 2021, 2023 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -603,7 +603,7 @@ def test_1209_response(mode, make_data_path):
     #
     if "arf" in mode:
         infile = make_data_path(ARFFILE)
-        with warnings.catch_warnings(record=True) as ws:
+        with warnings.catch_warnings(record=True):
             warnings.simplefilter("ignore")
             arf = io.read_arf(infile)
 
@@ -611,7 +611,7 @@ def test_1209_response(mode, make_data_path):
 
     if "rmf" in mode:
         infile = make_data_path(RMFFILE)
-        with warnings.catch_warnings(record=True) as ws:
+        with warnings.catch_warnings(record=True):
             warnings.simplefilter("ignore")
             rmf = io.read_rmf(infile)
 

--- a/sherpa/astro/tests/test_astro_data_xmm_unit.py
+++ b/sherpa/astro/tests/test_astro_data_xmm_unit.py
@@ -33,7 +33,6 @@ import pytest
 from sherpa.astro.data import DataARF, DataPHA, DataRMF
 from sherpa.astro import io
 from sherpa.astro import ui
-from sherpa.utils.err import IOErr
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils.testing import requires_data, requires_fits, requires_xspec
 
@@ -372,7 +371,7 @@ def check_rmf_grating(rmf):
 
 def check_warning(ftype, fname, w):
 
-    assert w.category == UserWarning
+    assert w.category is UserWarning
 
     # Can use startswith/endswith but if there is an error then it is
     # harder to see the difference.

--- a/sherpa/astro/tests/test_astro_data_xmm_unit.py
+++ b/sherpa/astro/tests/test_astro_data_xmm_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2024
+#  Copyright (C) 2024, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -525,6 +525,7 @@ def test_roundtrip_rmf(make_data_path, tmp_path):
     with warnings.catch_warnings(record=True) as ws:
         rmf1 = io.read_rmf(infile)
 
+    # Check we get the message about ENERG_LO=0 being replaced.
     assert len(ws) == 1
 
     outpath = tmp_path / "test.rmf"
@@ -536,7 +537,8 @@ def test_roundtrip_rmf(make_data_path, tmp_path):
 
     check_rmf(rmf2)
 
-    assert len(ws2) == 1
+    # Check there's no message, since ENERG_LO > 0 now.
+    assert len(ws2) == 0
 
 
 @requires_data
@@ -600,7 +602,7 @@ def test_read_rmf_grating(make_data_path):
 
 @requires_data
 @requires_fits
-def test_roundtrip_rmf(make_data_path, tmp_path):
+def test_roundtrip_rmf_grating(make_data_path, tmp_path):
     """Can we write out a XMM grating RMF file and then read it back in?"""
 
     infile = make_data_path(RMFFILE_GRATING)

--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -59,7 +59,7 @@ def validate_zero_replacement(ws, rtype, label, ethresh):
 
     assert len(ws) == 1
     w = ws[0]
-    assert w.category == UserWarning
+    assert w.category is UserWarning
 
     emsg = f"The minimum ENERG_LO in the {rtype} '{label}' " + \
            f"was 0 and has been replaced by {ethresh}"
@@ -1364,7 +1364,7 @@ def test_rsp_multi_1_label(arfexp, phaexp):
     #   - why is there "((flat))" and not "(flat)" for apply_arf?
     #   - there are not enough closing brackets
     #
-    expname = f'MultiResponseSumModel(apply_rmf(apply_arf((flat))'
+    expname = 'MultiResponseSumModel(apply_rmf(apply_arf((flat))'
     if phaexp:
         expname = f"220.9 * {expname}"
 
@@ -1458,7 +1458,7 @@ def test_rsp_multi_2_label(analysis, arfexp, phaexp):
     #   - see test_rsp_multi_1_label
     #   - multiple responses are not handled particularly well
     #
-    expname = f'MultiResponseSumModel(apply_rmf(apply_arf((flat),apply_rmf(apply_arf((flat))'
+    expname = 'MultiResponseSumModel(apply_rmf(apply_arf((flat),apply_rmf(apply_arf((flat))'
     if phaexp:
         expname = f"220.9 * {expname}"
 

--- a/sherpa/astro/tests/test_astro_pha_scale.py
+++ b/sherpa/astro/tests/test_astro_pha_scale.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2020, 2021
+#  Copyright (C) 2017, 2018, 2020, 2021, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -48,13 +48,12 @@ import numpy as np
 
 import pytest
 
-from sherpa.astro.data import DataARF, DataPHA, DataRMF
+from sherpa.astro.data import DataPHA
 from sherpa.astro.instrument import ARFModelPHA, RMFModelPHA, RSPModelPHA, \
     create_arf, create_delta_rmf
 from sherpa.astro import io
 from sherpa.models.basic import Const1D, StepHi1D
 from sherpa.stats import Chi2DataVar, CStat
-from sherpa.utils.err import ArgumentErr, DataErr
 
 from sherpa.utils.testing import requires_data, requires_fits, requires_group
 

--- a/sherpa/astro/tests/test_astro_plot.py
+++ b/sherpa/astro/tests/test_astro_plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2018 - 2024
+#  Copyright (C) 2007, 2015, 2018 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -30,7 +30,7 @@ from sherpa.astro.data import DataARF, DataPHA
 from sherpa.astro.instrument import create_delta_rmf
 from sherpa.astro.plot import SourcePlot, ComponentSourcePlot, \
     DataPHAPlot, ModelPHAHistogram, ModelHistogram, OrderPlot, \
-    EnergyFluxHistogram, PhotonFluxHistogram, _check_hist_bins, \
+    _check_hist_bins, \
     BkgModelPHAHistogram, BkgModelHistogram, BkgDataPlot, \
     ComponentModelPlot, ARFPlot, RMFPlot
 from sherpa.astro import plot as aplot

--- a/sherpa/astro/tests/test_cache.py
+++ b/sherpa/astro/tests/test_cache.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2018, 2019, 2021, 2022, 2023
+#  Copyright (C) 2018-2019, 2021-2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -51,6 +51,11 @@ def test_ARFModelPHA(make_data_path, clean_astro_ui):
     ui.set_model(ui.xsphabs.abs1 * (ui.xsapec.bubble + ui.powlaw1d.p1))
     ui.set_xsabund('angr')
     ui.set_xsxsect('vern')
+
+    abs1 = ui.get_model_component("abs1")
+    bubble = ui.get_model_component("bubble")
+    p1 = ui.get_model_component("p1")
+
     abs1.nh = 0.163
     abs1.nh.freeze()
     p1.ampl = 0.017
@@ -221,6 +226,7 @@ def test_cache_copy(clean_astro_ui):
     ui.set_source(ui.const1d.mdl)
 
     # again not 1
+    mdl = ui.get_model_component("mdl")
     mdl.c0 = 8
 
     # Copy the values from the plot structures, since get_xxx_plot

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -667,39 +667,6 @@ def test_abund_change_file_subset(tmp_path):
 
 
 @requires_xspec
-def test_abund_change_file_subset(tmp_path):
-    """What happens if send in too-few elements?"""
-
-    from sherpa.astro import xspec
-
-    elems = {n: i * 0.1 for i, n in enumerate(ELEMENT_NAMES)
-             if i < 10}
-
-    tmpname = tmp_path / "abunds.xspec"
-    with open(tmpname, "w") as tfh:
-        for v in elems.values():
-            tfh.write(f"{v}\n")
-
-    oval = xspec.get_xsabund()
-    try:
-        xspec.set_xsabund(str(tmpname))
-
-        abund = xspec.get_xsabund()
-        out = {n: xspec.get_xsabund(n)
-               for n in ELEMENT_NAMES}
-
-    finally:
-        xspec.set_xsabund(oval)
-
-    assert abund == 'file'
-    for i, n in enumerate(ELEMENT_NAMES):
-        if i < 10:
-            assert out[n] == pytest.approx(elems[n])
-        else:
-            assert out[n] == pytest.approx(0)
-
-
-@requires_xspec
 def test_xset_change():
     """Can we change the xset setting.
     """


### PR DESCRIPTION
# Summary

Some OGIP products from missions occasionally do not follow the OGIP and FITS standards. Provide workarounds for two recent cases from NuSTAR and NICER (TLMIN/MAX values were recorded as a string, and a QUALITY array was stored as a boolean array). Fix #2185.

# Details

The first commit adds tests that show the problem. Rather than add files to the sherpa test data, we manually create the problematic files on the fly. This has the advantage of being able to be precise in showing the problems (e.g. the bits where the OGIP/FITS standards are not being followed) and avoids the need to deal with adding more files to the test data area. There's also the issue that (hopefully) these are "ephemeral" files - e.g. the code that created them has - or will be - updated to fix the issue.

As shown in the tests, both FITS backends fail when reading in these files, but in different ways.

The first fix is for #2185. This is only for the astropy backend because the crates behaviour is internal to the crates module (any attempt to get the tlmin/max values when encoded as a string returns 0, and there's no obvious way to work around this [*]). I did discuss whether AstroPy should work around this in https://github.com/astropy/astropy/issues/17254 but it's felt better to address this problem here.

The second fix is for the QUALITY is boolean issue, which came in from a CIAO helpdesk ticket from NICER data which had a file like the following, with `QUALITY` having a type of `Byte` rather than `Int2`:

```
% dmlist ni3013010109mpu7_sr3c50.pha cols
 
--------------------------------------------------------------------------------
Columns for Table Block SPECTRUM
--------------------------------------------------------------------------------
 
ColNo  Name                 Unit        Type             Range
   1   CHANNEL                           Int4           0:1500               Pulse Invarient (PI) Channel
   2   COUNTS               count        Int4           -                    Counts per channel
   3   SYS_ERR                           Real8          -Inf:+Inf            Fractional systematic error
   4   QUALITY                           Byte                                Spectrum quality flag (0=good)
   5   GROUPING                          Int2           -                    Spectrum bin grouping flag
```

This is okay for AstroPy, which returns a 1D array of np.uint8 values, but for some reason crates reads this data in and creates a 2D array of np.uint8 values, with shape (nrows, 1). So the fix is to manually convert such an array back to 1D. This should be okay because np.uint8 is not a native FITS type, so is only used for Bit/Byte columns, and so it should be safe for the crates backend to make this conversion (also, it should only be being used in cases where we expect 1D arrays).

The remaining four commits are code clean ups, mainly to the tests, and were based on `ruff check`. This is a combination of preemptive  future-proofing and avoiding duplicated test code:

- lint checks reported by `ruff check` which include:
 - remove unused module and symbol imports
 - use `is` rather than `==` for a type check (the alternative is to use `isinstance` but that is not always the correct choice so I want to limit the changes here)
 - be explicit about where some symbols are coming from (e.g. the ui "magic" that both creates a model instance and creates a symbol to represent the instance is something the linters and type checkers find hard to understand)
 - no point in using a f-string if the string contains no "{}" elements
- we can drop `Optional` and `Union` from the typing statements as we now have a minimum of Python 3.10
- we can import several symbols from `collections.abc` rather than `typing` (these changes require Python 3.9)

The duplicated test code is a mixture of

- genuine duplicates, so we can remove one of them
- accidental name shadowing, so we need to fix up one or both names
  - and then in one case fix a test (which had been shadowed so not run) which actually wasn't doing what it should have been doing
  - update a related test to add parametrization over a function argument 

Not all of these files are directly related to the code I needed to change to fix the bugs, but they are somewhat related (that is, they are in the sherpa/astro/ tree). We could move them out to a separate PR but I didn't think it worthwhile.

---

[*] for the problem case in #2185 the existing crates behaviour happens to be the correct one, but this is purely fortuitous....