### PR TITLE
Add typing statements to the optimization code

### DIFF
--- a/sherpa/estmethods/__init__.py
+++ b/sherpa/estmethods/__init__.py
@@ -28,6 +28,7 @@ import warnings
 import numpy as np
 from numpy.linalg import LinAlgError
 
+from sherpa.stats import StatCallback
 from sherpa.utils import NoNewAttributesAfterInit, \
     FuncCounter, OutOfBoundErr, Knuth_close, \
     print_fields, is_iterable, list_to_open_interval, quad_coef, \
@@ -219,8 +220,7 @@ class Covariance(EstMethod):
         if statargs is not None or statkwargs is not None:
             warning("statargs/kwargs set but values unused")
 
-        def stat_cb(pars):
-            return statfunc(pars)[0]
+        stat_cb = StatCallback(statfunc)
 
         def fit_cb(scb, pars, parmins, parmaxes, i):
             # parameter i is a no-op usually
@@ -305,8 +305,7 @@ class Confidence(EstMethod):
         if statargs is not None or statkwargs is not None:
             warning("statargs/kwargs set but values unused")
 
-        def stat_cb(pars):
-            return statfunc(pars)[0]
+        stat_cb = StatCallback(statfunc)
 
         def fit_cb(pars, parmins, parmaxes, i):
             # freeze model parameter i
@@ -415,8 +414,7 @@ class Projection(EstMethod):
         if fitfunc is None:
             raise TypeError("fitfunc should not be none")
 
-        def stat_cb(pars):
-            return statfunc(pars)[0]
+        stat_cb = StatCallback(statfunc)
 
         def fit_cb(pars, parmins, parmaxes, i):
             # freeze model parameter i

--- a/sherpa/estmethods/__init__.py
+++ b/sherpa/estmethods/__init__.py
@@ -49,6 +49,9 @@ __all__ = ('EstNewMin', 'Covariance', 'Confidence',
            'est_hitnan')
 
 
+warning = logging.getLogger(__name__).warning
+
+
 # The return type for the estimation routines.
 #
 # It looks like the limits can be numbers or None.
@@ -157,8 +160,8 @@ class EstMethod(NoNewAttributesAfterInit):
                 thaw_par: Callable,
                 report_progress: Callable,
                 get_par_name: Callable,
-                statargs=(),
-                statkwargs={}
+                statargs: Any = None,
+                statkwargs: Any = None
                 ) -> EstReturn:
         """Estimate the error range.
 
@@ -198,8 +201,8 @@ class Covariance(EstMethod):
                 thaw_par: Callable,
                 report_progress: Callable,
                 get_par_name: Callable,
-                statargs=(),
-                statkwargs={}
+                statargs: Any = None,
+                statkwargs: Any = None
                 ) -> EstReturn:
         """Estimate the error range.
 
@@ -212,6 +215,9 @@ class Covariance(EstMethod):
         The statargs and statkwargs arguments are currently unused.
 
         """
+
+        if statargs is not None or statkwargs is not None:
+            warning("statargs/kwargs set but values unused")
 
         def stat_cb(pars):
             return statfunc(pars)[0]
@@ -280,8 +286,8 @@ class Confidence(EstMethod):
                 thaw_par: Callable,
                 report_progress: Callable,
                 get_par_name: Callable,
-                statargs=(),
-                statkwargs={}
+                statargs: Any = None,
+                statkwargs: Any = None
                 ) -> EstReturn:
 
         """Estimate the error range.
@@ -295,6 +301,9 @@ class Confidence(EstMethod):
 
 
         """
+
+        if statargs is not None or statkwargs is not None:
+            warning("statargs/kwargs set but values unused")
 
         def stat_cb(pars):
             return statfunc(pars)[0]
@@ -385,8 +394,8 @@ class Projection(EstMethod):
                 thaw_par: Callable,
                 report_progress: Callable,
                 get_par_name: Callable,
-                statargs=(),
-                statkwargs={}
+                statargs: Any = None,
+                statkwargs: Any = None
                 ) -> EstReturn:
         """Estimate the error range.
 
@@ -399,6 +408,9 @@ class Projection(EstMethod):
         The statargs and statkwargs arguments are currently unused.
 
         """
+
+        if statargs is not None or statkwargs is not None:
+            warning("statargs/kwargs set but values unused")
 
         if fitfunc is None:
             raise TypeError("fitfunc should not be none")

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -793,8 +793,8 @@ class IterFit:
                  pars: ArrayType,
                  parmins: ArrayType,
                  parmaxes: ArrayType,
-                 statargs: Sequence[Any] = (),
-                 statkwargs: Mapping[str, Any] | None = None,
+                 statargs: Any = None,
+                 statkwargs: Any = None,
                  cache: bool = True
                  ) -> OptReturn:
         """Exclude points that are significately far away from the best fit.
@@ -806,6 +806,9 @@ class IterFit:
         has converged or a maximum number of iterations has been reached.
         The error removal can be asymmetric, since there are separate
         options for the lower and upper limits.
+
+        .. versionchanged:: 4.17.1
+           The statargs and statkwargs arguments are now ignored.
 
         Raises
         ------
@@ -830,8 +833,9 @@ class IterFit:
         ========  ==========  ===========
 
         """
-        if statkwargs is None:
-            statkwargs = {}
+
+        if statargs is not None or statkwargs is not None:
+            warning("statargs/kwargs set but values unused")
 
         # Sigma-rejection can only be used with chi-squared;
         # raise exception if it is attempted with least-squares,
@@ -908,9 +912,9 @@ class IterFit:
                     self.stat.calc_staterror)
                 self.model.startup(cache)
                 final_fit_results = self.method.fit(statfunc,
-                                                    self.model.thawedpars,
-                                                    parmins, parmaxes,
-                                                    statargs, statkwargs)
+                                                    pars=self.model.thawedpars,
+                                                    parmins=parmins,
+                                                    parmaxes=parmaxes)
                 model_iterator = iter(self.model())
                 rejected = False
 
@@ -1006,19 +1010,25 @@ class IterFit:
             pars: ArrayType,
             parmins: ArrayType,
             parmaxes: ArrayType,
-            statargs: Sequence[Any] = (),
-            statkwargs: Mapping[str, Any] | None = None,
+            statargs: Any = None,
+            statkwargs: Any = None
             ) -> OptReturn:
+        """
 
-        if statkwargs is None:
-            statkwargs = {}
+        .. versionchanged:: 4.17.1
+           The statargs and statkwargs arguments are now ignored.
+
+        """
+
+        if statargs is not None or statkwargs is not None:
+            warning("statargs/kwargs set but values unused")
 
         if self.current_func is None:
-            return self.method.fit(statfunc, pars, parmins, parmaxes,
-                                   statargs, statkwargs)
+            return self.method.fit(statfunc, pars=pars,
+                                   parmins=parmins, parmaxes=parmaxes)
 
-        return self.current_func(statfunc, pars, parmins, parmaxes,
-                                 statargs, statkwargs)
+        return self.current_func(statfunc, pars=pars, parmins=parmins,
+                                 parmaxes=parmaxes)
 
 
 # What is the best way to annotate the return value here?

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -807,7 +807,7 @@ class IterFit:
         The error removal can be asymmetric, since there are separate
         options for the lower and upper limits.
 
-        .. versionchanged:: 4.17.1
+        .. versionchanged:: 4.18.0
            The statargs and statkwargs arguments are now ignored.
 
         Raises
@@ -1015,7 +1015,7 @@ class IterFit:
             ) -> OptReturn:
         """
 
-        .. versionchanged:: 4.17.1
+        .. versionchanged:: 4.18.0
            The statargs and statkwargs arguments are now ignored.
 
         """

--- a/sherpa/optmethods/__init__.py
+++ b/sherpa/optmethods/__init__.py
@@ -48,7 +48,7 @@ statistic values (note that per-bin here refers to the independent
 axis of the data being fit, and not the number of parameters being
 fit).
 
-.. versionchanged:: 4.17.1
+.. versionchanged:: 4.18.0
    The callback is no-longer sent extra information (that is,
    the statargs and statkwargs values) and is just sent an array
    of parameter values.
@@ -246,7 +246,7 @@ class OptMethod(NoNewAttributesAfterInit):
             ) -> OptReturn:
         """Run the optimiser.
 
-        .. versionchanged:: 4.17.1
+        .. versionchanged:: 4.18.0
            The statargs and statkwargs arguments are now ignored.
 
         .. versionchanged:: 4.16.0
@@ -284,7 +284,7 @@ class OptMethod(NoNewAttributesAfterInit):
 
         """
 
-        if statargs is not None and statkwargs is not None:
+        if statargs is not None or statkwargs is not None:
             warning("statargs/kwargs set but values unused")
 
         output = self._optfunc(statfunc, pars, parmins, parmaxes,

--- a/sherpa/optmethods/ncoresde.py
+++ b/sherpa/optmethods/ncoresde.py
@@ -433,13 +433,11 @@ class ncoresMyDifEvo(MyDifEvo):
     """
 
     .. versionchanged:: 4.17.1
-       Calling the object now requires named arguments and the
-       ordering has been changed to match the superclass.
+       The calling convention has been changed to match its superclass.
 
     """
 
     def __call__(self,
-                 *,
                  maxnfev: int,
                  ftol: float,
                  numcores: int | None = ncpus

--- a/sherpa/optmethods/ncoresde.py
+++ b/sherpa/optmethods/ncoresde.py
@@ -18,7 +18,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import numpy
+import numpy as np
 
 from sherpa.utils.parallel import parallel_map, ncpus
 from sherpa.utils import random
@@ -63,9 +63,9 @@ class Strategy:
 
     def calc(self, arg, pop):
         arg[-1] = self.func(arg[:-1])
-        tmp = numpy.empty(self.npar + 2)
+        tmp = np.empty(self.npar + 2)
         tmp[1:] = arg[:]
-        if numpy.finfo(numpy.float64).max == arg[-1]:
+        if np.finfo(np.float64).max == arg[-1]:
             tmp[0] = 0
         else:
             tmp[0] = 1
@@ -79,7 +79,7 @@ class Strategy0(Strategy):
 
     def __call__(self, pop, icurrent):
         r1, r2, r3 = self.init(3)
-        trial = numpy.array(pop[icurrent][:])
+        trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
         for _ in range(self.npar):
             trial[n] = pop[0][n] + self.sfactor * (pop[r2][n] - pop[r3][n])
@@ -94,7 +94,7 @@ class Strategy1(Strategy):
 
     def __call__(self, pop, icurrent):
         r1, r2, r3 = self.init(3)
-        trial = numpy.array(pop[icurrent][:])
+        trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
         for _ in range(self.npar):
             trial[n] = trial[n] + self.sfactor * (pop[r2][n] - pop[r3][n])
@@ -109,7 +109,7 @@ class Strategy2(Strategy):
 
     def __call__(self, pop, icurrent):
         r1, r2 = self.init(2)
-        trial = numpy.array(pop[icurrent][:])
+        trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
         for _ in range(self.npar):
             trial[n] = trial[n] + self.sfactor * (pop[0][n] - trial[n]) + \
@@ -125,7 +125,7 @@ class Strategy3(Strategy):
 
     def __call__(self, pop, icurrent):
         r1, r2, r3, r4 = self.init(4)
-        trial = numpy.array(pop[icurrent][:])
+        trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
         for _ in range(self.npar):
             trial[n] = pop[0][n] + \
@@ -142,7 +142,7 @@ class Strategy4(Strategy):
 
     def __call__(self, pop, icurrent):
         r1, r2, r3, r4, r5 = self.init(5)
-        trial = numpy.array(pop[icurrent][:])
+        trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
         for _ in range(self.npar):
             trial[n] = pop[r5][n] + \
@@ -159,7 +159,7 @@ class Strategy5(Strategy):
 
     def __call__(self, pop, icurrent):
         r1, r2, r3 = self.init(3)
-        trial = numpy.array(pop[icurrent][:])
+        trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
         for counter in range(self.npar):
             if random.random(self.rng) < self.xprob or \
@@ -175,7 +175,7 @@ class Strategy6(Strategy):
 
     def __call__(self, pop, icurrent):
         r1, r2, r3 = self.init(3)
-        trial = numpy.array(pop[icurrent][:])
+        trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
         for counter in range(self.npar):
             if random.random(self.rng) < self.xprob or \
@@ -191,7 +191,7 @@ class Strategy7(Strategy):
 
     def __call__(self, pop, icurrent):
         r1, r2 = self.init(2)
-        trial = numpy.array(pop[icurrent][:])
+        trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
         for counter in range(self.npar):
             if random.random(self.rng) < self.xprob or \
@@ -207,7 +207,7 @@ class Strategy8(Strategy):
 
     def __call__(self, pop, icurrent):
         r1, r2, r3, r4 = self.init(4)
-        trial = numpy.array(pop[icurrent][:])
+        trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
         for counter in range(self.npar):
             if random.random(self.rng) < self.xprob or \
@@ -223,7 +223,7 @@ class Strategy9(Strategy):
 
     def __call__(self, pop, icurrent):
         r1, r2, r3, r4, r5 = self.init(5)
-        trial = numpy.array(pop[icurrent][:])
+        trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
         for counter in range(self.npar):
             if random.random(self.rng) < self.xprob or \
@@ -240,7 +240,8 @@ class MyDifEvo(Opt):
 
     def __init__(self, func, xpar, xmin, xmax, npop, sfactor, xprob, step,
                  seed, rng=None):
-        Opt.__init__(self, func, xmin, xmax)
+        super().__init__(func, xmin, xmax)
+
         self.ncores_nm = ncoresNelderMead()
         self.key2 = Key2()
         self.npop = min(npop, 4096)
@@ -255,12 +256,12 @@ class MyDifEvo(Opt):
         #
         strats = [Strategy0, Strategy1, Strategy2, Strategy3, Strategy4,
                   Strategy5, Strategy6, Strategy7, Strategy8, Strategy9]
-        sseeds = numpy.random.SeedSequence(seed).spawn(len(strats))
+        sseeds = np.random.SeedSequence(seed).spawn(len(strats))
         self.strategies = [strat(self.func, self.npar, npop, sfactor, xprob,
-                                 rng=numpy.random.default_rng(sseed))
+                                 rng=np.random.default_rng(sseed))
                            for strat, sseed in zip(strats, sseeds)]
 
-        xpar = numpy.asarray(xpar)
+        xpar = np.asarray(xpar)
         if step is None:
             step = xpar * 1.2 + 1.2
         factor = 10
@@ -308,7 +309,7 @@ class MyDifEvo(Opt):
         # needed it when it was random.seed).
         #
         if self.rng is None:
-            numpy.random.seed(int(self.seed))
+            np.random.seed(int(self.seed))
 
         mypop = self.polytope
         best_trial = self.strategies[0](mypop, index)
@@ -324,12 +325,12 @@ class MyDifEvo(Opt):
     def apply_local_opt(self, arg, index):
         local_opt = self.local_opt[index % len(self.local_opt)]
         result = local_opt(self.func, arg[1:-1], self.xmin, self.xmax)
-        tmp = numpy.append(result[0], result[2])
-        result = numpy.append(tmp, result[1])
+        tmp = np.append(result[0], result[2])
+        result = np.append(tmp, result[1])
         return result
 
     def calc_key(self, indices, start=0, end=65536):
-        result = numpy.empty(len(indices), dtype=numpy.int64)
+        result = np.empty(len(indices), dtype=np.int64)
         for ii, index in enumerate(indices):
             # want to generate [start, end)
             rand = random.integers(self.rng, end - start) + start
@@ -354,10 +355,10 @@ class ncoresMyDifEvo(MyDifEvo):
         # random.seed but now changes the NumPy version.
         #
         if self.rng is None:
-            numpy.random.seed(self.seed)
+            np.random.seed(self.seed)
 
         mypop = self.polytope
-        old_fval = numpy.inf
+        old_fval = np.inf
         while nfev < maxnfev:
 
             # all_strategies has been set up so that each strategy has
@@ -386,7 +387,7 @@ class ncoresMyDifEvo(MyDifEvo):
                                    tol)
                 nfev += tmp_nfev
                 if tmp_fval < best_fval:
-                    best_par = numpy.append(tmp_par, tmp_fval)
+                    best_par = np.append(tmp_par, tmp_fval)
                     mypop[1] = best_par[:]
                     self.polytope.sort()
                     old_fval = tmp_fval

--- a/sherpa/optmethods/ncoresde.py
+++ b/sherpa/optmethods/ncoresde.py
@@ -54,6 +54,9 @@ class Key2:
 
 
 class Strategy:
+    """Create a trial set of parameters.
+
+    """
 
     def __init__(self,
                  func: OptimizerFunc,
@@ -110,7 +113,7 @@ class Strategy0(Strategy):
                  icurrent: int
                  ) -> np.ndarray:
         r1, r2, r3 = self.init(3)
-        trial = np.array(pop[icurrent][:])
+        trial = pop[icurrent].copy()
         n = random.integers(self.rng, self.npar)
         for _ in range(self.npar):
             trial[n] = pop[0][n] + self.sfactor * (pop[r2][n] - pop[r3][n])
@@ -128,7 +131,7 @@ class Strategy1(Strategy):
                  icurrent: int
                  ) -> np.ndarray:
         r1, r2, r3 = self.init(3)
-        trial = np.array(pop[icurrent][:])
+        trial = pop[icurrent].copy()
         n = random.integers(self.rng, self.npar)
         for _ in range(self.npar):
             trial[n] = trial[n] + self.sfactor * (pop[r2][n] - pop[r3][n])
@@ -146,7 +149,7 @@ class Strategy2(Strategy):
                  icurrent: int
                  ) -> np.ndarray:
         r1, r2 = self.init(2)
-        trial = np.array(pop[icurrent][:])
+        trial = pop[icurrent].copy()
         n = random.integers(self.rng, self.npar)
         for _ in range(self.npar):
             trial[n] = trial[n] + self.sfactor * (pop[0][n] - trial[n]) + \
@@ -165,7 +168,7 @@ class Strategy3(Strategy):
                  icurrent: int
                  ) -> np.ndarray:
         r1, r2, r3, r4 = self.init(4)
-        trial = np.array(pop[icurrent][:])
+        trial = pop[icurrent].copy()
         n = random.integers(self.rng, self.npar)
         for _ in range(self.npar):
             trial[n] = pop[0][n] + \
@@ -185,7 +188,7 @@ class Strategy4(Strategy):
                  icurrent: int
                  ) -> np.ndarray:
         r1, r2, r3, r4, r5 = self.init(5)
-        trial = np.array(pop[icurrent][:])
+        trial = pop[icurrent].copy()
         n = random.integers(self.rng, self.npar)
         for _ in range(self.npar):
             trial[n] = pop[r5][n] + \
@@ -205,7 +208,7 @@ class Strategy5(Strategy):
                  icurrent: int
                  ) -> np.ndarray:
         r1, r2, r3 = self.init(3)
-        trial = np.array(pop[icurrent][:])
+        trial = pop[icurrent].copy()
         n = random.integers(self.rng, self.npar)
         for counter in range(self.npar):
             if random.random(self.rng) < self.xprob or \
@@ -224,7 +227,7 @@ class Strategy6(Strategy):
                  icurrent: int
                  ) -> np.ndarray:
         r1, r2, r3 = self.init(3)
-        trial = np.array(pop[icurrent][:])
+        trial = pop[icurrent].copy()
         n = random.integers(self.rng, self.npar)
         for counter in range(self.npar):
             if random.random(self.rng) < self.xprob or \
@@ -243,7 +246,7 @@ class Strategy7(Strategy):
                  icurrent: int
                  ) -> np.ndarray:
         r1, r2 = self.init(2)
-        trial = np.array(pop[icurrent][:])
+        trial = pop[icurrent].copy()
         n = random.integers(self.rng, self.npar)
         for counter in range(self.npar):
             if random.random(self.rng) < self.xprob or \
@@ -262,7 +265,7 @@ class Strategy8(Strategy):
                  icurrent: int
                  ) -> np.ndarray:
         r1, r2, r3, r4 = self.init(4)
-        trial = np.array(pop[icurrent][:])
+        trial = pop[icurrent].copy()
         n = random.integers(self.rng, self.npar)
         for counter in range(self.npar):
             if random.random(self.rng) < self.xprob or \
@@ -281,7 +284,7 @@ class Strategy9(Strategy):
                  icurrent: int
                  ) -> np.ndarray:
         r1, r2, r3, r4, r5 = self.init(5)
-        trial = np.array(pop[icurrent][:])
+        trial = pop[icurrent].copy()
         n = random.integers(self.rng, self.npar)
         for counter in range(self.npar):
             if random.random(self.rng) < self.xprob or \

--- a/sherpa/optmethods/ncoresde.py
+++ b/sherpa/optmethods/ncoresde.py
@@ -435,14 +435,13 @@ class MyDifEvo(Opt):
         if self.rng is None:
             np.random.seed(int(self.seed))
 
-        mypop = self.polytope
-        best_trial = self.strategies[0](mypop, index)
+        best_trial = self.strategies[0](self.polytope, index)
         for ii in range(1, len(self.strategies)):
-            trial = self.strategies[ii](mypop, index)
+            trial = self.strategies[ii](self.polytope, index)
             if trial.statval < best_trial.statval:
                 best_trial = trial
 
-        if best_trial.statval < mypop[0][-1]:
+        if best_trial.statval < self.polytope[0][-1]:
             return self.apply_local_opt(best_trial, index)
 
         return best_trial
@@ -497,7 +496,6 @@ class ncoresMyDifEvo(MyDifEvo):
         if self.rng is None:
             np.random.seed(self.seed)
 
-        mypop = self.polytope
         old_fval = np.inf
         while nfev < maxnfev:
 
@@ -511,17 +509,17 @@ class ncoresMyDifEvo(MyDifEvo):
 
             for index, res in enumerate(results):
                 nfev += res.nfev
-                if res.statval < mypop[index][-1]:
+                if res.statval < self.polytope[index][-1]:
                     # SimplexRandom stores <par1, ..., parN, statval>
                     # in each row (index vaue).
                     tmp = np.append(res.pars, res.statval)
-                    mypop[index] = tmp
+                    self.polytope[index] = tmp
 
-            mypop.sort()
-            if mypop.check_convergence(ftol, 0):
+            self.polytope.sort()
+            if self.polytope.check_convergence(ftol, 0):
                 break
 
-            best = mypop[0]
+            best = self.polytope[0]
             best_fval = best[-1]
             if best_fval < old_fval:
                 best_par = best[:-1]
@@ -530,13 +528,13 @@ class ncoresMyDifEvo(MyDifEvo):
                 nfev += tmp.nfev
                 if tmp.statval < best_fval:
                     best_par = np.append(tmp.pars, tmp.statval)
-                    mypop[1] = best_par[:]
-                    mypop.sort()
+                    self.polytope[1] = best_par[:]
+                    self.polytope.sort()
                     old_fval = tmp.statval
                 else:
                     old_fval = best_fval
 
-        best_vertex = mypop[0]
+        best_vertex = self.polytope[0]
         best_par = best_vertex[:-1]
         best_fval = best_vertex[-1]
         return OptOutput(nfev=nfev,

--- a/sherpa/optmethods/ncoresde.py
+++ b/sherpa/optmethods/ncoresde.py
@@ -112,7 +112,9 @@ class Strategy0(Strategy):
                  pop: SimplexRandom,
                  icurrent: int
                  ) -> np.ndarray:
-        r1, r2, r3 = self.init(3)
+        # Although only two numbers are needed, leave as is since the
+        # code has been tested using this call.
+        _, r2, r3 = self.init(3)
         trial = pop[icurrent].copy()
         n = random.integers(self.rng, self.npar)
         for _ in range(self.npar):
@@ -130,7 +132,9 @@ class Strategy1(Strategy):
                  pop: SimplexRandom,
                  icurrent: int
                  ) -> np.ndarray:
-        r1, r2, r3 = self.init(3)
+        # Although only two numbers are needed, leave as is since the
+        # code has been tested using this call.
+        _, r2, r3 = self.init(3)
         trial = pop[icurrent].copy()
         n = random.integers(self.rng, self.npar)
         for _ in range(self.npar):
@@ -207,7 +211,9 @@ class Strategy5(Strategy):
                  pop: SimplexRandom,
                  icurrent: int
                  ) -> np.ndarray:
-        r1, r2, r3 = self.init(3)
+        # Although only two numbers are needed, leave as is since the
+        # code has been tested using this call.
+        _, r2, r3 = self.init(3)
         trial = pop[icurrent].copy()
         n = random.integers(self.rng, self.npar)
         for counter in range(self.npar):
@@ -264,7 +270,9 @@ class Strategy8(Strategy):
                  pop: SimplexRandom,
                  icurrent: int
                  ) -> np.ndarray:
-        r1, r2, r3, r4 = self.init(4)
+        # Although only three numbers are needed, leave as is since the
+        # code has been tested using this call.
+        _, r2, r3, r4 = self.init(4)
         trial = pop[icurrent].copy()
         n = random.integers(self.rng, self.npar)
         for counter in range(self.npar):

--- a/sherpa/optmethods/ncoresde.py
+++ b/sherpa/optmethods/ncoresde.py
@@ -18,22 +18,24 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from typing import Any
+
 import numpy as np
 
 from sherpa.utils.parallel import parallel_map, ncpus
 from sherpa.utils import random
 
 from .ncoresnm import ncoresNelderMead
-from .opt import Opt, SimplexRandom
+from .opt import Opt, OptimizerFunc, MyOptOutput, SimplexRandom
 
 
 class Key2:
 
-    def __init__(self, n=12):
+    def __init__(self, n: int = 12) -> None:
         self.nbit = n
         self.max_arg2 = 2**n - 1
 
-    def calc(self, arg1, arg2):
+    def calc(self, arg1: int, arg2: int) -> int:
         if arg2 > self.max_arg2:
             raise ValueError(f"arg2 ({arg2}) must be < {self.max_arg2}")
 
@@ -42,7 +44,7 @@ class Key2:
         key += arg2
         return key
 
-    def parse(self, key):
+    def parse(self, key: int) -> tuple[int, int]:
         arg1 = key
         arg1 >>= self.nbit
         arg2 = arg1
@@ -53,7 +55,14 @@ class Key2:
 
 class Strategy:
 
-    def __init__(self, func, npar, npop, sfactor, xprob, rng=None):
+    def __init__(self,
+                 func: OptimizerFunc,
+                 npar: int,
+                 npop: int,
+                 sfactor: float,
+                 xprob: float,
+                 rng: random.RandomType | None = None
+                 ) -> None:
         self.func = func
         self.npar = npar
         self.npop = npop
@@ -61,7 +70,26 @@ class Strategy:
         self.xprob = xprob
         self.rng = rng
 
-    def calc(self, arg, pop):
+    def __call__(self,
+                 pop: SimplexRandom,
+                 icurrent: int
+                 ) -> np.ndarray:
+        raise NotImplementedError
+
+    # The arg argument contains parameter values and then the
+    # statistic value (which will be updated by this call).
+    #
+    # The return value is the combination of
+    #      nfev, pars, statval
+    # where nfev is 1 if the values are "sensible" and 0 otherwise
+    # (relying on self.func to trigger any outside-parameter-range
+    # logic). This is essentially MyOptOutput but in a single array
+    # and the ordering is different.
+    #
+    def calc(self,
+             arg: np.ndarray,
+             pop: Any  # unused
+             ) -> np.ndarray:
         arg[-1] = self.func(arg[:-1])
         tmp = np.empty(self.npar + 2)
         tmp[1:] = arg[:]
@@ -71,13 +99,16 @@ class Strategy:
             tmp[0] = 1
         return tmp
 
-    def init(self, num):
+    def init(self, num: int) -> np.ndarray:
         return random.choice(self.rng, range(self.npop), num)
 
 
 class Strategy0(Strategy):
 
-    def __call__(self, pop, icurrent):
+    def __call__(self,
+                 pop: SimplexRandom,
+                 icurrent: int
+                 ) -> np.ndarray:
         r1, r2, r3 = self.init(3)
         trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
@@ -92,7 +123,10 @@ class Strategy0(Strategy):
 
 class Strategy1(Strategy):
 
-    def __call__(self, pop, icurrent):
+    def __call__(self,
+                 pop: SimplexRandom,
+                 icurrent: int
+                 ) -> np.ndarray:
         r1, r2, r3 = self.init(3)
         trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
@@ -107,7 +141,10 @@ class Strategy1(Strategy):
 
 class Strategy2(Strategy):
 
-    def __call__(self, pop, icurrent):
+    def __call__(self,
+                 pop: SimplexRandom,
+                 icurrent: int
+                 ) -> np.ndarray:
         r1, r2 = self.init(2)
         trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
@@ -123,7 +160,10 @@ class Strategy2(Strategy):
 
 class Strategy3(Strategy):
 
-    def __call__(self, pop, icurrent):
+    def __call__(self,
+                 pop: SimplexRandom,
+                 icurrent: int
+                 ) -> np.ndarray:
         r1, r2, r3, r4 = self.init(4)
         trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
@@ -140,7 +180,10 @@ class Strategy3(Strategy):
 
 class Strategy4(Strategy):
 
-    def __call__(self, pop, icurrent):
+    def __call__(self,
+                 pop: SimplexRandom,
+                 icurrent: int
+                 ) -> np.ndarray:
         r1, r2, r3, r4, r5 = self.init(5)
         trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
@@ -157,7 +200,10 @@ class Strategy4(Strategy):
 
 class Strategy5(Strategy):
 
-    def __call__(self, pop, icurrent):
+    def __call__(self,
+                 pop: SimplexRandom,
+                 icurrent: int
+                 ) -> np.ndarray:
         r1, r2, r3 = self.init(3)
         trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
@@ -173,7 +219,10 @@ class Strategy5(Strategy):
 
 class Strategy6(Strategy):
 
-    def __call__(self, pop, icurrent):
+    def __call__(self,
+                 pop: SimplexRandom,
+                 icurrent: int
+                 ) -> np.ndarray:
         r1, r2, r3 = self.init(3)
         trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
@@ -189,7 +238,10 @@ class Strategy6(Strategy):
 
 class Strategy7(Strategy):
 
-    def __call__(self, pop, icurrent):
+    def __call__(self,
+                 pop: SimplexRandom,
+                 icurrent: int
+                 ) -> np.ndarray:
         r1, r2 = self.init(2)
         trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
@@ -205,7 +257,10 @@ class Strategy7(Strategy):
 
 class Strategy8(Strategy):
 
-    def __call__(self, pop, icurrent):
+    def __call__(self,
+                 pop: SimplexRandom,
+                 icurrent: int
+                 ) -> np.ndarray:
         r1, r2, r3, r4 = self.init(4)
         trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
@@ -221,7 +276,10 @@ class Strategy8(Strategy):
 
 class Strategy9(Strategy):
 
-    def __call__(self, pop, icurrent):
+    def __call__(self,
+                 pop: SimplexRandom,
+                 icurrent: int
+                 ) -> np.ndarray:
         r1, r2, r3, r4, r5 = self.init(5)
         trial = np.array(pop[icurrent][:])
         n = random.integers(self.rng, self.npar)
@@ -245,8 +303,18 @@ class MyDifEvo(Opt):
 
     """
 
-    def __init__(self, func, xpar, xmin, xmax, npop, sfactor, xprob, step,
-                 seed, rng=None):
+    def __init__(self,
+                 func: OptimizerFunc,
+                 xpar: np.ndarray,
+                 xmin: np.ndarray,
+                 xmax: np.ndarray,
+                 npop: int,
+                 sfactor: float,
+                 xprob: float,
+                 step: np.ndarray | None,
+                 seed: int,
+                 rng: random.RandomType | None = None
+                 ) -> None:
         super().__init__(func, xmin, xmax)
 
         self.ncores_nm = ncoresNelderMead()
@@ -311,7 +379,7 @@ class MyDifEvo(Opt):
     #     best_val = best_vertex[-1]
     #     return self.nfev, best_val, best_par
 
-    def all_strategies(self, key):
+    def all_strategies(self, key: int) -> np.ndarray:
         rand, index = self.key2.parse(key)
 
         # Set the seed if RNG is not sent in. This used to change
@@ -333,14 +401,21 @@ class MyDifEvo(Opt):
             best_trial = self.apply_local_opt(best_trial, index)
         return best_trial
 
-    def apply_local_opt(self, arg, index):
+    def apply_local_opt(self,
+                        arg: np.ndarray,
+                        index: int
+                        ) -> np.ndarray:
         local_opt = self.local_opt[index % len(self.local_opt)]
         result = local_opt(self.func, arg[1:-1], self.xmin, self.xmax)
         tmp = np.append(result[0], result[2])
         result = np.append(tmp, result[1])
         return result
 
-    def calc_key(self, indices, start=0, end=65536):
+    def calc_key(self,
+                 indices,
+                 start: int = 0,
+                 end: int = 65536
+                 ) -> np.ndarray:
         result = np.empty(len(indices), dtype=np.int64)
         for ii, index in enumerate(indices):
             # want to generate [start, end)
@@ -366,7 +441,13 @@ class ncoresMyDifEvo(MyDifEvo):
 
     """
 
-    def __call__(self, *, maxnfev, ftol, numcores=ncpus):
+    def __call__(self,
+                 *,
+                 maxnfev: int,
+                 ftol: float,
+                 numcores: int | None = ncpus
+                 ) -> MyOptOutput:
+
         nfev = 0
 
         # Set the seed if RNG is not sent in. This used to change
@@ -451,12 +532,26 @@ class ncoresDifEvo:
     # The classes tend to take rng as an argument when constructing the
     # object, so follow that approach here.
     #
-    def __init__(self, rng=None):
+    def __init__(self,
+                 rng: random.RandomType | None = None
+                 ) -> None:
         self.rng = rng
 
-    def __call__(self, fcn, x, xmin, xmax, tol=1.0e-6, maxnfev=None, step=None,
-                 numcores=None, npop=None, seed=23, sfactor=0.85, xprob=0.7,
-                 verbose=0):
+    def __call__(self,
+                 fcn: OptimizerFunc,
+                 x: np.ndarray,
+                 xmin: np.ndarray,
+                 xmax: np.ndarray,
+                 tol: float = 1.0e-6,
+                 maxnfev: int | None = None,
+                 step: np.ndarray | None = None,
+                 numcores: int | None = None,
+                 npop: int | None = None,
+                 seed: int = 23,
+                 sfactor: float = 0.85,
+                 xprob: float = 0.7,
+                 verbose: Any = 0  # unused
+                 ) -> MyOptOutput:
 
         npar = len(x)
         if npop is None:

--- a/sherpa/optmethods/ncoresde.py
+++ b/sherpa/optmethods/ncoresde.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019 - 2021, 2023 - 2025
+#  Copyright (C) 2019-2021, 2023-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -26,7 +26,7 @@ from sherpa.utils.parallel import parallel_map, ncpus
 from sherpa.utils import random
 
 from .ncoresnm import ncoresNelderMead
-from .opt import FUNC_MAX, Opt, OptimizerFunc, MyOptOutput, SimplexRandom
+from .opt import FUNC_MAX, Opt, OptimizerFunc, OptOutput, SimplexRandom
 
 
 class Key2:
@@ -76,7 +76,7 @@ class Strategy:
     def __call__(self,
                  pop: SimplexRandom,
                  icurrent: int
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
 
         # The subclasses are assumed to follow:
         #
@@ -116,7 +116,7 @@ class Strategy:
     def calc(self,
              arg: np.ndarray,
              pop: Any  # unused
-             ) -> MyOptOutput:
+             ) -> OptOutput:
 
         funcval = self.func(arg[:-1])
         nfev = 1 if funcval != FUNC_MAX else 0
@@ -149,7 +149,7 @@ class Strategy0(Strategy):
     def __call__(self,
                  pop: SimplexRandom,
                  icurrent: int
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
         # Although only two numbers are needed, leave as is since the
         # code has been tested using this call.
         _, r2, r3 = self.init(3)
@@ -169,7 +169,7 @@ class Strategy1(Strategy):
     def __call__(self,
                  pop: SimplexRandom,
                  icurrent: int
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
         # Although only two numbers are needed, leave as is since the
         # code has been tested using this call.
         _, r2, r3 = self.init(3)
@@ -189,7 +189,7 @@ class Strategy2(Strategy):
     def __call__(self,
                  pop: SimplexRandom,
                  icurrent: int
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
         r1, r2 = self.init(2)
         trial = pop[icurrent].copy()
         n = self.select_par()
@@ -208,7 +208,7 @@ class Strategy3(Strategy):
     def __call__(self,
                  pop: SimplexRandom,
                  icurrent: int
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
         r1, r2, r3, r4 = self.init(4)
         trial = pop[icurrent].copy()
         n = self.select_par()
@@ -228,7 +228,7 @@ class Strategy4(Strategy):
     def __call__(self,
                  pop: SimplexRandom,
                  icurrent: int
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
         r1, r2, r3, r4, r5 = self.init(5)
         trial = pop[icurrent].copy()
         n = self.select_par()
@@ -248,7 +248,7 @@ class Strategy5(Strategy):
     def __call__(self,
                  pop: SimplexRandom,
                  icurrent: int
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
         # Although only two numbers are needed, leave as is since the
         # code has been tested using this call.
         _, r2, r3 = self.init(3)
@@ -268,7 +268,7 @@ class Strategy6(Strategy):
     def __call__(self,
                  pop: SimplexRandom,
                  icurrent: int
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
         r1, r2, r3 = self.init(3)
         trial = pop[icurrent].copy()
         n = self.select_par()
@@ -286,7 +286,7 @@ class Strategy7(Strategy):
     def __call__(self,
                  pop: SimplexRandom,
                  icurrent: int
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
         r1, r2 = self.init(2)
         trial = pop[icurrent].copy()
         n = self.select_par()
@@ -304,7 +304,7 @@ class Strategy8(Strategy):
     def __call__(self,
                  pop: SimplexRandom,
                  icurrent: int
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
         # Although only three numbers are needed, leave as is since the
         # code has been tested using this call.
         _, r2, r3, r4 = self.init(4)
@@ -324,7 +324,7 @@ class Strategy9(Strategy):
     def __call__(self,
                  pop: SimplexRandom,
                  icurrent: int
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
         r1, r2, r3, r4, r5 = self.init(5)
         trial = pop[icurrent].copy()
         n = self.select_par()
@@ -422,7 +422,7 @@ class MyDifEvo(Opt):
     #     best_val = best_vertex[-1]
     #     return self.nfev, best_val, best_par
 
-    def all_strategies(self, key: int) -> MyOptOutput:
+    def all_strategies(self, key: int) -> OptOutput:
         _, index = self.key2.parse(key)
 
         # Set the seed if RNG is not sent in. This used to change
@@ -446,9 +446,9 @@ class MyDifEvo(Opt):
         return best_trial
 
     def apply_local_opt(self,
-                        arg: MyOptOutput,
+                        arg: OptOutput,
                         index: int
-                        ) -> MyOptOutput:
+                        ) -> OptOutput:
         local_opt = self.local_opt[index % len(self.local_opt)]
         return local_opt(self.func, arg[2], self.xmin, self.xmax)
 
@@ -485,7 +485,7 @@ class ncoresMyDifEvo(MyDifEvo):
                  maxnfev: int,
                  ftol: float,
                  numcores: int | None = ncpus
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
 
         nfev = 0
 
@@ -504,7 +504,7 @@ class ncoresMyDifEvo(MyDifEvo):
             # and not have to think about parallel_map_rng.
             #
             keys = self.calc_key(range(self.npop))
-            results: list[MyOptOutput] = \
+            results: list[OptOutput] = \
                 parallel_map(self.all_strategies, keys, numcores)
 
             for index, (nfev_r, fval_r, pars_r) in enumerate(results):
@@ -593,7 +593,7 @@ class ncoresDifEvo:
                  sfactor: float = 0.85,
                  xprob: float = 0.7,
                  verbose: Any = 0  # unused
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
 
         npar = len(x)
         if npop is None:

--- a/sherpa/optmethods/ncoresde.py
+++ b/sherpa/optmethods/ncoresde.py
@@ -517,8 +517,8 @@ class ncoresMyDifEvo(MyDifEvo):
                     tmp = np.append(res.pars, res.statval)
                     mypop[index] = tmp
 
-            self.polytope.sort()
-            if self.polytope.check_convergence(ftol, 0):
+            mypop.sort()
+            if mypop.check_convergence(ftol, 0):
                 break
 
             best = mypop[0]
@@ -531,12 +531,12 @@ class ncoresMyDifEvo(MyDifEvo):
                 if tmp.statval < best_fval:
                     best_par = np.append(tmp.pars, tmp.statval)
                     mypop[1] = best_par[:]
-                    self.polytope.sort()
+                    mypop.sort()
                     old_fval = tmp.statval
                 else:
                     old_fval = best_fval
 
-        best_vertex = self.polytope[0]
+        best_vertex = mypop[0]
         best_par = best_vertex[:-1]
         best_fval = best_vertex[-1]
         return OptOutput(nfev=nfev,

--- a/sherpa/optmethods/ncoresde.py
+++ b/sherpa/optmethods/ncoresde.py
@@ -341,7 +341,7 @@ class Strategy9(Strategy):
 class MyDifEvo(Opt):
     """
 
-    .. versionchanged:: 4.17.1
+    .. versionchanged:: 4.18.0
        Some of the methods now use more-structured return types.
 
     """
@@ -476,7 +476,7 @@ class MyDifEvo(Opt):
 class ncoresMyDifEvo(MyDifEvo):
     """
 
-    .. versionchanged:: 4.17.1
+    .. versionchanged:: 4.18.0
        The calling convention has been changed to match its superclass.
 
     """

--- a/sherpa/optmethods/ncoresde.py
+++ b/sherpa/optmethods/ncoresde.py
@@ -18,6 +18,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from abc import ABCMeta, abstractmethod
 from typing import Any
 
 import numpy as np
@@ -53,7 +54,7 @@ class Key2:
         return arg1 - 1, arg2
 
 
-class Strategy:
+class Strategy(metaclass=ABCMeta):
     """Create a trial set of parameters.
 
     """
@@ -73,6 +74,7 @@ class Strategy:
         self.xprob = xprob
         self.rng = rng
 
+    @abstractmethod
     def __call__(self,
                  pop: SimplexRandom,
                  icurrent: int
@@ -436,8 +438,8 @@ class MyDifEvo(Opt):
             np.random.seed(int(self.seed))
 
         best_trial = self.strategies[0](self.polytope, index)
-        for ii in range(1, len(self.strategies)):
-            trial = self.strategies[ii](self.polytope, index)
+        for strategy in self.strategies[1:]:
+            trial = strategy(self.polytope, index)
             if trial.statval < best_trial.statval:
                 best_trial = trial
 

--- a/sherpa/optmethods/ncoresnm.py
+++ b/sherpa/optmethods/ncoresnm.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019 - 2021, 2023, 2024
+#  Copyright (C) 2019 - 2021, 2023 - 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -23,8 +23,7 @@ import numpy as np
 from sherpa.utils.parallel import ncpus
 
 from . import _saoopt  # type: ignore
-from .opt import MyNcores, Opt, SimplexNoStep, SimplexStep, \
-    SimplexRandom
+from .opt import MyNcores, Opt, SimplexStep
 
 __all__ = ('ncoresNelderMead', )
 
@@ -262,48 +261,54 @@ class NelderMead5(NelderMead0):
         return nfev, fmin, par
 
 
-class NelderMead6(NelderMeadBase):
+# This is only used by tests/test_opt_original.py when run directly,
+# not via pytest. Left commented out to make it easier to find.
+#
+# class NelderMead6(NelderMeadBase):
+#
+#     # TODO: do we really need this internal class?
+#     class MyNelderMead6(MyNelderMead):
+#
+#         def __call__(self, x, maxnfev, tol, step, finalsimplex, verbose):
+#             npar = len(x)
+#             simplex = SimplexNoStep(func=self.func, npop=npar + 1,
+#                                     xpar=x, xmin=self.xmin,
+#                                     xmax=self.xmax, step=None,
+#                                     seed=None, factor=None)
+#             return self.optimize(x, simplex, maxnfev, tol,
+#                                  finalsimplex, verbose)
+#
+#     def __call__(self, fcn, x, xmin, xmax, tol=1.0e-6,  maxnfev=None,
+#                  step=None, finalsimplex=1, verbose=0):
+#         my_nm_6 = NelderMead6.MyNelderMead6(fcn, xmin, xmax)
+#         if maxnfev is None:
+#             maxnfev = 512 * len(x)
+#         return my_nm_6(x, maxnfev, tol, step, finalsimplex, verbose)
 
-    # TODO: do we really need this internal class?
-    class MyNelderMead6(MyNelderMead):
 
-        def __call__(self, x, maxnfev, tol, step, finalsimplex, verbose):
-            npar = len(x)
-            simplex = SimplexNoStep(func=self.func, npop=npar + 1,
-                                    xpar=x, xmin=self.xmin,
-                                    xmax=self.xmax, step=None,
-                                    seed=None, factor=None)
-            return self.optimize(x, simplex, maxnfev, tol,
-                                 finalsimplex, verbose)
-
-    def __call__(self, fcn, x, xmin, xmax, tol=1.0e-6,  maxnfev=None,
-                 step=None, finalsimplex=1, verbose=0):
-        my_nm_6 = NelderMead6.MyNelderMead6(fcn, xmin, xmax)
-        if maxnfev is None:
-            maxnfev = 512 * len(x)
-        return my_nm_6(x, maxnfev, tol, step, finalsimplex, verbose)
-
-
-class NelderMead7(NelderMeadBase):
-
-    # TODO: do we really need this internal class?
-    class MyNelderMead7(MyNelderMead):
-
-        def __call__(self, x, maxnfev, tol, step, finalsimplex, verbose):
-            npar = len(x)
-            factor = 2
-            simplex = SimplexRandom(func=self.func, npop=npar + 1, xpar=x,
-                                    xmin=self.xmin, xmax=self.xmax,
-                                    step=None, seed=None, factor=factor)
-            return self.optimize(x, simplex, maxnfev, tol,
-                                 finalsimplex, verbose)
-
-    def __call__(self, fcn, x, xmin, xmax, tol=1.0e-6,  maxnfev=None,
-                 step=None, finalsimplex=1, verbose=0):
-        my_nm_7 = NelderMead7.MyNelderMead7(fcn, xmin, xmax)
-        if maxnfev is None:
-            maxnfev = 512 * len(x)
-        return my_nm_7(x, maxnfev, tol, step, finalsimplex, verbose)
+# This is only used by tests/test_opt_original.py when run directly,
+# not via pytest. Left commented out to make it easier to find.
+#
+# class NelderMead7(NelderMeadBase):
+#
+#     # TODO: do we really need this internal class?
+#     class MyNelderMead7(MyNelderMead):
+#
+#         def __call__(self, x, maxnfev, tol, step, finalsimplex, verbose):
+#             npar = len(x)
+#             factor = 2
+#             simplex = SimplexRandom(func=self.func, npop=npar + 1, xpar=x,
+#                                     xmin=self.xmin, xmax=self.xmax,
+#                                     step=None, seed=None, factor=factor)
+#             return self.optimize(x, simplex, maxnfev, tol,
+#                                  finalsimplex, verbose)
+#
+#     def __call__(self, fcn, x, xmin, xmax, tol=1.0e-6,  maxnfev=None,
+#                  step=None, finalsimplex=1, verbose=0):
+#         my_nm_7 = NelderMead7.MyNelderMead7(fcn, xmin, xmax)
+#         if maxnfev is None:
+#             maxnfev = 512 * len(x)
+#         return my_nm_7(x, maxnfev, tol, step, finalsimplex, verbose)
 
 
 class nmNcores(MyNcores):
@@ -339,53 +344,53 @@ class ncoresNelderMead:
         nfev = results[0]
         fmin = results[1]
         par = results[2]
-        solution_at = 0
         for ii in range(1, num):
             index = ii * 3
             nfev += results[index]
-            # print(ii, 'unpack_results: f', par, '=', fmin, '@', nfev, 'nfevs')
             if results[index + 1] < fmin:
                 fmin = results[index + 1]
                 par = results[index + 2]
-                solution_at = ii
-        # print('unpack_results: solution_@ =', solution_at)
+
         return nfev, fmin, par
 
 
-class ncoresNelderMeadRecursive(ncoresNelderMead):
-    """ As noted in the paper, terminating the simplex is not a simple task:
-    For any non-derivative method, the issue of termination is problematical as
-    well as highly sensitive to problem scaling. Since gradient information is
-    unavailable, it is provably impossible to verify closeness to optimality
-    simply by sampling f at a finite number of points. Most implementations
-    of direct search methods terminate based on two criteria intended to
-    reflect the progress of the algorithm: either the function values at the
-    vertices are close, or the simplex has become very small. """
-
-    # TODO: using a list as an argument triggers pylint dangerous-default-value check
-    #
-    # algo is the same as used in ncoresNelderMead but leave as is in case
-    # there is a need to have a different set of classes.
-    #
-    def __init__(self, algo=[NelderMead0(), NelderMead1(), NelderMead2(),
-                             NelderMead3(), NelderMead4(), NelderMead5()]):
-        ncoresNelderMead.__init__(self, algo)
-
-    def __call__(self, fcn, x, xmin, xmax, tol=EPSILON, maxnfev=None,
-                 numcores=ncpus):
-
-        return self.calc(fcn, x, xmin, xmax, tol, maxnfev, numcores)
-
-    def calc(self, fcn, x, xmin, xmax, tol=EPSILON, maxnfev=None,
-             numcores=ncpus, fval=np.inf, nfev=0):
-
-        num_algo = len(self.algo)
-        nm_ncores = nmNcores()
-        results = nm_ncores.calc(self.algo, numcores, fcn, x, xmin, xmax, tol, maxnfev)
-        tmp_nfev, fmin, par = self.unpack_results(num_algo, results)
-        nfev += tmp_nfev
-        # print('ncoresNelderMead::calc f', par, ' = ', fmin, '@', nfev)
-        if fmin < fval:
-            return self.calc(fcn, par, xmin, xmax, tol, maxnfev, numcores, fmin, nfev)
-
-        return nfev, fval, par
+# This code is currently unused. Left commented out to make it easier
+# to find.
+#
+# class ncoresNelderMeadRecursive(ncoresNelderMead):
+#     """ As noted in the paper, terminating the simplex is not a simple task:
+#     For any non-derivative method, the issue of termination is problematical as
+#     well as highly sensitive to problem scaling. Since gradient information is
+#     unavailable, it is provably impossible to verify closeness to optimality
+#     simply by sampling f at a finite number of points. Most implementations
+#     of direct search methods terminate based on two criteria intended to
+#     reflect the progress of the algorithm: either the function values at the
+#     vertices are close, or the simplex has become very small. """
+#
+#     # TODO: using a list as an argument triggers pylint dangerous-default-value check
+#     #
+#     # algo is the same as used in ncoresNelderMead but leave as is in case
+#     # there is a need to have a different set of classes.
+#     #
+#     def __init__(self, algo=[NelderMead0(), NelderMead1(), NelderMead2(),
+#                              NelderMead3(), NelderMead4(), NelderMead5()]):
+#         ncoresNelderMead.__init__(self, algo)
+#
+#     def __call__(self, fcn, x, xmin, xmax, tol=EPSILON, maxnfev=None,
+#                  numcores=ncpus):
+#
+#         return self.calc(fcn, x, xmin, xmax, tol, maxnfev, numcores)
+#
+#     def calc(self, fcn, x, xmin, xmax, tol=EPSILON, maxnfev=None,
+#              numcores=ncpus, fval=np.inf, nfev=0):
+#
+#         num_algo = len(self.algo)
+#         nm_ncores = nmNcores()
+#         results = nm_ncores.calc(self.algo, numcores, fcn, x, xmin, xmax, tol, maxnfev)
+#         tmp_nfev, fmin, par = self.unpack_results(num_algo, results)
+#         nfev += tmp_nfev
+#         # print('ncoresNelderMead::calc f', par, ' = ', fmin, '@', nfev)
+#         if fmin < fval:
+#             return self.calc(fcn, par, xmin, xmax, tol, maxnfev, numcores, fmin, nfev)
+#
+#         return nfev, fval, par

--- a/sherpa/optmethods/ncoresnm.py
+++ b/sherpa/optmethods/ncoresnm.py
@@ -46,6 +46,12 @@ EPSILON = float(np.finfo(np.float32).eps)
 
 
 class MyNelderMead(Opt):
+    """
+
+    .. versionchanged:: 4.17.1
+       The calling convention has changed to match its superclass.
+
+    """
 
     def __init__(self,
                  fcn: OptimizerFunc,
@@ -60,9 +66,9 @@ class MyNelderMead(Opt):
         self.shrink_coef = 0.5          # sigma
 
     def __call__(self,
-                 xpar: np.ndarray,
                  maxnfev: int,  # TODO: can this be None?
-                 tol: float,
+                 ftol: float,
+                 xpar: np.ndarray,
                  step: np.ndarray,
                  finalsimplex: int,
                  verbose: int
@@ -75,7 +81,7 @@ class MyNelderMead(Opt):
                               xpar=xpar, xmin=self.xmin,
                               xmax=self.xmax, step=step, seed=None,
                               factor=None)
-        return self.optimize(xpar, simplex, maxnfev, tol,
+        return self.optimize(xpar, simplex, maxnfev, ftol,
                              finalsimplex, verbose)
 
     def contract_in_out(self,
@@ -261,7 +267,7 @@ class NelderMead0(NelderMeadBase):
         if step is None:
             step = self.calc_step(x0)
 
-        return my_nm(xpar=x0, maxnfev=maxnfev, tol=tol, step=step,
+        return my_nm(xpar=x0, maxnfev=maxnfev, ftol=tol, step=step,
                      finalsimplex=finalsimplex, verbose=verbose)
 
 

--- a/sherpa/optmethods/ncoresnm.py
+++ b/sherpa/optmethods/ncoresnm.py
@@ -45,6 +45,8 @@ class MyNelderMead(Opt):
 
     def __call__(self, xpar, maxnfev, tol, step, finalsimplex, verbose):
 
+        # SimplexStep does not use factor when npop=npar + 1.
+        #
         npar = len(xpar)
         simplex = SimplexStep(func=self.func, npop=npar + 1,
                               xpar=xpar, xmin=self.xmin,

--- a/sherpa/optmethods/ncoresnm.py
+++ b/sherpa/optmethods/ncoresnm.py
@@ -95,6 +95,11 @@ class MyNelderMead(Opt):
 
         rho_chi = self.reflection_coef * self.expansion_coef
         rho_gamma = self.reflection_coef * self.contraction_coef
+
+        # This is presumably because SimplexStep was called with
+        # npop=npar + 1, so bad_index corresponds to the last pop
+        # element.
+        #
         bad_index = len(xpar)
 
         while self.nfev < maxnfev:
@@ -103,11 +108,10 @@ class MyNelderMead(Opt):
             if verbose > 2:
                 print(f'f{simplex[0, :-1]}={simplex[0, -1]:e}')
 
-            centroid = simplex.calc_centroid()
-
             if simplex.check_convergence(tol, finalsimplex):
                 break
 
+            centroid = simplex.calc_centroid()
             reflection_pt = simplex.move_vertex(centroid, self.reflection_coef)
 
             if simplex[0, -1] <= reflection_pt[-1] and \

--- a/sherpa/optmethods/ncoresnm.py
+++ b/sherpa/optmethods/ncoresnm.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019 - 2021, 2023 - 2025
+#  Copyright (C) 2019-2021, 2023-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -25,7 +25,7 @@ import numpy as np
 from sherpa.utils.parallel import SupportsQueue, ncpus
 
 from . import _saoopt  # type: ignore
-from .opt import MyNcores, Opt, OptimizerFunc, WorkerFunc, MyOptOutput, \
+from .opt import MyNcores, Opt, OptimizerFunc, WorkerFunc, OptOutput, \
     SimplexBase, SimplexStep
 
 __all__ = ('ncoresNelderMead', )
@@ -72,7 +72,7 @@ class MyNelderMead(Opt):
                  step: np.ndarray,
                  finalsimplex: int,
                  verbose: int
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
 
         # SimplexStep does not use factor when npop=npar + 1.
         #
@@ -135,7 +135,7 @@ class MyNelderMead(Opt):
                  tol: float,
                  finalsimplex: int,
                  verbose: int
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
 
         rho_chi = self.reflection_coef * self.expansion_coef
         rho_gamma = self.reflection_coef * self.contraction_coef
@@ -211,7 +211,7 @@ class NelderMeadBase:
                  step: np.ndarray | None = None,
                  finalsimplex: int | None = 1,
                  verbose: int = 0
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
         raise NotImplementedError()
 
     def get_maxnfev(self, maxnfev: int | None, npar: int) -> int:
@@ -233,7 +233,7 @@ class NelderMead0(NelderMeadBase):
                  step: np.ndarray | None = None,
                  finalsimplex: int | None = 1,
                  verbose: int = 0
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
         return self.neldermead0(fcn, xpar, xmin, xmax, step=step,
                                 finalsimplex=finalsimplex,
                                 maxnfev=maxnfev, tol=tol,
@@ -253,7 +253,7 @@ class NelderMead0(NelderMeadBase):
                     maxnfev: int | None = None,
                     tol: float = 1.0e-6,
                     verbose: int = 0
-                    ) -> MyOptOutput:
+                    ) -> OptOutput:
         """
 
         .. versionchanged:: 4.18.0
@@ -295,7 +295,7 @@ class NelderMead3(NelderMead0):
                  step: np.ndarray | None = None,
                  finalsimplex: int | None = None,
                  verbose: int = 0
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
 
         # Avoid having a mutable argument
         if finalsimplex is None:
@@ -328,7 +328,7 @@ class NelderMead4(NelderMead0):
                  finalsimplex: int | None = None,
                  verbose: int = 0,
                  reflect: bool = True
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
 
         # Avoid having a mutable argument
         if finalsimplex is None:
@@ -367,7 +367,7 @@ class NelderMead5(NelderMead0):
                  finalsimplex: int | None = 1,
                  verbose: int = 0,
                  reflect: bool = True
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
         init = 0
         iquad = 1
         simp = 1.0e-2 * tol
@@ -438,7 +438,7 @@ class nmNcores(MyNcores):
     def my_worker(self,
                   opt: WorkerFunc,
                   idval: int,
-                  out_q: SupportsQueue[tuple[int, list[MyOptOutput]]],
+                  out_q: SupportsQueue[tuple[int, list[OptOutput]]],
                   err_q: SupportsQueue[Exception],
                   fcn: OptimizerFunc,
                   x: np.ndarray,
@@ -487,7 +487,7 @@ class ncoresNelderMead:
                  tol: float = EPSILON,
                  maxnfev: int | None = None,
                  numcores=ncpus
-                 ) -> MyOptOutput:
+                 ) -> OptOutput:
 
         nm_ncores = nmNcores()
         results = nm_ncores.calc(self.algo, numcores, fcn, x, xmin,
@@ -495,8 +495,8 @@ class ncoresNelderMead:
         return self.unpack_results(results)
 
     def unpack_results(self,
-                       results: list[MyOptOutput]
-                       ) -> MyOptOutput:
+                       results: list[OptOutput]
+                       ) -> OptOutput:
         """
 
         .. versionchanged:: 4.18.0
@@ -540,7 +540,7 @@ class ncoresNelderMead:
 #                  tol: float = EPSILON,
 #                  maxnfev: int | None = None,
 #                  numcores=ncpus
-#                  ) -> MyOptOutput:
+#                  ) -> OptOutput:
 #
 #         return self.calc(fcn, x, xmin, xmax, tol, maxnfev, numcores)
 #
@@ -554,7 +554,7 @@ class ncoresNelderMead:
 #              numcores=ncpus,
 #              fval: float = np.inf,
 #              nfev: int = 0
-#              ) -> MyOptOutput:
+#              ) -> OptOutput:
 #
 #         nm_ncores = nmNcores()
 #         results = nm_ncores.calc(self.algo, numcores, fcn, x, xmin,

--- a/sherpa/optmethods/ncoresnm.py
+++ b/sherpa/optmethods/ncoresnm.py
@@ -185,7 +185,9 @@ class MyNelderMead(Opt):
         best_vertex = simplex[0]
         best_par = best_vertex[:-1]
         best_val = best_vertex[-1]
-        return self.nfev, best_val, best_par
+        return OptOutput(nfev=self.nfev,
+                         statval=best_val,
+                         pars=best_par)
 
 
 class NelderMeadBase:
@@ -312,7 +314,9 @@ class NelderMead3(NelderMead0):
             _saoopt.neldermead(verbose, maxnfev, init, finalsimplex,
                                tol, step, xmin, xmax, x0, fcn)
 
-        return nfev, fmin, par
+        return OptOutput(nfev=nfev,
+                         statval=fmin,
+                         pars=par)
 
 
 class NelderMead4(NelderMead0):
@@ -351,7 +355,9 @@ class NelderMead4(NelderMead0):
             _saoopt.minim(reflect, verbose, maxnfev - nfev, init, iquad, simp,
                           tol*10, step, xmin, xmax, x0, fcn)
         nfev += tmpnfev
-        return nfev, fmin, par
+        return OptOutput(nfev=nfev,
+                         statval=fmin,
+                         pars=par)
 
 
 class NelderMead5(NelderMead0):
@@ -380,7 +386,9 @@ class NelderMead5(NelderMead0):
         par, fmin, nfev, ifault = \
             _saoopt.minim(reflect, verbose, maxnfev, init, iquad, simp, tol*10,
                           step, xmin, xmax, x0, fcn)
-        return nfev, fmin, par
+        return OptOutput(nfev=nfev,
+                         statval=fmin,
+                         pars=par)
 
 
 # This is only used by tests/test_opt_original.py when run directly,
@@ -509,14 +517,18 @@ class ncoresNelderMead:
         #
         assert len(results) > 0
 
-        nfev, fmin, par = results[0]
-        for nfev1, fmin1, par1 in results[1:]:
-            nfev += nfev1
-            if fmin1 < fmin:
-                fmin = fmin1
-                par = par1
+        nfev = results[0].nfev
+        fmin = results[0].statval
+        par = results[0].pars
+        for res in results[1:]:
+            nfev += res.nfev
+            if res.statval < fmin:
+                fmin = res.statval
+                par = res.pars
 
-        return nfev, fmin, par
+        return OptOutput(nfev=nfev,
+                         statval=fmin,
+                         pars=par)
 
 
 # This code is currently unused. Left commented out to make it easier

--- a/sherpa/optmethods/ncoresnm.py
+++ b/sherpa/optmethods/ncoresnm.py
@@ -282,7 +282,7 @@ class NelderMead1(NelderMead0):
 class NelderMead2(NelderMead0):
 
     def calc_step(self, x: np.ndarray) -> np.ndarray:
-        return np.abs(x)
+        return abs(x)
 
 
 class NelderMead3(NelderMead0):
@@ -341,7 +341,7 @@ class NelderMead4(NelderMead0):
         x0 = np.asarray(xpar)
         n = len(x0)
         if step is None:
-            step = np.abs(x0) + 1.2
+            step = abs(x0) + 1.2
 
         maxnfev = self.get_maxnfev(maxnfev, n)
         init = 0

--- a/sherpa/optmethods/ncoresnm.py
+++ b/sherpa/optmethods/ncoresnm.py
@@ -341,11 +341,11 @@ class NelderMead4(NelderMead0):
         iquad = 1
         simp = 1.0e-2 * tol
         step = np.full(n, 0.4)
-        self.par, self.fmin, tmpnfev, ifault = \
+        par, fmin, tmpnfev, ifault = \
             _saoopt.minim(reflect, verbose, maxnfev - nfev, init, iquad, simp,
                           tol*10, step, xmin, xmax, x0, fcn)
-        self.nfev = nfev + tmpnfev
-        return self.nfev, self.fmin, self.par
+        nfev += tmpnfev
+        return nfev, fmin, par
 
 
 class NelderMead5(NelderMead0):
@@ -549,4 +549,5 @@ class ncoresNelderMead:
 #             return self.calc(fcn, par, xmin, xmax, tol, maxnfev,
 #                              numcores, fval=fmin, nfev=nfev)
 #
+#         # TODO: shouldn't this return fmin rather than fval?
 #         return nfev, fval, par

--- a/sherpa/optmethods/ncoresnm.py
+++ b/sherpa/optmethods/ncoresnm.py
@@ -48,7 +48,7 @@ EPSILON = float(np.finfo(np.float32).eps)
 class MyNelderMead(Opt):
     """
 
-    .. versionchanged:: 4.17.1
+    .. versionchanged:: 4.18.0
        The calling convention has changed to match its superclass.
 
     """
@@ -256,7 +256,7 @@ class NelderMead0(NelderMeadBase):
                     ) -> MyOptOutput:
         """
 
-        .. versionchanged:: 4.17.1
+        .. versionchanged:: 4.18.0
            Most of the arguments must now be given by name.
 
         """
@@ -463,7 +463,7 @@ class nmNcores(MyNcores):
 class ncoresNelderMead:
     """
 
-    .. versionchanged:: 4.17.1
+    .. versionchanged:: 4.18.0
        The default for the algo parameter is now None.
 
     """
@@ -499,7 +499,7 @@ class ncoresNelderMead:
                        ) -> MyOptOutput:
         """
 
-        .. versionchanged:: 4.17.1
+        .. versionchanged:: 4.18.0
            The num arguments has been removed.
 
         """

--- a/sherpa/optmethods/ncoresnm.py
+++ b/sherpa/optmethods/ncoresnm.py
@@ -18,6 +18,8 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from collections.abc import Sequence
+
 import numpy as np
 
 from sherpa.utils.parallel import ncpus
@@ -33,7 +35,8 @@ EPSILON = np.float64(np.finfo(np.float32).eps)
 class MyNelderMead(Opt):
 
     def __init__(self, fcn, xmin, xmax):
-        Opt.__init__(self, fcn, xmin, xmax)
+        super().__init__(fcn, xmin, xmax)
+
         self.expansion_coef = 2.0          # chi
         self.contraction_coef = 0.5          # gamma
         self.reflection_coef = 1.0          # rho
@@ -325,12 +328,23 @@ class nmNcores(MyNcores):
 
 
 class ncoresNelderMead:
+    """
 
-    # TODO: using a list as an argument triggers pylint dangerous-default-value check
-    def __init__(self, algo=[NelderMead0(), NelderMead1(), NelderMead2(),
-                             NelderMead3(), NelderMead4(), NelderMead5()]):
-        # NelderMead6(), NelderMead7()]):
-        self.algo = algo
+    .. versionchanged:: 4.17.1
+       The default for the algo parameter is now None.
+
+    """
+
+    def __init__(self,
+                 algo: Sequence[NelderMeadBase] | None = None
+                 ) -> None:
+        if algo is None:
+            self.algo = [NelderMead0(), NelderMead1(), NelderMead2(),
+                         NelderMead3(), NelderMead4(), NelderMead5()]
+            # NelderMead6(), NelderMead7()]):
+
+        else:
+            self.algo = algo
 
     def __call__(self, fcn, x, xmin, xmax, tol=EPSILON, maxnfev=None,
                  numcores=ncpus):
@@ -367,15 +381,6 @@ class ncoresNelderMead:
 #     reflect the progress of the algorithm: either the function values at the
 #     vertices are close, or the simplex has become very small. """
 #
-#     # TODO: using a list as an argument triggers pylint dangerous-default-value check
-#     #
-#     # algo is the same as used in ncoresNelderMead but leave as is in case
-#     # there is a need to have a different set of classes.
-#     #
-#     def __init__(self, algo=[NelderMead0(), NelderMead1(), NelderMead2(),
-#                              NelderMead3(), NelderMead4(), NelderMead5()]):
-#         ncoresNelderMead.__init__(self, algo)
-#
 #     def __call__(self, fcn, x, xmin, xmax, tol=EPSILON, maxnfev=None,
 #                  numcores=ncpus):
 #
@@ -389,7 +394,6 @@ class ncoresNelderMead:
 #         results = nm_ncores.calc(self.algo, numcores, fcn, x, xmin, xmax, tol, maxnfev)
 #         tmp_nfev, fmin, par = self.unpack_results(num_algo, results)
 #         nfev += tmp_nfev
-#         # print('ncoresNelderMead::calc f', par, ' = ', fmin, '@', nfev)
 #         if fmin < fval:
 #             return self.calc(fcn, par, xmin, xmax, tol, maxnfev, numcores, fmin, nfev)
 #

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -19,6 +19,7 @@
 #
 
 from collections.abc import Callable, Sequence
+import operator
 from typing import Concatenate, ParamSpec
 
 import numpy as np
@@ -192,6 +193,13 @@ class Opt:
         return func_bounds_wrapper
 
 
+# The simplex field is a npop by (npar + 1) array, where each row
+# contains the parameter values and then the corresponding statistic
+# value for that set of parameters.
+#
+# The __get/setitem__ calls allow the object to index into the "pars +
+# statistic array" by number (the pop argument).
+#
 class SimplexBase:
 
     def __init__(self,
@@ -210,6 +218,7 @@ class SimplexBase:
         self.xmax = xmax
         self.npar = len(xpar)
         self.rng = rng
+
         self.simplex = self.init(npop=npop, xpar=np.asarray(xpar),
                                  step=step, seed=seed, factor=factor)
 
@@ -361,11 +370,12 @@ class SimplexBase:
                 (self.simplex[ii] - self.simplex[0])
             self.simplex[ii, -1] = self.func(self.simplex[ii, :-1])
 
-    def sort_me(self,
-                simp: np.ndarray
+    @staticmethod
+    def sort_me(simp: np.ndarray
                 ) -> np.ndarray:
+        """Reorder the simplex by the statistic value (low to high)"""
         myshape = simp.shape
-        tmp = np.array(sorted(simp, key=lambda arg: arg[-1]))
+        tmp = np.array(sorted(simp, key=operator.itemgetter(-1)))
         tmp.reshape(myshape)
         return tmp
 

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -19,6 +19,7 @@
 #
 
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 import operator
 
 import numpy as np
@@ -43,12 +44,23 @@ FUNC_MAX = float(np.finfo(np.float64).max)
 #
 OptimizerFunc = Callable[[np.ndarray], float]
 
-# Represent the data sent around by the optimizers:
-# - the number of function evaluations
-# - the statistic value
-# - the parameter values
-#
-OptOutput = tuple[int, float, np.ndarray]
+@dataclass(kw_only=True)
+class OptOutput:
+    """Represent the data sent around by the optimizers.
+
+    .. versionadded:: 4.18.0
+
+    """
+
+    nfev: int
+    """The number of function evaluations."""
+
+    statval: float
+    """The statistic value."""
+
+    pars: np.ndarray
+    """The parameter values."""
+
 
 # WorkerFunc could be done as a Protocol, but the argument names are
 # not consistent, and it also requires **kwargs, which has not been

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -89,14 +89,27 @@ class Opt:
                  xmin: ArrayType,
                  xmax: ArrayType
                  ) -> None:
-        self.npar = len(xmin)
         self.xmin = np.asarray(xmin)
         self.xmax = np.asarray(xmax)
+        self.npar = len(self.xmin)
+        if len(self.xmax) != self.npar:
+            raise ValueError("xmin and xmax must be the same size")
+
+        # The function count should only be done on "valid" ranges,
+        # hence the ordering here.
+        #
         self.func_count = FuncCounter(func)
-        self.func = self.func_bounds(self.func_count, self.npar, xmin, xmax)
+        self.func = self.func_bounds(self.func_count, self.npar,
+                                     self.xmin, self.xmax)
 
     @property
     def nfev(self) -> int:
+        """How many evaluations of the function have been made?
+
+        This does not count proposed values which were outside the
+        parameter limits.
+
+        """
         return self.func_count.nfev
 
     def _outside_limits(self,

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -138,6 +138,16 @@ class Opt:
         self.func = self.func_bounds(self.func_count, self.npar,
                                      self.xmin, self.xmax)
 
+    # The sub-classes have different arguments, but do have maxnfev
+    # and ftol as common values.
+    #
+    def __call__(self,
+                 maxnfev: int,
+                 ftol: float,
+                 *args,
+                 **kwargs) -> MyOptOutput:
+        raise NotImplementedError
+
     @property
     def nfev(self) -> int:
         """How many evaluations of the function have been made?

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -247,16 +247,19 @@ class SimplexBase:
         return False
 
         # TODO: what is this code meant to be doing as it is unreachable?
-        num = 2.0 * abs(self.simplex[0, -1] - self.simplex[-1, -1])
-        denom = abs(self.simplex[0, -1]) + abs(self.simplex[-1, -1]) + 1.0
-        if num / denom > ftol:
-            return False
-
-        func_vals = [col[-1] for col in self.simplex]
-        if np.std(func_vals) > ftol:
-            return False
-
-        return True
+        #
+        # It has therefore been commented out.
+        #
+        # num = 2.0 * abs(self.simplex[0, -1] - self.simplex[-1, -1])
+        # denom = abs(self.simplex[0, -1]) + abs(self.simplex[-1, -1]) + 1.0
+        # if num / denom > ftol:
+        #     return False
+        #
+        # func_vals = [col[-1] for col in self.simplex]
+        # if np.std(func_vals) > ftol:
+        #     return False
+        #
+        # return True
 
     def eval_simplex(self,
                      npop: int,

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019 - 2021, 2023 - 2025
+#  Copyright (C) 2019-2021, 2023-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -43,13 +43,20 @@ FUNC_MAX = float(np.finfo(np.float64).max)
 #
 OptimizerFunc = Callable[[np.ndarray], float]
 
+# WorkerFunc could be done as a Protocol, but the argument names are
+# not consistent, and it also requires **kwargs, which has not been
+# handled well by pyright. Concatenate could be used to at least
+# indicate the extra arguments but that requires Python 3.11 (as
+# Concatenate in Python 3.10 can not end with an ellipsis).
+#
 MyOptOutput = tuple[int, float, np.ndarray]
 WorkerFunc = Callable[[OptimizerFunc,
                        np.ndarray,
                        np.ndarray,
                        np.ndarray,
                        float,
-                       int | None],
+                       int | None
+                       ],
                       MyOptOutput]
 
 
@@ -71,6 +78,11 @@ class MyNcores:
              maxnfev: int | None
              ) -> list[MyOptOutput]:
         """Apply each function to the arguments, running in parallel."""
+
+        # Safety check
+        nfuncs = len(funcs)
+        if nfuncs == 0:
+            raise TypeError("funcs can not be empty")
 
         for func in funcs:
             if not callable(func):

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -54,6 +54,7 @@ WorkerFunc = Callable[[OptimizerFunc,
                        int | None],
                       MyOptOutput]
 
+
 class MyNcores:
     """Support distributed processing."""
 

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -201,8 +201,8 @@ class SimplexBase:
                  xmin: ArrayType,
                  xmax: ArrayType,
                  step: np.ndarray | None,
-                 seed: int,
-                 factor: float,
+                 seed: int | None,
+                 factor: float | None,
                  rng: RandomType | None = None
                  ) -> None:
         self.func = func
@@ -304,8 +304,8 @@ class SimplexBase:
              npop: int,
              xpar: np.ndarray,
              step: np.ndarray | None,
-             seed: int,
-             factor: float
+             seed: int | None,
+             factor: float | None
              ) -> np.ndarray:
         raise NotImplementedError("init has not been implemented")
 
@@ -314,8 +314,8 @@ class SimplexBase:
                             simplex: np.ndarray,
                             start: int,
                             npop: int,
-                            seed: int,
-                            factor: float
+                            seed: int | None,
+                            factor: float | None
                             ) -> np.ndarray:
         # Set the seed when there is no RNG set, otherwise the RNG
         # determines the state.
@@ -329,6 +329,9 @@ class SimplexBase:
         if start >= npop:
             return simplex
 
+        # At this point it is assumed the caller has set factor.
+        #
+        assert factor is not None, "caller did not set factor"
         deltas = factor * np.abs(np.asarray(xpar))
         for ii in range(start, npop):
             simplex[ii][:-1] = \
@@ -358,7 +361,8 @@ class SimplexBase:
                 (self.simplex[ii] - self.simplex[0])
             self.simplex[ii, -1] = self.func(self.simplex[ii, :-1])
 
-    def sort_me(self, simp: np.ndarray
+    def sort_me(self,
+                simp: np.ndarray
                 ) -> np.ndarray:
         myshape = simp.shape
         tmp = np.array(sorted(simp, key=lambda arg: arg[-1]))
@@ -375,8 +379,8 @@ class SimplexNoStep(SimplexBase):
              npop: int,
              xpar: np.ndarray,
              step: np.ndarray | None,
-             seed: int,
-             factor: float
+             seed: int | None,
+             factor: float | None
              ) -> np.ndarray:
         npar1 = self.npar + 1
         simplex = np.empty((npop, npar1))
@@ -401,8 +405,8 @@ class SimplexStep(SimplexBase):
              npop: int,
              xpar: np.ndarray,
              step: np.ndarray | None,
-             seed: int,
-             factor: float
+             seed: int | None,
+             factor: float | None
              ) -> np.ndarray:
 
         # This should raise an error, but as it is low-level code, just
@@ -427,8 +431,8 @@ class SimplexRandom(SimplexBase):
              npop: int,
              xpar: np.ndarray,
              step: np.ndarray | None,
-             seed: int,
-             factor: float
+             seed: int | None,
+             factor: float | None
              ) -> np.ndarray:
         npar1 = self.npar + 1
         simplex = np.empty((npop, npar1))

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -159,8 +159,19 @@ class Opt:
         if len(self.xmax) != self.npar:
             raise ValueError("xmin and xmax must be the same size")
 
-        # The function count should only be done on "valid" ranges,
-        # hence the ordering here.
+        # The function counter - that is FuncCounter(func) - should
+        # only be evaluated after checking whether the parameter
+        # values are valid - which is handled by self.func_bounds.
+        # That is,
+        #
+        #    self.func = self.func_bounds(FuncCounter(func), ...)
+        #
+        # rather than
+        #
+        #    self.func = FuncCounter(self.func_bounds(func, ...))
+        #
+        # which would count proposed parameter values which were out
+        # of bounds.
         #
         self.func_count = FuncCounter(func)
         self.func = self.func_bounds(self.func_count, self.npar,

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -71,7 +71,8 @@ class MyNcores:
              xmax: np.ndarray,
              tol: float,
              maxnfev: int | None
-             ) -> list:
+             ) -> list[MyOptOutput]:
+        """Apply each function to the arguments, running in parallel."""
 
         for func in funcs:
             if not callable(func):
@@ -80,6 +81,8 @@ class MyNcores:
         # See sherpa.utils.parallel for the logic used here.
         # At this point we can assume that context is not None,
         # since multi is True.
+        #
+        # Should this shard by numcores?
         #
         assert context is not None
         manager = context.Manager()
@@ -96,7 +99,7 @@ class MyNcores:
     def my_worker(self,
                   opt: WorkerFunc,
                   idval: int,
-                  out_q: SupportsQueue[tuple[int, list]],
+                  out_q: SupportsQueue[tuple[int, list[MyOptOutput]]],
                   err_q: SupportsQueue[Exception],
                   fcn: OptimizerFunc,
                   x: np.ndarray,

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -39,6 +39,8 @@ FUNC_MAX = float(np.finfo(np.float64).max)
 # Some code assumes the first argument is an ndarray, but is this always
 # the case? For now assume that the data is always sent as an ndarray.
 #
+# sherpa.stats.StatCallback converts a StatFunc into an OptimizerFunc.
+#
 OptimizerFunc = Callable[[np.ndarray], float]
 
 MyOptOutput = tuple[int, float, np.ndarray]

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -43,13 +43,19 @@ FUNC_MAX = float(np.finfo(np.float64).max)
 #
 OptimizerFunc = Callable[[np.ndarray], float]
 
+# Represent the data sent around by the optimizers:
+# - the number of function evaluations
+# - the statistic value
+# - the parameter values
+#
+OptOutput = tuple[int, float, np.ndarray]
+
 # WorkerFunc could be done as a Protocol, but the argument names are
 # not consistent, and it also requires **kwargs, which has not been
 # handled well by pyright. Concatenate could be used to at least
 # indicate the extra arguments but that requires Python 3.11 (as
 # Concatenate in Python 3.10 can not end with an ellipsis).
 #
-MyOptOutput = tuple[int, float, np.ndarray]
 WorkerFunc = Callable[[OptimizerFunc,
                        np.ndarray,
                        np.ndarray,
@@ -57,7 +63,7 @@ WorkerFunc = Callable[[OptimizerFunc,
                        float,
                        int | None
                        ],
-                      MyOptOutput]
+                      OptOutput]
 
 
 class MyNcores:
@@ -76,7 +82,7 @@ class MyNcores:
              xmax: np.ndarray,
              tol: float,
              maxnfev: int | None
-             ) -> list[MyOptOutput]:
+             ) -> list[OptOutput]:
         """Apply each function to the arguments, running in parallel."""
 
         # Safety check
@@ -109,7 +115,7 @@ class MyNcores:
     def my_worker(self,
                   opt: WorkerFunc,
                   idval: int,
-                  out_q: SupportsQueue[tuple[int, list[MyOptOutput]]],
+                  out_q: SupportsQueue[tuple[int, list[OptOutput]]],
                   err_q: SupportsQueue[Exception],
                   fcn: OptimizerFunc,
                   x: np.ndarray,
@@ -155,7 +161,7 @@ class Opt:
                  maxnfev: int,
                  ftol: float,
                  *args,
-                 **kwargs) -> MyOptOutput:
+                 **kwargs) -> OptOutput:
         raise NotImplementedError
 
     @property

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -267,8 +267,8 @@ class SimplexBase:
                  rng: RandomType | None = None
                  ) -> None:
         self.func = func
-        self.xmin = np.asarray(xmin)
-        self.xmax = np.asarray(xmax)
+        self.xmin = np.asanyarray(xmin)
+        self.xmax = np.asanyarray(xmax)
         self.npar = len(xpar)
         self.rng = rng
 

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -175,7 +175,7 @@ class SimplexBase:
     def __setitem__(self, index, val):
         self.simplex[index] = val
 
-    def calc_centroid(self) -> SupportsFloat:
+    def calc_centroid(self) -> np.ndarray:
         return np.mean(self.simplex[:-1, :], 0)
 
     def check_convergence(self,

--- a/sherpa/optmethods/opt.py
+++ b/sherpa/optmethods/opt.py
@@ -20,7 +20,6 @@
 
 from collections.abc import Callable, Sequence
 import operator
-from typing import Concatenate, ParamSpec
 
 import numpy as np
 
@@ -37,13 +36,10 @@ __all__ = ('Opt', 'MyNcores', 'SimplexRandom', 'SimplexNoStep',
 
 FUNC_MAX = float(np.finfo(np.float64).max)
 
-P = ParamSpec("P")
-
-# The extra parameters can likely be removed from this.
 # Some code assumes the first argument is an ndarray, but is this always
 # the case? For now assume that the data is always sent as an ndarray.
 #
-OptimizerFunc = Callable[Concatenate[np.ndarray, P], float]
+OptimizerFunc = Callable[[np.ndarray], float]
 
 MyOptOutput = tuple[int, float, np.ndarray]
 WorkerFunc = Callable[[OptimizerFunc,
@@ -198,11 +194,11 @@ class Opt:
             xmin = np.asarray([- np.inf for ii in range(npar)])
             xmax = np.asarray([np.inf for ii in range(npar)])
 
-        def func_bounds_wrapper(x, *args):
+        def func_bounds_wrapper(x):
             if self._outside_limits(x, xmin, xmax):
                 return FUNC_MAX
 
-            return func(x, *args)
+            return func(x)
 
         return func_bounds_wrapper
 

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -712,8 +712,11 @@ def montecarlo(fcn: StatFunc,
             nfev = result[4]['nfev']
         else:
             ncores_nm = ncoresNelderMead()
-            nfev, nfval, x = \
-                ncores_nm(stat_cb0, x, xmin, xmax, ftol, mymaxfev, numcores)
+            result = ncores_nm(stat_cb0, x, xmin, xmax, ftol,
+                               mymaxfev, numcores)
+            nfev = result.nfev
+            nfval = result.statval
+            x = result.pars
 
         if verbose:
             print(f'f_nm{x}={nfval:.14e} in {nfev} nfev')
@@ -732,13 +735,13 @@ def montecarlo(fcn: StatFunc,
         else:
             ncores_de = ncoresDifEvo()
             mystep = None
-            tmp_nfev, tmp_fmin, tmp_par = \
-                ncores_de(stat_cb0, x, xmin, xmax, ftol, mymaxfev, mystep,
-                          numcores, pop, seed, weight, xprob, verbose)
-            nfev += tmp_nfev
-            if tmp_fmin < nfval:
-                nfval = tmp_fmin
-                x = tmp_par
+            result = ncores_de(stat_cb0, x, xmin, xmax, ftol,
+                               mymaxfev, mystep, numcores, pop, seed,
+                               weight, xprob, verbose)
+            nfev += result.nfev
+            if result.statval < nfval:
+                nfval = result.statval
+                x = result.pars
 
         if verbose:
             print(f'f_de_nm{x}={nfval:.14e} in {nfev} nfev')
@@ -797,14 +800,13 @@ def montecarlo(fcn: StatFunc,
             nfev += result[4]['nfev']
         else:
             ncores_nm = ncoresNelderMead()
-            tmp_nfev, tmp_fmin, tmp_par = \
-                ncores_nm(stat_cb0, x, xmin, xmax, ftol, maxfev - nfev,
-                          numcores)
-            nfev += tmp_nfev
+            result = ncores_nm(stat_cb0, x, xmin, xmax, ftol, maxfev - nfev,
+                               numcores)
+            nfev += result.nfev
             # There is a bug here somewhere using broyden_tridiagonal
-            if tmp_fmin < fval:
-                fval = tmp_fmin
-                x = tmp_par
+            if result.statval < fval:
+                fval = result.statval
+                x = result.pars
 
     ierr = 0
     if nfev >= maxfev:

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -74,7 +74,7 @@ from typing import SupportsFloat
 
 import numpy as np
 
-from sherpa.stats import StatCallback
+from sherpa.stats import StatCallback, PerBinStatCallback
 from sherpa.utils._utils import sao_fcmp  # type: ignore
 from sherpa.utils import FuncCounter, random
 from sherpa.utils.parallel import parallel_map
@@ -1270,8 +1270,7 @@ def lmdif(fcn: StatFunc,
     if maxfev is None:
         maxfev = 256 * len(x)
 
-    def stat_cb1(pars):
-        return fcn(pars)[1]
+    stat_cb1 = PerBinStatCallback(fcn)
 
     def fcn_parallel(pars, fvec):
         fd_jac = fdJac(stat_cb1, fvec, pars)

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -718,6 +718,8 @@ def montecarlo(fcn: StatFunc,
 
         ############################## nmDifEvo #############################
 
+        # TODO: what happens here when numcores > 1?
+        #
         ofval = FUNC_MAX
         while nfev < maxfev:
 

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -74,6 +74,7 @@ from typing import SupportsFloat
 
 import numpy as np
 
+from sherpa.stats import StatCallback
 from sherpa.utils._utils import sao_fcmp  # type: ignore
 from sherpa.utils import FuncCounter, random
 from sherpa.utils.parallel import parallel_map
@@ -196,25 +197,6 @@ def _update_reported_nfev(result: OptReturn,
     result[4]['nfev'] += nfev
 
 
-class Callback:
-    """Handle the callback argument for the optimizers.
-
-    See Also
-    --------
-    InfinitePotential
-
-    """
-
-    __slots__ = ("func",)
-
-    def __init__(self,
-                 func: StatFunc) -> None:
-        self.func = func
-
-    def __call__(self, pars: np.ndarray) -> float:
-        return self.func(pars)[0]
-
-
 class InfinitePotential:
     """Ensure the parameter values stay within bounds.
 
@@ -222,10 +204,6 @@ class InfinitePotential:
     return "infinity" (here defined to be the maximum value we'd
     expect rather than inf, to avoid causing problems to the
     optimizer).
-
-    See Also
-    --------
-    Callback
 
     Notes
     -----
@@ -350,7 +328,7 @@ def difevo_nm(fcn: StatFunc,
               weighting_factor: float
               ) -> OptReturn:
 
-    stat_cb0 = Callback(fcn)
+    stat_cb0 = StatCallback(fcn)
 
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 
@@ -660,7 +638,7 @@ def montecarlo(fcn: StatFunc,
 
     """
 
-    stat_cb0 = Callback(fcn)
+    stat_cb0 = StatCallback(fcn)
 
     x, xmin, xmax = _check_args(x0, xmin, xmax)
 

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2016, 2018 - 2025
+#  Copyright (C) 2007, 2016, 2018-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -195,6 +195,33 @@ def _update_reported_nfev(result: OptReturn,
     """
 
     result[4]['nfev'] += nfev
+
+
+# Left in in case anyone is using it.
+#
+class Callback(StatCallback):
+    """This class is deprecated.
+
+    .. deprecated:: 4.18.0
+       Use StatCallback instead.
+
+    .. versionadded:: 4.17.1
+
+    """
+
+    def __init__(self, func: StatFunc) -> None:
+        # Since:
+        #
+        # - warnings.deprecated needs Python 3.13
+        # - warnings.warn(..., category=DeprecationWarning) does not
+        #   create a message in normal use, so is easy to miss
+        #
+        # just go with an explicit log message. As this class is new
+        # it is not expected to have been used, so the exact method of
+        # getting a warning to the user is hoped not to be important.
+        #
+        warning("Callback is deprecated: use StatCallback instead")
+        super().__init__(func)
 
 
 class InfinitePotential:

--- a/sherpa/optmethods/tests/test_ncoresopt.py
+++ b/sherpa/optmethods/tests/test_ncoresopt.py
@@ -20,9 +20,9 @@
 import pytest
 
 from sherpa.optmethods import _tstoptfct  # type: ignore
-from sherpa.optmethods.optfcts import Callback
 from sherpa.optmethods.ncoresnm import ncoresNelderMead
 from sherpa.optmethods.ncoresde import ncoresDifEvo
+from sherpa.stats import StatCallback
 
 
 NCORES_NM = ncoresNelderMead()
@@ -36,7 +36,7 @@ def init(name, npar):
 
 def tst_opt(opt, fcn, npar, reltol=1.0e-3, abstol=1.0e-3):
     x0, xmin, xmax, fmin = init(fcn.__name__, npar)
-    nfev, fval, par = opt(Callback(fcn), x0, xmin, xmax)
+    nfev, fval, par = opt(StatCallback(fcn), x0, xmin, xmax)
     assert fmin == pytest.approx(fval, rel=reltol, abs=abstol)
 
 

--- a/sherpa/optmethods/tests/test_ncoresopt.py
+++ b/sherpa/optmethods/tests/test_ncoresopt.py
@@ -36,8 +36,8 @@ def init(name, npar):
 
 def tst_opt(opt, fcn, npar, reltol=1.0e-3, abstol=1.0e-3):
     x0, xmin, xmax, fmin = init(fcn.__name__, npar)
-    nfev, fval, par = opt(StatCallback(fcn), x0, xmin, xmax)
-    assert fmin == pytest.approx(fval, rel=reltol, abs=abstol)
+    res = opt(StatCallback(fcn), x0, xmin, xmax)
+    assert fmin == pytest.approx(res.statval, rel=reltol, abs=abstol)
 
 
 @pytest.mark.parametrize("opt", [NCORES_NM, NCORES_DE])

--- a/sherpa/optmethods/tests/test_opt_original.py
+++ b/sherpa/optmethods/tests/test_opt_original.py
@@ -94,8 +94,8 @@ from sherpa.optmethods.ncoresde import ncoresDifEvo #, DifEvo, ncoresDifEvoNelde
 from sherpa.optmethods.ncoresnm import ncoresNelderMead, NelderMead0, NelderMead1, \
     NelderMead2, NelderMead3, NelderMead4, NelderMead5 #, NelderMead6, NelderMead7
 from sherpa.optmethods.opt import SimplexNoStep, SimplexStep, SimplexRandom
-from sherpa.optmethods.optfcts import Callback
 from sherpa.optmethods import _tstoptfct  # type: ignore
+from sherpa.stats import StatCallback
 
 
 def Ackley(x):
@@ -541,7 +541,7 @@ def tst_unc_opt(algorithms, npar):
 
     def tst_algo(opt, fcn, name, num):
         x0, xmin, xmax, fmin = _tstoptfct.init(name, num)
-        result = opt(Callback(fcn), x0, xmin, xmax)
+        result = opt(StatCallback(fcn), x0, xmin, xmax)
         opt_name = opt.__class__.__name__
         print(opt_name, result[2], '=', result[1], 'in', result[0], 'nfevs')
 

--- a/sherpa/optmethods/tests/test_opt_original.py
+++ b/sherpa/optmethods/tests/test_opt_original.py
@@ -90,9 +90,9 @@ import numpy as np
 
 import pytest
 
-from sherpa.optmethods.ncoresde import DifEvo, ncoresDifEvo, ncoresDifEvoNelderMead
+from sherpa.optmethods.ncoresde import ncoresDifEvo #, DifEvo, ncoresDifEvoNelderMead
 from sherpa.optmethods.ncoresnm import ncoresNelderMead, NelderMead0, NelderMead1, \
-    NelderMead2, NelderMead3, NelderMead4, NelderMead5, NelderMead6, NelderMead7
+    NelderMead2, NelderMead3, NelderMead4, NelderMead5 #, NelderMead6, NelderMead7
 from sherpa.optmethods.opt import SimplexNoStep, SimplexStep, SimplexRandom
 from sherpa.optmethods.optfcts import Callback
 from sherpa.optmethods import _tstoptfct  # type: ignore
@@ -946,9 +946,11 @@ if __name__ == "__main__":
     algo_nm: list[Any]
 
     if options.difevo:
-        algo_de = [DifEvo()]
+        # algo_de = [DifEvo()]
+        raise ValueError("DifEvo is currently commented out as unused in Sherpa")
     elif options.combine:
-        algo_de = [ncoresDifEvoNelderMead()]
+        # algo_de = [ncoresDifEvoNelderMead()]
+        raise ValueError("ncoresDifEvoNelderMead is currently broken")
     else:
         algo_de = [ncoresDifEvo()]
 
@@ -958,7 +960,9 @@ if __name__ == "__main__":
     else:
         algo_nm = [NelderMead0(), NelderMead1(), NelderMead2(),
                    NelderMead3(), NelderMead4(), NelderMead5(),
-                   NelderMead6(), NelderMead7()]
+                   # Comment out as these classes are currently unused by Sherpa
+                   # NelderMead6(), NelderMead7()]
+                   ]
 
     if options.unc_opt:
         if options.run_de:

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -1160,3 +1160,34 @@ class WStat(Likelihood):
         assert self._calc is not None  # for typing
         return self._calc(data_src, data_model, nelems, exp_src, exp_bkg,
                           data_bkg, backscales, truncation_value)
+
+
+# Optimisers and error estimators often need access to just one of the
+# return values from a StatFunc call (normally the statistic value,
+# but not always). The statistic functions could return a
+# more-structured result (e.g. a dict or a dataclass), but this would
+# not stop the need for some way to extract just the desired data.
+#
+# There are multiple ways of doing this - such as a class or a
+# decorator - and it's not obvious there's much of a difference.
+# Using a class currently (when supporting Python 3.10 and 3.11) has
+# advantages in expressing the type information.
+#
+class StatCallback:
+    """Return the statistic value for a set of parameters.
+
+    .. versionadded:: 4.17.1
+
+    """
+
+    __slots__ = ("func", )
+
+    def __init__(self,
+                 func: StatFunc
+                 ) -> None:
+        self.func = func
+
+    def __call__(self,
+                 pars: np.ndarray
+                 ) -> float:
+        return self.func(pars)[0]

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -1178,6 +1178,10 @@ class StatCallback:
 
     .. versionadded:: 4.18.0
 
+    See Also
+    --------
+    PerBinStatCallback
+
     """
 
     __slots__ = ("func", )
@@ -1191,3 +1195,27 @@ class StatCallback:
                  pars: np.ndarray
                  ) -> float:
         return self.func(pars)[0]
+
+
+class PerBinStatCallback:
+     """Return the per-bin statistic values for a set of parameters.
+
+     .. versionadded:: 4.18.0
+
+     See Also
+     --------
+     StatCallback
+
+     """
+
+     __slots__ = ("func", )
+
+     def __init__(self,
+                  func: StatFunc
+                  ) -> None:
+         self.func = func
+
+     def __call__(self,
+                  pars: np.ndarray
+                  ) -> np.ndarray:
+         return self.func(pars)[1]

--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2015 - 2020, 2022, 2024 - 2025
+#  Copyright (C) 2009, 2015-2020, 2022, 2024-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1176,7 +1176,7 @@ class WStat(Likelihood):
 class StatCallback:
     """Return the statistic value for a set of parameters.
 
-    .. versionadded:: 4.17.1
+    .. versionadded:: 4.18.0
 
     """
 

--- a/sherpa/utils/parallel.py
+++ b/sherpa/utils/parallel.py
@@ -734,9 +734,6 @@ def create_seeds(rng: RandomType | None,
 
     """
 
-    # TODO: Should the seed be created for a larger (i.e. more bits)
-    # data type?
-    #
     maxval = np.iinfo(np.uint64).max
     if rng is None:
         root_seed = np.random.randint(maxval, dtype=np.uint64)

--- a/sherpa/utils/random.py
+++ b/sherpa/utils/random.py
@@ -33,6 +33,7 @@ from typing import Literal, SupportsFloat, overload
 import numpy as np
 
 from .numeric_types import SherpaFloat
+from .types import ArrayType
 
 # This should probably be an explicit type alias but for now leave it
 # like this. Users are expected to use the Generator rather than
@@ -155,7 +156,7 @@ SizeType = int | Sequence[int] | np.ndarray
 def uniform(rng: RandomType | None,
             low: float,
             high: float,
-            size: Literal[None]
+            size: Literal[None] = None
             ) -> float:
     ...
 
@@ -167,9 +168,19 @@ def uniform(rng: RandomType | None,
             ) -> np.ndarray:
     ...
 
+# Technically size can be given here but assume this is not used
+# in Sherpa.
+@overload
 def uniform(rng: RandomType | None,
-            low: float,
-            high: float,
+            low: ArrayType,
+            high: ArrayType,
+            size: Literal[None] = None
+            ) -> np.ndarray:
+    ...
+
+def uniform(rng: RandomType | None,
+            low: float | ArrayType,
+            high: float | ArrayType,
             size: SizeType | None = None
             ) -> float | np.ndarray:
     """Create a random value within a uniform range.

--- a/sherpa/utils/types.py
+++ b/sherpa/utils/types.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2024, 2025
+#  Copyright (C) 2024-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -26,7 +26,7 @@ in Python matures.
 
 """
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Sequence
 from typing import Any, Concatenate, ParamSpec, Protocol
 
 import numpy as np

--- a/sherpa/utils/types.py
+++ b/sherpa/utils/types.py
@@ -54,15 +54,11 @@ StatResults = tuple[float, np.ndarray]
 
 # Represent statistic evaluation.
 #
-# There is partial support for sending extra information to the
-# statistics function. At present all that is required is that the
-# first argument is ArrayType and the rest are ignored.
-#
-StatFunc = Callable[Concatenate[ArrayType, P], StatResults]
+StatFunc = Callable[[ArrayType], StatResults]
 
 # What is the best typing rule here?
 #
-StatErrFunc = Callable[..., ArrayType]
+StatErrFunc = Callable[[ArrayType], ArrayType]
 
 # What do the optimization functions return?
 #
@@ -101,7 +97,7 @@ class FitFunc(Protocol):
                  pars: ArrayType,
                  parmins: ArrayType,
                  parmaxes: ArrayType,
-                 statargs: Sequence[Any] = (),
-                 statkwargs: Mapping[str, Any] | None = None
+                 statargs: Any = None,
+                 statkwargs: Any = None
                  ) -> OptReturn:
         ...


### PR DESCRIPTION
# Summary

Add typing statements to the optimization code. As part of this some of the classes and routines have seen changes in behaviour: use of keyword-only arguments, dropping the incomplete support for `statargs` and `statkwargs`, and removal of some optimization code not used by Sherpa. This is only visible to users calling the optimization routines directly.

# Details

This is taken from #2022. The aim here was not to change the code, just add typing statements, but as discussed below that did not quite happen. However, these are all low-level code changes that should not, hopefully, affect users. I have been using `mypy` and `pyright` to assess the code, and you can see certain areas where they agree and some where they do not: this does complicate deciding "what's the best thing to do" ...

In order to be able to change the code I felt I needed to understand the code, which meant adding typing rules to try to clarify things. The optimization code takes advantage of "callbacks" - or local lambda functions - to pass around functions and convert them from one thing to another. So the main aim here is identifying what the function signatures / types are. As part of doing this I have "removed" the `statargs/statkwargs` code - well, left the arguments in but they now default to `None` and if set create a warning log message - because

- the code was incomplete (e.g. the estimation error code never did anything with the arguments)
- given that we are sending around "callbacks", users can create their own to convert their stats function to match the existing interface
- by removing things we can simplify the types (we don't need to worry about extra arguments).

As the commits go by you can see some of my thinking change - e.g. 

- does this take an `ArrayType`, which is a sequence or `ndarray`, or can we specialize it to just `ndarray`
- can a value be None (sometimes it can but tracking when this changes is awkward and I don't guarantee that I get all of them)
- do I want to bother with supporting NumPy float values (e.g. mark a type as `SupportsFloat`) or shall I just say `float` and use `float(x)` in a few places to reduce the number of warnings from the type checkers
- can a value be a scalar or a list (the `***simplex` argument is a good example of this since it has support for being sent a list but generally seems to only use a scalar, but the C++ gets sent a list if memory serves me correctly)

so this is often "best guess". There is at least one place where we start with a function that can take multiple arguments and endup saying "it can only take a single argument" because, as far as I can make out, that's all we ever send in, so it's much clearer to finally be able to specify it. 

There are definitely things that can be done to improve this code, but I think this is a good "chunk" of changes to review, merge, and review downstream changes. And I do have a bunch of changes in #2022 that extend this PR, so I don't really want to be changing things too much here if we can help it.