### PR TITLE
Set `cache=0` by default for models that are fast to calculate

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -883,6 +883,14 @@ available.
    The ``sherpa/astro/xspec/__init__.py`` file also lists the supported
    XSPEC versions.
 
+#. Should new XSPEC models use caching?
+
+   By default, the generated code does not say anything special about caching, so new
+   models will be cached as usual. Once the models are added, you can run
+   ``pytest --run-speed sherpa/astro/xspec/tests/test_xspec_caching_performance.py``
+   to see if the models are cached. If caching slows down the run, the test may fail.
+   See notes in ``sherpa/astro/xspec/tests/test_xspec_caching_performance.py`` for details.
+
 Never forget to update the year of the copyright notice?
 --------------------------------------------------------
 

--- a/sherpa/astro/models/__init__.py
+++ b/sherpa/astro/models/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-#  Copyright (C) 2007, 2016, 2018, 2019, 2021 - 2024
+#  Copyright (C) 2007, 2016, 2018-2019, 2021-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -93,6 +93,7 @@ class Atten(RegriddableModel1D):
         self.heiiRatio = Parameter(name, 'heiiRatio', 0.01, 0, 1)
         ArithmeticModel.__init__(self, name,
                                  (self.hcol, self.heiRatio, self.heiiRatio))
+        self.cache = 0
 
     @modelCacher1d
     def calc(self, p, *args, **kwargs):
@@ -157,6 +158,7 @@ class BBody(RegriddableModel1D):
         self.kT = Parameter(name, 'kT', 1, 0.1, 1000, 0, 1e+10, 'keV')
         self.ampl = Parameter(name, 'ampl', 1, 1e-20, 1e+20, 1e-20, 1e+20)
         ArithmeticModel.__init__(self, name, (self.space, self.kT, self.ampl))
+        self.cache = 0
 
     def guess(self, dep, *args, **kwargs):
         if args[0][0] > args[0][-1]:
@@ -215,6 +217,7 @@ class BBodyFreq(RegriddableModel1D):
         self.T = Parameter(name, 'T', 1e+06, 1000, 1e+10, 1000, 1e+10)
         self.ampl = Parameter(name, 'ampl', 1, 0, hard_min=0)
         ArithmeticModel.__init__(self, name, (self.T, self.ampl))
+        self.cache = 0
 
     def guess(self, dep, *args, **kwargs):
         vmax = get_peak(dep, *args)
@@ -352,6 +355,7 @@ class BPL1D(RegriddableModel1D):
         ArithmeticModel.__init__(self, name,
                                  (self.gamma1, self.gamma2,
                                   self.eb, self.ref, self.ampl))
+        self.cache = 0
 
     def guess(self, dep, *args, **kwargs):
         pos = get_position(dep, *args)
@@ -427,6 +431,7 @@ class Dered(RegriddableModel1D):
         self.rv = Parameter(name, 'rv', 10, 1e-10, 1000, tinyval)
         self.nhgal = Parameter(name, 'nhgal', 1e-07, 1e-07, 100000)
         ArithmeticModel.__init__(self, name, (self.rv, self.nhgal))
+        self.cache = 0
 
     @modelCacher1d
     def calc(self, p, *args, **kwargs):
@@ -478,6 +483,7 @@ class Edge(RegriddableModel1D):
         self.abs = Parameter(name, 'abs', 1, 0)
         ArithmeticModel.__init__(self, name,
                                  (self.space, self.thresh, self.abs))
+        self.cache = 0
 
     @modelCacher1d
     def calc(self, p, *args, **kwargs):
@@ -693,7 +699,7 @@ class Voigt1D(RegriddableModel1D):
         self.ampl = Parameter(name, 'ampl', 1.0)
         ArithmeticModel.__init__(self, name,
                                  (self.fwhm_g, self.fwhm_l, self.pos, self.ampl))
-        return
+        self.cache = 0
 
     def get_center(self):
         return (self.pos.val,)
@@ -873,6 +879,7 @@ class NormBeta1D(RegriddableModel1D):
         self.ampl = Parameter(name, 'ampl', 1, 0)
         ArithmeticModel.__init__(self, name,
                                  (self.pos, self.width, self.index, self.ampl))
+        self.cache = 0
 
     def get_center(self):
         return (self.pos.val,)
@@ -931,6 +938,7 @@ class Schechter(RegriddableModel1D):
         self.ref = Parameter(name, 'ref', 1)
         self.norm = Parameter(name, 'norm', 1)
         ArithmeticModel.__init__(self, name, (self.alpha, self.ref, self.norm))
+        self.cache = 0
 
     def guess(self, dep, *args, **kwargs):
         norm = guess_amplitude(dep, *args)

--- a/sherpa/astro/models/tests/test_astro_model.py
+++ b/sherpa/astro/models/tests/test_astro_model.py
@@ -79,18 +79,12 @@ def test_create_and_evaluate(name, cls):
         assert out.shape == x.shape
 
 
-@pytest.mark.parametrize("cls", [models.Atten,
-                                 models.BBody,
-                                 models.BBodyFreq,
-                                 models.BPL1D,
+@pytest.mark.parametrize("cls", [
                                  models.Beta1D,
-                                 models.Edge,
                                  models.LineBroad,
                                  models.Lorentz1D,
-                                 models.NormBeta1D,
                                  models.PseudoVoigt1D,
-                                 models.Schechter,
-                                 models.Voigt1D])
+                                 ])
 def test_send_keyword_1d_with_cache(cls):
     """What happens if we use an un-supported keyword and use caching?"""
 

--- a/sherpa/astro/models/tests/test_astro_model_cache.py
+++ b/sherpa/astro/models/tests/test_astro_model_cache.py
@@ -1,0 +1,68 @@
+#
+#  Copyright (C) 2025
+#  MIT
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+"""Cache tests for the models.
+
+These tests check if models are evaluated faster without caching than with
+caching. For very simple models (like a constant) looking up a value
+in the cache is comparable or even faster than skipping the cache-lookup
+and evaluating the model every time.
+Of course, NOT caching also reduced the memory footprint, so it should
+only be done if it is beneficial on runtime.
+
+The tests in this file are not run by default, because there are too many
+false positive and false negatives from just other random processes in the
+operating system that can affect the runtime of the tests.
+
+To run tests in this file use `pytest --runspeed`.
+
+"""
+import pytest
+from sherpa.astro import models
+from sherpa.models import ArithmeticModel
+from sherpa.conftest import get_runtime_with_cache
+
+
+modellist = models.__all__
+modellist = list(set(modellist) - set(["JDPileup", "LineBroad"]))
+modellist.sort()
+
+
+@pytest.mark.speed
+@pytest.mark.parametrize("modelcls", modellist)
+def test_runtime_with_cache(modelcls):
+    """Check if a model is evaluated faster with cache than without.
+
+    This test will fail if the runtime with cache is slower than without;
+    independent of the default setting of the cache. It is meant for developers
+    to interactively try out things, and should not be run by default.
+    """
+
+    # use an identifier in case there is an error
+    mdl = getattr(models, modelcls)()
+    # Skip everything that is not an Arithmetic model
+    # Easier to filter out here given the current design.
+    if not isinstance(mdl, ArithmeticModel):
+        return
+
+    # Cache for 2D models still under discussion
+    if mdl.ndim > 1:
+        return
+
+    get_runtime_with_cache(mdl, timing=True)

--- a/sherpa/astro/optical/__init__.py
+++ b/sherpa/astro/optical/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2016, 2017, 2018, 2019, 2020, 2021, 2023
+#  Copyright (C) 2011, 2016-2021, 2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -43,6 +43,7 @@ from sherpa.models.model import ArithmeticModel, RegriddableModel1D
 from sherpa.utils import sao_fcmp
 from sherpa.utils.err import ModelErr
 from sherpa.utils.numeric_types import SherpaFloat
+from sherpa.models.model import modelCacher1d
 
 _tol = numpy.finfo(numpy.float32).eps
 
@@ -171,7 +172,7 @@ class AbsorptionEdge(RegriddableModel1D):
 
     # We can turn on model caching with this commented-out feature,
     # if we find we need it.
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         y = numpy.ones_like(x)
@@ -224,7 +225,7 @@ class AccretionDisk(RegriddableModel1D):
         ArithmeticModel.__init__(self, name,
                                  (self.ref, self.beta, self.ampl, self.norm))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -298,7 +299,7 @@ class AbsorptionGaussian(RegriddableModel1D):
         ArithmeticModel.__init__(self, name, (self.fwhm, self.pos,
                                               self.ewidth, self.limit))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -371,7 +372,7 @@ class AbsorptionLorentz(RegriddableModel1D):
         ArithmeticModel.__init__(self, name,
                                  (self.fwhm, self.pos, self.ewidth))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -441,7 +442,7 @@ class EmissionLorentz(RegriddableModel1D):
         ArithmeticModel.__init__(self, name, (self.fwhm, self.pos,
                                               self.flux, self.kurt))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -521,7 +522,7 @@ class OpticalGaussian(RegriddableModel1D):
         ArithmeticModel.__init__(self, name, (self.fwhm, self.pos,
                                               self.tau, self.limit))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -613,7 +614,7 @@ class EmissionGaussian(RegriddableModel1D):
                                  (self.fwhm, self.pos, self.flux,
                                   self.skew, self.limit))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -700,7 +701,7 @@ class BlackBody(RegriddableModel1D):
         ArithmeticModel.__init__(self, name,
                                  (self.refer, self.ampl, self.temperature))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         c1 = 1.438786e8
@@ -777,7 +778,7 @@ class Bremsstrahlung(RegriddableModel1D):
         ArithmeticModel.__init__(self, name,
                                  (self.refer, self.ampl, self.temperature))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         if 0.0 == p[0]:
@@ -836,7 +837,7 @@ class BrokenPowerlaw(RegriddableModel1D):
                                  (self.refer, self.ampl, self.index1,
                                   self.index2))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         if 0.0 == p[0]:
             raise ValueError('model evaluation failed, ' +
@@ -891,7 +892,7 @@ class CCM(RegriddableModel1D):
 
         ArithmeticModel.__init__(self, name, (self.ebv, self.r))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         y = numpy.zeros_like(x)
@@ -1023,7 +1024,7 @@ class LogAbsorption(RegriddableModel1D):
         ArithmeticModel.__init__(self, name, (self.fwhm, self.pos,
                                               self.tau))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -1115,8 +1116,9 @@ class LogEmission(RegriddableModel1D):
         ArithmeticModel.__init__(self, name,
                                  (self.fwhm, self.pos, self.flux,
                                   self.skew))
+        self.cache = 0
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -1210,7 +1212,7 @@ class Polynomial(RegriddableModel1D):
         pars.append(self.offset)
         ArithmeticModel.__init__(self, name, pars)
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         y = numpy.zeros_like(x)
@@ -1262,7 +1264,7 @@ class Powerlaw(RegriddableModel1D):
         ArithmeticModel.__init__(self, name,
                                  (self.refer, self.ampl, self.index))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         if 0.0 == p[0]:
             raise ValueError('model evaluation failed, ' +
@@ -1329,7 +1331,7 @@ class Recombination(RegriddableModel1D):
                                  (self.refer, self.ampl,
                                   self.temperature, self.fwhm))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         if 0.0 == p[0]:
             raise ValueError('model evaluation failed, ' +
@@ -1384,7 +1386,7 @@ class XGal(RegriddableModel1D):
 
         ArithmeticModel.__init__(self, name, (self.ebv,))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
 
@@ -1462,7 +1464,7 @@ class FM(RegriddableModel1D):
                                               self.width, self.c1, self.c2,
                                               self.c3, self.c4))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         x = 10000. / x
@@ -1515,7 +1517,7 @@ class LMC(RegriddableModel1D):
 
         ArithmeticModel.__init__(self, name, (self.ebv,))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         # convert from wavelength in Angstroms to 1/microns
@@ -1594,7 +1596,7 @@ class SM(RegriddableModel1D):
 
         ArithmeticModel.__init__(self, name, (self.ebv,))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         # convert from wavelength in Angstroms to 1/microns
@@ -1655,7 +1657,7 @@ class SMC(RegriddableModel1D):
 
         ArithmeticModel.__init__(self, name, (self.ebv,))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         # convert from wavelength in Angstroms to 1/microns
@@ -1756,7 +1758,7 @@ class Seaton(RegriddableModel1D):
 
         ArithmeticModel.__init__(self, name, (self.ebv,))
 
-    # @modelCacher1d
+    @modelCacher1d
     def calc(self, p, x, xhi=None, **kwargs):
         x = numpy.asarray(x, dtype=SherpaFloat)
         # convert from wavelength in Angstroms to 1/microns

--- a/sherpa/astro/optical/tests/test_optical_model_cache.py
+++ b/sherpa/astro/optical/tests/test_optical_model_cache.py
@@ -1,0 +1,68 @@
+#
+#  Copyright (C) 2025
+#  MIT
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+"""Cache tests for the models.
+
+These tests check if models are evaluated faster without caching than with
+caching. For very simple models (like a constant) looking up a value
+in the cache is comparable or even faster than skipping the cache-lookup
+and evaluating the model every time.
+Of course, NOT caching also reduced the memory footprint, so it should
+only be done if it is beneficial on runtime.
+
+The tests in this file are not run by default, because there are too many
+false positive and false negatives from just other random processes in the
+operating system that can affect the runtime of the tests.
+
+To run tests in this file use `pytest --runspeed`.
+
+"""
+import pytest
+from sherpa.astro import optical
+from sherpa.models import ArithmeticModel
+from sherpa.conftest import get_runtime_with_cache
+
+
+modellist = optical.__all__
+modellist = list(set(modellist) - set(['AbsorptionVoigt', 'EmissionVoigt']))
+modellist.sort()
+
+
+@pytest.mark.speed
+@pytest.mark.parametrize("modelcls", modellist)
+def test_runtime_with_cache(modelcls):
+    """Check if a model is evaluated faster with cache than without.
+
+    This test will fail if the runtime with cache is slower than without;
+    independent of the default setting of the cache. It is meant for developers
+    to interactively try out things, and should not be run by default.
+    """
+
+    # use an identifier in case there is an error
+    mdl = getattr(optical, modelcls)()
+    # Skip everything that is not an Arithmetic model
+    # Easier to filter out here given the current design.
+    if not isinstance(mdl, ArithmeticModel):
+        return
+
+    # Cache for 2D models still under discussion
+    if mdl.ndim > 1:
+        return
+
+    get_runtime_with_cache(mdl, timing=True)

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -3131,6 +3131,7 @@ class XSbbody(XSAdditiveModel):
         self.kT = XSParameter(name, 'kT', 3.0, 1.e-2, 100., 1e-4, 200, units='keV')
 
         XSAdditiveModel.__init__(self, name, (self.kT, ))
+        self.cache = 0
 
 
 class XSbbodyrad(XSAdditiveModel):
@@ -3163,6 +3164,7 @@ class XSbbodyrad(XSAdditiveModel):
         self.kT = XSParameter(name, 'kT', 3., 1e-3, 100, 1e-4, 200, units='keV')
 
         XSAdditiveModel.__init__(self, name, (self.kT, ))
+        self.cache = 0
 
 
 # DOC-NOTE: the XSPEC documentation has a different parameter order to
@@ -7683,6 +7685,7 @@ class XSdiskpn(XSAdditiveModel):
         self.R_in = XSParameter(name, 'R_in', 6., 6., 1000., 6.0, 1000, units='R_g')
 
         XSAdditiveModel.__init__(self, name, (self.T_max, self.R_in))
+        self.cache = 0
 
 
 @version_at_least("12.14.0")
@@ -8070,6 +8073,7 @@ class XSexpdec(XSAdditiveModel):
         self.factor = XSParameter(name, 'factor', 1.0, 0., 100.0, 0.0, 100)
 
         XSAdditiveModel.__init__(self, name, (self.factor, ))
+        self.cache = 0
 
 
 @version_at_least("12.14.0")
@@ -9624,6 +9628,7 @@ class XSnsa(XSAdditiveModel):
 
         pars = (self.LogT_eff, self.M_ns, self.R_ns, self.MagField)
         XSAdditiveModel.__init__(self, name, pars)
+        self.cache = 0
 
 
 class XSnsagrav(XSAdditiveModel):
@@ -9663,6 +9668,7 @@ class XSnsagrav(XSAdditiveModel):
 
         pars = (self.LogT_eff, self.NSmass, self.NSrad)
         XSAdditiveModel.__init__(self, name, pars)
+        self.cache = 0
 
 
 class XSnsatmos(XSAdditiveModel):
@@ -10042,6 +10048,7 @@ class XSoptxagn(XSAdditiveModel):
                 self.rcor, self.logrout, self.kT_e, self.tau, self.Gamma,
                 self.fpl, self.fcol, self.tscat, self.Redshift)
         XSAdditiveModel.__init__(self, name, pars)
+        self.cache = 0
 
 
 class XSoptxagnf(XSAdditiveModel):
@@ -10124,6 +10131,7 @@ class XSoptxagnf(XSAdditiveModel):
                 self.rcor, self.logrout, self.kT_e, self.tau, self.Gamma,
                 self.fpl, self.Redshift)
         XSAdditiveModel.__init__(self, name, pars)
+        self.cache = 0
 
 
 class XSpegpwrlw(XSAdditiveModel):
@@ -10646,6 +10654,7 @@ class XSredge(XSAdditiveModel):
         self.kT = XSParameter(name, 'kT', 1., 0.001, 100., 0.001, 100, units='keV')
 
         XSAdditiveModel.__init__(self, name, (self.edge, self.kT))
+        self.cache = 0
 
     def guess(self, dep, *args, **kwargs):
         XSAdditiveModel.guess(self, dep, *args, **kwargs)
@@ -10727,6 +10736,7 @@ class XSrefsch(XSAdditiveModel):
                 self.T_disk, self.xi, self.Betor10, self.Rin, self.Rout,
                 self.accuracy)
         XSAdditiveModel.__init__(self, name, pars)
+        self.cache = 0
 
 
 class XSrnei(XSAdditiveModel):

--- a/sherpa/astro/xspec/tests/test_xspec_caching_performance.py
+++ b/sherpa/astro/xspec/tests/test_xspec_caching_performance.py
@@ -33,13 +33,7 @@ operating system that can affect the runtime of the tests.
 (Of course, one could be more sophisticated and run the tests multiple times,
 but the runtime is already > 2 min on my machine, so I don't want to do that.)
 
-Instead, the idea of this file is that is it easy for developers to switch the
-test on and watch what happens when they work on any relevant code change.
-Simply rename the test from
-`do_not_test_evaluate_additive_xspec_model_normwrapper` to
-`test_evaluate_additive_xspec_model_normwrapper` and run pytest watching the
-results (possibly with a different number of points in `make_grid_dense`).
-
+To run tests in this file use `pytest --runspeed`.
 
 In tests on a Mac M1 system on Sherpa 4.17 we find the following models
 are consistently faster without the decorator:
@@ -51,7 +45,6 @@ are consistently faster without the decorator:
 - optxagn, optxagnf
 - pregpwrlw
 - redge, refsch
-
 
 For larger grids also: xposm
 but in ns-type models, it's only nsa, nsagrav, not the other two.
@@ -96,9 +89,10 @@ def make_grid_dense():
     return elo, ehi, wlo, whi
 
 
+@pytest.mark.speed
 @requires_xspec
 @pytest.mark.parametrize("modelcls", get_xspec_models())
-def do_not_test_evaluate_additive_xspec_model_normwrapper(modelcls):
+def test_evaluate_additive_xspec_model_normwrapper(modelcls):
     """Does the `sherpa.astro.xspec.eval_xspec_with_fixed_norm`
     wrapper change the results?
 

--- a/sherpa/astro/xspec/tests/test_xspec_caching_performance.py
+++ b/sherpa/astro/xspec/tests/test_xspec_caching_performance.py
@@ -116,9 +116,6 @@ def test_evaluate_additive_xspec_model_normwrapper(modelcls):
     mdl.norm = 1
     evals = mdl(elo, ehi)
 
-    # This test would be useless if run with a default norm=1
-    #mdl.norm = 0.123 * mdl.norm.val
-
     # The norm=1 case has been run for initialization.
     # So, this should pull the value from the cache and be very fast.
     start_time_decorated = time.perf_counter()

--- a/sherpa/astro/xspec/tests/test_xspec_caching_performance.py
+++ b/sherpa/astro/xspec/tests/test_xspec_caching_performance.py
@@ -1,0 +1,148 @@
+#
+#  Copyright (C) 2025
+#  MIT
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+"""Speed tests for the XSPEC additive models.
+
+These tests check if additive XSPEC models are evaluated faster with
+the norm decorator than without it. For complex models that is likely
+the case, but for very simple models (like a constant) looking up a value
+in the cache is comparable or even faster than skipping the cache-lookup
+and evaluating the model every time.
+Of course, NOT caching also reduced the memory footprint, so it should
+only be done if it is beneficial on runtime.
+
+The tests in this file are not run by default, because there are too many
+false positive and false negatives from just other random processes in the
+operating system that can affect the runtime of the tests.
+(Of course, one could be more sophisticated and run the tests multiple times,
+but the runtime is already > 2 min on my machine, so I don't want to do that.)
+
+Instead, the idea of this file is that is it easy for developers to switch the
+test on and watch what happens when they work on any relevant code change.
+Simply rename the test from
+`do_not_test_evaluate_additive_xspec_model_normwrapper` to
+`test_evaluate_additive_xspec_model_normwrapper` and run pytest watching the
+results (possibly with a different number of points in `make_grid_dense`).
+
+
+In tests on a Mac M1 system on Sherpa 4.17 we find the following models
+are consistently faster without the decorator:
+
+- bbody, bbodyrad, zbbody
+- diskpn
+- expdec
+- nsa, nsagrav, nsatmos, nsmax
+- optxagn, optxagnf
+- pregpwrlw
+- redge, refsch
+
+
+For larger grids also: xposm
+but in ns-type models, it's only nsa, nsagrav, not the other two.
+"""
+import inspect
+import time
+import types
+
+import numpy as np
+import pytest
+
+from sherpa.utils.testing import requires_xspec
+try:
+    from sherpa.astro.xspec.tests.test_xspec import get_xspec_models, _hc
+except ImportError:
+    # The tests won't run anyway without XSPEC, so just define a dummy
+    get_xspec_models = lambda: []
+
+
+def make_grid_dense():
+    """Return the 'standard' contiguous grid used in these tests.
+
+    Returns elo, ehi, wlo, whi where the e-xxx values are in keV and
+    the w-xxx values in Angstrom. The *lo/*hi values are this grid
+    separated out into bin edges.
+
+    The following condition holds: *hi[i] > *lo[i], and the
+    values in the two arrays are either monotonically increasing
+    or decreasing.
+
+    """
+    # XSgaussian has peak at 6.5 keV and sigma ~ 0.1 keV
+    # so need to get to around 7 keV
+    egrid = np.linspace(0.1, 10.01, num=1024, endpoint=True)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    wgrid = _hc / egrid
+    whi = wgrid[:-1]
+    wlo = wgrid[1:]
+
+    return elo, ehi, wlo, whi
+
+
+@requires_xspec
+@pytest.mark.parametrize("modelcls", get_xspec_models())
+def do_not_test_evaluate_additive_xspec_model_normwrapper(modelcls):
+    """Does the `sherpa.astro.xspec.eval_xspec_with_fixed_norm`
+    wrapper change the results?
+
+    It should not (within numerical tolerances).
+    The hard part in this test is to obtain a "clean" version of the
+    model without the wrapper.
+    """
+
+    from sherpa.astro import xspec
+
+    # use an identifier in case there is an error
+    mdl = modelcls()
+    # Skip everything that is not an additive model
+    # Easier to filter out here given the current design.
+    if not isinstance(mdl, xspec.XSAdditiveModel):
+        return
+
+    elo, ehi, wlo, whi = make_grid_dense()
+
+    # run once in case there is a startup time for loading
+    mdl.norm = 1
+    evals = mdl(elo, ehi)
+
+    # This test would be useless if run with a default norm=1
+    #mdl.norm = 0.123 * mdl.norm.val
+
+    # The norm=1 case has been run for initialization.
+    # So, this should pull the value from the cache and be very fast.
+    start_time_decorated = time.perf_counter()
+    evals = mdl(elo, ehi)
+    end_time_decorated = time.perf_counter()
+    assert mdl._cache_ctr['hits'] == 1
+    # Now, modify the model to remove `sherpa.astro.xspec.eval_xspec_with_fixed_norm`
+    # decorator and empty the cache to make sure we are not using the cached value.
+    mdl.calc = types.MethodType(inspect.unwrap(mdl.calc), mdl)
+    mdl.cache_clear()
+    start_time_clean = time.perf_counter()
+    evals_no_wrapper = mdl(elo, ehi)
+    end_time_clean = time.perf_counter()
+    assert mdl._cache_ctr['hits'] == 0
+    assert len(mdl._cache) == 0
+
+    assert evals == pytest.approx(evals_no_wrapper)
+
+    run_time_decorated = end_time_decorated - start_time_decorated
+    run_time_clean = end_time_clean - start_time_clean
+    assert run_time_decorated < run_time_clean

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -115,12 +115,15 @@ def pytest_addoption(parser):
     parser.addoption("--runzenodo", action="store_true", default=False,
                      help="run tests that query Zenodo (requires internet)")
 
+    parser.addoption("--runspeed", action="store_true", default=False,
+                     help="run tests check speed and caching choices (results can vary randomly)")
+
 
 def pytest_collection_modifyitems(config, items):
 
     # Skip tests unless --runxxx given in cli
     #
-    for label in ["slow", "zenodo"]:
+    for label in ["slow", "zenodo", "speed"]:
         opt = "--run{}".format(label)
         if config.getoption(opt):
             continue
@@ -131,7 +134,7 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(skip)
 
 
-# Whilelist of known warnings. One can associate different warning messages
+# Whitelist of known warnings. One can associate different warning messages
 # to the same warning class
 known_warnings = {
     DeprecationWarning:

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016, 2018 - 2024
+#  Copyright (C) 2010, 2016, 2018-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -150,6 +150,7 @@ class Box1D(RegriddableModel1D):
         self.xhi = Parameter(name, 'xhi', 1)
         self.ampl = Parameter(name, 'ampl', 1)
         ArithmeticModel.__init__(self, name, (self.xlow, self.xhi, self.ampl))
+        self.cache = 0
 
     def guess(self, dep, *args, **kwargs):
         lo, hi = guess_bounds(args[0])
@@ -165,9 +166,11 @@ class Box1D(RegriddableModel1D):
 
 
 class Const(ArithmeticModel):
+
     def __init__(self, name='const'):
         self.c0 = Parameter(name, 'c0', 1)
         ArithmeticModel.__init__(self, name, (self.c0,))
+        self.cache = 0
 
     def guess(self, dep, *args, **kwargs):
         min = dep.min()
@@ -299,6 +302,7 @@ class Delta1D(RegriddableModel1D):
         self.pos = Parameter(name, 'pos', 0)
         self.ampl = Parameter(name, 'ampl', 1)
         ArithmeticModel.__init__(self, name, (self.pos, self.ampl))
+        self.cache = 0
 
     def get_center(self):
         return (self.pos.val,)
@@ -1040,6 +1044,7 @@ class Scale1D(Const1D):
     def __init__(self, name='scale1d'):
         Const1D.__init__(self, name)
         self.integrate = False
+        self.cache = 0
 
 
 class Sin(RegriddableModel1D):
@@ -1156,6 +1161,7 @@ class StepHi1D(RegriddableModel1D):
         self.xcut = Parameter(name, 'xcut', 0)
         self.ampl = Parameter(name, 'ampl', 1, 0)
         ArithmeticModel.__init__(self, name, (self.xcut, self.ampl))
+        self.cache = 0
 
     def guess(self, dep, *args, **kwargs):
         cut = guess_bounds(args[0], False)
@@ -1205,6 +1211,7 @@ class StepLo1D(RegriddableModel1D):
         self.xcut = Parameter(name, 'xcut', 0)
         self.ampl = Parameter(name, 'ampl', 1, 0)
         ArithmeticModel.__init__(self, name, (self.xcut, self.ampl))
+        self.cache = 0
 
     def guess(self, dep, *args, **kwargs):
         cut = guess_bounds(args[0], False)

--- a/sherpa/models/tests/test_basic_cache.py
+++ b/sherpa/models/tests/test_basic_cache.py
@@ -1,0 +1,70 @@
+#
+#  Copyright (C) 2025
+#  MIT
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+"""Cache tests for the models.
+
+These tests check ifmodels are evaluated faster without caching than with
+caching. For very simple models (like a constant) looking up a value
+in the cache is comparable or even faster than skipping the cache-lookup
+and evaluating the model every time.
+Of course, NOT caching also reduced the memory footprint, so it should
+only be done if it is beneficial on runtime.
+
+The tests in this file are not run by default, because there are too many
+false positive and false negatives from just other random processes in the
+operating system that can affect the runtime of the tests.
+(Of course, one could be more sophisticated and run the tests multiple times,
+but the runtime is already > 2 min on my machine, so I don't want to do that.)
+
+To run tests in this file use `pytest --runspeed`.
+
+"""
+import pytest
+from sherpa.models import ArithmeticModel
+from sherpa.models import basic
+from sherpa.conftest import get_runtime_with_cache
+
+
+modellist = basic.__all__
+modellist = list(set(modellist) - set(["Integrate1D", "TableModel", "UserModel"]))
+modellist.sort()
+
+
+@pytest.mark.speed
+@pytest.mark.parametrize("modelcls", modellist)
+def test_runtime_with_cache(modelcls):
+    """Check if a model is evaluated faster with cache than without.
+
+    This test will fail if the runtime with cache is slower than without;
+    independent of the default setting of the cache. It is meant for developers
+    to interactively try out things, and should not be run by default.
+    """
+
+    # use an identifier in case there is an error
+    mdl = getattr(basic, modelcls)()
+    # Skip everything that is not an Arithmetic model
+    # Easier to filter out here given the current design.
+    if not isinstance(mdl, ArithmeticModel):
+        return
+
+    # Cache for 2D models still under discussion
+    if mdl.ndim > 1:
+        return
+
+    get_runtime_with_cache(mdl, timing=True)

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -1252,18 +1252,24 @@ def test_cache_not_used_in_fit():
     How do we do that without relying too much on the internal
     implementation?
     """
-    mdl = Const1D('con1')
-    mdl.c0 = 1
-    dat = Data1D('data', np.arange(4), 2 * np.ones(4), np.ones(4))
+    mdl = Gauss1D('con1')
+    mdl.ampl = 1
+    mdl.pos = 0
+    mdl.fwhm = 1
+    dat = Data1D('data', [-2, -1, 0, 1, 2,], [0.05, 1, 2, 1, 0.05], np.ones(5))
     fit = Fit(dat, mdl)
     res = fit.fit()
-    assert mdl.c0.val == pytest.approx(2)
+    assert mdl.ampl.val == pytest.approx(2.02, rel=1e-2)
+    assert mdl.pos.val == pytest.approx(0, abs=1e-6)
     assert len(mdl._cache) == 5
 
     mdl.cache_clear()
-    mdl.c0 = 1
+    mdl.ampl = 1
+    mdl.pos = 0
+    mdl.fwhm = 1
     res = fit.fit(cache=False)
-    assert mdl.c0.val == pytest.approx(2)
+    assert mdl.ampl.val == pytest.approx(2.02, rel=1e-2)
+    assert mdl.pos.val == pytest.approx(0, abs=1e-6)
     assert len(mdl._cache) == 0
     # We cleared the cache and then called the fit with `cache=False`.
     # After the fit, the cache is still empty, so presumably it was never used.
@@ -1403,8 +1409,8 @@ def test_cache_status_multiple(caplog):
     # cache_status.
     #
     p = Polynom1D()
-    b = Box1D()
-    c = Const1D()
+    b = Sin()
+    c = Gauss1D()
     mdl = c * (2 * p + b)
 
     # One model is not cached
@@ -1434,7 +1440,7 @@ def test_cache_status_multiple(caplog):
         tokens.append(toks)
 
     toks = tokens[0]
-    assert toks[0] == 'const1d'
+    assert toks[0] == 'gauss1d'
     assert toks[2] == '2'
     assert toks[4] == '1'
     assert toks[6] == '2'
@@ -1446,7 +1452,7 @@ def test_cache_status_multiple(caplog):
     assert toks[6] == '2'
 
     toks = tokens[2]
-    assert toks[0] == 'box1d'
+    assert toks[0] == 'sin'
     assert toks[2] == '0'
     assert toks[4] == '0'
     assert toks[6] == '0'
@@ -1486,8 +1492,8 @@ def test_cache_clear_multiple():
     """Check cache_clear for a combined model."""
 
     p = Polynom1D()
-    b = Box1D()
-    c = Const1D()
+    b = Sin()
+    c = Gauss1D()
     mdl = c * (p + 2 * b)
 
     # Ensure one component doesn't use the cache


### PR DESCRIPTION
## Summary

Based on benchmarking for typical Sherpa use cases, some models are faster to re-calculate than to cache. For those models, the default cache size it now set to 0 to save runtime and memory.

## Details
This also adds a new mark "speed" to select speed tests to run.
That test is written for XSPEC modes, but similar benchmarking has been done for basic Sherpa models (see #2258).

fixes #2258