### PR TITLE
Make sure all datastack-wrapped functions are added to namespace

### DIFF
--- a/sherpa/astro/datastack/__init__.py
+++ b/sherpa/astro/datastack/__init__.py
@@ -220,17 +220,17 @@ import types
 
 from sherpa.astro import ui
 from sherpa.utils.logging import config_logger
-from sherpa.utils import public
 from sherpa.astro.datastack.ds import DataStack
 
 from .utils import set_template_id
 
 logger = config_logger(__name__)
 
-__all__ = ['set_template_id', 'DataStack']
+__all__ = ['set_template_id', 'DataStack',
+           'clean', 'set_stack_verbosity', 'set_stack_verbose',
+           ]
 
 
-@public
 def set_stack_verbosity(level):
     """Change the logging level.
 
@@ -256,7 +256,6 @@ def set_stack_verbosity(level):
     logger.setLevel(level)
 
 
-@public
 def set_stack_verbose(verbose=True):
     """Should stack functions print informational messages?
 
@@ -354,15 +353,15 @@ _module = sys.modules[__name__]
 for attr in dir(ui):
     func = getattr(ui, attr)
     if isinstance(func, types.FunctionType):
-        setattr(_module, attr, public(_sherpa_ui_wrap(func)))
+        setattr(_module, attr, _sherpa_ui_wrap(func))
+        __all__.append(attr)
 
 for funcname in ['clear_stack', 'show_stack', 'get_stack_ids',
                  'query', 'query_by_header_keyword', 'query_by_obsid']:
-    setattr(_module, funcname, public(
-        _datastack_wrap(getattr(DataStack, funcname))))
+    setattr(_module, funcname, _datastack_wrap(getattr(DataStack, funcname)))
+    __all__.append(funcname)
 
 
-@public
 def clean():
     """Remove the models and data from the data stack and Sherpa.
 

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -812,12 +812,9 @@ def test_operations_datastack_group(ds_setup, ds_datadir):
 def test_wrapped_funcs_in_all():
     """This is a regression test for #2270
 
-    Before #2270 several convenience functions using different
-    types of magic were used and interacted such that not every
-    wrapped function was added to __all__, in particular when one of them
-    is an alias for another. It's very unlikely that that same failure
-    mode will happen again, so this is a very rudamentary test where we are
-    just checking that both functions exisit.
+    Check that aliased routines (here set_model/set_source) are present
+    both in the module and are exported by it. It is not worth checking every
+    possible symbol.
     """
     func = datastack.set_model
     func = datastack.set_source

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014, 2015, 2016, 2018, 2019, 2020, 2021
+#  Copyright (C) 2014-2016, 2018-2021, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -807,3 +807,19 @@ def test_operations_datastack_group(ds_setup, ds_datadir):
     assert np.allclose(d1.get_dep(filter=True)[15:20], [5., 5., 6., 7., 10.])
     datastack.ungroup('myid')
     assert np.all(d1.get_dep(filter=True)[15:20] == [3., 7., 1., 6., 4.])
+
+
+def test_wrapped_funcs_in_all():
+    """This is a regression test for #2270
+
+    Before #2270 several convenience functions using different
+    types of magic were used and interacted such that not every
+    wrapped function was added to __all__, in particular when one of them
+    is an alias for another. It's very unlikely that that same failure
+    mode will happen again, so this is a very rudamentary test where we are
+    just checking that both functions exisit.
+    """
+    func = datastack.set_model
+    func = datastack.set_source
+    assert 'set_model' in datastack.__all__
+    assert 'set_source' in datastack.__all__

--- a/sherpa/astro/datastack/utils.py
+++ b/sherpa/astro/datastack/utils.py
@@ -1,5 +1,6 @@
 #
-# Copyright (C) 2015, 2016, 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2015-2016, 2020, 2025
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -19,7 +20,6 @@
 
 import re
 
-from sherpa.utils import public
 from sherpa.utils.logging import config_logger
 import sherpa
 from sherpa import plot as shplot
@@ -28,13 +28,16 @@ logger = config_logger(__name__)
 
 ID_STR = '__ID'
 
+__all__ = ['model_wrapper', 'load_wrapper', 'simple_wrapper',
+           'fit_wrapper', 'plot_wrapper', 'set_template_id',
+           'load_error_msg', 'create_stack_model']
+
 try:
     import stk
 except:
     logger.warning("could not import stk library. CIAO stack files and syntax will be disabled")
 
 
-@public
 def model_wrapper(func):
     def wrapfunc(self, model):
         """Run a model-setting function for each of the datasets."""
@@ -61,7 +64,6 @@ def model_wrapper(func):
     return wrapfunc
 
 
-@public
 def create_stack_model(model, id_):
     """Create any model components for the given data set.
 
@@ -149,7 +151,6 @@ def _create_stack_model(model, model_id, model_components=None):
     return model, model_comps
 
 
-@public
 def load_wrapper(load_func):
     """Override a native Sherpa data loading function."""
 
@@ -182,7 +183,6 @@ def load_wrapper(load_func):
     return _load
 
 
-@public
 def simple_wrapper(func):
     def wrapfunc(self, *args, **kwargs):
         """Apply an arbitrary Sherpa function to each of the datasets.
@@ -202,7 +202,6 @@ def simple_wrapper(func):
     return wrapfunc
 
 
-@public
 def fit_wrapper(func):
     def _fit(self, *args, **kwargs):
         """Fit or error analysis for all the datasets in the stack.
@@ -221,7 +220,6 @@ def fit_wrapper(func):
     return _fit
 
 
-@public
 def plot_wrapper(func):
     def plot(self, *args, **kwargs):
         """Call the Sherpa plot ``func`` for each dataset.
@@ -244,7 +242,6 @@ def plot_wrapper(func):
     return plot
 
 
-@public
 def set_template_id(newid):
     """Change the template used for model components.
 
@@ -280,7 +277,6 @@ def set_template_id(newid):
     ID_STR = newid
 
 
-@public
 def load_error_msg(id_):
     """The error message when an invalid id is given."""
     return "When called from a datastack instance, an ID cannot be " + \

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -3618,23 +3618,6 @@ def zeroin(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32, tol=1.0e-2):
         return [[xb, fb], [[xa, fa], [xc, fc]], myfcn.nfev]
 
 
-def public(f):
-    """Use a decorator to avoid retyping function/class names.
-
-    * Based on an idea by Duncan Booth:
-    http://groups.google.com/group/comp.lang.python/msg/11cbb03e09611b8a
-    * Improved via a suggestion by Dave Angel:
-    http://groups.google.com/group/comp.lang.python/msg/3d400fb22d8a42e1
-
-    See also https://bugs.python.org/issue26632
-
-    """
-    _all = sys.modules[f.__module__].__dict__.setdefault('__all__', [])
-    if f.__name__ not in _all:  # Prevent duplicates if run from an IDE.
-        _all.append(f.__name__)
-    return f
-
-
 def send_to_pager(txt: str, filename=None, clobber: bool = False) -> None:
     """Write out the given string, using pagination if supported.
 


### PR DESCRIPTION
## Summary
Complete the `datastack` namspace for functions wrapped to operate on datastacks

## Details
 The datastack modules used a decorator called `public` that would add a decorated function to `__all__` to save the programmer to type it out as a string. That decorator also did some checks to ensure that a function was not added twice, which then cause functions are are aliases to other functions not to be added.
The first commit replaces that machinery with direct string access to `__all__`.

The second commit removed the new unsued `public` from utils. It's not used in other parts of sherpa. Technically, `public` could have been used outside of Sherpa by users, but I hope not. (The linked Python issue that is discussed in the now removed code has a lot of voices saying why that might be a bad idea.)