### PR TITLE
Allow Sherpa to build against XSPEC 12.15.0

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -405,7 +405,7 @@ version then you can use four helper scripts:
    the compiled code (``sherpa/astro/xspec/src/_xspec.cc``) and
    Python (``sherpa/astro/xspec/__init__.py``). The Python code
    lacks documentation and some values either need adding (e.g.
-   the Sherpa version) or lnks checked and possibly updated (due
+   the Sherpa version) or links checked and possibly updated (due
    to the way that XSPEC models are documented). The compiled code
    can likely be ignored since `update_xspec_functions.py` should
    be all that is needed, but it is displayed as a safety check.

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -369,7 +369,7 @@ Checking against a previous XSPEC version
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you have a version of Sherpa compiled with a previous XSPEC
-version then you can use three helper scripts:
+version then you can use four helper scripts:
 
 #. ``scripts/check_xspec_update.py``
 
@@ -407,6 +407,12 @@ version then you can use three helper scripts:
    lacks documentation and some values either need adding (e.g.
    the Sherpa version) or lnks checked and possibly updated (due
    to the way that XSPEC models are documented).
+
+#. ``scripts/update_xspec_docs.py``
+
+   This will report the suggested contents for the
+   ``docs/model_classes/astro_xspec.rst`` given a ``model.dat`` file
+   from XSPEC.
 
 These routines are designed to simplify the process but are not
 guaranteed to handle all cases (as the model.dat file syntax is not
@@ -858,6 +864,10 @@ available.
       New models should be added to both the ``Classes`` rubric - sorted
       by addtive and then multiplicative models, using an alphabetical
       sorting - and to the appropriate ``inheritance-diagram`` rule.
+
+      The ``scripts/update_xspec_docs.py`` script will create the
+      contents of most of the file (from the ``.. rubric:: Classes``
+      line onwards).
 
 #. Documentation updates
 

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -345,7 +345,7 @@ Update the XSPEC bindings?
 --------------------------
 
 The :py:mod:`sherpa.astro.xspec` module currently supports
-:term:`XSPEC` versions 12.14.1, 12.14.0, 12.13.1, 12.13.0, 12.12.1,
+:term:`XSPEC` versions 12.15.0, 12.14.1, 12.14.0, 12.13.1, 12.13.0, 12.12.1,
 and 12.12.0.
 It may build against newer versions, but if it does it will not provide
 access to any new models in the release. The following sections of the
@@ -406,7 +406,9 @@ version then you can use four helper scripts:
    Python (``sherpa/astro/xspec/__init__.py``). The Python code
    lacks documentation and some values either need adding (e.g.
    the Sherpa version) or lnks checked and possibly updated (due
-   to the way that XSPEC models are documented).
+   to the way that XSPEC models are documented). The compiled code
+   can likely be ignored since `update_xspec_functions.py` should
+   be all that is needed, but it is displayed as a safety check.
 
 #. ``scripts/update_xspec_docs.py``
 

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -148,5 +148,5 @@ Glossary
        `models from XSPEC
        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html>`_.
 
-       Sherpa can be built to use XSPEC versions 12.14.1, 12.14.0,
-       12.13.1, 12.13.0, 12.12.1, and 12.12.0.
+       Sherpa can be built to use XSPEC versions 12.15.0, 12.14.1,
+       12.14.0, 12.13.1, 12.13.0, 12.12.1, and 12.12.0.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -239,7 +239,20 @@ by the actual path to the HEADAS installation, and the versions of
 the libraries - such as ``CCfits_2.6`` - may need to be changed to
 match the contents of the XSPEC installation.
 
-1. If the full XSPEC 12.14.1 system has been built then use::
+1. If the full XSPEC 12.15.0 system has been built then use::
+
+       with_xspec = True
+       xspec_version = 12.15.0
+       xspec_lib_dirs = $HEADAS/lib
+       xspec_include_dirs = $HEADAS/include
+       xspec_libraries = XSFunctions XSUtil XS hdsp_6.35
+       ccfits_libraries = CCfits_2.7
+       wcslib_libraries = wcs-8.3
+
+   where the version numbers were taken from version 6.35 of HEASOFT and
+   may need updating with a newer release.
+
+2. If the full XSPEC 12.14.1 system has been built then use::
 
        with_xspec = True
        xspec_version = 12.14.1
@@ -252,7 +265,7 @@ match the contents of the XSPEC installation.
    where the version numbers were taken from version 6.34 of HEASOFT and
    may need updating with a newer release.
 
-2. If the full XSPEC 12.14.0 system has been built then use::
+3. If the full XSPEC 12.14.0 system has been built then use::
 
        with_xspec = True
        xspec_version = 12.14.0
@@ -265,7 +278,7 @@ match the contents of the XSPEC installation.
    where the version numbers were taken from version 6.33.1 of HEASOFT and
    may need updating with a newer release.
 
-3. If the full XSPEC 12.13.1 system has been built then use::
+4. If the full XSPEC 12.13.1 system has been built then use::
 
        with_xspec = True
        xspec_version = 12.13.1
@@ -278,7 +291,7 @@ match the contents of the XSPEC installation.
    where the version numbers were taken from version 6.32 of HEASOFT and
    may need updating with a newer release.
 
-4. If the full XSPEC 12.13.0 system has been built then use::
+5. If the full XSPEC 12.13.0 system has been built then use::
 
        with_xspec = True
        xspec_version = 12.13.0
@@ -288,7 +301,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.6
        wcslib_libraries = wcs-7.7
 
-5. If the full XSPEC 12.12.1 system has been built then use::
+6. If the full XSPEC 12.12.1 system has been built then use::
 
        with_xspec = True
        xspec_version = 12.12.1
@@ -298,7 +311,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.6
        wcslib_libraries = wcs-7.7
 
-6. If the full XSPEC 12.12.0 system has been built then use::
+7. If the full XSPEC 12.12.0 system has been built then use::
 
        with_xspec = True
        xspec_version = 12.12.0
@@ -308,7 +321,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.6
        wcslib_libraries = wcs-7.3.1
 
-7. If the model-only build of XSPEC - created with the
+8. If the model-only build of XSPEC - created with the
    ``--enable-xs-models-only`` flag when building HEASOFT - has been
    installed, then the configuration is similar, but the library names
    may not need version numbers and locations, depending on how the
@@ -333,7 +346,7 @@ module, but a quick check of an installed version can be made with
 the following command::
 
     % python -c 'from sherpa.astro import xspec; print(xspec.get_xsversion())'
-    12.14.1
+    12.15.0
 
 Other options
 ^^^^^^^^^^^^^

--- a/docs/model_classes/astro_xspec.rst
+++ b/docs/model_classes/astro_xspec.rst
@@ -215,11 +215,13 @@ The sherpa.astro.xspec module
       XSsrcut
       XSsresc
       XSssa
+      XSsssed
       XSstep
       XSswind1
       XStapec
       XSthcomp
       XSuvred
+      XSvagauss
       XSvapec
       XSvarabs
       XSvashift
@@ -231,7 +233,9 @@ The sherpa.astro.xspec module
       XSvcph
       XSvequil
       XSvexpcheb6
+      XSvgabs
       XSvgadem
+      XSvgaussian
       XSvgnei
       XSvmcflow
       XSvmeka
@@ -274,6 +278,7 @@ The sherpa.astro.xspec module
       XSzcutoffpl
       XSzdust
       XSzedge
+      XSzgabs
       XSzgauss
       XSzhighect
       XSzigm
@@ -285,8 +290,11 @@ The sherpa.astro.xspec module
       XSzpowerlw
       XSzredden
       XSzsmdust
+      XSzvagauss
       XSzvarabs
       XSzvfeabs
+      XSzvgabs
+      XSzvgaussian
       XSzvphabs
       XSzwabs
       XSzwndabs
@@ -296,10 +304,10 @@ The sherpa.astro.xspec module
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: XSagauss XSagnsed XSagnslim XSapec XSbapec XSbbody XSbbodyrad XSbcempow XSbcheb6 XSbcie XSbcoolflow XSbcph XSbequil XSbexpcheb6 XSbexrav XSbexriv XSbgadem XSbgnei XSbkn2pow XSbknpower XSbmc XSbnei XSbnpshock XSbpshock XSbremss XSbrnei XSbsedov XSbsnapec XSbtapec XSbvapec XSbvcempow XSbvcheb6 XSbvcie XSbvcoolflow XSbvcph XSbvequil XSbvexpcheb6 XSbvgadem XSbvgnei XSbvnei XSbvnpshock XSbvpshock XSbvrnei XSbvsedov XSbvtapec XSbvvapec XSbvvcie XSbvvgadem XSbvvgnei XSbvvnei XSbvvnpshock XSbvvpshock XSbvvrnei XSbvvsedov XSbvvtapec XSbvvwdem XSbvwdem XSbwcycl XSbwdem XSc6mekl XSc6pmekl XSc6pvmkl XSc6vmekl XScarbatm XScemekl XScempow XScevmkl XScflow XScheb6 XScie XScompLS XScompPS XScompST XScompTT XScompbb XScompmag XScomptb XScompth XScoolflow XScph XScplinear XScutoffpl XSdisk XSdiskbb XSdiskir XSdiskline XSdiskm XSdisko XSdiskpbb XSdiskpn XSeebremss XSeplogpar XSeqpair XSeqtherm XSequil XSexpcheb6 XSexpdec XSezdiskbb XSgadem XSgaussian XSgnei XSgrad XSgrbcomp XSgrbjet XSgrbm XShatm XSjet XSkerrbb XSkerrd XSkerrdisk XSkyrline XSlaor XSlaor2 XSlogpar XSlorentz XSmeka XSmekal XSmkcflow XSnei XSnlapec XSnpshock XSnsa XSnsagrav XSnsatmos XSnsmax XSnsmaxg XSnsx XSnteea XSnthComp XSoptxagn XSoptxagnf XSpegpwrlw XSpexmon XSpexrav XSpexriv XSplcabs XSposm XSpowerlaw XSpshock XSqsosed XSraymond XSredge XSrefsch XSrnei XSsedov XSsirf XSslimbh XSsnapec XSsrcut XSsresc XSssa XSstep XStapec XSvapec XSvbremss XSvcempow XSvcheb6 XSvcie XSvcoolflow XSvcph XSvequil XSvexpcheb6 XSvgadem XSvgnei XSvmcflow XSvmeka XSvmekal XSvnei XSvnpshock XSvoigt XSvpshock XSvraymond XSvrnei XSvsedov XSvtapec XSvvapec XSvvcie XSvvgadem XSvvgnei XSvvnei XSvvnpshock XSvvpshock XSvvrnei XSvvsedov XSvvtapec XSvvwdem XSvwdem XSwdem XSzagauss XSzbbody XSzbknpower XSzbremss XSzcutoffpl XSzgauss XSzkerrbb XSzlogpar XSzpowerlw
+.. inheritance-diagram:: XSagauss XSagnsed XSagnslim XSapec XSbapec XSbbody XSbbodyrad XSbcempow XSbcheb6 XSbcie XSbcoolflow XSbcph XSbequil XSbexpcheb6 XSbexrav XSbexriv XSbgadem XSbgnei XSbkn2pow XSbknpower XSbmc XSbnei XSbnpshock XSbpshock XSbremss XSbrnei XSbsedov XSbsnapec XSbtapec XSbvapec XSbvcempow XSbvcheb6 XSbvcie XSbvcoolflow XSbvcph XSbvequil XSbvexpcheb6 XSbvgadem XSbvgnei XSbvnei XSbvnpshock XSbvpshock XSbvrnei XSbvsedov XSbvtapec XSbvvapec XSbvvcie XSbvvgadem XSbvvgnei XSbvvnei XSbvvnpshock XSbvvpshock XSbvvrnei XSbvvsedov XSbvvtapec XSbvvwdem XSbvwdem XSbwcycl XSbwdem XSc6mekl XSc6pmekl XSc6pvmkl XSc6vmekl XScarbatm XScemekl XScempow XScevmkl XScflow XScheb6 XScie XScompLS XScompPS XScompST XScompTT XScompbb XScompmag XScomptb XScompth XScoolflow XScph XScplinear XScutoffpl XSdisk XSdiskbb XSdiskir XSdiskline XSdiskm XSdisko XSdiskpbb XSdiskpn XSeebremss XSeplogpar XSeqpair XSeqtherm XSequil XSexpcheb6 XSexpdec XSezdiskbb XSgadem XSgaussian XSgnei XSgrad XSgrbcomp XSgrbjet XSgrbm XShatm XSjet XSkerrbb XSkerrd XSkerrdisk XSkyrline XSlaor XSlaor2 XSlogpar XSlorentz XSmeka XSmekal XSmkcflow XSnei XSnlapec XSnpshock XSnsa XSnsagrav XSnsatmos XSnsmax XSnsmaxg XSnsx XSnteea XSnthComp XSoptxagn XSoptxagnf XSpegpwrlw XSpexmon XSpexrav XSpexriv XSplcabs XSposm XSpowerlaw XSpshock XSqsosed XSraymond XSredge XSrefsch XSrnei XSsedov XSsirf XSslimbh XSsnapec XSsrcut XSsresc XSssa XSsssed XSstep XStapec XSvagauss XSvapec XSvbremss XSvcempow XSvcheb6 XSvcie XSvcoolflow XSvcph XSvequil XSvexpcheb6 XSvgadem XSvgaussian XSvgnei XSvmcflow XSvmeka XSvmekal XSvnei XSvnpshock XSvoigt XSvpshock XSvraymond XSvrnei XSvsedov XSvtapec XSvvapec XSvvcie XSvvgadem XSvvgnei XSvvnei XSvvnpshock XSvvpshock XSvvrnei XSvvsedov XSvvtapec XSvvwdem XSvwdem XSwdem XSzagauss XSzbbody XSzbknpower XSzbremss XSzcutoffpl XSzgauss XSzkerrbb XSzlogpar XSzpowerlw XSzvagauss XSzvgaussian
    :parts: 1
 
-.. inheritance-diagram:: XSSSS_ice XSTBabs XSTBfeo XSTBgas XSTBgrain XSTBpcf XSTBrel XSTBvarabs XSabsori XSacisabs XScabs XSconstant XScyclabs XSdust XSedge XSexpabs XSexpfac XSgabs XSheilin XShighecut XShrefl XSismabs XSismdust XSlog10con XSlogconst XSlyman XSnotch XSolivineabs XSpcfabs XSphabs XSplabs XSpwab XSredden XSsmedge XSspexpcut XSspline XSswind1 XSuvred XSvarabs XSvphabs XSwabs XSwndabs XSxion XSxscat XSzTBabs XSzbabs XSzdust XSzedge XSzhighect XSzigm XSzpcfabs XSzphabs XSzredden XSzsmdust XSzvarabs XSzvfeabs XSzvphabs XSzwabs XSzwndabs XSzxipab XSzxipcf
+.. inheritance-diagram:: XSSSS_ice XSTBabs XSTBfeo XSTBgas XSTBgrain XSTBpcf XSTBrel XSTBvarabs XSabsori XSacisabs XScabs XSconstant XScyclabs XSdust XSedge XSexpabs XSexpfac XSgabs XSheilin XShighecut XShrefl XSismabs XSismdust XSlog10con XSlogconst XSlyman XSnotch XSolivineabs XSpcfabs XSphabs XSplabs XSpwab XSredden XSsmedge XSspexpcut XSspline XSswind1 XSuvred XSvarabs XSvgabs XSvphabs XSwabs XSwndabs XSxion XSxscat XSzTBabs XSzbabs XSzdust XSzedge XSzgabs XSzhighect XSzigm XSzpcfabs XSzphabs XSzredden XSzsmdust XSzvarabs XSzvfeabs XSzvgabs XSzvphabs XSzwabs XSzwndabs XSzxipab XSzxipcf
    :parts: 1
 
 .. inheritance-diagram:: XScflux XScglumin XSclumin XScpflux XSgsmooth XSireflect XSkdblur XSkdblur2 XSkerrconv XSkyconv XSlsmooth XSpartcov XSrdblur XSreflect XSrfxconv XSrgsxsrc XSsimpl XSthcomp XSvashift XSvmshift XSxilconv XSzashift XSzmshift

--- a/docs/model_classes/astro_xspec.rst
+++ b/docs/model_classes/astro_xspec.rst
@@ -130,6 +130,7 @@ The sherpa.astro.xspec module
       XSexpdec
       XSexpfac
       XSezdiskbb
+      XSfeklor
       XSgabs
       XSgadem
       XSgaussian
@@ -160,6 +161,7 @@ The sherpa.astro.xspec module
       XSlog10con
       XSlogconst
       XSlogpar
+      XSlorabs
       XSlorentz
       XSlsmooth
       XSlyman
@@ -202,6 +204,7 @@ The sherpa.astro.xspec module
       XSreflect
       XSrefsch
       XSrfxconv
+      XSrgsext
       XSrgsxsrc
       XSrnei
       XSsedov
@@ -237,6 +240,8 @@ The sherpa.astro.xspec module
       XSvgadem
       XSvgaussian
       XSvgnei
+      XSvlorabs
+      XSvlorentz
       XSvmcflow
       XSvmeka
       XSvmekal
@@ -244,6 +249,7 @@ The sherpa.astro.xspec module
       XSvnei
       XSvnpshock
       XSvoigt
+      XSvoigtabs
       XSvphabs
       XSvpshock
       XSvraymond
@@ -256,6 +262,8 @@ The sherpa.astro.xspec module
       XSvvgnei
       XSvvnei
       XSvvnpshock
+      XSvvoigt
+      XSvvoigtabs
       XSvvpshock
       XSvvrnei
       XSvvsedov
@@ -278,12 +286,15 @@ The sherpa.astro.xspec module
       XSzcutoffpl
       XSzdust
       XSzedge
+      XSzfeklor
       XSzgabs
       XSzgauss
       XSzhighect
       XSzigm
       XSzkerrbb
       XSzlogpar
+      XSzlorabs
+      XSzlorentz
       XSzmshift
       XSzpcfabs
       XSzphabs
@@ -295,7 +306,13 @@ The sherpa.astro.xspec module
       XSzvfeabs
       XSzvgabs
       XSzvgaussian
+      XSzvlorabs
+      XSzvlorentz
+      XSzvoigt
+      XSzvoigtabs
       XSzvphabs
+      XSzvvoigt
+      XSzvvoigtabs
       XSzwabs
       XSzwndabs
       XSzxipab
@@ -304,11 +321,11 @@ The sherpa.astro.xspec module
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: XSagauss XSagnsed XSagnslim XSapec XSbapec XSbbody XSbbodyrad XSbcempow XSbcheb6 XSbcie XSbcoolflow XSbcph XSbequil XSbexpcheb6 XSbexrav XSbexriv XSbgadem XSbgnei XSbkn2pow XSbknpower XSbmc XSbnei XSbnpshock XSbpshock XSbremss XSbrnei XSbsedov XSbsnapec XSbtapec XSbvapec XSbvcempow XSbvcheb6 XSbvcie XSbvcoolflow XSbvcph XSbvequil XSbvexpcheb6 XSbvgadem XSbvgnei XSbvnei XSbvnpshock XSbvpshock XSbvrnei XSbvsedov XSbvtapec XSbvvapec XSbvvcie XSbvvgadem XSbvvgnei XSbvvnei XSbvvnpshock XSbvvpshock XSbvvrnei XSbvvsedov XSbvvtapec XSbvvwdem XSbvwdem XSbwcycl XSbwdem XSc6mekl XSc6pmekl XSc6pvmkl XSc6vmekl XScarbatm XScemekl XScempow XScevmkl XScflow XScheb6 XScie XScompLS XScompPS XScompST XScompTT XScompbb XScompmag XScomptb XScompth XScoolflow XScph XScplinear XScutoffpl XSdisk XSdiskbb XSdiskir XSdiskline XSdiskm XSdisko XSdiskpbb XSdiskpn XSeebremss XSeplogpar XSeqpair XSeqtherm XSequil XSexpcheb6 XSexpdec XSezdiskbb XSgadem XSgaussian XSgnei XSgrad XSgrbcomp XSgrbjet XSgrbm XShatm XSjet XSkerrbb XSkerrd XSkerrdisk XSkyrline XSlaor XSlaor2 XSlogpar XSlorentz XSmeka XSmekal XSmkcflow XSnei XSnlapec XSnpshock XSnsa XSnsagrav XSnsatmos XSnsmax XSnsmaxg XSnsx XSnteea XSnthComp XSoptxagn XSoptxagnf XSpegpwrlw XSpexmon XSpexrav XSpexriv XSplcabs XSposm XSpowerlaw XSpshock XSqsosed XSraymond XSredge XSrefsch XSrnei XSsedov XSsirf XSslimbh XSsnapec XSsrcut XSsresc XSssa XSsssed XSstep XStapec XSvagauss XSvapec XSvbremss XSvcempow XSvcheb6 XSvcie XSvcoolflow XSvcph XSvequil XSvexpcheb6 XSvgadem XSvgaussian XSvgnei XSvmcflow XSvmeka XSvmekal XSvnei XSvnpshock XSvoigt XSvpshock XSvraymond XSvrnei XSvsedov XSvtapec XSvvapec XSvvcie XSvvgadem XSvvgnei XSvvnei XSvvnpshock XSvvpshock XSvvrnei XSvvsedov XSvvtapec XSvvwdem XSvwdem XSwdem XSzagauss XSzbbody XSzbknpower XSzbremss XSzcutoffpl XSzgauss XSzkerrbb XSzlogpar XSzpowerlw XSzvagauss XSzvgaussian
+.. inheritance-diagram:: XSagauss XSagnsed XSagnslim XSapec XSbapec XSbbody XSbbodyrad XSbcempow XSbcheb6 XSbcie XSbcoolflow XSbcph XSbequil XSbexpcheb6 XSbexrav XSbexriv XSbgadem XSbgnei XSbkn2pow XSbknpower XSbmc XSbnei XSbnpshock XSbpshock XSbremss XSbrnei XSbsedov XSbsnapec XSbtapec XSbvapec XSbvcempow XSbvcheb6 XSbvcie XSbvcoolflow XSbvcph XSbvequil XSbvexpcheb6 XSbvgadem XSbvgnei XSbvnei XSbvnpshock XSbvpshock XSbvrnei XSbvsedov XSbvtapec XSbvvapec XSbvvcie XSbvvgadem XSbvvgnei XSbvvnei XSbvvnpshock XSbvvpshock XSbvvrnei XSbvvsedov XSbvvtapec XSbvvwdem XSbvwdem XSbwcycl XSbwdem XSc6mekl XSc6pmekl XSc6pvmkl XSc6vmekl XScarbatm XScemekl XScempow XScevmkl XScflow XScheb6 XScie XScompLS XScompPS XScompST XScompTT XScompbb XScompmag XScomptb XScompth XScoolflow XScph XScplinear XScutoffpl XSdisk XSdiskbb XSdiskir XSdiskline XSdiskm XSdisko XSdiskpbb XSdiskpn XSeebremss XSeplogpar XSeqpair XSeqtherm XSequil XSexpcheb6 XSexpdec XSezdiskbb XSfeklor XSgadem XSgaussian XSgnei XSgrad XSgrbcomp XSgrbjet XSgrbm XShatm XSjet XSkerrbb XSkerrd XSkerrdisk XSkyrline XSlaor XSlaor2 XSlogpar XSlorentz XSmeka XSmekal XSmkcflow XSnei XSnlapec XSnpshock XSnsa XSnsagrav XSnsatmos XSnsmax XSnsmaxg XSnsx XSnteea XSnthComp XSoptxagn XSoptxagnf XSpegpwrlw XSpexmon XSpexrav XSpexriv XSplcabs XSposm XSpowerlaw XSpshock XSqsosed XSraymond XSredge XSrefsch XSrnei XSsedov XSsirf XSslimbh XSsnapec XSsrcut XSsresc XSssa XSsssed XSstep XStapec XSvagauss XSvapec XSvbremss XSvcempow XSvcheb6 XSvcie XSvcoolflow XSvcph XSvequil XSvexpcheb6 XSvgadem XSvgaussian XSvgnei XSvlorentz XSvmcflow XSvmeka XSvmekal XSvnei XSvnpshock XSvoigt XSvpshock XSvraymond XSvrnei XSvsedov XSvtapec XSvvapec XSvvcie XSvvgadem XSvvgnei XSvvnei XSvvnpshock XSvvoigt XSvvpshock XSvvrnei XSvvsedov XSvvtapec XSvvwdem XSvwdem XSwdem XSzagauss XSzbbody XSzbknpower XSzbremss XSzcutoffpl XSzfeklor XSzgauss XSzkerrbb XSzlogpar XSzlorentz XSzpowerlw XSzvagauss XSzvgaussian XSzvlorentz XSzvoigt XSzvvoigt
    :parts: 1
 
-.. inheritance-diagram:: XSSSS_ice XSTBabs XSTBfeo XSTBgas XSTBgrain XSTBpcf XSTBrel XSTBvarabs XSabsori XSacisabs XScabs XSconstant XScyclabs XSdust XSedge XSexpabs XSexpfac XSgabs XSheilin XShighecut XShrefl XSismabs XSismdust XSlog10con XSlogconst XSlyman XSnotch XSolivineabs XSpcfabs XSphabs XSplabs XSpwab XSredden XSsmedge XSspexpcut XSspline XSswind1 XSuvred XSvarabs XSvgabs XSvphabs XSwabs XSwndabs XSxion XSxscat XSzTBabs XSzbabs XSzdust XSzedge XSzgabs XSzhighect XSzigm XSzpcfabs XSzphabs XSzredden XSzsmdust XSzvarabs XSzvfeabs XSzvgabs XSzvphabs XSzwabs XSzwndabs XSzxipab XSzxipcf
+.. inheritance-diagram:: XSSSS_ice XSTBabs XSTBfeo XSTBgas XSTBgrain XSTBpcf XSTBrel XSTBvarabs XSabsori XSacisabs XScabs XSconstant XScyclabs XSdust XSedge XSexpabs XSexpfac XSgabs XSheilin XShighecut XShrefl XSismabs XSismdust XSlog10con XSlogconst XSlorabs XSlyman XSnotch XSolivineabs XSpcfabs XSphabs XSplabs XSpwab XSredden XSsmedge XSspexpcut XSspline XSswind1 XSuvred XSvarabs XSvgabs XSvlorabs XSvoigtabs XSvphabs XSvvoigtabs XSwabs XSwndabs XSxion XSxscat XSzTBabs XSzbabs XSzdust XSzedge XSzgabs XSzhighect XSzigm XSzlorabs XSzpcfabs XSzphabs XSzredden XSzsmdust XSzvarabs XSzvfeabs XSzvgabs XSzvlorabs XSzvoigtabs XSzvphabs XSzvvoigtabs XSzwabs XSzwndabs XSzxipab XSzxipcf
    :parts: 1
 
-.. inheritance-diagram:: XScflux XScglumin XSclumin XScpflux XSgsmooth XSireflect XSkdblur XSkdblur2 XSkerrconv XSkyconv XSlsmooth XSpartcov XSrdblur XSreflect XSrfxconv XSrgsxsrc XSsimpl XSthcomp XSvashift XSvmshift XSxilconv XSzashift XSzmshift
+.. inheritance-diagram:: XScflux XScglumin XSclumin XScpflux XSgsmooth XSireflect XSkdblur XSkdblur2 XSkerrconv XSkyconv XSlsmooth XSpartcov XSrdblur XSreflect XSrfxconv XSrgsext XSrgsxsrc XSsimpl XSthcomp XSvashift XSvmshift XSxilconv XSzashift XSzmshift
    :parts: 1

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -30,7 +30,8 @@ from .extensions import build_ext
 #
 SUPPORTED_VERSIONS = [(12, 12, 0), (12, 12, 1),
                       (12, 13, 0), (12, 13, 1),
-                      (12, 14, 0), (12, 14, 1)]
+                      (12, 14, 0), (12, 14, 1),
+                      (12, 15, 0)]
 
 
 # We could use packaging.versions.Version here, but for our needs we

--- a/scripts/update_xspec_docs.py
+++ b/scripts/update_xspec_docs.py
@@ -122,8 +122,8 @@ if __name__ == "__main__":
         sys.stderr.write(f"Usage: {sys.argv[0]} infile\n")
         sys.exit(1)
 
-    # The script coud instead process sherpa/astro/xspec/__init__.py
-    # but let's indicate what we expect.
+    # The script could instead process sherpa/astro/xspec/__init__.py
+    # but it is better to be explicit here.
     #
     mdefs = xspec.parse_xspec_model_description(sys.argv[1])
     report_docs(mdefs)

--- a/scripts/update_xspec_docs.py
+++ b/scripts/update_xspec_docs.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+
+#
+#  Copyright (C) 2025
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Usage:
+
+  ./update_xspec_docs.py infile
+
+Aim:
+
+Display updated contents for parts of the
+
+    docs/model_classes/astro_xspec.rst
+
+file. The input file is the model.dat file.
+
+"""
+
+import sys
+
+from sherpa.astro.utils import xspec
+
+
+def restrict_models(models: list[xspec.ModelDefinition]
+                    ) -> list[xspec.ModelDefinition]:
+    """What models do we support?"""
+
+    out = []
+    for model in models:
+        if not isinstance(model, (xspec.AddModelDefinition,
+                                  xspec.MulModelDefinition,
+                                  xspec.ConModelDefinition)):
+            continue
+
+        try:
+            if model.flags[1] == 1:
+                # drop per-spectrum models
+                continue
+
+        except:
+            pass
+
+        out.append(model)
+
+    assert len(out) > 0, "What happened to the models?"
+    return out
+
+
+def report_classes(models: list[xspec.ModelDefinition]) -> None:
+    """List the classes"""
+
+    def p1(x):
+        print(f"   {x}")
+
+    def p2(x):
+        print(f"      {x}")
+
+
+    p1(".. rubric:: Classes")
+    print()
+    p1(".. autosummary::")
+    p2(":toctree: api")
+    print()
+
+    names = [m.name for m in models]
+
+    for name in sorted(names):
+        p2(f"XS{name}")
+
+    print("")
+
+
+def report_inheritance(models: list[xspec.ModelDefinition],
+                       cls: xspec.ModelDefinition
+                       ) -> None:
+    """List the inheritance-diagram line for these models."""
+
+    wanted = [m.name for m in models if isinstance(m, cls)]
+    names = sorted(wanted)
+    diagram = " ".join([f"XS{n}" for n in names])
+
+    print("")
+    print(f".. inheritance-diagram:: {diagram}")
+    print("   :parts: 1")
+
+
+def report_docs(models: list[xspec.ModelDefinition]) -> None:
+    """Given the list of models, what should the docs say?"""
+
+    wanted = restrict_models(models)
+    report_classes(wanted)
+
+    print("Class Inheritance Diagram")
+    print("=========================")
+
+    report_inheritance(wanted, xspec.AddModelDefinition)
+    report_inheritance(wanted, xspec.MulModelDefinition)
+    report_inheritance(wanted, xspec.ConModelDefinition)
+
+
+if __name__ == "__main__":
+
+    if len(sys.argv) != 2:
+        sys.stderr.write(f"Usage: {sys.argv[0]} infile\n")
+        sys.exit(1)
+
+    # The script coud instead process sherpa/astro/xspec/__init__.py
+    # but let's indicate what we expect.
+    #
+    mdefs = xspec.parse_xspec_model_description(sys.argv[1])
+    report_docs(mdefs)

--- a/scripts/update_xspec_functions.py
+++ b/scripts/update_xspec_functions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-#  Copyright (C) 2024
+#  Copyright (C) 2024, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -22,7 +22,7 @@
 
 """Usage:
 
-  ./update_spec_functions.py infile
+  ./update_spec_functions.py version infile
 
 Aim:
 
@@ -36,68 +36,450 @@ This code should be placed in _xspec.cc between the
 
   // End model definitions
 
-marks but please note that you will need to add back in the
+marks. To try and support old versions the script takes the current
+_xspec.cc file and uses that as a basis for this section, so that
+existing version checks will remain, but this is only meant as a
+starting point, so check the output.
 
-    #ifdef XSPEC_x_y_x
-    #else
-    #endif
-
-lines as there's no way to identify them (i.e. add them automatically)
-from just a single model.dat file.
+The XSPEC version should be given in dotted form - e.g. 12.15.0 - and
+without any patch level.
 
 """
 
-from typing import Optional
+from importlib import resources
+from pathlib import Path
 import sys
+from typing import Literal
 
 from sherpa.astro.utils import xspec
 
 
-def report_model_definitions(models: list[xspec.ModelDefinition]) -> None:
-    """Print to stdout the code needed to bind to the models."""
+# Should really provide better typing
+ModelName = str
+ModelDefinition = str
 
-    prev = None
+# A version can be major, minor, micro or, to support '#else' lines,
+# the string "older", but that's only for the "state" handling.
+#
+Version = tuple[int, int, int]
+StateVersion = Version | Literal["older"]
+
+State = tuple[ModelName, ModelDefinition, StateVersion | None] | None
+
+# Store a set of #ifdef...#else lines by
+# - a dictionary where the key is each "#" line and the
+#   values are the lines guarded by that check
+# - a checksum value which just gives a combination of
+#   all the "#.." lines so we can easily look for
+#   a compatible set of lines.
+#
+Checksum = str
+Storage = tuple[dict[str, list[str]], Checksum]
+
+NO_CHECKSUM: Checksum = "<none>"
+
+START_MACRO = "// Start model definitions"
+END_MACRO = "// End model definitions"
+
+
+def convert_version(smajor: str, sminor: str, smicro: str) -> Version:
+    """Convert version tuple"""
+
+    try:
+        major = int(smajor)
+        minor = int(sminor)
+        micro = int(smicro)
+    except ValueError as ve:
+        raise ValueError(f"version={smajor}/{sminor}/{smicro} elements must be integers") from ve
+
+    return major, minor, micro
+
+
+def parse_version(ver: str) -> Version:
+    """Convert version to its components."""
+
+    match ver.split("."):
+        case [smajor, sminor, smicro]:
+            return convert_version(smajor, sminor, smicro)
+
+        case _:
+            raise ValueError(f"version={ver} should match 'X.Y.Z'")
+
+
+def grab_version(inline: str) -> Version:
+    """Given an #ifdef/#else line, grab the version"""
+
+    toks = inline.split()
+    if len(toks) != 2:
+        raise ValueError(f"Expected two tokens in '{inline}'")
+
+    if not toks[1].startswith("XSPEC_"):
+        raise ValueError(f"Expected XSPEC_X_Y_Z in '{inline}'")
+
+    version = toks[1][6:]
+    match version.split("_"):
+        case [smajor, sminor, smicro]:
+            return convert_version(smajor, sminor, smicro)
+
+        case _:
+            raise ValueError(f"version={toks[1]} should match 'XSPEC_X_Y_Z'")
+
+
+def make_xspec_macro(version: Version) -> str:
+    """Create the XSPEC macro for this version."""
+    return "XSPEC_{0}_{1}_{2}".format(*version)
+
+
+def find_file() -> Path:
+    """Find the _xspec.cc file"""
+
+    basepath = Path("sherpa") / "astro" / "xspec" / "src" / "_xspec.cc"
+
+    # Is this run from the base directory?
+    if basepath.exists():
+        return basepath
+
+    # Is it run from scripts?
+    inpath = Path("..") / basepath
+    if inpath.exists():
+        return inpath
+
+    # Can we find it from the installed location (which implies an
+    # editable install)? This is not ideal, since it is somewhat
+    # mis-using the importlib machinery. The files is labelled as
+    # returning a Traversable object which is not quite a Path, so
+    # explicitly convert it here (even though the actual return type
+    # is a Path).
+    #
+    with resources.as_file(resources.files("sherpa.astro.xspec")) as fs:
+        infile = str(fs)
+
+    inpath = Path(infile) / "src" / "_xspec.cc"
+    if inpath.exists():
+        return inpath
+
+    raise OSError("Unable to find sherpa/astro/xspec/src/_xspec.cc")
+
+
+def get_current_version() -> list[str]:
+    """Return the current model definitions.
+
+    This looks for, in order
+       sherpa/astro/xspec/src/_xspec.cc
+       ../sherpa/astro/xspec/src/_xspec.cc
+       <installed version>
+
+    """
+
+    inpath = find_file()
+    store = []
+    with open(inpath, "rt") as fh:
+        state = 0
+        for inline in fh.readlines():
+            if state == 0:
+                if inline.find(START_MACRO) > -1:
+                    state = 1
+                continue
+
+            if inline.find(END_MACRO) > -1:
+                break
+
+            store.append(inline.strip())
+
+    if len(store) == 0:
+        raise OSError(f"No definitions found in {inpath}")
+
+    return store
+
+
+def process_definitions(invals: list[str]
+                        ) -> tuple[dict[ModelName, ModelDefinition],
+                                   dict[ModelName, dict[StateVersion, ModelDefinition]]
+                                   ]:
+    """Extract the 'meaning' of each line
+
+    We have
+       - blank lines
+       - model definitins
+       - start macro definition
+       - change macro definition
+       - end macro definition
+
+    Drop the blank lines and identify the model name and any version
+    constraints.
+
+    """
+
+    versioned = {}
+    unversioned = {}
+    version: StateVersion | None = None
+    for inval in invals:
+        if inval == "":
+            continue
+
+        if inval == "#endif":
+            assert version is not None, "Unexpected #endif"
+            version = None
+            continue
+
+        if inval.startswith("#ifdef"):
+            assert version is None, "Unexpected #ifdef"
+            version = grab_version(inval)
+            continue
+
+        if inval == "#else":
+            assert version is not None
+            version = "older"
+            continue
+
+        if inval == "#elif":
+            assert version is not None
+            nversion = grab_version(inval)
+            assert version != "older" and nversion < version, f"Version mismatch: {version} {nversion}"
+            version = nversion
+            continue
+
+        assert not inval.startswith("#"), f"Errr: {inval}"
+
+        pos = inval.find("// ")
+        if pos == -1:
+            assert ValueError(f"Missing // <model name> in '{inval}'")
+
+        # To allow extra info added to the model name - e.g. "// XSfoobar  look at Xsfoo"
+        # grab just the first word
+        modelname = inval[pos + 3:].split()[0]
+        model = inval[:pos].rstrip()
+
+        assert modelname not in unversioned, f"model={modelname} already seen"
+
+        if version is None:
+            assert modelname not in versioned, f"model={modelname} already seen"
+            unversioned[modelname] = model
+            continue
+
+        if modelname in versioned:
+            versioned[modelname][version] = model
+            continue
+
+        versioned[modelname] = {version: model}
+
+    assert len(unversioned) > 0, "What did I do?"
+    assert len(versioned) > 0, "What did I do?"
+    assert version is None, "somehow version constraint checks failed"
+    return unversioned, versioned
+
+
+def get_definition(mname: ModelName, mdef: ModelDefinition) -> str:
+    return f"  {mdef:48s} // {mname}"
+
+
+def fake_storage(line: str) -> Storage:
+    """There should be a better way of indicating this."""
+
+    # Using "older" here is not ideal
+    return {"older": [line]}, NO_CHECKSUM
+
+
+def print_storage(stored: Storage) -> None:
+    """Display the stored lines."""
+
+    for keyline, lines in stored[0].items():
+        print(keyline)
+        for line in lines:
+            print(line)
+
+    print("#endif")
+
+
+def get_multiple(versioned: dict[StateVersion, ModelDefinition],
+                 name: ModelName
+                 ) -> Storage:
+    """Create the #ifdef/... chain."""
+
+    out = {}
+    checksum = ""
+    for version, mdef in versioned.items():
+        if len(out) == 0:
+            assert version != "older"
+            key = f"#ifdef {make_xspec_macro(version)}"
+        elif version != "older":
+            key = f"#elif {make_xspec_macro(version)}"
+        else:
+            key = "#else"
+
+        # We need this to store a list, even though here the list is
+        # only ever a singleton.
+        #
+        out[key] = [get_definition(name, mdef)]
+        checksum += key
+
+    return out, checksum
+
+
+def get_unversioned(version: Version,
+                    olddef: ModelDefinition,
+                    name: ModelName,
+                    newdef: ModelDefinition
+                    ) -> Storage:
+    """Do we need to add a version to the definition?"""
+
+    if olddef == newdef:
+        # Ugh: special casing the "no-version" constraint is not ideal
+        line = get_definition(name, olddef)
+        return fake_storage(line)
+
+    return get_multiple({version: newdef, "older": olddef}, name)
+
+
+def get_versioned(version: Version,
+                  old: dict[StateVersion, ModelDefinition],
+                  name: ModelName,
+                  newdef: ModelDefinition
+                  ) -> Storage:
+    """Add the new definion to the existing ones."""
+
+    assert len(old) > 0
+
+    # If the first element is the same as new then we do not need to
+    # change anything.
+    #
+    if list(old.values())[0] == newdef:
+        return get_multiple(old, name)
+
+    # Assume that version is not in old
+    assert version not in old
+    new = {version: newdef} | old
+    return get_multiple(new, name)
+
+
+def get_new(version: Version,
+            name: ModelName,
+            newdef: ModelDefinition
+            ) -> Storage:
+    """Add the new definition"""
+
+    return get_multiple({version: newdef}, name)
+
+
+def report_model_definitions(version: Version,
+                             old_unversioned: dict[ModelName, ModelDefinition],
+                             old_versioned: dict[ModelName, dict[StateVersion, ModelDefinition]],
+                             models: list[xspec.ModelDefinition]
+                             ) -> None:
+    """Print to stdout the code needed to bind to the models.
+
+    There is a limited attempt to combine multiple neighbouring
+    conditions which have the same set of version constraints, but it
+    is not intended to be perfect.
+
+    """
+
+    print(f"  {START_MACRO}")
+
+    stored: Storage | None = None
+
+    prev_mtype = None
     for model in models:
-        prev = print_model(model, prev)
 
+        # For the moment models that are calculated per-spectrum are unsupported.
+        try:
+            if model.flags[1] == 1:
+                continue
+        except IndexError:
+            pass
 
-def print_model(model: xspec.ModelDefinition,
-                prev: Optional[str]) -> Optional[str]:
-    """Print out a model"""
+        # Assume an unsupported model; should this happen?
+        try:
+            new_def = xspec.model_to_compiled(model)[0]
 
-    try:
-        code = xspec.model_to_compiled(model)
-    except ValueError:
-        # Assume an unsupported model
-        # sys.stderr.write(f"# Unsupported: {model.name} / {model.funcname}\n")
-        return prev
+            # Remove the leading spaces, to make the handling of old
+            # and new definitions easier.
+            #
+            if new_def.startswith("  "):
+                new_def = new_def[2:]
 
-    # For the moment models that are calculated per-spectrum are unsupported.
-    try:
-        if model.flags[1] == 1:
-            return prev
-    except IndexError:
-        pass
+        except ValueError:
+            continue
 
-    # If we have changed "type" then print a new line
-    if prev is not None and prev != model.modeltype:
-        print("")
+        if prev_mtype is None or prev_mtype != model.modeltype:
+            # Display any stored lines as this is the "end" of this
+            # sequence.
+            #
+            if stored is not None:
+                print_storage(stored)
+                stored = None
 
-    # Add in the model name as a comment
-    print(f"{code[0]:50s} // XS{model.name}")
-    return model.modeltype
+            print("")
+
+        prev_mtype = model.modeltype
+
+        mname = f"XS{model.name}"
+        if mname in old_unversioned:
+            nstore = get_unversioned(version, old_unversioned[mname], mname, new_def)
+
+        elif mname in old_versioned:
+            nstore = get_versioned(version, old_versioned[mname], mname, new_def)
+
+        else:
+            nstore = get_new(version, mname, new_def)
+
+        if nstore[1] == NO_CHECKSUM:
+            # This is unversioned, so we can display any stored values
+            # and then this line.
+            if stored is not None:
+                print_storage(stored)
+                stored = None
+
+            lines = nstore[0]["older"]
+            assert len(lines) == 1
+            print(lines[0])
+            continue
+
+        # Store them if there's no current storage.
+        #
+        if stored is None:
+            stored = nstore
+            continue
+
+        # Are the checksums the same? If they are then we can add the
+        # new lines into the current storage area. If they are not
+        # then we display the storage and swap in the new lines.
+        #
+        if stored[1] == nstore[1]:
+            # Add the various lines into each section
+            for key, lines in nstore[0].items():
+                assert len(lines) == 1, f"len={len(lines)} lines='{lines}'"
+                stored[0][key].extend(lines)
+
+            continue
+
+        print_storage(stored)
+        stored = nstore
+
+    # Print out any remaining stored lines.
+    #
+    if stored is not None:
+        print_storage(stored)
+        stored = None  # not really needed
+
+    print("")
+    print(f"  {END_MACRO}")
+
 
 
 if __name__ == "__main__":
 
-    if len(sys.argv) != 2:
-        sys.stderr.write(f"Usage: {sys.argv[0]} infile\n")
+    if len(sys.argv) != 3:
+        sys.stderr.write(f"Usage: {sys.argv[0]} version infile\n")
         sys.exit(1)
+
+    version = parse_version(sys.argv[1])
+    current = process_definitions(get_current_version())
 
     # This errors out in case of significant model-support issues
     # (e.g. a periodic model parameter) but can also just be an
     # issue with a poorly-specified interchange format (the model.dat
     # file) which may just need changes to this routine.
     #
-    mdefs = xspec.parse_xspec_model_description(sys.argv[1])
-    report_model_definitions(mdefs)
+    mdefs = xspec.parse_xspec_model_description(sys.argv[2])
+    report_model_definitions(version, current[0], current[1], mdefs)

--- a/scripts/update_xspec_functions.py
+++ b/scripts/update_xspec_functions.py
@@ -22,7 +22,7 @@
 
 """Usage:
 
-  ./update_spec_functions.py version infile
+  ./update_xspec_functions.py version infile
 
 Aim:
 

--- a/scripts/update_xspec_functions.py
+++ b/scripts/update_xspec_functions.py
@@ -146,7 +146,7 @@ def find_file() -> Path:
 
     # Can we find it from the installed location (which implies an
     # editable install)? This is not ideal, since it is somewhat
-    # mis-using the importlib machinery. The files is labelled as
+    # mis-using the importlib machinery. The files call is labelled as
     # returning a Traversable object which is not quite a Path, so
     # explicitly convert it here (even though the actual return type
     # is a Path).

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -654,6 +654,8 @@ set_xsabund("lodd")
 set_xscosmo(72, 0.02, 0.71)
 set_xsxsect("vern")
 set_xsxset("APECROOT", "3.0.9")
+set_xsxset("NEIAPECROOT", "3.0.9")
+set_xsxset("NEIVERS", "3.0.4")
 """
 
 _canonical_pha_no_response = """import numpy
@@ -2340,6 +2342,8 @@ set_xsabund("angr")
 set_xscosmo(70, 0, 0.73)
 set_xsxsect("bcmc")
 set_xsxset("APECROOT", "3.0.9")
+set_xsxset("NEIAPECROOT", "3.0.9")
+set_xsxset("NEIVERS", "3.0.4")
 """
 
     _canonical_pha_basic += _canonical_extra

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015, 2016, 2018 - 2021, 2023, 2024
+#  Copyright (C) 2015, 2016, 2018 - 2021, 2023 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -653,6 +653,7 @@ set_xschatter(0)
 set_xsabund("lodd")
 set_xscosmo(72, 0.02, 0.71)
 set_xsxsect("vern")
+set_xsxset("APECROOT", "3.0.9")
 """
 
 _canonical_pha_no_response = """import numpy
@@ -2338,6 +2339,7 @@ set_xschatter(0)
 set_xsabund("angr")
 set_xscosmo(70, 0, 0.73)
 set_xsxsect("bcmc")
+set_xsxset("APECROOT", "3.0.9")
 """
 
     _canonical_pha_basic += _canonical_extra
@@ -2398,11 +2400,8 @@ def compare_lines(expected, got):
     elines = expected.split('\n')
     glines = got.split('\n')
 
-    # _dump_lines(elines)
-    # _dump_lines(glines)
-
     for e, g in zip(elines, glines):
-        assert e == g
+        assert e == g, f"expected='{e}' got='{g}'"
 
     # Do the line length after checking for the file
     # contents as it is easier to see what the difference

--- a/sherpa/astro/utils/tests/test_astro_utils_xspec.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_xspec.py
@@ -799,7 +799,7 @@ order    " "  -1.   -3.    -3.      -1.       -1.       -1
     expected = '''
 @version_at_least("11.0.4")
 class XSrgsxsrc(XSConvolutionKernel):
-    """The XSPEC rgsxsrc model:  TBD
+    """The XSPEC rgsxsrc convolution model:  TBD
 
     The model is described at [1]_.
 

--- a/sherpa/astro/utils/tests/test_astro_utils_xspec.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_xspec.py
@@ -571,7 +571,7 @@ PyMODINIT_FUNC PyInit__models(void) {
 
 @requires_xspec
 def test_create_model_multiplicative(caplog):
-    """Fake up a multplicative model"""
+    """Fake up a multiplicative  model"""
 
     model = StringIO("""abcd           1  0.         1.e20           foos    mul  0
 nH      cm^-3   1.0   1.e-6  1.e-5  1.e19  1.e20   -0.01
@@ -637,7 +637,7 @@ PyMODINIT_FUNC PyInit__models(void) {
 
 @requires_xspec
 def test_create_model_multiplicative_xspec(caplog):
-    """Fake up a multplicative model for XSPEC"""
+    """Fake up a multiplicative model for XSPEC"""
 
     model = StringIO("""abcd           1  0.         1.e20           foos    mul  0
 nH      cm^-3   1.0   1.e-6  1.e-5  1.e19  1.e20   -0.01

--- a/sherpa/astro/utils/tests/test_astro_utils_xspec.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_xspec.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2023 - 2025
+#  Copyright (C) 2021, 2023-2025
 #  Smithsonian Astrophysical Observatory
 #
 #

--- a/sherpa/astro/utils/xspec.py
+++ b/sherpa/astro/utils/xspec.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2012 - 2016, 2020 - 2025
+#  Copyright (C) 2012-2016, 2020-2025
 #  Smithsonian Astrophysical Observatory
 #
 #

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -20,10 +20,10 @@
 
 """Support for XSPEC models.
 
-Sherpa supports versions 12.14.1, 12.14.0, 12.13.1, 12.13.0, 12.12.1, and
-12.12.0 of XSPEC [1]_, and can be built against the model library or
-the full application.  There is no guarantee of support for older or
-newer versions of XSPEC.
+Sherpa supports versions 12.15.0, 12.14.1, 12.14.0, 12.13.1, 12.13.0,
+12.12.1, and 12.12.0 of XSPEC [1]_, and can be built against the model
+library or the full application.  There is no guarantee of support for
+older or newer versions of XSPEC.
 
 To be able to use most routines from this module, the HEADAS environment
 variable must be set. The `get_xsversion` function can be used to return the
@@ -8157,6 +8157,40 @@ class XSezdiskbb(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, (self.T_max, ))
 
 
+@version_at_least("12.15.0")
+class XSfeklor(XSAdditiveModel):
+    """The XSPEC feklor model: Fe K fluourescence line at high resolution
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    norm
+       The total emission (in photom/cm^2/s) in the line.
+
+    See Also
+    --------
+    XSzfeklor
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelFeklor.html
+
+    """
+
+    __function__ = "C_FeKfromSevenLorentzians"
+
+    def __init__(self, name='feklor'):
+
+        # norm parameter is automatically added by XSAdditiveModel
+        pars = ()
+        XSAdditiveModel.__init__(self, name, pars)
+
+
 class XSgaussian(XSAdditiveModel):
     """The XSPEC gaussian model: gaussian line profile.
 
@@ -9234,7 +9268,7 @@ class XSlorentz(XSAdditiveModel):
 
     See Also
     --------
-    XSgaussian, XSvoigt
+    XSgaussian, XSvlorentz, XSvoigt, XSzlorentz
 
     References
     ----------
@@ -12117,6 +12151,46 @@ class XSvgnei(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, pars)
 
 
+@version_at_least("12.15.0")
+class XSvlorentz(XSAdditiveModel):
+    """The XSPEC vlorentz model: lorentz line profile with width in velocity.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    LineE
+       Line energy in keV
+    Width
+       FWHM of line in km/s
+    norm
+       The flux, in photon/cm^2/s, in the line.
+
+    See Also
+    --------
+    XSlorentz, XSzvlorentz
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVlorentz.html
+
+    """
+
+    __function__ = "C_vlorentzianLine"
+
+    def __init__(self, name='vlorentz'):
+        self.LineE = XSParameter(name, 'LineE', 6.5, min=0.0, max=1000000.0, hard_min=0.0, hard_max=1000000.0, units='keV')
+        self.Width = XSParameter(name, 'Width', 10.0, min=0.0, max=10.0, hard_min=0.0, hard_max=20.0, units='km/s')
+
+        # norm parameter is automatically added by XSAdditiveModel
+        pars = (self.LineE, self.Width)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
 class XSvmeka(XSAdditiveModel):
     """The XSPEC vmeka model: emission, hot diffuse gas (Mewe-Gronenschild).
 
@@ -12457,7 +12531,7 @@ class XSvoigt(XSAdditiveModel):
 
     See Also
     --------
-    XSgauss, XSlorentz
+    XSgauss, XSlorentz, XSvvoigt, XSzvoigt
 
     References
     ----------
@@ -13308,6 +13382,49 @@ class XSvvnpshock(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, pars)
 
 
+@version_at_least("12.15.0")
+class XSvvoigt(XSAdditiveModel):
+    """The XSPEC vvoigt model: Voigt line profile with widths in km/s
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    LineE
+       Line energy in keV.
+    Sigma
+       Gaussian line width in km/s.
+    Gamma
+       Lorentzian FWHM in km/s.
+    norm
+       The total emission (in photom/cm^2/s) in the line.
+
+    See Also
+    --------
+    XSvoigt, XSzvvoigt
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVvoigt.html
+
+    """
+
+    __function__ = "C_vvoigtLine"
+
+    def __init__(self, name='vvoigt'):
+        self.LineE = XSParameter(name, 'LineE', 6.5, min=0.0, max=1000000.0, hard_min=0.0, hard_max=1000000.0, units='keV')
+        self.Sigma = XSParameter(name, 'Sigma', 10.0, min=0.0, max=10.0, hard_min=0.0, hard_max=20.0, units='km/s')
+        self.Gamma = XSParameter(name, 'Gamma', 10.0, min=0.0, max=10.0, hard_min=0.0, hard_max=20.0, units='km/s')
+
+        # norm parameter is automatically added by XSAdditiveModel
+        pars = (self.LineE, self.Sigma, self.Gamma)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
 class XSvvpshock(XSAdditiveModel):
     """The XSPEC vvpshock model: plane-parallel shocked plasma, constant temperature.
 
@@ -14074,6 +14191,42 @@ class XSzcutoffpl(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, pars)
 
 
+@version_at_least("12.15.0")
+class XSzfeklor(XSAdditiveModel):
+    """The XSPEC zfeklor model: Fe K fluourescence line at high resolution
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    Redshift
+    norm
+       The total emission (in photom/cm^2/s) in the line.
+
+    See Also
+    --------
+    XSfeklor
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelFeklor.html
+
+    """
+
+    __function__ = "C_zFeKfromSevenLorentzians"
+
+    def __init__(self, name='zfeklor'):
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0, hard_min=-0.999, hard_max=10.0, frozen=True)
+
+        # norm parameter is automatically added by XSAdditiveModel
+        pars = (self.Redshift,)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
 class XSzgauss(XSAdditiveModel):
     """The XSPEC zgauss model: gaussian line profile.
 
@@ -14238,6 +14391,52 @@ class XSzlogpar(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, pars)
 
 
+@version_at_least("12.15.0")
+class XSzlorentz(XSAdditiveModel):
+    """The XSPEC zlorentz model: lorentz line profile.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    LineE
+        The line energy, in keV.
+    Width
+        The FWHM of the line, in keV.
+    Redshift
+        The redshift of the line.
+    norm
+        The flux in the line, in units of photon/cm^2/s.
+
+    See Also
+    --------
+    XSlorentz, XSzvlorentz
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelLorentz.html
+
+    """
+
+    __function__ = "C_zlorentzianLine"
+
+    def __init__(self, name='zlorentz'):
+        self.LineE = XSParameter(name, 'LineE', 6.5, min=0.0, max=1e6,
+                                 hard_min=0.0, hard_max=1e6, units='keV')
+        self.Width = XSParameter(name, 'Width', 0.01, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='keV')
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
+                                    hard_min=-0.999, hard_max=10.0, frozen=True)
+
+        # norm parameter is automatically added by XSAdditiveModel
+        pars = (self.LineE, self.Width, self.Redshift)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
 class XSzpowerlw(XSAdditiveModel):
     """The XSPEC zpowerlw model: redshifted power law photon spectrum.
 
@@ -14362,6 +14561,153 @@ class XSzvgaussian(XSAdditiveModel):
         self.Redshift = mkRedshift(name)
 
         pars = (self.LineE, self.Sigma, self.Redshift)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
+@version_at_least("12.15.0")
+class XSzvlorentz(XSAdditiveModel):
+    """The XSPEC zvlorentz model: lorentz line profile with width in velocity.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    LineE
+       Line energy in keV
+    Width
+       FWHM of line in km/s
+    Redshift
+       The redshift of the line.
+    norm
+       The flux, in photon/cm^2/s, in the line.
+
+    See Also
+    --------
+    XSvlorentz, XSzlorentz
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVlorentz.html
+
+    """
+
+    __function__ = "C_zvlorentzianLine"
+
+    def __init__(self, name='zvlorentz'):
+        self.LineE = XSParameter(name, 'LineE', 6.5, min=0.0, max=1e6,
+                                 hard_min=0.0, hard_max=1e6, units='keV')
+        self.Width = XSParameter(name, 'Width', 10.0, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='km/s')
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
+                                    hard_min=-0.999, hard_max=10.0, frozen=True)
+
+        # norm parameter is automatically added by XSAdditiveModel
+        pars = (self.LineE, self.Width, self.Redshift)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
+
+@version_at_least("12.15.0")
+class XSzvoigt(XSAdditiveModel):
+    """The XSPEC zvoigt model: Voigt line profile.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    LineE
+       The line energy, in keV.
+    Sigma
+       The gaussian line width, in keV.
+    Gamma
+       The lorentzian FWHM line width, in keV.
+    Redshift
+       The redshift of the line.
+    norm
+       The flux in the line, in units of photon/cm^2/s.
+
+    See Also
+    --------
+    XSvoigt, XSzvvoigt
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVoigt.html
+
+    """
+
+    __function__ = "C_zvoigtLine"
+
+    def __init__(self, name='zvoigt'):
+        self.LineE = XSParameter(name, 'LineE', 6.5, min=0.0, max=1e6,
+                                 hard_min=0.0, hard_max=1e6, units='keV')
+        self.Sigma = XSParameter(name, 'Sigma', 0.01, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='keV')
+        self.Gamma = XSParameter(name, 'Gamma', 0.01, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='keV')
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
+                                    hard_min=-0.999, hard_max=10.0, frozen=True)
+
+        # norm parameter is automatically added by XSAdditiveModel
+        pars = (self.LineE, self.Sigma, self.Gamma, self.Redshift)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
+@version_at_least("12.15.0")
+class XSzvvoigt(XSAdditiveModel):
+    """The XSPEC zvvoigt model: Voigt line profile with widths in km/s.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    LineE
+       Line energy in keV.
+    Sigma
+       Gaussian line width in km/s.
+    Gamma
+       Lorentzian FWHM in km/s.
+    Redshift
+       The line redshift.
+    norm
+       The total emission (in photom/cm^2/s) in the line.
+
+    See Also
+    --------
+    XSvvoigt, XSzvoigt
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVvoigt.html
+
+    """
+
+    __function__ = "C_zvvoigtLine"
+
+    def __init__(self, name='zvvoigt'):
+        self.LineE = XSParameter(name, 'LineE', 6.5, min=0.0, max=1e6,
+                                 hard_min=0.0, hard_max=1e6, units='keV')
+        self.Sigma = XSParameter(name, 'Sigma', 10.0, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='km/s')
+        self.Gamma = XSParameter(name, 'Gamma', 10.0, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='km/s')
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
+                                    hard_min=-0.999, hard_max=10.0, frozen=True)
+
+        # norm parameter is automatically added by XSAdditiveModel
+        pars = (self.LineE, self.Sigma, self.Gamma, self.Redshift)
         XSAdditiveModel.__init__(self, name, pars)
 
 
@@ -15053,6 +15399,49 @@ class XSlog10con(XSMultiplicativeModel):
     def __init__(self, name='log10con'):
         self.log10fac = XSParameter(name, 'log10fac', 0.0, -20.0, 20, -20, 20)
         XSMultiplicativeModel.__init__(self, name, (self.log10fac, ))
+
+
+@version_at_least("12.15.0")
+class XSlorabs(XSMultiplicativeModel):
+    """The XSPEC lorabs model: lorentzian absorption line.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    LineE
+       The line energy in keV.
+    Width
+       The line width (FWHM) in keV.
+    Strength
+       The line depth in keV.
+
+    See Also
+    --------
+    XSvlorabs, XSzlorabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelLorabs.html
+
+    """
+
+    __function__ = "C_lorentzianAbsorptionLine"
+
+    def __init__(self, name='lorabs'):
+        self.LineE = XSParameter(name, 'LineE', 1.0, min=0.0, max=1e6,
+                                 hard_min=0.0, hard_max=1e6, units='keV')
+        self.Width = XSParameter(name, 'Width', 0.01, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='keV')
+        self.Strength = XSParameter(name, 'Strength', 1.0, min=0.0,
+                                    max=1e6, hard_min=0.0, hard_max=1e6, units='keV')
+
+        pars = (self.LineE, self.Width, self.Strength)
+        XSMultiplicativeModel.__init__(self, name, pars)
 
 
 class XSlyman(XSMultiplicativeModel):
@@ -16065,6 +16454,93 @@ class XSvgabs(XSMultiplicativeModel):
         XSMultiplicativeModel.__init__(self, name, pars)
 
 
+@version_at_least("12.15.0")
+class XSvlorabs(XSMultiplicativeModel):
+    """The XSPEC vlorabs model: lorentzian absorption line with width in km/s.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    LineE
+       The line energy in keV.
+    Width
+       The line width (FWHM) in km/s.
+    Strength
+       The line depth in keV.
+
+    See Also
+    --------
+    XSlorabs, XSzvlorabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVlorabs.html
+
+    """
+
+    __function__ = "C_vlorentzianAbsorptionLine"
+
+    def __init__(self, name='vlorabs'):
+        self.LineE = XSParameter(name, 'LineE', 1.0, min=0.0, max=1e6, hard_min=0.0, hard_max=1e6, units='km/s')
+        self.Width = XSParameter(name, 'Width', 10.0, min=0.0, max=10.0, hard_min=0.0, hard_max=20.0, units='km/s')
+        self.Strength = XSParameter(name, 'Strength', 1.0, min=0.0, max=1e6, hard_min=0.0, hard_max=1e6, units='keV')
+
+        pars = (self.LineE, self.Width, self.Strength)
+        XSMultiplicativeModel.__init__(self, name, pars)
+
+
+@version_at_least("12.15.0")
+class XSvoigtabs(XSMultiplicativeModel):
+    """The XSPEC voigtabs model: voigt absorption line.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    LineE
+       The line energy in keV.
+    Sigma
+       The gaussian line width in keV.
+    Width
+       The lorentzian line width (FWHM) in keV.
+    Strength
+       The line depth in keV.
+
+    See Also
+    --------
+    XSvvoigtabs, XSzvoigtabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVoigtabs.html
+
+    """
+
+    __function__ = "C_voigtAbsorptionLine"
+
+    def __init__(self, name='voigtabs'):
+        self.LineE = XSParameter(name, 'LineE', 1.0, min=0.0, max=1e6,
+                                 hard_min=0.0, hard_max=1e6, units='km/s')
+        self.Sigma = XSParameter(name, 'Sigma', 0.01, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='keV')
+        self.Width = XSParameter(name, 'Width', 0.01, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='keV')
+        self.Strength = XSParameter(name, 'Strength', 1.0, min=0.0, max=1e6,
+                                    hard_min=0.0, hard_max=1e6, units='keV')
+
+        pars = (self.LineE, self.Sigma, self.Width, self.Strength)
+        XSMultiplicativeModel.__init__(self, name, pars)
+
+
 class XSvphabs(XSMultiplicativeModel):
     """The XSPEC vphabs model: photoelectric absorption.
 
@@ -16116,6 +16592,53 @@ class XSvphabs(XSMultiplicativeModel):
         self.Co = XSParameter(name, 'Co', 1., 0., 1000., 0.0, 1000, frozen=True)
         self.Ni = XSParameter(name, 'Ni', 1., 0., 1000., 0.0, 1000, frozen=True)
         XSMultiplicativeModel.__init__(self, name, (self.nH, self.He, self.C, self.N, self.O, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.S, self.Cl, self.Ar, self.Ca, self.Cr, self.Fe, self.Co, self.Ni))
+
+
+@version_at_least("12.15.0")
+class XSvvoigtabs(XSMultiplicativeModel):
+    """The XSPEC vvoigtabs model: voigt absorption line with widths in km/s.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    LineE
+       The line energy in keV.
+    Sigma
+       The gaussian line width in km/s.
+    Width
+       The lorentzian line width (FWHM) in km/s.
+    Strength
+       The line depth in keV.
+
+    See Also
+    --------
+    XSvoigtabs, XSzvvoigtabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVvoigtabs.html
+
+    """
+
+    __function__ = "C_vvoigtAbsorptionLine"
+
+    def __init__(self, name='vvoigtabs'):
+        self.LineE = XSParameter(name, 'LineE', 1.0, min=0.0, max=1e6,
+                                 hard_min=0.0, hard_max=1e6, units='km/s')
+        self.Sigma = XSParameter(name, 'Sigma', 10.0, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='km/s')
+        self.Width = XSParameter(name, 'Width', 10.0, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='km/s')
+        self.Strength = XSParameter(name, 'Strength', 1.0, min=0.0, max=1e6,
+                                    hard_min=0.0, hard_max=1e6, units='keV')
+
+        pars = (self.LineE, self.Sigma, self.Width, self.Strength)
+        XSMultiplicativeModel.__init__(self, name, pars)
 
 
 class XSwabs(XSMultiplicativeModel):
@@ -16579,6 +17102,49 @@ class XSzigm(XSMultiplicativeModel):
         XSMultiplicativeModel.__init__(self, name, (self.redshift, self.model, self.lyman_limit))
 
 
+@version_at_least("12.15.0")
+class XSzlorabs(XSMultiplicativeModel):
+    """The XSPEC zlorabs model: lorentzian absorption line.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    LineE
+       The line energy in keV.
+    Width
+       The line width (FWHM) in keV.
+    Strength
+       The line depth in keV.
+    Redshift
+       The line redshift.
+
+    See Also
+    --------
+    XSlorabs, XSzvlorabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelLorabs.html
+
+    """
+
+    __function__ = "C_zlorentzianAbsorptionLine"
+
+    def __init__(self, name='zlorabs'):
+        self.LineE = XSParameter(name, 'LineE', 1.0, min=0.0, max=1e6, hard_min=0.0, hard_max=1e6, units='km/s')
+        self.Width = XSParameter(name, 'Width', 0.01, min=0.0, max=10.0, hard_min=0.0, hard_max=20.0, units='keV')
+        self.Strength = XSParameter(name, 'Strength', 1.0, min=0.0, max=1e6, hard_min=0.0, hard_max=1e6, units='keV')
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0, hard_min=-0.999, hard_max=10.0, frozen=True)
+
+        pars = (self.LineE, self.Width, self.Strength, self.Redshift)
+        XSMultiplicativeModel.__init__(self, name, pars)
+
+
 class XSzpcfabs(XSMultiplicativeModel):
     """The XSPEC zpcfabs model: partial covering fraction absorption.
 
@@ -16651,6 +17217,155 @@ class XSzphabs(XSMultiplicativeModel):
         self.Redshift = mkRedshift(name)
 
         pars = (self.nH, self.redshift)
+        XSMultiplicativeModel.__init__(self, name, pars)
+
+
+@version_at_least("12.15.0")
+class XSzvlorabs(XSMultiplicativeModel):
+    """The XSPEC zvlorabs model: lorentzian absorption line with width in km/s.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    LineE
+       The line energy in keV.
+    Width
+       The line width (FWHM) in km/s.
+    Strength
+       The line depth in keV.
+    Redshift
+       The line redshift.
+
+    See Also
+    --------
+    XSvlorabs, XSzlorabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVlorabs.html
+
+    """
+
+    __function__ = "C_zvlorentzianAbsorptionLine"
+
+    def __init__(self, name='zvlorabs'):
+        self.LineE = XSParameter(name, 'LineE', 1.0, min=0.0, max=1e6,
+                                 hard_min=0.0, hard_max=1e6, units='km/s')
+        self.Width = XSParameter(name, 'Width', 10.0, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='km/s')
+        self.Strength = XSParameter(name, 'Strength', 1.0, min=0.0, max=1e6,
+                                    hard_min=0.0, hard_max=1e6, units='keV')
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
+                                    hard_min=-0.999, hard_max=10.0, frozen=True)
+
+        pars = (self.LineE, self.Width, self.Strength, self.Redshift)
+        XSMultiplicativeModel.__init__(self, name, pars)
+
+
+@version_at_least("12.15.0")
+class XSzvoigtabs(XSMultiplicativeModel):
+    """The XSPEC zvoigtabs model: voigt absorption line.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    LineE
+       The line energy in keV.
+    Sigma
+       The gaussian line width in keV.
+    Width
+       The lorentzian line width (FWHM) in keV.
+    Strength
+       The line depth in keV.
+    Redshift
+       The redshift of the line.
+
+    See Also
+    --------
+    XSvoigtabs, XSzvvoigtabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVoigtabs.html
+
+    """
+
+    __function__ = "C_zvoigtAbsorptionLine"
+
+    def __init__(self, name='zvoigtabs'):
+        self.LineE = XSParameter(name, 'LineE', 1.0, min=0.0, max=1e6,
+                                 hard_min=0.0, hard_max=1e6, units='km/s')
+        self.Sigma = XSParameter(name, 'Sigma', 0.01, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='keV')
+        self.Width = XSParameter(name, 'Width', 0.01, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='keV')
+        self.Strength = XSParameter(name, 'Strength', 1.0, min=0.0, max=1e6,
+                                    hard_min=0.0, hard_max=1e6, units='keV')
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
+                                    hard_min=-0.999, hard_max=10.0, frozen=True)
+
+        pars = (self.LineE, self.Sigma, self.Width, self.Strength, self.Redshift)
+        XSMultiplicativeModel.__init__(self, name, pars)
+
+
+@version_at_least("12.15.0")
+class XSzvvoigtabs(XSMultiplicativeModel):
+    """The XSPEC zvvoigtabs model: voigt absorption line with widths in km/s.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    LineE
+       The line energy in keV.
+    Sigma
+       The gaussian line width in km/s.
+    Width
+       The lorentzian line width (FWHM) in km/s.
+    Strength
+       The line depth in keV.
+    Redshift
+       The line redshift.
+
+    See Also
+    --------
+    XSvvoigtabs, XSzvoigtabs
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelVvoigtabs.html
+
+    """
+
+    __function__ = "C_zvvoigtAbsorptionLine"
+
+    def __init__(self, name='zvvoigtabs'):
+        self.LineE = XSParameter(name, 'LineE', 1.0, min=0.0, max=1e6,
+                                 hard_min=0.0, hard_max=1e6, units='km/s')
+        self.Sigma = XSParameter(name, 'Sigma', 10.0, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='km/s')
+        self.Width = XSParameter(name, 'Width', 10.0, min=0.0, max=10.0,
+                                 hard_min=0.0, hard_max=20.0, units='km/s')
+        self.Strength = XSParameter(name, 'Strength', 1.0, min=0.0, max=1e6,
+                                    hard_min=0.0, hard_max=1e6, units='keV')
+        self.Redshift = XSParameter(name, 'Redshift', 0.0, min=-0.999, max=10.0,
+                                    hard_min=-0.999, hard_max=10.0, frozen=True)
+
+        pars = (self.LineE, self.Sigma, self.Width, self.Strength, self.Redshift)
         XSMultiplicativeModel.__init__(self, name, pars)
 
 
@@ -17931,6 +18646,52 @@ class XSrfxconv(XSConvolutionKernel):
         XSConvolutionKernel.__init__(self, name, pars)
 
 
+@version_at_least("12.15.0")
+class XSrgsext(XSConvolutionKernel):
+    """The XSPEC rgsext convolution model: convolve an RGS spectrum for extended emission
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.17.1
+       This model requires XSPEC 12.15.0 or later.
+
+    Parameters
+    ----------
+    order
+        The order, which must be -1 to -3 inclusive.
+    factor
+        additional smoothing factor (1 means no change)
+
+    See Also
+    --------
+    XSrgsxsrc
+
+    Notes
+    -----
+    Unlike XSPEC, the convolution model is applied directly to the model, or
+    models, rather than using the multiplication symbol.
+
+    The ``set_xsxset`` function must be used to set the RGS_XSOURCE_FILE
+    value to point to a file as described in [1]_. There is currently no
+    support for reading in data from the XFLT keywords.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRgsext.html
+
+    """
+
+    __function__ = "C_rgsExtendedSource"
+
+    def __init__(self, name='rgsext'):
+        self.order = XSParameter(name, 'order', -1.0, min=-3.0, max=-1.0, hard_min=-3.0, hard_max=-1.0, frozen=True)
+        self.factor = XSParameter(name, 'factor', 1.0, min=1e-06, max=1000000.0, hard_min=1e-06, hard_max=1000000.0, frozen=True)
+
+        pars = (self.order, self.factor)
+        XSConvolutionKernel.__init__(self, name, pars)
+
+
 class XSrgsxsrc(XSConvolutionKernel):
     """The XSPEC rgsxsrc convolution model: convolve an RGS spectrum for extended emission.
 
@@ -17943,13 +18704,18 @@ class XSrgsxsrc(XSConvolutionKernel):
     order
         The order, which must be -1 to -3 inclusive.
 
+    See Also
+    --------
+    XSrgsext
+
     Notes
     -----
     Unlike XSPEC, the convolution model is applied directly to the model, or
     models, rather than using the multiplication symbol.
 
     The ``set_xsxset`` function must be used to set the RGS_XSOURCE_FILE
-    value to point to a file as described in [1]_.
+    value to point to a file as described in [1]_. There is currently no
+    support for reading in data from the XFLT keywords.
 
     References
     ----------
@@ -17958,7 +18724,7 @@ class XSrgsxsrc(XSConvolutionKernel):
 
     """
 
-    _calc = _xspec.rgsxsrc
+    __function__ = "C_rgsxsrc" if equal_or_greater_than("12.15.0") else "rgsxsrc"
 
     def __init__(self, name='xsrgsxsrc'):
         self.order = XSParameter(name, 'order', -1.0, min=-3.0, max=-1,

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1,4 +1,4 @@
-//  Copyright (C) 2007, 2015 - 2024
+//  Copyright (C) 2007, 2015 - 2025
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -482,9 +482,11 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM(C_carbatm, 4),              // XScarbatm
 #ifdef XSPEC_12_14_0
   XSPECMODELFCT_C_NORM(C_cemMekal, 7),             // XScemekl
-  XSPECMODELFCT_C_NORM(C_cempow, 7),               // XScempow
 #else
   XSPECMODELFCT_NORM(cemekl, 7),                   // XScemekl
+#endif
+#ifdef XSPEC_12_14_0
+  XSPECMODELFCT_C_NORM(C_cempow, 7),               // XScempow
 #endif
   XSPECMODELFCT_C_NORM(C_cemVMekal, 20),           // XScevmkl
   XSPECMODELFCT_C_NORM(C_xscflw, 6),               // XScflow
@@ -526,6 +528,9 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM(C_expcheb6, 11),            // XSexpcheb6
 #endif
   XSPECMODELFCT_NORM(ezdiskbb, 2),                 // XSezdiskbb
+#ifdef XSPEC_12_15_0
+  XSPECMODELFCT_C_NORM(C_FeKfromSevenLorentzians, 1), // XSfeklor
+#endif
   XSPECMODELFCT_C_NORM(C_gaussianLine, 3),         // XSgaussian
   XSPECMODELFCT_C_NORM(C_gaussDem, 7),             // XSgadem
   XSPECMODELFCT_C_NORM(C_gnei, 6),                 // XSgnei
@@ -574,6 +579,16 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM(C_raysmith, 4),             // XSraymond
   XSPECMODELFCT_NORM(xredge, 3),                   // XSredge
   XSPECMODELFCT_NORM(xsrefsch, 14),                // XSrefsch
+
+#ifdef XSPEC_12_15_0
+  XSPECMODELFCT_CON(C_rgsExtendedSource, 2),       // XSrgsext
+#endif
+#ifdef XSPEC_12_15_0
+  XSPECMODELFCT_CON(C_rgsxsrc, 1),                 // XSrgsxsrc
+#else
+  XSPECMODELFCT_CON_F77(rgsxsrc, 1),               // XSrgsxsrc
+#endif
+
   XSPECMODELFCT_C_NORM(C_rnei, 6),                 // XSrnei
   XSPECMODELFCT_C_NORM(C_sedov, 6),                // XSsedov
   XSPECMODELFCT_C_NORM(C_sirf, 10),                // XSsirf
@@ -608,6 +623,9 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM(C_vgaussianLine, 3),        // XSvgaussian
 #endif
   XSPECMODELFCT_C_NORM(C_vgnei, 18),               // XSvgnei
+#ifdef XSPEC_12_15_0
+  XSPECMODELFCT_C_NORM(C_vlorentzianLine, 3),      // XSvlorentz
+#endif
   XSPECMODELFCT_C_NORM(C_vmeka, 18),               // XSvmeka
   XSPECMODELFCT_C_NORM(C_vmekal, 19),              // XSvmekal
   XSPECMODELFCT_C_NORM(C_xsvmcf, 19),              // XSvmcflow
@@ -627,6 +645,9 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM(C_vvgnei, 35),              // XSvvgnei
   XSPECMODELFCT_C_NORM(C_vvnei, 34),               // XSvvnei
   XSPECMODELFCT_C_NORM(C_vvnpshock, 36),           // XSvvnpshock
+#ifdef XSPEC_12_15_0
+  XSPECMODELFCT_C_NORM(C_vvoigtLine, 4),           // XSvvoigt
+#endif
   XSPECMODELFCT_C_NORM(C_vvpshock, 35),            // XSvvpshock
   XSPECMODELFCT_C_NORM(C_vvrnei, 35),              // XSvvrnei
   XSPECMODELFCT_C_NORM(C_vvsedov, 35),             // XSvvsedov
@@ -639,10 +660,21 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C_NORM(C_zBrokenPowerLaw, 5),      // XSzbknpower
   XSPECMODELFCT_NORM(xszbrm, 3),                   // XSzbremss
   XSPECMODELFCT_C_NORM(C_zcutoffPowerLaw, 4),      // XSzcutoffpl
+#ifdef XSPEC_12_15_0
+  XSPECMODELFCT_C_NORM(C_zFeKfromSevenLorentzians, 2), // XSzfeklor
+#endif
   XSPECMODELFCT_C_NORM(C_xszgau, 4),               // XSzgauss
   XSPECMODELFCT_C_NORM(C_zkerrbb, 10),             // XSzkerrbb
   XSPECMODELFCT_C_NORM(C_zLogpar, 5),              // XSzlogpar
+#ifdef XSPEC_12_15_0
+  XSPECMODELFCT_C_NORM(C_zlorentzianLine, 4),      // XSzlorentz
+#endif
   XSPECMODELFCT_C_NORM(C_zpowerLaw, 3),            // XSzpowerlw
+#ifdef XSPEC_12_15_0
+  XSPECMODELFCT_C_NORM(C_zvlorentzianLine, 4),     // XSzvlorentz
+  XSPECMODELFCT_C_NORM(C_zvoigtLine, 5),           // XSzvoigt
+  XSPECMODELFCT_C_NORM(C_zvvoigtLine, 5),          // XSzvvoigt
+#endif
 
   XSPECMODELFCT_C(C_xsabsori, 6),                  // XSabsori
   XSPECMODELFCT_C(C_acisabs, 8),                   // XSacisabs
@@ -666,6 +698,9 @@ static PyMethodDef XSpecMethods[] = {
 #endif
   XSPECMODELFCT_C(C_logconst, 1),                  // XSlogconst
   XSPECMODELFCT_C(C_log10con, 1),                  // XSlog10con
+#ifdef XSPEC_12_15_0
+  XSPECMODELFCT_C(C_lorentzianAbsorptionLine, 3),  // XSlorabs
+#endif
   XSPECMODELFCT(xslyman, 4),                       // XSlyman
   XSPECMODELFCT(xsntch, 3),                        // XSnotch
 #ifdef XSPEC_12_12_1
@@ -695,7 +730,14 @@ static PyMethodDef XSpecMethods[] = {
 #ifdef XSPEC_12_14_1
   XSPECMODELFCT_C(C_vgaussianAbsorptionLine, 3),   // XSvgabs
 #endif
+#ifdef XSPEC_12_15_0
+  XSPECMODELFCT_C(C_vlorentzianAbsorptionLine, 3), // XSvlorabs
+  XSPECMODELFCT_C(C_voigtAbsorptionLine, 4),       // XSvoigtabs
+#endif
   XSPECMODELFCT(xsvphb, 18),                       // XSvphabs
+#ifdef XSPEC_12_15_0
+  XSPECMODELFCT_C(C_vvoigtAbsorptionLine, 4),      // XSvvoigtabs
+#endif
   XSPECMODELFCT(xsabsw, 1),                        // XSwabs
   XSPECMODELFCT(xswnab, 2),                        // XSwndabs
   XSPECMODELFCT(xsxirf, 13),                       // XSxion
@@ -708,8 +750,16 @@ static PyMethodDef XSpecMethods[] = {
 #endif
   XSPECMODELFCT(xszhcu, 3),                        // XSzhighect
   XSPECMODELFCT(zigm, 3),                          // XSzigm
+#ifdef XSPEC_12_15_0
+  XSPECMODELFCT_C(C_zlorentzianAbsorptionLine, 4), // XSzlorabs
+#endif
   XSPECMODELFCT(xszabp, 3),                        // XSzpcfabs
   XSPECMODELFCT(xszphb, 2),                        // XSzphabs
+#ifdef XSPEC_12_15_0
+  XSPECMODELFCT_C(C_zvlorentzianAbsorptionLine, 4), // XSzvlorabs
+  XSPECMODELFCT_C(C_zvoigtAbsorptionLine, 5),      // XSzvoigtabs
+  XSPECMODELFCT_C(C_zvvoigtAbsorptionLine, 5),     // XSzvvoigtabs
+#endif
   XSPECMODELFCT(zxipab, 5),                        // XSzxipab
   XSPECMODELFCT_C(C_zxipcf, 4),                    // XSzxipcf
   XSPECMODELFCT(xszcrd, 2),                        // XSzredden
@@ -724,7 +774,9 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT(xszvfe, 5),                        // XSzvfeabs
 #ifdef XSPEC_12_14_1
   XSPECMODELFCT_C(C_zvgaussianAbsorptionLine, 4),  // XSzvgabs
+#endif
 
+#ifdef XSPEC_12_14_1
   XSPECMODELFCT_C_NORM(C_zvgaussianLine, 4),       // XSzvgaussian
 #endif
 
@@ -748,7 +800,6 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_CON(C_rdblur, 4),                  // XSrdblur
   XSPECMODELFCT_CON(C_reflct, 5),                  // XSreflect
   XSPECMODELFCT_CON(C_rfxconv, 5),                 // XSrfxconv
-  XSPECMODELFCT_CON_F77(rgsxsrc, 1),               // XSrgsxsrc
   XSPECMODELFCT_CON(C_simpl, 3),                   // XSsimpl
   XSPECMODELFCT_CON_F77(thcompf, 4),               // XSthcomp
   XSPECMODELFCT_CON(C_vashift, 1),                 // XSvashift

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -37,7 +37,7 @@ from sherpa.utils.err import ParameterErr
 #    '(XSConvolutionKernel)'
 # in `xspec/__init__.py`
 #
-XSPEC_MODELS_COUNT = 289
+XSPEC_MODELS_COUNT = 210 + 72 + 24
 
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh

--- a/sherpa/astro/xspec/tests/test_xspec_con.py
+++ b/sherpa/astro/xspec/tests/test_xspec_con.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2023, 2024
+#  Copyright (C) 2020, 2021, 2023 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -57,6 +57,7 @@ XSPEC_CON_MODELS = [('cflux', 1, 2),
                     ('rdblur', 1, 3),
                     ('reflect', 1, 4),
                     ('rfxconv', 2, 3),
+                    ('rgsext', 0, 2),
                     ('rgsxsrc', 0, 1),
                     ('simpl', 2, 1),
                     ('thcomp', 3, 1),

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016 - 2025
+#  Copyright (C) 2016-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -859,10 +859,11 @@ def set_xspec_atomdb_version():
         return
 
     # XSPEC 12.15.0 switches the AtomDB version from 3.0.9 to 3.1.2
-    # which can changes enough to cause the test to fail. The
-    # tolerances could be changed but instead try setting the AtomDB
+    # and this can cause tests to fail. The tolerances could be
+    # changed but instead try setting the AtomDB
     # version. Unfortunately the current interface is rather limited
-    # (see #2216), so this is done globally.
+    # (see #2216), so this is done globally. Eventually this will
+    # (hopefully) be removed, or the settings updated.
     #
     xspec.set_xsxset("APECROOT", "3.0.9")
     xspec.set_xsxset("NEIAPECROOT", "3.0.9")

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016 - 2024
+#  Copyright (C) 2016 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -865,6 +865,8 @@ def set_xspec_atomdb_version():
     # (see #2216), so this is done globally.
     #
     xspec.set_xsxset("APECROOT", "3.0.9")
+    xspec.set_xsxset("NEIAPECROOT", "3.0.9")
+    xspec.set_xsxset("NEIVERS", "3.0.4")
 
 
 # Fixtures that control access to the tests, based on the availability

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -851,6 +851,22 @@ def xsmodel():
     return func
 
 
+@pytest.fixture(scope="session", autouse=True)
+def set_xspec_atomdb_version():
+    """Ensure the AtomDB abundance is 3.0.9 if XSPEC is enabled."""
+
+    if not has_xspec:
+        return
+
+    # XSPEC 12.15.0 switches the AtomDB version from 3.0.9 to 3.1.2
+    # which can changes enough to cause the test to fail. The
+    # tolerances could be changed but instead try setting the AtomDB
+    # version. Unfortunately the current interface is rather limited
+    # (see #2216), so this is done globally.
+    #
+    xspec.set_xsxset("APECROOT", "3.0.9")
+
+
 # Fixtures that control access to the tests, based on the availability
 # of external "features" (normally this is the presence of optional
 # modules). These used to be decorators in sherpa.utils.testing.


### PR DESCRIPTION
# Summary

Allow building against XSPEC 12.15.0. Adds the following 17 models:

- additive: XSfeklor, XSvlorentz, XSvvoigt, XSzfeklor, XSzlorentz, XSzvlorentz, XSzvoigt, XSzvvoigt
- convolution: XSrgsext
- multiplicative: XSlorabs, XSvlorabs, XSvoigtabs, XSvvoigtabs, XSzlorabs, XSzvorlabs, XSzvoigtabs, XSzvvoigtabs

The XSPEC initialization file (~/.xspec/Xspec.init) may need to be removed or the AtomDB version in it updated before using XSPEC models.

# Details

The first commit updates the scripts `add_xspec_model.py` and `update_xspec_functions.py` to reduce friction. The `sherpa.astro.utils.xspec` code used by `add_xspec_model.py` is primarily intended to support XSPEC user models, and so the output required manipulation when used for XSPEC, so the code has been updated to support this "internal" use to better match the Python code used in `sherpa.astro.xspec` (adding a version decorator, a "versionchanged" note, and a reference link with a best-guess for the XSPEC HTML documentation location). The `update_xspec_functions.py` code preciously did not recognize version constraints - the `#ifdef XSPEC_x_y_z` lines used to indicate function changes over time for a model - because there's no encoding of this information in XSPEC itself. The code now takes the existing `sherpa/astro/xspec/src/_xspec.cc` file and uses that to define the version constraints for each model, and uses that to create the new output. It does not create the smallest possible set of `#ifdef` lines, but it is a huge improvement over the previous approach. 

The second commit adds a new helper script - `scripts/update_xspec_docs.py`` which automates the update of the ``docs/model_classes/astro_xspec.rst`` file. It turns out I missed some changes in the XSPEC 12.14.x series so this also updates the ``astro_xspec.rst`` file to reflect these new models.

The last commit adds support for XSPEC 12.15.0. Unfortunately you can not build against 12.15.0 without these changes. There are new models, but no parameter changes.

When testing

- you may need to update or remove `~/.xspec/Xspec.init` to addres AtomDb version updates
- the tests force a particular AtomDB version (3.0.9) that was used in recent XSPEC releases (the default for 12.15.0 is 3.1.2 or so); this is not ideal and we need something like #2224 to handle this more gracefully

There's no conda build of 12.15.0 so we can not test this with the CI runs yet. 

# Notes

The "biggest issue" I see here is the "let's just run all XSPEC tests with AtomDB 3.0.9" pytest fixture that is added. I see this as a stop-gap until either - or both - of 

- XSPEC 12.15.0 is the oldest version we expect to build against
- we get something like #2224 merged which gives direct access to the AtomDB version used by XSPEC and we can relpace a global fixture with a more test-appropriate one (this cuold technically be done here but it's more awkward to do)