### PR TITLE
REGION: test CXCDM region parser, when available

### DIFF
--- a/sherpa/astro/utils/src/_region.cc
+++ b/sherpa/astro/utils/src/_region.cc
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2009, 2016, 2020, 2021, 2022
+//  Copyright (C) 2009, 2016, 2020-2022, 2025
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -379,6 +379,18 @@ PyInit__region(void)
     Py_DECREF(&pyRegion_Type);
     Py_DECREF(m);
   }
+
+  // Add a symbol to indicate whether the module was built with the
+  // USE_CXCDM_PARSER macro set.
+  //
+  PyModule_AddIntConstant(m, "USE_CXCDM_PARSER",
+#ifdef USE_CXCDM_PARSER
+			  1
+#else
+			  0
+#endif
+			  );
+
   return m;
 
 }

--- a/sherpa/astro/utils/src/_region.cc
+++ b/sherpa/astro/utils/src/_region.cc
@@ -383,13 +383,11 @@ PyInit__region(void)
   // Add a symbol to indicate whether the module was built with the
   // USE_CXCDM_PARSER macro set.
   //
-  PyModule_AddIntConstant(m, "USE_CXCDM_PARSER",
 #ifdef USE_CXCDM_PARSER
-			  1
+  PyModule_AddIntConstant(m, "USE_CXCDM_PARSER", 1);
 #else
-			  0
+  PyModule_AddIntConstant(m, "USE_CXCDM_PARSER", 0);
 #endif
-			  );
 
   return m;
 


### PR DESCRIPTION
# Summary

Allow the region module to know how it was built (whether reading FITS binary region files is supported). This allows for improvements to the tests.

# Details

The region code allows binary region files to be read in, but ONLY if it was built with the `USE_CXCDM_PARSER` macro set. So we can add a test or two of this behaviour, but how does the test know what behaviour to expect? We could use a heuristic, such as "does this appear to be a CIAO build", but it is **MUCH** better to just encode the macro setting into the module so we can ask it. We do this with the new `sherpa.astro.utils._region.USE_CXCDM_PARSER` constant. It is 1 if it was set and 0 otherwise.

It appears that even though it was added with `PyModuke_AddIntConstant` you can actually change this value. I do not see the point in trying to deal with this as this is a highly-specialized variable which users should not know about.

I wanted this to make it more obvious I was doing the right thing in 

- #1948