### PR TITLE
Improve test coverage of the optimization code

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -4378,7 +4378,7 @@ def setup_multicore_data(s: Session) -> tuple[ArithmeticModel, ArithmeticModel]:
 #
 @pytest.mark.skipif(not multi, reason="multi-core support not enabled")
 @pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
-@pytest.mark.parametrize("ncores", [1, 2, 3])
+@pytest.mark.parametrize("ncores", [1, pytest.param(2, marks=pytest.mark.cores), 3])
 def test_method_numcores_levmar(session, ncores):
     """Check we can use numcores>1 with levmar"""
 
@@ -4411,7 +4411,7 @@ def test_method_numcores_levmar(session, ncores):
 
 @pytest.mark.skipif(not multi, reason="multi-core support not enabled")
 @pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
-@pytest.mark.parametrize("ncores", [1, 3])  # save some time not using ncores=2
+@pytest.mark.parametrize("ncores", [1, pytest.param(2, marks=pytest.mark.cores), 3])
 def test_errors_numcores_levmar_proj(session, ncores):
     """Check we can use numcores>1 with proj"""
 
@@ -4445,7 +4445,7 @@ def test_errors_numcores_levmar_proj(session, ncores):
 
 @pytest.mark.skipif(not multi, reason="multi-core support not enabled")
 @pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
-@pytest.mark.parametrize("ncores", [1, 3])  # save some time not using ncores=2
+@pytest.mark.parametrize("ncores", [1, pytest.param(2, marks=pytest.mark.cores), 3])
 def test_errors_numcores_levmar_conf(session, ncores):
     """Check we can use numcores>1 with conf"""
 
@@ -4541,7 +4541,7 @@ def check_moncar(ncores, fr, g1, g2) -> None:
 
 @pytest.mark.skipif(not multi, reason="multi-core support not enabled")
 @pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
-@pytest.mark.parametrize("ncores", [1, 2, 3])
+@pytest.mark.parametrize("ncores", [1, pytest.param(2, marks=pytest.mark.cores), 3])
 def test_method_numcores_moncar(session, ncores):
     """Check we can use numcores>1 with moncar"""
 

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -4556,12 +4556,6 @@ def test_method_numcores_moncar(session, ncores):
 
     s.set_method_opt("numcores", ncores)
 
-    # The random state is taken from the rng parameter of the
-    # optimizer, which does not fit in well with the current design
-    # (Sherpa 4.16).
-    #
-    # rng = np.random.RandomState(8273)
-    # s.set_rng(rng)
     assert s.get_rng() is None  # Note if this changes
 
     rng = np.random.RandomState(8273)

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2020 - 2025
+#  Copyright (C) 2016, 2018, 2020-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -69,7 +69,7 @@ def skip_if_no_io(request):
 
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("as_string", [True, False])
 def test_model_identifiers_set_globally(session, as_string):
     """Check we create a global symbol for the models.
@@ -170,7 +170,7 @@ def test_astro_model_identifiers_set_globally():
     s.clean()
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_does_clean_remove_model_identifiers(session):
     """Check whether clean() will remove model identifiers.
 
@@ -292,13 +292,13 @@ def test_zero_division_calc_stat(caplog):
     assert ui._get_stat_info()[0].rstat is np.nan
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_iter_method_name_default(session):
     s = session()
     assert s.get_iter_method_name() == "none"
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("opt", ["none", "sigmarej"])
 def test_set_iter_method_valid(session, opt):
     s = session()
@@ -306,7 +306,7 @@ def test_set_iter_method_valid(session, opt):
     assert s.get_iter_method_name() == opt
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_set_iter_method_unknown_string(session):
     s = session()
     with pytest.raises(TypeError,
@@ -314,7 +314,7 @@ def test_set_iter_method_unknown_string(session):
         s.set_iter_method("not a method")
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_set_iter_method_not_a_string(session):
     s = session()
     with pytest.raises(ArgumentTypeErr,
@@ -322,13 +322,13 @@ def test_set_iter_method_not_a_string(session):
         s.set_iter_method(23)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_iter_method_opt_default(session):
     s = session()
     assert s.get_iter_method_opt() == {}
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_iter_method_opt_sigmarej(session):
     s = session()
     s.set_iter_method("sigmarej")
@@ -338,14 +338,14 @@ def test_get_iter_method_opt_sigmarej(session):
     assert keys == set(["grow", "lrej", "hrej", "maxiters"])
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_iter_method_opt_sigmarej_lrej(session):
     s = session()
     s.set_iter_method("sigmarej")
     assert s.get_iter_method_opt("lrej") == pytest.approx(3)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("opt,key", [("none", "lrej"), ("sigmarej", "fast")])
 def test_get_iter_method_opt_unknown(session, opt, key):
     s = session()
@@ -355,7 +355,7 @@ def test_get_iter_method_opt_unknown(session, opt, key):
         s.get_iter_method_opt(key)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_set_iter_method_opt_sigmarej_lrej(session):
     s = session()
     s.set_iter_method("sigmarej")
@@ -363,7 +363,7 @@ def test_set_iter_method_opt_sigmarej_lrej(session):
     assert s.get_iter_method_opt("lrej") == pytest.approx(5)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("setting", ['chisqr', 'compmodel', 'compsource', 'data',
                                      "model_component", "source_component",
                                      'delchi', 'fit', 'kernel', 'model',
@@ -377,7 +377,7 @@ def test_id_checks_session(session, setting):
         s.load_arrays(setting, [1, 2], [1, 2])
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("setting", ['cdf', 'energy', 'lr', 'photon', 'pdf', 'scatter', 'trace'])
 def test_id_checks_session_unexpected(session, setting):
     """These identifiers are allowed. Should they be?"""
@@ -411,7 +411,7 @@ def test_id_checks_astro_session(session, success, setting):
             s.load_arrays(setting, [1, 2], [1, 2])
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("plottype", ["source_component", "compsource",
                                       "model_component", "compmodel"])
 def test_plot_component(session, plottype):
@@ -437,7 +437,7 @@ def test_plot_component(session, plottype):
     s.plot(plottype, mdl)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("plottype", ["source_component", "compsource",
                                       "model_component", "compmodel"])
 def test_plot_component_fails(session, plottype):
@@ -1235,7 +1235,7 @@ def test_show_bkg_source_output():
     assert len(toks) == 10
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("idval", [None, "foo"])
 def test_show_filter(idval, session):
     """Is show_filter doing anything sensible?"""
@@ -1260,7 +1260,7 @@ def test_show_filter(idval, session):
     assert len(toks) == 5
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("idval", [None, 1])
 @pytest.mark.parametrize("label", ["source", "model"])
 def test_show_model(idval, label, session):
@@ -1303,7 +1303,7 @@ def test_show_model(idval, label, session):
     assert len(toks) == 8
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_show_method(session):
     """Is show_method doing anything sensible?"""
 
@@ -1333,7 +1333,7 @@ def test_show_method(session):
     assert len(toks) == 12
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_show_stat(session):
     """Is show_stat doing anything sensible?"""
 
@@ -1356,7 +1356,7 @@ def test_show_stat(session):
     assert toks[2] == ""
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_show_fit(session):
     """Cover a number of internal routines to check show_fit works."""
 
@@ -1443,7 +1443,7 @@ def test_show_fit(session):
     assert len(toks) == 32
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("label", ["proj", "unc"])
 def test_get_int_xxx_recalc_false(session, label):
     """Check we call the recalc=False path, even with no data loaded."""
@@ -1460,7 +1460,7 @@ def test_get_int_xxx_recalc_false(session, label):
     assert plotobj.x is None
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("label", ["proj", "unc"])
 def test_get_reg_xxx_recalc_false(session, label):
     """Check we call the recalc=False path, even with no data loaded."""
@@ -1508,7 +1508,7 @@ def setup_template_model(session, make_data_path, interp="default"):
 
 
 @requires_data
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("label", ["model", "source"])
 def test_get_xxx_component_plot_with_templates_recalc_true(session, label, make_data_path, skip_if_no_io):
     """What is the intended behavior for template models?
@@ -1536,7 +1536,7 @@ def test_get_xxx_component_plot_with_templates_recalc_true(session, label, make_
 
 
 @requires_data
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("label", ["model", "source"])
 def test_get_xxx_component_plot_with_templates_recalc_true_no_interp(session, label, make_data_path, skip_if_no_io):
     """What is the intended behavior for template models?
@@ -1561,7 +1561,7 @@ def test_get_xxx_component_plot_with_templates_recalc_true_no_interp(session, la
 
 
 @requires_data
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("label", ["model", "source"])
 def test_get_xxx_component_plot_with_templates_recalc_false(session, label, make_data_path, skip_if_no_io):
     """What is the intended behavior for template models?
@@ -1606,7 +1606,7 @@ def test_get_xxx_component_plot_with_templates_recalc_false(session, label, make
 
 
 @requires_data
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("label", ["model", "source"])
 def test_get_xxx_component_plot_with_templates_recalc_false_no_interp(session, label, make_data_path, skip_if_no_io):
     """What is the intended behavior for template models?
@@ -1652,7 +1652,7 @@ def test_get_xxx_component_plot_with_templates_recalc_false_no_interp(session, l
 
 
 @requires_data
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("label", ["model", "source"])
 def test_get_xxx_component_plot_with_templates_data1d(session, label, make_data_path, skip_if_no_io):
     """What is the intended behavior for template models?  Data1D
@@ -1696,7 +1696,7 @@ def test_get_xxx_component_plot_with_templates_data1d(session, label, make_data_
 
 
 @requires_data
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("label", ["model", "source"])
 def test_get_xxx_component_plot_with_templates_data1d_no_interp(session, label, make_data_path, skip_if_no_io):
     """What is the intended behavior for template models?  Data1D, no interpolator
@@ -1744,7 +1744,7 @@ def test_get_xxx_component_plot_with_templates_data1d_no_interp(session, label, 
 
 
 @requires_data
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("label", ["model", "source"])
 def test_get_xxx_component_plot_with_templates_data1dint(session, label, make_data_path):
     """What is the intended behavior for template models?  Data1DInt"""
@@ -1785,7 +1785,7 @@ def test_get_xxx_component_plot_with_templates_data1dint(session, label, make_da
 
 
 @requires_data
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("label", ["model", "source"])
 def test_get_xxx_component_plot_with_templates_data1dint_no_interp(session, label, make_data_path):
     """What is the intended behavior for template models?  Data1DInt, no interpolator"""
@@ -2074,7 +2074,7 @@ def check_stat_info_basic(sinfo, name, ids, numpoints, statval):
     assert sinfo.statval == pytest.approx(statval)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_stat_info_basic_one(session):
     """Check get_stat_info with one dataset"""
 
@@ -2095,7 +2095,7 @@ def test_get_stat_info_basic_one(session):
     check_stat_info_basic(sinfo[0], "Dataset [1]", [1], 3, 9)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_stat_info_basic_two(session):
     """Check get_stat_info with two datasets"""
 
@@ -2197,7 +2197,7 @@ class DummyClass:
     pass
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_add_model_errors_out(session):
     """The model class needs to be derived from ArithmeticModel."""
 
@@ -2209,7 +2209,7 @@ def test_add_model_errors_out(session):
         s.add_model(DummyClass)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_source_with_convolved_model(session):
     """Check we get an error.
 
@@ -2392,7 +2392,7 @@ def test_fit_checks_kwarg(session, msg):
         s.fit(unknown_argument=True)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("alias,original",
                          [("compsource", "source_component"),
                           ("compmodel", "model_component")])
@@ -2716,7 +2716,7 @@ def test_save_resid_ascii_data2d(session, kwargs, expected, idval, tmp_path, ski
     check_save_ascii2d(session, expected, out, s.save_resid, idval, kwargs, check_str)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_load_template_model_error_mismatched_header(session, tmp_path):
     """Check error handling: col names and col values differ"""
 
@@ -2730,7 +2730,7 @@ def test_load_template_model_error_mismatched_header(session, tmp_path):
         s.load_template_model("tmp", str(mfile))
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_load_template_model_error_no_pars(session, tmp_path):
     """Check error handling: no parameter column"""
 
@@ -2744,7 +2744,7 @@ def test_load_template_model_error_no_pars(session, tmp_path):
         s.load_template_model("tmp", str(mfile))
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_load_template_model_error_no_modelfile(session, tmp_path):
     """Check error handling: no modelfile"""
 
@@ -2758,7 +2758,7 @@ def test_load_template_model_error_no_modelfile(session, tmp_path):
         s.load_template_model("tmp", str(mfile))
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_load_template_model_error_no_modelflag(session, tmp_path):
     """Check error handling: no modelfile"""
 
@@ -2772,7 +2772,7 @@ def test_load_template_model_error_no_modelflag(session, tmp_path):
         s.load_template_model("tmp", str(mfile))
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_load_template_model_error_1_col(session, tmp_path):
     """Check error handling: template file has < 2 columns"""
 
@@ -2790,7 +2790,7 @@ def test_load_template_model_error_1_col(session, tmp_path):
         s.load_template_model("tmp", str(mfile))
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_load_template_model_error_multi_col(session, tmp_path):
     """Check error handling: template file has > 2 columns"""
 
@@ -2808,7 +2808,7 @@ def test_load_template_model_error_multi_col(session, tmp_path):
         s.load_template_model("tmp", str(mfile))
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_method_unknown(session):
     """Check we error out"""
 
@@ -2818,7 +2818,7 @@ def test_get_method_unknown(session):
         s.get_method("bob")
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_method_opt_unknown(session):
     """Check we error out"""
 
@@ -2830,7 +2830,7 @@ def test_get_method_opt_unknown(session):
         s.get_method_opt("bob")
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_method_opt_known(session):
     """Check we get a result.
 
@@ -2845,7 +2845,7 @@ def test_get_method_opt_known(session):
     assert s.get_method_opt("factor") == pytest.approx(100.0)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_set_iter_method_opt_unknown(session):
     """Check we error out"""
 
@@ -2855,7 +2855,7 @@ def test_set_iter_method_opt_unknown(session):
         s.set_iter_method_opt("bob", True)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_stat_unknown(session):
     """Check we error out"""
 
@@ -2865,7 +2865,7 @@ def test_get_stat_unknown(session):
         s.get_stat("bob")
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_indep(session):
     """Somehow we were not calling the Session version"""
 
@@ -2877,7 +2877,7 @@ def test_get_indep(session):
     assert got[0] == pytest.approx([2, 3, 4])
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_dims(session):
     """Somehow we were not calling the Session version"""
 
@@ -2888,7 +2888,7 @@ def test_get_dims(session):
     assert got == (2, 3)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("etype", ["stat", "sys"])
 @pytest.mark.parametrize("idval", [None, "bob"])
 def test_load_xxxerror(session, etype, idval, tmp_path, skip_if_no_io):
@@ -2914,7 +2914,7 @@ def test_load_xxxerror(session, etype, idval, tmp_path, skip_if_no_io):
     assert get(idval) == pytest.approx([1.1, 2.2, 0.0])
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("idval", [None, "bob"])
 def test_fake_fixed(session, idval):
     """Basic check of fake"""
@@ -2943,7 +2943,7 @@ def test_fake_fixed(session, idval):
     assert s.get_dep(idval) == pytest.approx([4, 7, 11])
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("idval", [None, "bob"])
 def test_fake_random(session, idval):
     """Basic check of fake"""
@@ -2970,7 +2970,7 @@ def test_fake_random(session, idval):
     assert s.get_dep(idval) == pytest.approx([9, 4, 11])
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_save_filter_excluded_everything(session, tmp_path):
     """Check we error out"""
 
@@ -2987,7 +2987,7 @@ def test_save_filter_excluded_everything(session, tmp_path):
         s.save_filter(str(ofile))
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_save_filter_noticed_everything(session, tmp_path):
     """Check we error out"""
 
@@ -3001,7 +3001,7 @@ def test_save_filter_noticed_everything(session, tmp_path):
         s.save_filter(str(ofile))
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_add_model_types_simple(session):
     """coverage check"""
 
@@ -3014,7 +3014,7 @@ def test_add_model_types_simple(session):
     assert len(s.list_models()) == 31
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_add_model_types_scalar(session):
     """coverage check"""
 
@@ -3026,7 +3026,7 @@ def test_add_model_types_scalar(session):
     assert len(s.list_models()) == 31
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_model_component_sent_str(session):
     """Just to match test_get_model_component_sent_model"""
 
@@ -3037,7 +3037,7 @@ def test_get_model_component_sent_str(session):
     assert s.get_model_component("g1") == mdl
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_model_component_sent_model(session):
     """coverage check"""
 
@@ -3048,7 +3048,7 @@ def test_get_model_component_sent_model(session):
     assert s.get_model_component(mdl) == mdl
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_create_model_component_sent_model(session):
     """coverage check"""
 
@@ -3059,7 +3059,7 @@ def test_create_model_component_sent_model(session):
     assert s.create_model_component(mdl) == mdl
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_create_model_component_sent_unknown(session):
     """coverage check"""
 
@@ -3070,7 +3070,7 @@ def test_create_model_component_sent_unknown(session):
         s.create_model_component("notamodel1d", "g1")
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_reset_sent_model(session):
     """Check model behavior"""
 
@@ -3091,7 +3091,7 @@ def test_reset_sent_model(session):
     assert mdl.c0.val == pytest.approx(2)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_reset_sent_id(session):
     """Check behavior when sent an id"""
 
@@ -3118,7 +3118,7 @@ def test_reset_sent_id(session):
     assert mdl2.pos.val == pytest.approx(10)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_reset_sent_nothing(session):
     """Check behavior when sent nothing"""
 
@@ -3145,7 +3145,7 @@ def test_reset_sent_nothing(session):
     assert mdl2.pos.val == pytest.approx(10)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_model_type_basic(session):
     """Check behavior"""
 
@@ -3162,7 +3162,7 @@ def test_get_model_type_basic(session):
     assert s.get_model_type(mdl1 + mdl2) == "binaryopmodel"
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_model_pars_str(session):
     """Check behavior"""
 
@@ -3173,7 +3173,7 @@ def test_get_model_pars_str(session):
     assert s.get_model_pars("g1") == ["fwhm", "pos", "ampl"]
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_model_pars_model(session):
     """Check behavior"""
 
@@ -3184,7 +3184,7 @@ def test_get_model_pars_model(session):
     assert s.get_model_pars(mdl) == ["fwhm", "pos", "ampl"]
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_num_par(session):
     """Check behavior"""
 
@@ -3201,7 +3201,7 @@ def test_get_num_par(session):
     assert s.get_num_par(2) == 3
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_model_component_checks_model_name(session):
     """Check corner case"""
 
@@ -3213,7 +3213,7 @@ def test_model_component_checks_model_name(session):
         s.create_model_component("gauss1d", "gauss1d")
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_model_component_checks_builtin_name(session):
     """Check corner case"""
 
@@ -3225,7 +3225,7 @@ def test_model_component_checks_builtin_name(session):
         s.create_model_component("gauss1d", "exit")
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_conf_opt_none(session):
     """Check corner case
 
@@ -3549,7 +3549,7 @@ def test_bkg_fit_data_with_no_model():
         s.get_stat_info()
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_do_not_fold_all_models(session, tmp_path, skip_if_no_io):
     """Corner case of _add_convolution_models
 
@@ -3603,7 +3603,7 @@ def test_do_not_fold_all_models(session, tmp_path, skip_if_no_io):
     assert tbl2([1, 2, 3]) == pytest.approx([10, 5, 2])
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_delete_psf_not_there(session):
     """delete_psf does nothing if no PSF exist"""
 
@@ -3613,7 +3613,7 @@ def test_delete_psf_not_there(session):
     assert s.list_psf_ids() == []
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_delete_psf_there(session):
     """delete_psf removes the PSF"""
 
@@ -3633,7 +3633,7 @@ def test_delete_psf_there(session):
     assert s.list_psf_ids() == [1]
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_fit_ignores_repeated_otherid(session, caplog):
 
     s = session()
@@ -3701,7 +3701,7 @@ def test_fit_ignores_repeated_otherid(session, caplog):
     assert s.calc_chisqr("1", 1, 1, "1") == pytest.approx(d2 + d1)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_get_draws_wants_errors(session):
 
     s = session()
@@ -3716,7 +3716,7 @@ def test_get_draws_wants_errors(session):
         s.get_draws(niter=1)
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("method", ["proj", "unc"])
 def test_get_int_xxx_otherids(method, session):
     """Corner case.
@@ -3752,7 +3752,7 @@ def test_get_int_xxx_otherids(method, session):
     assert plot.y == pytest.approx([125, 101, 86, 80, 83])
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("method", ["proj", "unc"])
 def test_get_reg_xxx_otherids(method, session):
     """Corner case.
@@ -3867,7 +3867,7 @@ def test_pack_image():
     assert s.pack_image() is not None
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("idval", [None, 1, "bob"])
 def test_show_kernel(session, idval):
 
@@ -3895,7 +3895,7 @@ def test_show_kernel(session, idval):
     assert len(toks) == 12
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_show_kernel_multi(session):
 
     s = session()
@@ -3921,7 +3921,7 @@ def test_show_kernel_multi(session):
     assert len(toks) == 3
 
 
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_load_conv_model_instance(session):
     """Corner case"""
 
@@ -3955,7 +3955,7 @@ def check_fit_results(s, datasets, parnames, parvals, istatval, statval, numpoin
 
 
 @pytest.mark.parametrize("id1", [1, 2])
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 def test_fit_data1d_mix_data(id1, session):
     """Check what happens with a mix of datasets with/without data.
 
@@ -4377,7 +4377,7 @@ def setup_multicore_data(s: Session) -> tuple[ArithmeticModel, ArithmeticModel]:
 # Note: gridsearch is too slow to test this way
 #
 @pytest.mark.skipif(not multi, reason="multi-core support not enabled")
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ncores", [1, 2, 3])
 def test_method_numcores_levmar(session, ncores):
     """Check we can use numcores>1 with levmar"""
@@ -4410,7 +4410,7 @@ def test_method_numcores_levmar(session, ncores):
 
 
 @pytest.mark.skipif(not multi, reason="multi-core support not enabled")
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ncores", [1, 3])  # save some time not using ncores=2
 def test_errors_numcores_levmar_proj(session, ncores):
     """Check we can use numcores>1 with proj"""
@@ -4444,7 +4444,7 @@ def test_errors_numcores_levmar_proj(session, ncores):
 
 
 @pytest.mark.skipif(not multi, reason="multi-core support not enabled")
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ncores", [1, 3])  # save some time not using ncores=2
 def test_errors_numcores_levmar_conf(session, ncores):
     """Check we can use numcores>1 with conf"""
@@ -4540,7 +4540,7 @@ def check_moncar(ncores, fr, g1, g2) -> None:
 
 
 @pytest.mark.skipif(not multi, reason="multi-core support not enabled")
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ncores", [1, 2, 3])
 def test_method_numcores_moncar(session, ncores):
     """Check we can use numcores>1 with moncar"""

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -114,7 +114,9 @@ RUNOPTS = [("slow", "run slow tests",
            ("zenodo", "run tests that query Zenodo (requires internet)",
             "requires internet access to Zenodo"),
            ("speed", "run tests check speed and caching choices (results can vary randomly)",
-            "check if model caching improves evaluation time")
+            "check if model caching improves evaluation time"),
+           ("session", "run Session tests as well as AstroSession ones",
+            "test Session as well as AstroSession")
            ]
 
 

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -116,7 +116,9 @@ RUNOPTS = [("slow", "run slow tests",
            ("speed", "run tests check speed and caching choices (results can vary randomly)",
             "check if model caching improves evaluation time"),
            ("session", "run Session tests as well as AstroSession ones",
-            "test Session as well as AstroSession")
+            "test Session as well as AstroSession"),
+           ("cores", "run extra multi-core optimization tests",
+            "add more multi-core tests")
            ]
 
 

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -106,32 +106,39 @@ TEST_DATA_OPTION = "--test-data"
 # for adding a command-line option to let slow-running tests be run
 # (not by default), which combines with existing code and options.
 #
+
+# The elements are name, help string, text for marker
+#
+RUNOPTS = [("slow", "run slow tests",
+            "mark test as slow to run"),
+           ("zenodo", "run tests that query Zenodo (requires internet)",
+            "requires internet access to Zenodo"),
+           ("speed", "run tests check speed and caching choices (results can vary randomly)",
+            "check if model caching improves evaluation time")
+           ]
+
+
 def pytest_addoption(parser):
     parser.addoption("-D", TEST_DATA_OPTION, action="store",
                      help="Alternative location of test data files")
 
-    parser.addoption("--runslow", action="store_true", default=False,
-                     help="run slow tests")
-
-    parser.addoption("--runzenodo", action="store_true", default=False,
-                     help="run tests that query Zenodo (requires internet)")
-
-    parser.addoption("--runspeed", action="store_true", default=False,
-                     help="run tests check speed and caching choices (results can vary randomly)")
+    for name, msg, _ in RUNOPTS:
+        parser.addoption(f"--run{name}", action="store_true",
+                         default=False, help=msg)
 
 
 def pytest_collection_modifyitems(config, items):
 
     # Skip tests unless --runxxx given in cli
     #
-    for label in ["slow", "zenodo", "speed"]:
-        opt = "--run{}".format(label)
+    for name, _, _ in RUNOPTS:
+        opt = f"--run{name}"
         if config.getoption(opt):
             continue
 
-        skip = pytest.mark.skip(reason="need {} option to run".format(opt))
+        skip = pytest.mark.skip(reason=f"need {opt} option to run")
         for item in items:
-            if label in item.keywords:
+            if name in item.keywords:
                 item.add_marker(skip)
 
 
@@ -321,7 +328,7 @@ def pytest_configure(config):
     This configuration hook overrides the default mechanism for test data self-discovery, if the --test-data command line
     option is provided
 
-    It also adds support for the "slow" and "zenodo" test markers.
+    It also adds support for the Sherpa-specific test markers.
 
     Parameters
     ----------
@@ -334,8 +341,8 @@ def pytest_configure(config):
     except ValueError:  # option not defined from command line, no-op
         pass
 
-    config.addinivalue_line("markers", "slow: mark test as slow to run")
-    config.addinivalue_line("markers", "zenodo: indicates requires internet access to Zenodo")
+    for name, _, msg in RUNOPTS:
+        config.addinivalue_line("markers", f"{name}: {msg}")
 
 
 @pytest.fixture(scope="session")

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1454,7 +1454,7 @@ class Fit(NoNewAttributesAfterInit):
             # have the case that self.stat and self._iterfit.stat were
             # not guaranteed to be the same).
             #
-            # Could we skip this if newpars is them same as thawedpars?
+            # Could we skip this if newpars is the same as thawedpars?
             #
             fval_new, _ = cb(newpars)
 

--- a/sherpa/optmethods/tests/test_opt_original.py
+++ b/sherpa/optmethods/tests/test_opt_original.py
@@ -816,18 +816,29 @@ def tst_unc_opt(algorithms, npar):
         chebyquad(name, algo)
 
 
+SIMPLEX_SEED = 234
+
+def make_simplex_kwargs():
+    """Need a new RNG each time we call it."""
+    return [
+        {"seed": SIMPLEX_SEED, "rng": None},
+        {"seed": SIMPLEX_SEED, "rng": np.random.RandomState(SIMPLEX_SEED)},
+        {"seed": None, "rng": np.random.RandomState(SIMPLEX_SEED)},
+    ]
+
+
+@pytest.mark.parametrize("kwargs", make_simplex_kwargs())
 @pytest.mark.parametrize("npar", [10])
-def test_simplexnostep(npar):
+def test_simplexnostep(npar, kwargs):
     """This was part of the if __main__ section of sherpa.optmethods.opt with npar as an argument"""
 
     x0 = np.array(npar * [-1.2, 1.0])
     xmin = npar * [-1000, -1000]
     xmax = npar * [1000, 1000]
     factor = 10
-    seed = 234
     simp = SimplexNoStep(func=Rosenbrock, npop=len(x0) + 1, xpar=x0,
-                         xmin=xmin, xmax=xmax, step=None, seed=seed,
-                         factor=factor)
+                         xmin=xmin, xmax=xmax, step=None, factor=factor,
+                         **kwargs)
     print('simp =\n', simp.simplex)
 
     # It's not clear what to actually test here, so just try this.
@@ -840,18 +851,18 @@ def test_simplexnostep(npar):
     assert simp.simplex[:, -1] == pytest.approx(expected)
 
 
+@pytest.mark.parametrize("kwargs", make_simplex_kwargs())
 @pytest.mark.parametrize("npar", [10])
-def test_simplexstep(npar):
+def test_simplexstep(npar, kwargs):
     """This was part of the if __main__ section of sherpa.optmethods.opt with npar as an argument"""
 
     x0 = np.array(npar * [-1.2, 1.0])
     xmin = npar * [-1000, -1000]
     xmax = npar * [1000, 1000]
     factor = 10
-    seed = 234
     simp = SimplexStep(func=Rosenbrock, npop= len(x0) + 2, xpar=x0,
-                       xmin=xmin, xmax=xmax, step=x0 + 1.2, seed=seed,
-                       factor=factor)
+                       xmin=xmin, xmax=xmax, step=x0 + 1.2,
+                       factor=factor, **kwargs)
     print('simp =\n', simp.simplex)
 
     # It's not clear what to actually test here, so just try this.
@@ -866,18 +877,18 @@ def test_simplexstep(npar):
     assert simp.simplex[:, -1] == pytest.approx(expected)
 
 
+@pytest.mark.parametrize("kwargs", make_simplex_kwargs())
 @pytest.mark.parametrize("npar", [10])
-def test_simplexrandom(npar):
+def test_simplexrandom(npar, kwargs):
     """This was part of the if __main__ section of sherpa.optmethods.opt with npar as an argument"""
 
     x0 = np.array(npar * [-1.2, 1.0])
     xmin = npar * [-1000, -1000]
     xmax = npar * [1000, 1000]
     factor = 10
-    seed = 234
     simp = SimplexRandom(func=Rosenbrock, npop=len(x0) + 5, xpar=x0,
                          xmin=xmin, xmax=xmax, step=x0 + 1.2,
-                         seed=seed, factor=factor)
+                         factor=factor, **kwargs)
     print('simp =\n', simp.simplex)
 
     # It's not clear what to actually test here, so just try this.

--- a/sherpa/optmethods/tests/test_opt_unit.py
+++ b/sherpa/optmethods/tests/test_opt_unit.py
@@ -37,9 +37,12 @@ def rosenbrock(x):
 SEED = 2354
 
 
-@pytest.mark.parametrize("rng", [None,
-                                 np.random.RandomState(2354)])
-def test_is_simplexbase_repeatable(rng):
+@pytest.mark.parametrize("kwargs",
+                         [{"seed": SEED, "rng": None},
+                          {"seed": SEED, "rng": np.random.RandomState(SEED)},
+                          {"seed": None, "rng": np.random.RandomState(SEED)},
+                          ])
+def test_is_simplexbase_repeatable(kwargs):
     """The SimplexBase* classes uses RNG, so can we make it repeatable?
 
     This is based on the 'if __name__ == "__main__"' section of
@@ -56,8 +59,8 @@ def test_is_simplexbase_repeatable(rng):
     xmin = [-1000, -1000]
     xmax = [1000, 1000]
     simp = SimplexRandom(func=rosenbrock, npop=4, xpar=x0, xmin=xmin,
-                         xmax=xmax, step=x0 + 1.2, seed=SEED,
-                         factor=10, rng=rng)
+                         xmax=xmax, step=x0 + 1.2, factor=10,
+                         **kwargs)
 
     # After the first line, which is the x0 array + function value,
     # the next three rows have 2 random numbers and then the function

--- a/sherpa/optmethods/tests/test_opt_unit.py
+++ b/sherpa/optmethods/tests/test_opt_unit.py
@@ -75,7 +75,7 @@ def test_is_simplexbase_repeatable(kwargs):
 
 
 def test_is_simplexbase_repeatable_post_117():
-    """test_is_simplese_repeatable with a post NumPy 1.17 RNG.
+    """test_is_simplexbase_repeatable with a post NumPy 1.17 RNG.
 
     It's not clear how "repeatable" this will be (i.e. using
     a fixed seed is not guaranteed to give the same results

--- a/sherpa/sim/tests/test_asymmetric.py
+++ b/sherpa/sim/tests/test_asymmetric.py
@@ -276,13 +276,15 @@ def test_resample_rmd(make_data_path):
 
 @requires_data
 @requires_fits
-def test_warning(make_data_path):
+def test_warning(make_data_path, clean_astro_ui):
 
     infile = make_data_path('gro.txt')
     ui.load_ascii_with_errors(1, infile)
     powlaw1d = PowLaw1D('p1')
     ui.set_model(powlaw1d)
     ui.fit()
+    assert ui.get_rng() is None  # review the test if this fails
+    ui.set_rng(np.random.RandomState(56243))
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         ui.resample_data(1, 3)


### PR DESCRIPTION
# Summary

Improve test coverage for the optimization code. There is no functional change to Sherpa.

# Details

These are tests that were suggested when working on #2022. It makes sense to take them now before that work gets finished. There is also a typo in a comment in `sherpa/fit.py` that I included.

The tests generally extend the checks of the "rng/seed" handling of the optimization code (this was changed in #1735 to better support the modern NumPy RNG code, but this code is complicated to test as it was originally written with a combination of an explicit seed value and also relying on the "system" [1] random state). So whilst reviewing this code I've realized we can improve our test coverage a little bit in a few places.

The optimization code has multi-core support which we haven't really tested in our CI runs. The CI runners on GitHub now have multi-core capabilities, so we can add some explicit checks with `numcores=1, 2, 3` and compare the results. This shows some "interesting" behaviour, in that the results can depend on OS/architecture and it's not clear why. So these tests are really thought of as regression tests, just to check that the code continues working as expected, rather than being a set of tests from "first principles" (e.g. where we know the correct answer).

[1] one thing I had to do as part of #1735 was determine whether the "random state" was coming from `np.random` or `random` and try to rationalize the code so the randomness could be better understood