### PR TITLE
Add missed pep 639 config update 

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -235,7 +235,7 @@ should be updated to match the output above::
     fftw_libraries=fftw3
 
     region=local
-    region-include_dirs=${ASCDS_INSTALL}/include
+    region_include_dirs=${ASCDS_INSTALL}/include
     region_lib_dirs=${ASCDS_INSTALL}/lib
     region_libraries=region ascdm
     region_use_cxc_parser=True

--- a/scripts/use_ciao_config
+++ b/scripts/use_ciao_config
@@ -76,7 +76,7 @@ sed -i="" "s|#disable_group=True|disable_group=True|" $cfg
 sed -i="" "s|#disable_stk=True|disable_stk=True|" $cfg
 
 sed -i="" "s|#region=local|region=local|" $cfg
-sed -i="" "s|#region-include_dirs=build/include|region-include_dirs=${CONDA_PREFIX}/include|" $cfg
+sed -i="" "s|#region_include_dirs=build/include|region_include_dirs=${CONDA_PREFIX}/include|" $cfg
 sed -i="" "s|#region_lib_dirs=build/lib|region_lib_dirs=${CONDA_PREFIX}/lib|" $cfg
 sed -i="" "s|#region_libraries=region|region_libraries=region ascdm|" $cfg
 sed -i="" "s|#region_use_cxc_parser=False|region_use_cxc_parser=True|" $cfg
@@ -84,7 +84,7 @@ sed -i="" "s|#region_use_cxc_parser=False|region_use_cxc_parser=True|" $cfg
 sed -i="" "s|#wcs=local|wcs=local|" $cfg
 # Historically the setup file has used the wrong form here
 # so support both 'include-dirs' and 'include_dirs'.
-sed -i="" "s|#wcs-include.dirs=build/include|wcs-include_dirs=${CONDA_PREFIX}/include|" $cfg
+sed -i="" "s|#wcs_include.dirs=build/include|wcs_include_dirs=${CONDA_PREFIX}/include|" $cfg
 sed -i="" "s|#wcs_lib_dirs=build/lib|wcs_lib_dirs=${CONDA_PREFIX}/lib|" $cfg
 sed -i="" "s|#wcs_libraries=wcs|wcs_libraries=wcs|" $cfg
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@
 # change the default location of libraries and headers and the name
 # of the library to be linked (usually region)
 # (include multiple values by separating them with spaces)
-#region-include_dirs=build/include
+#region_include_dirs=build/include
 #region_lib_dirs=build/lib
 #region_libraries=region
 #


### PR DESCRIPTION
# Summary
https://github.com/sherpa/sherpa/pull/2249 had a few stragglers in the update I missed when reviewing. This should get all the needed renames.

# detail
`region-include_dir` and `wcs-include_dir` were updated in `helpers/sherpa_config.py` to `region_include_dir` and `wcs_include_dir`, but that change got missed in some of the scripts that interact with them. This closes that loop.