### PR TITLE
drop "iterative fit method" in error-estimation screen output when not set

### DIFF
--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -504,7 +504,7 @@ class ErrorEstResults(NoNewAttributesAfterInit):
 
         out.append(f'Confidence Method     = {self.methodname}')
 
-        if self.iterfitname is not None or self.iterfitname != 'none':
+        if self.iterfitname is not None and self.iterfitname != 'none':
             out.append(f'Iterative Fit Method  = {self.iterfitname.capitalize()}')
 
         out.extend([f'Fitting Method        = {self.fitname}',

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2020 - 2024
+#  Copyright (C) 2017, 2018, 2020 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -666,7 +666,7 @@ def test_show_all_basic(clean_ui):
     assert expected == got
 
 
-def test_show_conf_basic(clean_ui):
+def test_show_conf_basic(clean_ui, check_str):
     """Set up a very basic data/model/fit"""
 
     ui.load_arrays(1, [1, 2, 4], [3, 5, 5])
@@ -676,21 +676,21 @@ def test_show_conf_basic(clean_ui):
 
     out = StringIO()
     ui.show_conf(outfile=out)
-    got = out.getvalue().split('\n')
+    got = out.getvalue()
 
-    assert len(got) == 12
-    assert got[0] == "Confidence:Dataset               = 1"
-    assert got[1] == "Confidence Method     = confidence"
-    assert got[2] == "Iterative Fit Method  = None"
-    assert got[3] == "Fitting Method        = levmar"
-    assert got[4] == "Statistic             = chi2gehrels"
-    assert got[5] == "confidence 1-sigma (68.2689%) bounds:"
-    assert got[6] == "   Param            Best-Fit  Lower Bound  Upper Bound"
-    assert got[7] == "   -----            --------  -----------  -----------"
-    assert got[8] == "   mdl.c0            4.19798     -1.85955      1.85955"
-    assert got[9] == ""
-    assert got[10] == ""
-    assert got[11] == ""
+    check_str(got,
+              ["Confidence:Dataset               = 1",
+               "Confidence Method     = confidence",
+               "Fitting Method        = levmar",
+               "Statistic             = chi2gehrels",
+               "confidence 1-sigma (68.2689%) bounds:",
+               "   Param            Best-Fit  Lower Bound  Upper Bound",
+               "   -----            --------  -----------  -----------",
+               "   mdl.c0            4.19798     -1.85955      1.85955",
+               "",
+               "",
+               ""
+               ])
 
 
 @pytest.mark.parametrize("string", [True, False])


### PR DESCRIPTION
# Summary

The screen output when calling an error-estimation routine like conf will no-longer return the iterative-fit method name when it is set to None.

# Details

This was found by a type checker (after some other changes, not included here). The "error" here is the check

    if val is not None or val != 'none':
        add-output including val.capitalize()

The type checker noted that a None value does not have a capitalize method (although technically it does). The change is to use "and" rather than "or" - which also makes it match the ErrorEstResults code match the FitResults code.

This then leads to a test failure, since we no-longer create the line

    Iterative Fit Method  = None

in the output.

This is technically a breaking change, since the output of UI commands like `conf()` will change, but it's hard to easily document this, and it is unlikely that most users would notice.

# Example

The `conf` call no-longer adds the line `Iterative Fit Method  = None`:

## CIAO 4.17

```
sherpa In [1]: load_arrays(1, [10, 20, 40, 70], [20, 25, 22, 23])

sherpa In [2]: set_source(scale1d.mdl)

sherpa In [3]: fit()
Dataset               = 1
Method                = levmar
Statistic             = chi2gehrels
Initial fit statistic = 54.5858
Final fit statistic   = 0.385061 at function evaluation 4
Data points           = 4
Degrees of freedom    = 3
Probability [Q-value] = 0.943311
Reduced statistic     = 0.128354
Change in statistic   = 54.2007
   mdl.c0         22.3837      +/- 2.90456     

sherpa In [4]: conf()
mdl.c0 lower bound:	-2.90456
mdl.c0 upper bound:	2.90456
Dataset               = 1
Confidence Method     = confidence
Iterative Fit Method  = None
Fitting Method        = levmar
Statistic             = chi2gehrels
confidence 1-sigma (68.2689%) bounds:
   Param            Best-Fit  Lower Bound  Upper Bound
   -----            --------  -----------  -----------
   mdl.c0            22.3837     -2.90456      2.90456

```

## this PR

```
>>> from sherpa import ui
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
>>> ui.load_arrays(1, [10, 20, 40, 70], [20, 25, 22, 23])
>>> ui.set_source(ui.scale1d.mdl)
>>> ui.fit()
Dataset               = 1
Method                = levmar
Statistic             = chi2gehrels
Initial fit statistic = 54.5858
Final fit statistic   = 0.385061 at function evaluation 4
Data points           = 4
Degrees of freedom    = 3
Probability [Q-value] = 0.943311
Reduced statistic     = 0.128354
Change in statistic   = 54.2007
   mdl.c0         22.3837      +/- 2.90456     
>>> ui.conf()
mdl.c0 lower bound:	-2.90456
mdl.c0 upper bound:	2.90456
Dataset               = 1
Confidence Method     = confidence
Fitting Method        = levmar
Statistic             = chi2gehrels
confidence 1-sigma (68.2689%) bounds:
   Param            Best-Fit  Lower Bound  Upper Bound
   -----            --------  -----------  -----------
   mdl.c0            22.3837     -2.90456      2.90456
>>> 
```

If we then add in an iterative-fit method we see the output:

```
>>> ui.set_iter_method("sigmarej")
>>> ui.fit()
Dataset               = 1
Iterative Fit Method  = Sigmarej
Method                = levmar
Statistic             = chi2gehrels
Initial fit statistic = 0.385061
Final fit statistic   = 0.385061 at function evaluation 2
Data points           = 4
Degrees of freedom    = 3
Probability [Q-value] = 0.943311
Reduced statistic     = 0.128354
Change in statistic   = 0
   mdl.c0         22.3837      +/- 2.90456     
>>> ui.conf()
mdl.c0 lower bound:	-2.90456
mdl.c0 upper bound:	2.90456
Dataset               = 1
Confidence Method     = confidence
Iterative Fit Method  = Sigmarej
Fitting Method        = levmar
Statistic             = chi2gehrels
confidence 1-sigma (68.2689%) bounds:
   Param            Best-Fit  Lower Bound  Upper Bound
   -----            --------  -----------  -----------
   mdl.c0            22.3837     -2.90456      2.90456
>>> 
```