### PR TITLE
Add new public methods to access the components of a model

### DIFF
--- a/docs/evaluation/combine.rst
+++ b/docs/evaluation/combine.rst
@@ -340,7 +340,7 @@ has many separate emissions lines::
 
     >>> spectral_lines = {'[O I]': 6300, 'Hα': 6563, '[N II]': 6586, '[S II]': 6716, '[S II]': 6731}
     >>> jetlines = [models.Gauss1D(line) for line in spectral_lines.keys()]
-    >>> jetemission = models.Const1D('background') + sum(jetlines)
+    >>> jetemission = models.Const1D('background') + np.sum(jetlines)
     >>> for line, wave in spectral_lines.items():
     ...     jetemission[line].pos = wave
     ...     jetemission[line].fwhm = 0.1

--- a/docs/evaluation/combine.rst
+++ b/docs/evaluation/combine.rst
@@ -272,7 +272,24 @@ it can be evaluated on a grid by passing in an array of values::
 
     >>> sim_model([-1.0, 0, 1])
     array([  1.52587891e-05,   1.00003815e+00,   5.34057617e-05])
-    
+
+In the example above, the model consists of two components ``sim1`` and ``sim2``
+and we keep referencing them by their original variables. In general, more complex models
+with more components can be built, which will then be arranged in a tree where the
+leaves are the original components and the internal nodes are the either
+:py:class:`~sherpa.models.model.BinaryOpModel` (which combine two models) or
+:py:class:`~sherpa.models.model.UnaryOpModel` (with modify just one model on
+the level below, e.g. by taking the absolute value of the output of the lower level model)
+instances. Those models can be quite deep and thus Sherpa provides a syntax to access the
+components of a model tree either by name or by model class. If more than one component
+matches the name or class, a list of all matching components is returned::
+
+    >>> sim_model['sim2']
+    <Gauss1D model instance 'sim2'>
+    >>> sim_model[models.Gauss1D]
+    [<Gauss1D model instance 'sim1'>, <Gauss1D model instance 'sim2'>]
+
+
 Setting up the model
 --------------------
 
@@ -310,6 +327,24 @@ parameter is now linked to the ``g1.pos`` value::
        g2.fwhm      thawed          0.1  1.17549e-38  3.40282e+38           
        g2.pos       linked          0.5       expr: g1.pos + 0.5           
        g2.ampl      thawed            1 -3.40282e+38  3.40282e+38           
+
+
+An alternative way to write the code above is to select the model components by name::
+
+    >>> mdl['g2'].fwhm = 0.1
+
+While not necessary in this example, it can make it easier to keep track of a
+model with many components and simplify code that loops over model components.
+In the following example we want to built a model for the jet from a young star that
+has many separate emissions lines::
+
+    >>> spectral_lines = {'[O I]': 6300, 'Hα': 6563, '[N II]': 6586, '[S II]': 6716, '[S II]': 6731}
+    >>> jetlines = [models.Gauss1D(line) for line in spectral_lines.keys()]
+    >>> jetemission = models.Const1D('background') + sum(jetlines)
+    >>> for line, wave in spectral_lines.items():
+    ...     jetemission[line].pos = wave
+    ...     jetemission[line].fwhm = 0.1
+    >>> jetemission['Hα'].fwhm = 5.
 
 .. note::
 

--- a/docs/model_classes/model.rst
+++ b/docs/model_classes/model.rst
@@ -17,7 +17,6 @@ The sherpa.models.model module
       ArithmeticModel
       CompositeModel
       BinaryOpModel
-      FilterModel
       MultigridSumModel
       NestedModel
       RegriddableModel
@@ -36,5 +35,5 @@ The sherpa.models.model module
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: Model ArithmeticConstantModel ArithmeticFunctionModel ArithmeticModel CompositeModel BinaryOpModel FilterModel MultigridSumModel NestedModel RegriddableModel RegriddableModel1D RegriddableModel2D SimulFitModel UnaryOpModel
+.. inheritance-diagram:: Model ArithmeticConstantModel ArithmeticFunctionModel ArithmeticModel CompositeModel BinaryOpModel MultigridSumModel NestedModel RegriddableModel RegriddableModel1D RegriddableModel2D SimulFitModel UnaryOpModel
    :parts: 1

--- a/docs/models/index.rst
+++ b/docs/models/index.rst
@@ -603,9 +603,23 @@ Alternatively, you can obtain a list of all components with::
     [<Gauss1D model instance 'g1'>, <Gauss1D model instance 'g2'>]
 
 where the ``include_composites`` argument controls whether
-composite models are included in the list or only the leaves. Models can also
-be iterated over to access the individual components - but note that
-this may include composite models.
+composite models are included in the list or only the leaves.
+As a convenience, for example for working interactively in a notebook,
+the same functionality is available as attribute access,
+which can shorten the notation. Here, if the result is a single model,
+it will be returned directly, while a list of models is returned if more
+than one component matches::
+
+    >>> mdl['g2']
+    <Gauss1D model instance 'g2'>
+    >>> mdl[basic.Gauss1D]
+    [<Gauss1D model instance 'g1'>, <Gauss1D model instance 'g2'>]
+
+This allows a very compressed syntax to change the parameters of a single
+component, for example ``mdl['g2'].ampl = 5``.
+
+Models can also be iterated over to access the individual components -
+but note that this may include composite models.
 
     >>> for cpt in iter(mdl):
     ...     print(cpt.name, type(cpt))

--- a/docs/models/index.rst
+++ b/docs/models/index.rst
@@ -84,7 +84,7 @@ represented by the following model::
     >>> back = basic.Const1D('back')
     >>> mdl1 = src1 + back
     >>> print(mdl1)
-    (src1 + back)
+    src1 + back
        Param        Type          Value          Min          Max      Units
        -----        ----          -----          ---          ---      -----
        src1.fwhm    thawed           10  1.17549e-38  3.40282e+38
@@ -98,7 +98,7 @@ is two times higher than the first::
     >>> src2 = basic.Gauss1D('src2')
     >>> mdl2 = src2 + 2 * back
     >>> print(mdl2)
-    (src2 + (2 * back))
+    src2 + 2.0 * back
        Param        Type          Value          Min          Max      Units
        -----        ----          -----          ---          ---      -----
        src2.fwhm    thawed           10  1.17549e-38  3.40282e+38
@@ -256,7 +256,7 @@ independent and dependent axes may be used, but the
 a data object will return the correct data (assuming the
 dimensionality and type match)::
 
-    >>> mdl.guess(*data.to_guess())
+    >>> mdl.guess(*data.to_guess())  # doctest: +SKIP
 
 Note that the soft limits can be changed, as in this example
 which ensures the position of the gaussian falls within the
@@ -264,12 +264,14 @@ grid of points (since this is the common situation; if the source
 is meant to lie outside the data range then the limits will
 need to be increased manually)::
 
+    >>> from sherpa.data import Data2D
+    >>> from sherpa.models import basic
     >>> yg, xg = np.mgrid[4000:4050:10, 3000:3070:10]
     >>> r2 = (xg - 3024.2)**2 + (yg - 4011.7)**2
     >>> zg = 2400 * np.exp(-r2 / 1978.2)
     >>> d2d = Data2D('example', xg.flatten(), yg.flatten(), zg.flatten(),
-                     shape=zg.shape)
-    >>> mdl = Gauss2D('mdl')
+    ...              shape=zg.shape)
+    >>> mdl = basic.Gauss2D('mdl')
     >>> print(mdl)
     mdl
        Param        Type          Value          Min          Max      Units
@@ -285,7 +287,7 @@ need to be increased manually)::
     mdl
        Param        Type          Value          Min          Max      Units
        -----        ----          -----          ---          ---      -----
-       mdl.fwhm     thawed           10  1.17549e-38  3.40282e+38
+       mdl.fwhm     thawed           60         0.06        60000
        mdl.xpos     thawed         3020         3000         3060
        mdl.ypos     thawed         4010         4000         4040
        mdl.ellip    frozen            0            0        0.999
@@ -408,7 +410,7 @@ gaussian::
     >>> sigma = basic.Scale1D('sigma')
     >>> sigma.c0 = 10
     >>> print(sigma)
-    sep
+    sigma
        Param        Type          Value          Min          Max      Units
        -----        ----          -----          ---          ---      -----
        sigma.c0     thawed           10 -3.40282e+38  3.40282e+38
@@ -422,7 +424,7 @@ which creates
     g1
        Param        Type          Value          Min          Max      Units
        -----        ----          -----          ---          ---      -----
-       g1.fwhm      linked      23.5482 expr: numpy.multiply(2.3548200450309493, sigma.c0)
+       g1.fwhm      linked      23.5482 expr: 2.3548200450309493 * sigma.c0
        g1.pos       thawed         1200 -3.40282e+38  3.40282e+38
        g1.ampl      thawed            1 -3.40282e+38  3.40282e+38
 
@@ -435,7 +437,7 @@ and, because ``g2.fwhm`` is still linked to ``g1.fwhm``
        Param        Type          Value          Min          Max      Units
        -----        ----          -----          ---          ---      -----
        g2.fwhm      linked      23.5482            expr: g1.fwhm
-       g2.pos       linked         9434    expr: (g1.pos + 8234)
+       g2.pos       linked         9434      expr: g1.pos + 8234
        g2.ampl      thawed            1 -3.40282e+38  3.40282e+38
 
 .. note::
@@ -563,8 +565,7 @@ soft limits of these parameters.
     >>> g2.lpars
     (<Parameter 'fwhm' of model 'g1'>, <Parameter 'c0' of model 'sep'>)
     >>> for idx, par in enumerate(mdl.pars, 1):
-    ...     print(idx, fullname)
-    ...
+    ...     print(idx, par.fullname)
     1 g1.fwhm
     2 g1.pos
     3 g1.ampl
@@ -574,31 +575,48 @@ soft limits of these parameters.
     >>> mdl.lpars
     (<Parameter 'c0' of model 'sep'>,)
     >>> for idx, par in enumerate(mdl.get_thawed_pars(), 1):
-    ...     print(idx, fullname)
-    ...
+    ...     print(idx, par.fullname)
     1 g1.fwhm
     2 g1.pos
     3 g1.ampl
     4 g2.ampl
     5 sep.c0
 
-Composite models can be queried to find the individual components
-using the ``parts`` attribute, which contains a tuple of the
-components. These components can themselves be composite objects, and
-so can be further explored using ``parts``. Alternatively, models can
+We can think of a complex model as a tree of components, where the leaves are
+the individual components and nodes are composite models (e.g.
+a `sherpa.models.model.BinaryOpModel` that adds to model components together).
+There are several ways to access the components of a model, by model name
+(the list will have one entry if the model name is unique, or more if it
+appears more than once)::
+
+    >>> mdl.get_components_by_name('g2')
+    [<Gauss1D model instance 'g2'>]
+
+or by type::
+
+    >>> mdl.get_components_by_class(basic.Gauss1D)
+    [<Gauss1D model instance 'g1'>, <Gauss1D model instance 'g2'>]
+
+Alternatively, you can obtain a list of all components with::
+
+    >>> mdl.get_parts(include_composites=False)
+    [<Gauss1D model instance 'g1'>, <Gauss1D model instance 'g2'>]
+
+where the ``include_composites`` argument controls whether
+composite models are included in the list or only the leaves. Models can also
 be iterated over to access the individual components - but note that
 this may include composite models.
 
     >>> for cpt in iter(mdl):
     ...     print(cpt.name, type(cpt))
-    ...
+    g1 + g2 <class 'sherpa.models.model.BinaryOpModel'>
     g1 <class 'sherpa.models.basic.Gauss1D'>
     g2 <class 'sherpa.models.basic.Gauss1D'>
     >>> for cpt in iter(g1 + 2 * g2):
     ...     print(cpt.name, type(cpt))
-    ...
+    g1 + 2.0 * g2 <class 'sherpa.models.model.BinaryOpModel'>
     g1 <class 'sherpa.models.basic.Gauss1D'>
-    (2.0 * g2) <class 'sherpa.models.model.BinaryOpModel'>
+    2.0 * g2 <class 'sherpa.models.model.BinaryOpModel'>
     2.0 <class 'sherpa.models.model.ArithmeticConstantModel'>
     g2 <class 'sherpa.models.basic.Gauss1D'>
 
@@ -615,7 +633,7 @@ times. The repeat values are actually links to the original version::
     >>> b1.xhi = 10
     >>> b2.xlow = -1
     >>> for idx, par in enumerate(mdl.pars, 1):
-    ...     print(f"{idx} {par.model:5s} {par.name:6s} {par.val}  {par.link is not None}")
+    ...     print(f"{idx} {par.modelname:5s} {par.name:6s} {par.val}  {par.link is not None}")
     ...
     1 scale c0       5.0  False
     2 box1  xlow     0.0  False

--- a/pytest.ini
+++ b/pytest.ini
@@ -29,7 +29,6 @@ doctest_norecursedirs =
     docs/install.rst
     docs/mcmc
     docs/model_classes
-    docs/models
     docs/optimisers
     docs/overview
     #docs/plots

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -537,11 +537,12 @@ def test_composite_iter():
     parts = list(m)
 
     assert type(parts[0]) is BinaryOpModel
-    assert type(parts[1]) is ArithmeticConstantModel
-    assert parts[1].val == 3.0
-    assert parts[2] is out.m
-    assert parts[3] is out.m2
-    assert len(parts) == 4
+    assert type(parts[1]) is BinaryOpModel
+    assert type(parts[2]) is ArithmeticConstantModel
+    assert parts[2].val == 3.0
+    assert parts[3] is out.m
+    assert parts[4] is out.m2
+    assert len(parts) == 5
 
     assert m(4) == 10
 
@@ -553,11 +554,12 @@ def test_composite_iter_ufunc():
     parts = list(m)
 
     assert type(parts[0]) is BinaryOpModel
-    assert type(parts[1]) is ArithmeticConstantModel
-    assert parts[1].val == 3.0
-    assert parts[2] is out.m
-    assert parts[3] is out.m2
-    assert len(parts) == 4
+    assert type(parts[1]) is BinaryOpModel
+    assert type(parts[2]) is ArithmeticConstantModel
+    assert parts[2].val == 3.0
+    assert parts[3] is out.m
+    assert parts[4] is out.m2
+    assert len(parts) == 5
 
     assert m(4) == 10
 

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -36,7 +36,7 @@ import pytest
 
 from sherpa.data import Data1D
 from sherpa.models.model import ArithmeticModel, ArithmeticConstantModel, \
-    ArithmeticFunctionModel, BinaryOpModel, FilterModel, Model, NestedModel, \
+    ArithmeticFunctionModel, BinaryOpModel, Model, NestedModel, \
     UnaryOpModel, RegridWrappedModel, modelCacher1d
 from sherpa.models.parameter import Parameter, hugeval, tinyval
 from sherpa.models.basic import Sin, Const1D, Box1D, LogParabola, Polynom1D, \
@@ -614,15 +614,6 @@ def test_composite_complex_expression():
     y1 = cmplx(out.x)
     y2 = (3 * m + m2) / (m ** 3.2)
     assert y1 == y2
-
-
-def test_filter():
-    out = setup_composite()
-    m = out.s[::2]
-
-    assert type(m) is FilterModel
-
-    assert np.all(m(out.xx) == out.s(out.xx)[::2])
 
 
 def test_nested():

--- a/sherpa/models/tests/test_model_get_components.py
+++ b/sherpa/models/tests/test_model_get_components.py
@@ -1,0 +1,158 @@
+#
+#  Copyright (C) 2025
+#  MIT
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+"""Test several methods to get the components of a more complex model.
+
+These tests could be in the test_model.py file, but that file is already pretty
+long, so we move them out to a separate file for easier readability.
+"""
+from typing import Literal
+import pytest
+
+from sherpa.models.basic import Gauss1D, Polynom1D
+from sherpa.models.model import ArithmeticConstantModel, BinaryOpModel, ArithmeticModel
+
+class Gauss1DSubClass(Gauss1D):
+    """A Gauss1D model with a different name to test get_components_by_name."""
+    pass
+
+l1 = Gauss1D('l1')
+l2 = Gauss1D('l_other_name')
+l_same_name = Gauss1D('l1')
+l1_subclass = Gauss1DSubClass('l1_subclass')
+l2_subclass_same_name = Gauss1DSubClass('l1')
+b = Polynom1D('b')
+
+
+@pytest.mark.parametrize("func", ['get_parts', '_get_parts'])
+@pytest.mark.parametrize("remove_duplicates", [True, False])
+def test_get_parts_composite(func: Literal['get_parts'] | Literal['_get_parts'], remove_duplicates: bool):
+    """Test the get_components method of a composite model."""
+    mdl = l1 + (0.5 * l2) + b + b
+    parts = getattr(mdl, func)(remove_duplicates=remove_duplicates)
+    if remove_duplicates:
+        assert len(parts) == 8
+    else:
+        assert len(parts) == 9
+        assert parts == [p for p in mdl]
+    for i in [0, 1, 2, 4]:
+        assert isinstance(parts[i], BinaryOpModel)
+    assert parts[3] == l1
+    assert isinstance(parts[5], ArithmeticConstantModel)
+    assert parts[6] == l2
+    assert parts[7] == b
+    if not remove_duplicates:
+        assert parts[8] == b
+
+
+@pytest.mark.parametrize("remove_duplicates", [True, False])
+def test_get_parts(remove_duplicates: bool):
+    """Test the get_components method of a non-composite model."""
+    parts = l1.get_parts(remove_duplicates=remove_duplicates)
+    assert len(parts) == 1
+    assert parts[0] == l1
+    assert parts == [p for p in l1]
+
+
+@pytest.mark.parametrize("func", ['get_parts', '_get_parts'])
+@pytest.mark.parametrize("remove_duplicates", [True, False])
+def test_get_parts_composite_no_composites(func: Literal['get_parts'] | Literal['_get_parts'], remove_duplicates: bool):
+    """Test the get_components method of a model."""
+    # Test the get_components method
+    mdl = l1 + (0.5 * l2) + b + b
+    parts = getattr(mdl, func)(include_composites=False, remove_duplicates=remove_duplicates)
+    if remove_duplicates:
+        assert len(parts) == 4
+    else:
+        assert len(parts) == 5
+
+    assert parts[0] == l1
+    assert isinstance(parts[1], ArithmeticConstantModel)
+    assert parts[2] == l2
+    assert parts[3] == b
+    if not remove_duplicates:
+        assert parts[4] == b
+
+
+def test_get_components_by_name():
+    """Test the get_components method of a model."""
+    # Simple case: One component with the name
+    assert [l2] == l2.get_components_by_name('l_other_name')
+
+    with pytest.raises(KeyError, match="No components found with name 'ls'"):
+        parts = l2.get_components_by_name('ls')
+
+
+def test_get_components_by_name_composite():
+    """Test the get_components method of a composite model."""
+    # Simple case: One component with the name
+    mdl = l1 + (0.5 * l2) + b + b + l_same_name
+    assert [l2] == mdl.get_components_by_name('l_other_name')
+
+    # One component appears twice
+    assert [b] == mdl.get_components_by_name('b')
+
+    # More than one component with the same string name
+    assert [l1, l_same_name] == mdl.get_components_by_name('l1')
+
+
+    with pytest.raises(KeyError, match="No components found with name 'ls'"):
+        parts = mdl.get_components_by_name('ls')
+
+
+def test_components_by_class():
+    """Test the get_components method of a model."""
+    assert [l1] == l1.get_components_by_class(Gauss1D)
+
+
+def test_components_by_class_composite():
+    """Test the get_components method of a model."""
+    mdl = l1 + (0.5 * l2) + b + b + l_same_name
+
+    # Simple case: One component with the class
+    parts = mdl.get_components_by_class(ArithmeticConstantModel)
+    assert len(parts) == 1
+    assert isinstance(parts[0], ArithmeticConstantModel)
+    assert parts[0].name == '0.5'
+
+    # Simple case: Each component appears only once
+    mdl = l1 + (0.5 * l2) + b + b + l_same_name
+    assert [l1, l2, l_same_name] == mdl.get_components_by_class(Gauss1D)
+
+    # One component appears twice
+    assert [b] == mdl.get_components_by_class(Polynom1D)
+
+
+def test_components_by_class_subclass_composite():
+    """Test the get_components method of a model in the presence of subclasses."""
+    mdl = l1 * l1_subclass - abs(l_same_name)
+    assert [l1_subclass] == mdl.get_components_by_class(Gauss1DSubClass)
+
+    assert [l1, l1_subclass, l_same_name] == mdl.get_components_by_class(Gauss1D)
+
+    assert [l1, l_same_name] == mdl.get_components_by_class(Gauss1D, subclass_ok=False)
+
+    with pytest.raises(KeyError, match="No components found with type '<class 'sherpa.models.basic.Polynom1D'>'"):
+        parts = mdl.get_components_by_class(Polynom1D)
+
+    parts = mdl.get_components_by_class(ArithmeticModel, subclass_ok=True)
+    assert len(parts) == 6
+
+    with pytest.raises(KeyError, match="No components found with type '<class 'sherpa.models.model.ArithmeticModel'>'"):
+        parts = mdl.get_components_by_class(ArithmeticModel, subclass_ok=False)

--- a/sherpa/models/tests/test_model_get_components.py
+++ b/sherpa/models/tests/test_model_get_components.py
@@ -94,31 +94,41 @@ def test_get_components_by_name():
     """Test the get_components method of a model."""
     # Simple case: One component with the name
     assert [l2] == l2.get_components_by_name('l_other_name')
+    assert l2 == l2['l_other_name']
 
     with pytest.raises(KeyError, match="No components found with name 'ls'"):
         parts = l2.get_components_by_name('ls')
 
+    with pytest.raises(KeyError, match="No components found with name 'ls'"):
+        parts = l2['ls']
 
 def test_get_components_by_name_composite():
     """Test the get_components method of a composite model."""
     # Simple case: One component with the name
     mdl = l1 + (0.5 * l2) + b + b + l_same_name
     assert [l2] == mdl.get_components_by_name('l_other_name')
+    assert l2 == mdl['l_other_name']
 
     # One component appears twice
     assert [b] == mdl.get_components_by_name('b')
+    assert b == mdl['b']
 
     # More than one component with the same string name
     assert [l1, l_same_name] == mdl.get_components_by_name('l1')
+    assert [l1, l_same_name] == mdl['l1']
 
 
     with pytest.raises(KeyError, match="No components found with name 'ls'"):
         parts = mdl.get_components_by_name('ls')
 
+    with pytest.raises(KeyError, match="No components found with name 'no such name'"):
+        parts = mdl['no such name']
+
 
 def test_components_by_class():
     """Test the get_components method of a model."""
     assert [l1] == l1.get_components_by_class(Gauss1D)
+    assert l1 == l1[Gauss1D]
 
 
 def test_components_by_class_composite():
@@ -131,20 +141,28 @@ def test_components_by_class_composite():
     assert isinstance(parts[0], ArithmeticConstantModel)
     assert parts[0].name == '0.5'
 
+    parts = mdl[ArithmeticConstantModel]
+    assert isinstance(parts, ArithmeticConstantModel)
+    assert parts.name == '0.5'
+
     # Simple case: Each component appears only once
     mdl = l1 + (0.5 * l2) + b + b + l_same_name
     assert [l1, l2, l_same_name] == mdl.get_components_by_class(Gauss1D)
+    assert [l1, l2, l_same_name] == mdl[Gauss1D]
 
     # One component appears twice
     assert [b] == mdl.get_components_by_class(Polynom1D)
+    assert b == mdl[Polynom1D]
 
 
 def test_components_by_class_subclass_composite():
     """Test the get_components method of a model in the presence of subclasses."""
     mdl = l1 * l1_subclass - abs(l_same_name)
     assert [l1_subclass] == mdl.get_components_by_class(Gauss1DSubClass)
+    assert l1_subclass == mdl[Gauss1DSubClass]
 
     assert [l1, l1_subclass, l_same_name] == mdl.get_components_by_class(Gauss1D)
+    assert [l1, l1_subclass, l_same_name] == mdl[Gauss1D]
 
     assert [l1, l_same_name] == mdl.get_components_by_class(Gauss1D, subclass_ok=False)
 
@@ -156,3 +174,14 @@ def test_components_by_class_subclass_composite():
 
     with pytest.raises(KeyError, match="No components found with type '<class 'sherpa.models.model.ArithmeticModel'>'"):
         parts = mdl.get_components_by_class(ArithmeticModel, subclass_ok=False)
+
+
+def test_getitem_invalid():
+    """Try to get an item with an invalid key type."""
+    mdl = l1 + (0.5 * l2) + b + b + l_same_name
+    with pytest.raises(TypeError, match="Invalid key type"):
+        mdl[1]  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="Invalid key type"):
+        mdl[None]  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="Invalid key type"):
+        mdl[True]  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Add new methods to select the components of a model. 

## Details

All `CompositeModels` (which will be at the root of a tree  of models for any model with more than a single component) gain methods to select components either by string name (`mdl.get_components_by_name()`) or by class, e.g. to get all `Gauss1D` components (`mdl.get_components_by_class()`). In order to implement that smoothly, the `mdl._get_parts()` method is now part of the API as `get_parts` with parameters to return only the leaves of the tree and to include or exclude the nodes (`UniaryOpModel` or `BinaryOpModel`).

For convenience, there is also dictionary-like access by name (e.g. `mdl['line2']`) and by class (`mdl[Gauss1D]`).

## Design decisions

- I have chosen to have an inconsistent return type for attribute access: If there is only one element, it's returned directly, if there is more than one, it returns a list. In practice, I anticipate that this will be mostly used in cases where the user knows if the selector is unique (e.g. the name of the spectral line - see my example in the docs). Then, always writing `mdl['S II'][0].fwhm=3` is a lot of extra boilerplate, but I also don't want it to fail with an error just because more than one element matches. "Practicality beats purity". Access by functions consistently returns lists.
- For selectors not found in the model, I raise a `KeyError` because it behaves like a dictionary.
- Currently, the implementation lives in the new methods, the dictionary-like access is just for convenience and syntactic sugar. It could be removed if it feels too magic, but I really, really like it for its convenience and compressed notation.
- One could argue that the dict-like access should only work for strings and not for classes. That might make it a bit less magical -> Decided to make it work for both classes and strings.
- As long as the dictionary-like access is the main avenue of use, long and descriptive names or the methods are OK. If we think that the methods are going to be used interactively or in notebooks, they need to get much shorter names.



closes #2221