### PR TITLE
Faster hash for modelCacher1D

### DIFF
--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -333,17 +333,7 @@ from sherpa.utils.numeric_types import SherpaFloat
 from .op import get_precedences_op, get_precedence_expr, \
     get_precedence_lhs, get_precedence_rhs
 from .parameter import Parameter, expand_par
-
-# What routine do we use for the hash in modelCacher1d?  As we do not
-# need cryptographic security go for a "quick" algorithm, but md5 is
-# not guaranteed to always be present.  There has been no attempt to
-# check the run times of these routines for the expected data sizes
-# they will be used with.
-#
-try:
-    from hashlib import md5 as hashfunc
-except ImportError:
-    from hashlib import sha256 as hashfunc
+from hashlib import sha256 as hashfunc
 
 info = logging.getLogger(__name__).info
 warning = logging.getLogger(__name__).warning

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -23,13 +23,6 @@ import logging
 import operator
 import warnings
 
-# Repeat the logic from sherpa/models/model.py
-#
-try:
-    from hashlib import md5 as hashfunc
-except ImportError:
-    from hashlib import sha256 as hashfunc
-
 import numpy as np
 
 import pytest
@@ -44,6 +37,7 @@ from sherpa.models.basic import Sin, Const1D, Box1D, LogParabola, Polynom1D, \
     Const2D, Gauss2D, Scale2D, Poisson
 from sherpa.fit import Fit
 from sherpa.utils.err import ModelErr, ParameterErr
+from sherpa.models.model import hashfunc
 
 
 def validate_warning(warning_capturer, parameter_name="norm",


### PR DESCRIPTION
## Summary
Select a faster hashing algorithm for the model cache by default 

## Details
Benchmarking indicates that sha265 is a factor of 3-4 faster than md5, and md5 is actually not available on every system, so there is no reason to use md5 as default. While sha256 might not be cyptographically secure (it has been shown that is can be broken in less time than the key length alone might indicate) collisions are still so unlikely (like 2^63 or something like that) that it's not a concern for this application.

See https://github.com/hamogu/sherpa-opt-benchmark/blob/main/notebooks/select_hash_for_caching.ipynb for details of the benchmarking.

### How important is this overall?
I've profiled real X-ray fitting cases, in particular Chandra ACIS spectroscopy from RW Aur A, which are fit wit ha combination of 4 APEC models (https://github.com/hamogu/sherpa-opt-benchmark/blob/main/notebooks/xspec_norm.ipynb). Looking at the outputs of those profiling runs, I find that the "md5" function takes up about 1% of the total runtime of the fit, obviously with the exact number changing with the datasets and models used.

### Is it worth it?
So, with this patch, the fraction of time spend calculating the hash goes down from 1% to 0.25%, which should speed up Sherpa by 0.75% overall. That's not great, but I did the investigation anyway, because I'm looking for the bottlenecks in the fitting in the context of #767 and #1990, so we might as well take it. I was a bit concerned about the note in the code that said that we had no idea about the speed impact of the cache, so potenitally this could have been more important; but at least we know that now.

## Alternatives
An even faster alterantive would be to not hash the key to the dict at all. Since dicts are internally implemented as hashmaps, the lookup in a dict is very insensitive to the length of the key. However, without hashing in the sherpa code, the dict would save the full input as the key value, and that has a memory impact. We can quantify that impact easily: It is domianted by the xhi and xlo (if present) arrays. The dict always holds the model output as the value and that output has the same number of entries as the xlo/xhi array. So, not hashing increases the size of the dict by a factor of 2 (or 3 if xhi is present). I posit that in most cases, that size is irrelevant, for example, for a typical, unbinned RGS or HETG grating spectrum and a cache of size 5 in a scenario where the user has 20 different instances of XSPEC models, the total size of all caches would go up from about 0.15 MB to 0.4 MB - a difference hardly measurable on today's computers. On the other hand, if you use Sherpa for models with > 1e6 points in xlo, then the cache size can become prohibitively large just from holding the model output (there is currently no mechanism to deal with this automatically). I forsee very few situations where saving a factor 2 in memory on the cache size actually makes a difference.

Yet, I don't think it's worth our time to investigate this closer just to shave off another 0.25% of runtime. 

## Build on top of #2166

This PR doesn't require #2166, but I built it on top of tht PR to avoid conflicts since they touch the same lines of code.