### PR TITLE
Use `modelCacher1D` (now aliased to `modelCacher`) for 2D models

### DIFF
--- a/docs/evaluation/cache.rst
+++ b/docs/evaluation/cache.rst
@@ -43,6 +43,12 @@ a value in the cache. An obvious example is a scale or constant model
 but this also applies to some fast analytical
 models such as an XSPEC black body (`sherpa.astro.xspec.XSbbody`).
 
+The cache is also switched off for models in 2D, because in 2D we often have much
+larger arrays and thus the cache would use more memory. On the other hand, there is
+also the potential to save more time, given the longer computations needed for 2D models.
+So, for 2D models, the user needs to explicitly set the cache size to a positive number
+(`mdl.cache=3` for example) to turn on the cache.
+
 Can I turn off this behavior for other models?
 ==============================================
 

--- a/docs/evaluation/cache.rst
+++ b/docs/evaluation/cache.rst
@@ -3,9 +3,9 @@ Caching model evaluations
 =========================
 
 Sherpa contains a rudimentary system for caching the results
-of 1D model evaluations in order to speed up the time to evaluate
-models, at the expense of using more memory.
-The :py:func:`~sherpa.models.model.modelCacher1d`
+of model evaluations on one or more dimensions in order to speed up the
+time to evaluate models, at the expense of using more memory.
+The :py:func:`~sherpa.models.model.modelCacher`
 function decorator is applied to the
 :py:meth:`~sherpa.models.model.ArithmeticModel.calc` method of
 :py:class:`~sherpa.models.model.ArithmeticModel` models, and this then
@@ -20,16 +20,16 @@ but your performance might be improved with different settings.
 What models are cached?
 =======================
 
-A model uses the cache if ``@modelCacher1d`` is applied to the ``calc`` method
-**and** `model.cache` is set to a positive integer.
-Unfortunately it is not easy to check weather ``@modelCacher1d`` is applied without
-looking at the source codeb- or by running a test as shown below,
-:ref:`in the example section <example-modelcacher1d>`.
+There is unfortunately no easy way to determine whether a model
+uses the cache without either viewing the model definition - looking
+for the application of ``@modelCacher`` to the ``calc`` method - or
+by running a test as shown below,
+:ref:`in the example section <example-modelcacher>`.
 
 When is the cache useful?
 =========================
 
-At present most 1D models use the cache by default.
+At present most models use the cache by default.
 It is intended to improve fit performance, but the actual
 time saved depends on the model and the data being fit.
 Compared to most built-in sherpa models, models in the optional XSPEC model
@@ -113,7 +113,7 @@ default value for this attribute is 5).
 Examples
 ========
 
-.. _example-modelcacher1d:
+.. _example-modelcacher:
 
 Checking the cache
 ------------------

--- a/docs/model_classes/model.rst
+++ b/docs/model_classes/model.rst
@@ -30,6 +30,7 @@ The sherpa.models.model module
    .. autosummary::
       :toctree: api
 
+      modelCacher
       modelCacher1d
 
 Class Inheritance Diagram

--- a/sherpa/astro/models/__init__.py
+++ b/sherpa/astro/models/__init__.py
@@ -1025,6 +1025,7 @@ class Beta2D(RegriddableModel2D):
         ArithmeticModel.__init__(self, name,
                                  (self.r0, self.xpos, self.ypos, self.ellip,
                                   self.theta, self.ampl, self.alpha))
+        self.cache = 0
 
     def get_center(self):
         return (self.xpos.val, self.ypos.val)
@@ -1107,6 +1108,7 @@ class DeVaucouleurs2D(RegriddableModel2D):
         ArithmeticModel.__init__(self, name,
                                  (self.r0, self.xpos, self.ypos, self.ellip,
                                   self.theta, self.ampl))
+        self.cache = 0
 
     def get_center(self):
         return (self.xpos.val, self.ypos.val)
@@ -1193,6 +1195,7 @@ class HubbleReynolds(RegriddableModel2D):
         ArithmeticModel.__init__(self, name,
                                  (self.r0, self.xpos, self.ypos, self.ellip,
                                   self.theta, self.ampl))
+        self.cache = 0
 
     def get_center(self):
         return (self.xpos.val, self.ypos.val)
@@ -1269,6 +1272,7 @@ class Lorentz2D(RegriddableModel2D):
         ArithmeticModel.__init__(self, name,
                                  (self.fwhm, self.xpos, self.ypos, self.ellip,
                                   self.theta, self.ampl))
+        self.cache = 0
 
     def get_center(self):
         return (self.xpos.val, self.ypos.val)
@@ -1484,6 +1488,7 @@ class Sersic2D(RegriddableModel2D):
         ArithmeticModel.__init__(self, name,
                                  (self.r0, self.xpos, self.ypos, self.ellip,
                                   self.theta, self.ampl, self.n))
+        self.cache = 0
 
     def get_center(self):
         return (self.xpos.val, self.ypos.val)
@@ -1551,7 +1556,9 @@ class Disk2D(RegriddableModel2D):
         self.ampl = Parameter(name, 'ampl', 1)  # p[2]
         self.r0 = Parameter(name, 'r0', 1, 0)  # p[3]
         ArithmeticModel.__init__(self, name, (self.xpos, self.ypos, self.ampl, self.r0))
+        self.cache = 0
 
+    @modelCacher
     def calc(self, p, x, y, *args, **kwargs):
         # Compute radii
         r2 = (x - p[0]) ** 2 + (y - p[1]) ** 2
@@ -1606,6 +1613,7 @@ class Shell2D(RegriddableModel2D):
         self.r0 = Parameter(name, 'r0', 1, 0)  # p[3]
         self.width = Parameter(name, 'width', 0.1, 0)
         ArithmeticModel.__init__(self, name, (self.xpos, self.ypos, self.ampl, self.r0, self.width))
+        self.cache = 0
 
     @modelCacher
     def calc(self, p, x, y, *args, **kwargs):

--- a/sherpa/astro/models/__init__.py
+++ b/sherpa/astro/models/__init__.py
@@ -23,7 +23,11 @@ import numpy
 
 from sherpa.models.basic import clean_kwargs1d, clean_kwargs2d
 from sherpa.models.parameter import Parameter, tinyval
-from sherpa.models.model import ArithmeticModel, RegriddableModel2D, RegriddableModel1D, modelCacher1d
+from sherpa.models.model import (ArithmeticModel,
+                                 RegriddableModel2D, RegriddableModel1D,
+                                 modelCacher,
+                                 )
+
 from sherpa.astro.utils import apply_pileup
 from sherpa.utils import bool_cast, lgam
 from sherpa.utils.err import ModelErr
@@ -95,7 +99,7 @@ class Atten(RegriddableModel1D):
                                  (self.hcol, self.heiRatio, self.heiiRatio))
         self.cache = 0
 
-    @modelCacher1d
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
         # atten should act like xsphabs, never integrate.
@@ -178,7 +182,7 @@ class BBody(RegriddableModel1D):
                'max': modampl * _guess_ampl_scale}
         param_apply_limits(mod, self.ampl, **kwargs)
 
-    @modelCacher1d
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.bbody(p, *args, **kwargs)
@@ -236,7 +240,7 @@ class BBodyFreq(RegriddableModel1D):
         param_apply_limits(mod, self.ampl, **kwargs)
         param_apply_limits(t, self.t, **kwargs)
 
-    @modelCacher1d
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.bbodyfreq(p, *args, **kwargs)
@@ -306,7 +310,7 @@ class Beta1D(RegriddableModel1D):
         norm = guess_amplitude_at_ref(self.r0.val, dep, *args)
         param_apply_limits(norm, self.ampl, **kwargs)
 
-    @modelCacher1d
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.beta1d(p, *args, **kwargs)
@@ -367,7 +371,7 @@ class BPL1D(RegriddableModel1D):
         norm = guess_amplitude_at_ref(self.ref.val, dep, *args)
         param_apply_limits(norm, self.ampl, **kwargs)
 
-    @modelCacher1d
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.bpl1d(p, *args, **kwargs)
@@ -433,7 +437,7 @@ class Dered(RegriddableModel1D):
         ArithmeticModel.__init__(self, name, (self.rv, self.nhgal))
         self.cache = 0
 
-    @modelCacher1d
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.dered(p, *args, **kwargs)
@@ -485,7 +489,7 @@ class Edge(RegriddableModel1D):
                                  (self.space, self.thresh, self.abs))
         self.cache = 0
 
-    @modelCacher1d
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.edge(p, *args, **kwargs)
@@ -550,7 +554,7 @@ class LineBroad(RegriddableModel1D):
                'max': modampl * _guess_ampl_scale}
         param_apply_limits(mod, self.ampl, **kwargs)
 
-    @modelCacher1d
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.linebroad(p, *args, **kwargs)
@@ -618,7 +622,7 @@ class Lorentz1D(RegriddableModel1D):
         else:
             param_apply_limits(norm, self.ampl, **kwargs)
 
-    @modelCacher1d
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.lorentz1d(p, *args, **kwargs)
@@ -734,7 +738,7 @@ class Voigt1D(RegriddableModel1D):
                 'max': aprime * _guess_ampl_scale}
         param_apply_limits(ampl, self.ampl, **kwargs)
 
-    @modelCacher1d
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.wofz(p, *args, **kwargs)
@@ -821,7 +825,7 @@ class PseudoVoigt1D(RegriddableModel1D):
                 'max': aprime * _guess_ampl_scale}
         param_apply_limits(ampl, self.ampl, **kwargs)
 
-    @modelCacher1d
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
 
@@ -898,7 +902,7 @@ class NormBeta1D(RegriddableModel1D):
             ampl[key] *= norm
         param_apply_limits(ampl, self.ampl, **kwargs)
 
-    @modelCacher1d
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs1d(self, kwargs)
         return _modelfcts.nbeta1d(p, *args, **kwargs)
@@ -944,7 +948,7 @@ class Schechter(RegriddableModel1D):
         norm = guess_amplitude(dep, *args)
         param_apply_limits(norm, self.norm, **kwargs)
 
-    @modelCacher1d
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         if not self.integrate:
             raise ModelErr('alwaysint', self.name)
@@ -1021,7 +1025,6 @@ class Beta2D(RegriddableModel2D):
         ArithmeticModel.__init__(self, name,
                                  (self.r0, self.xpos, self.ypos, self.ellip,
                                   self.theta, self.ampl, self.alpha))
-        self.cache = 0
 
     def get_center(self):
         return (self.xpos.val, self.ypos.val)
@@ -1039,6 +1042,7 @@ class Beta2D(RegriddableModel2D):
         param_apply_limits(norm, self.ampl, **kwargs)
         param_apply_limits(rad, self.r0, **kwargs)
 
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.beta2d(p, *args, **kwargs)
@@ -1103,7 +1107,6 @@ class DeVaucouleurs2D(RegriddableModel2D):
         ArithmeticModel.__init__(self, name,
                                  (self.r0, self.xpos, self.ypos, self.ellip,
                                   self.theta, self.ampl))
-        self.cache = 0
 
     def get_center(self):
         return (self.xpos.val, self.ypos.val)
@@ -1121,6 +1124,7 @@ class DeVaucouleurs2D(RegriddableModel2D):
         param_apply_limits(norm, self.ampl, **kwargs)
         param_apply_limits(rad, self.r0, **kwargs)
 
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.devau(p, *args, **kwargs)
@@ -1189,7 +1193,6 @@ class HubbleReynolds(RegriddableModel2D):
         ArithmeticModel.__init__(self, name,
                                  (self.r0, self.xpos, self.ypos, self.ellip,
                                   self.theta, self.ampl))
-        self.cache = 0
 
     def get_center(self):
         return (self.xpos.val, self.ypos.val)
@@ -1207,6 +1210,7 @@ class HubbleReynolds(RegriddableModel2D):
         param_apply_limits(norm, self.ampl, **kwargs)
         param_apply_limits(rad, self.r0, **kwargs)
 
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.hr(p, *args, **kwargs)
@@ -1265,7 +1269,6 @@ class Lorentz2D(RegriddableModel2D):
         ArithmeticModel.__init__(self, name,
                                  (self.fwhm, self.xpos, self.ypos, self.ellip,
                                   self.theta, self.ampl))
-        self.cache = 0
 
     def get_center(self):
         return (self.xpos.val, self.ypos.val)
@@ -1281,6 +1284,7 @@ class Lorentz2D(RegriddableModel2D):
         param_apply_limits(ypos, self.ypos, **kwargs)
         param_apply_limits(norm, self.ampl, **kwargs)
 
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.lorentz2d(p, *args, **kwargs)
@@ -1480,7 +1484,6 @@ class Sersic2D(RegriddableModel2D):
         ArithmeticModel.__init__(self, name,
                                  (self.r0, self.xpos, self.ypos, self.ellip,
                                   self.theta, self.ampl, self.n))
-        self.cache = 0
 
     def get_center(self):
         return (self.xpos.val, self.ypos.val)
@@ -1498,6 +1501,7 @@ class Sersic2D(RegriddableModel2D):
         param_apply_limits(norm, self.ampl, **kwargs)
         param_apply_limits(rad, self.r0, **kwargs)
 
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.sersic(p, *args, **kwargs)
@@ -1603,6 +1607,7 @@ class Shell2D(RegriddableModel2D):
         self.width = Parameter(name, 'width', 0.1, 0)
         ArithmeticModel.__init__(self, name, (self.xpos, self.ypos, self.ampl, self.r0, self.width))
 
+    @modelCacher
     def calc(self, p, x, y, *args, **kwargs):
         """Homogeneously emitting spherical shell,
         projected along the z-direction

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1335,6 +1335,7 @@ class Box2D(RegriddableModel2D):
         param_apply_limits(yhi, self.yhi, **kwargs)
         param_apply_limits(norm, self.ampl, **kwargs)
 
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.box2d(p, *args, **kwargs)
@@ -1369,6 +1370,7 @@ class Const2D(RegriddableModel2D, Const):
         Const.__init__(self, name)
         self.cache = 0
 
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.const2d(p, *args, **kwargs)
@@ -1467,6 +1469,7 @@ class Delta2D(RegriddableModel2D):
         param_apply_limits(ypos, self.ypos, **kwargs)
         param_apply_limits(norm, self.ampl, **kwargs)
 
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.delta2d(p, *args, **kwargs)
@@ -1539,6 +1542,7 @@ class Gauss2D(RegriddableModel2D):
         ArithmeticModel.__init__(self, name,
                                  (self.fwhm, self.xpos, self.ypos, self.ellip,
                                   self.theta, self.ampl))
+        self.cache = 0
 
     def get_center(self):
         return (self.xpos.val, self.ypos.val)
@@ -1626,6 +1630,7 @@ class SigmaGauss2D(Gauss2D):
         ArithmeticModel.__init__(self, name,
                                  (self.sigma_a, self.sigma_b, self.xpos,
                                   self.ypos, self.theta, self.ampl))
+        self.cache = 0
 
     def guess(self, dep, *args, **kwargs):
         xpos, ypos = guess_position(dep, *args)
@@ -1637,7 +1642,6 @@ class SigmaGauss2D(Gauss2D):
         param_apply_limits(fwhm, self.sigma_b, **kwargs)
         param_apply_limits(norm, self.ampl, **kwargs)
 
-    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.sigmagauss2d(p, *args, **kwargs)
@@ -1713,6 +1717,7 @@ class NormGauss2D(RegriddableModel2D):
         ArithmeticModel.__init__(self, name,
                                  (self.fwhm, self.xpos, self.ypos, self.ellip,
                                   self.theta, self.ampl))
+        self.cache = 0
 
     def get_center(self):
         return (self.xpos.val, self.ypos.val)
@@ -1802,6 +1807,7 @@ class Polynom2D(RegriddableModel2D):
                                  (self.c, self.cy1, self.cy2, self.cx1,
                                   self.cx1y1, self.cx1y2, self.cx2,
                                   self.cx2y1, self.cx2y2))
+        self.cache = 0
 
     def guess(self, dep, *args, **kwargs):
         x0min = args[0].min()

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1642,6 +1642,7 @@ class SigmaGauss2D(Gauss2D):
         param_apply_limits(fwhm, self.sigma_b, **kwargs)
         param_apply_limits(norm, self.ampl, **kwargs)
 
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.sigmagauss2d(p, *args, **kwargs)

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -30,8 +30,11 @@ from sherpa.utils.guess import get_position, guess_amplitude, \
     guess_fwhm, guess_position, guess_reference, param_apply_limits
 
 from .parameter import Parameter, tinyval
-from .model import ArithmeticModel, modelCacher1d, CompositeModel, \
-    ArithmeticFunctionModel, RegriddableModel2D, RegriddableModel1D
+from .model import (ArithmeticModel,
+                    modelCacher1d, modelCacher,
+                    CompositeModel, ArithmeticFunctionModel,
+                    RegriddableModel2D, RegriddableModel1D,
+)
 from . import _modelfcts  # type: ignore
 
 warning = logging.getLogger(__name__).warning
@@ -1536,7 +1539,6 @@ class Gauss2D(RegriddableModel2D):
         ArithmeticModel.__init__(self, name,
                                  (self.fwhm, self.xpos, self.ypos, self.ellip,
                                   self.theta, self.ampl))
-        self.cache = 0
 
     def get_center(self):
         return (self.xpos.val, self.ypos.val)
@@ -1554,6 +1556,7 @@ class Gauss2D(RegriddableModel2D):
         param_apply_limits(norm, self.ampl, **kwargs)
         param_apply_limits(fwhm, self.fwhm, **kwargs)
 
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.gauss2d(p, *args, **kwargs)
@@ -1623,7 +1626,6 @@ class SigmaGauss2D(Gauss2D):
         ArithmeticModel.__init__(self, name,
                                  (self.sigma_a, self.sigma_b, self.xpos,
                                   self.ypos, self.theta, self.ampl))
-        self.cache = 0
 
     def guess(self, dep, *args, **kwargs):
         xpos, ypos = guess_position(dep, *args)
@@ -1635,6 +1637,7 @@ class SigmaGauss2D(Gauss2D):
         param_apply_limits(fwhm, self.sigma_b, **kwargs)
         param_apply_limits(norm, self.ampl, **kwargs)
 
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.sigmagauss2d(p, *args, **kwargs)
@@ -1710,7 +1713,6 @@ class NormGauss2D(RegriddableModel2D):
         ArithmeticModel.__init__(self, name,
                                  (self.fwhm, self.xpos, self.ypos, self.ellip,
                                   self.theta, self.ampl))
-        self.cache = 0
 
     def get_center(self):
         return (self.xpos.val, self.ypos.val)
@@ -1735,6 +1737,7 @@ class NormGauss2D(RegriddableModel2D):
                 ampl[key] *= norm
         param_apply_limits(ampl, self.ampl, **kwargs)
 
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.ngauss2d(p, *args, **kwargs)
@@ -1799,7 +1802,6 @@ class Polynom2D(RegriddableModel2D):
                                  (self.c, self.cy1, self.cy2, self.cx1,
                                   self.cx1y1, self.cx1y2, self.cx2,
                                   self.cx2y1, self.cx2y2))
-        self.cache = 0
 
     def guess(self, dep, *args, **kwargs):
         x0min = args[0].min()
@@ -1845,6 +1847,7 @@ class Polynom2D(RegriddableModel2D):
         param_apply_limits(c22, self.cx2y1, **kwargs)
         param_apply_limits(c22, self.cx2y2, **kwargs)
 
+    @modelCacher
     def calc(self, p, *args, **kwargs):
         kwargs = clean_kwargs2d(self, kwargs)
         return _modelfcts.poly2d(p, *args, **kwargs)

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -341,7 +341,8 @@ warning = logging.getLogger(__name__).warning
 
 __all__ = ('Model', 'CompositeModel', 'SimulFitModel',
            'ArithmeticConstantModel', 'ArithmeticModel', 'RegriddableModel1D', 'RegriddableModel2D',
-           'UnaryOpModel', 'BinaryOpModel',  'modelCacher1d',
+           'UnaryOpModel', 'BinaryOpModel',
+           'modelCacher1d', 'modelCacher',
            'ArithmeticFunctionModel', 'NestedModel', 'MultigridSumModel')
 
 
@@ -374,12 +375,17 @@ def boolean_to_byte(boolean_value: bool) -> bytes:
 
 
 def modelCacher1d(func: Callable) -> Callable:
-    """A decorator to cache 1D ArithmeticModel evaluations.
+    """A decorator to cache ArithmeticModel evaluations.
 
-    Apply to the `calc` method of a 1D model to allow the model
+    Apply to the `calc` method of a model to allow the model
     evaluation to be cached. The decision is based on the `integrate`
     setting, the evaluation grid, parameter values, and the keywords
     sent to the model.
+
+    For historic reasons, this decorator was implemented for 1D models
+    first. However, it is general enough that it works in higher dimensions,
+    too. It can be used as either ``@modelCacher1d`` or ``@modelCacher``;
+    the names are aliases for each other.
 
     Notes
     -----
@@ -472,6 +478,8 @@ def modelCacher1d(func: Callable) -> Callable:
 
     return cache_model
 
+
+modelCacher = modelCacher1d
 
 # It is tempting to convert the explicit class names below into calls
 # to super(), but this is problematic since it ends up breaking a

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -400,14 +400,14 @@ def modelCacher1d(func: Callable) -> Callable:
 
         def MyModel(ArithmeticModel):
             ...
-            @modelCacher1d
+            @modelCacher
             def calc(self, p, *args, **kwargs):
                 ...
 
     """
 
     @functools.wraps(func)
-    def cache_model(cls, pars, xlo, *args, **kwargs):
+    def cache_model(cls, pars, *args, **kwargs):
         # Counts all accesses, even those that do not use the cache.
         cache_ctr = cls._cache_ctr
         cache_ctr['check'] += 1
@@ -415,14 +415,14 @@ def modelCacher1d(func: Callable) -> Callable:
         # Short-cut if the cache is not being used.
         #
         if cls.cache == 0:
-            return func(cls, pars, xlo, *args, **kwargs)
+            return func(cls, pars, *args, **kwargs)
 
         # Up until Sherpa 4.12.2 we used the kwargs to define the
         # integrate setting, with
         # boolean_to_byte(kwargs.get('integrate', False)) but
         # unfortunately this is used in code like
         #
-        #    @modelCacher1d
+        #    @modelCacher
         #    def calc(..):
         #        kwargs['integrate'] = self.integrate
         #        return somefunc(... **kwargs)
@@ -440,10 +440,9 @@ def modelCacher1d(func: Callable) -> Callable:
             integrate = kwargs.get('integrate', False)
 
         data = [np.array(pars).tobytes(),
-                boolean_to_byte(integrate),
-                np.asarray(xlo).tobytes()]
-        if args:
-            data.append(np.asarray(args[0]).tobytes())
+                boolean_to_byte(integrate)]
+        for arg in args:
+            data.append(np.asarray(arg).tobytes())
 
         # Add any keyword arguments to the list. This will
         # include the xhi named argument if given. Can the
@@ -463,7 +462,7 @@ def modelCacher1d(func: Callable) -> Callable:
 
         # Evaluate the model.
         #
-        vals = func(cls, pars, xlo, *args, **kwargs)
+        vals = func(cls, pars, *args, **kwargs)
 
         # remove first item in queue and remove from cache
         # if the cache is full.

--- a/sherpa/models/tests/test_caching.py
+++ b/sherpa/models/tests/test_caching.py
@@ -166,8 +166,8 @@ def test_evaluate_cache_regrid2d():
     assert not hasattr(rmdl, 'cache')
 
 
-def test_evaluate_cache1dint():
-    """Check we run with caching on: 1dint"""
+def test_evaluate_cache2dint():
+    """Check we run with caching on: 2dint"""
 
     x0lo = np.array([-20, -1, 10])
     x1lo = np.array([-25, -1, -10])

--- a/sherpa/models/tests/test_caching.py
+++ b/sherpa/models/tests/test_caching.py
@@ -35,7 +35,7 @@ def test_default_cache_size(modelclass):
     """Check the default cache size for some models."""
 
     mdl = modelclass()
-    assert mdl.cache == 5
+    assert mdl.cache == 0
 
 
 def test_evaluate_no_cache2d():
@@ -175,6 +175,7 @@ def test_evaluate_cache1dint():
     x1hi = np.array([-10, 1, -8])
 
     mdl = Polynom2D()
+    mdl.cache = 12
     assert len(mdl._cache) == 0
 
     # Check the default values

--- a/sherpa/models/tests/test_caching.py
+++ b/sherpa/models/tests/test_caching.py
@@ -1,0 +1,152 @@
+#
+#  Copyright (C) 2025
+#  Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+"""Tests related to caching model evaluations
+
+Test with 1D data are in test_model.py and might be moved here at a later point.
+"""
+import numpy as np
+import pytest
+
+from sherpa.data import Data2D
+from sherpa.models import Polynom2D, Gauss2D
+from sherpa.astro.models import Beta2D, Lorentz2D
+from sherpa.models.model import UnaryOpModel, BinaryOpModel, RegridWrappedModel
+
+
+@pytest.mark.parametrize("modelclass", [Polynom2D, Gauss2D, Beta2D, Lorentz2D])
+def test_default_cache_size(modelclass):
+    """Check the default cache size for some models."""
+
+    mdl = modelclass()
+    assert mdl.cache == 5
+
+
+def test_evaluate_no_cache2d():
+    """Check we can turn off caching: 2d"""
+
+    x0grid = np.array([2, 10, 1.5])
+    x1grid = np.array([-2, 0, 3.])
+
+    mdl = Polynom2D()
+    mdl.integrate = False
+    mdl.cache = 0
+    assert len(mdl._cache) == 0
+
+    # Check the default values
+    expected = np.ones(3)
+    assert mdl(x0grid, x1grid) == pytest.approx(expected)
+    assert len(mdl._cache) == 0
+
+    mdl.cx1 = 5
+    mdl.cy1 = 2
+
+    expected = 1 + 2 * x0grid + 5 * x1grid
+    assert mdl(x1grid, x0grid) == pytest.approx(expected)
+    assert len(mdl._cache) == 0
+
+
+def test_evaluate_cache2d():
+    """Check we run with caching on: 1d"""
+
+    x0grid = np.array([2, 10, 1.5])
+    x1grid = np.array([-2, 0, 3.])
+
+    mdl = Polynom2D()
+    mdl.integrate = False
+    mdl.cache = 5
+    assert len(mdl._cache) == 0
+
+    # Check the default values
+    expected = np.ones(3)
+    assert mdl(x1grid, x0grid) == pytest.approx(expected)
+    # Model has been run once, so there is one entry in the cache
+    assert len(mdl._cache) == 1
+    assert mdl._cache[list(mdl._cache.keys())[0]] == pytest.approx(expected)
+
+    mdl.cx1 = 5
+    mdl.cy1 = 2
+
+    expected2 = 1 + 2 * x0grid + 5 * x1grid
+    assert mdl(x1grid, x0grid) == pytest.approx(expected2)
+    assert len(mdl._cache) == 2
+
+    # Now, the model has run a second time, so there are two entries in the cache
+    assert mdl._cache[list(mdl._cache.keys())[0]] == pytest.approx(expected)
+    assert mdl._cache[list(mdl._cache.keys())[1]] == pytest.approx(expected2)
+
+
+def test_cache_is_actually_used():
+    """Most other tests check that the cache has values in it,
+    but not that those values are actually returned.
+    Here, we manipulate the cached value and then call the model
+    to check that the cached value is used.
+    """
+    x0grid = [2, 10, 1.5]
+    x1grid = [-2, 0, 3.]
+
+    mdl = Polynom2D()
+    mdl.integrate = False
+    mdl.cache = 5
+
+    assert len(mdl._cache) == 0
+
+    # Check the default values
+    expected = np.ones(3)
+    assert mdl(x0grid, x1grid) == pytest.approx(expected)
+
+    # Manipulate the values in the cache
+    mdl._cache[list(mdl._cache.keys())[0]] = 2 * expected
+    assert mdl(x0grid, x1grid) == pytest.approx(2 * expected)
+
+
+def test_evaluate_cache_regrid2d():
+    """How about a regridded model?"""
+
+    mdl = Lorentz2D()
+
+    x0 = np.arange(0, 10, 0.1)
+    x1 = np.arange(2, 20, 0.1)
+    rmdl = mdl.regrid(x0, x1)
+
+    assert isinstance(rmdl, RegridWrappedModel)
+    assert not hasattr(rmdl, 'cache')
+
+
+def test_evaluate_cache1dint():
+    """Check we run with caching on: 1dint"""
+
+    x0lo = np.array([-20, -1, 10])
+    x1lo = np.array([-25, -1, -10])
+    x0hi = np.array([-10, 1, 15])
+    x1hi = np.array([-10, 1, -8])
+
+    mdl = Polynom2D()
+    assert len(mdl._cache) == 0
+
+    # Check the default values
+    expected = np.array([150, 4, 10])
+    assert mdl(x0lo, x1lo, x0hi, x1hi) == pytest.approx(expected)
+    assert len(mdl._cache) == 1
+    assert mdl._cache[list(mdl._cache.keys())[0]] == pytest.approx(expected)
+
+    # Manipulate the values in the cache to check if it's used
+    mdl._cache[list(mdl._cache.keys())[0]] = 2 * expected
+    assert mdl(x0lo, x1lo, x0hi, x1hi) == pytest.approx(2 * expected)
+


### PR DESCRIPTION
## Summary
Set up caching for 2D models

## Details
For a long time, `modelCacher1D` has accepted an arbitrary number of arguments. That is useful because 1D models can be at points (x) or integrated over bins (xlo, xhi). However, that means that is seamlessly also works for (x0, x1) in 2D models or (x0lo, x0hi, x1lo, x1hi) in integrated 2D models. This commit adds an alias `modelCacher = modelCacher1D` (for backwards compatibility we should not remove the old name and I don't see a reason to deprecate it either) and starts using is on some more complex 2D models.

This was mentioned in: 
https://github.com/sherpa/sherpa/discussions/2276