### PR TITLE
Note support for Python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/sherpa/badge/)](https://sherpa.readthedocs.io/)
 [![DOI](https://zenodo.org/badge/683/sherpa/sherpa.svg)](https://zenodo.org/badge/latestdoi/683/sherpa/sherpa)
 [![GPLv3+ License](https://img.shields.io/badge/license-GPLv3+-blue.svg)](https://www.gnu.org/copyleft/gpl.html)
-![Python version](https://img.shields.io/badge/Python-3.10,3.11,3.12-green.svg?style=flat)
+![Python version](https://img.shields.io/badge/Python-3.10,3.11,3.12,3.13-green.svg?style=flat)
 
 <!-- TOC *generated with [DocToc](https://github.com/thlorenz/doctoc)* -->
 **Table of Contents**
@@ -86,7 +86,7 @@ documentation, and should be read if the following is not sufficient.
 It is strongly recommended that some form of *virtual environment* is
 used with Sherpa.
 
-Sherpa is tested against Python versions 3.10 and 3.11 with experimental support for Python 3.12.
+Sherpa is tested against Python versions 3.10, 3.11, 3.12, and with experimental support for Python 3.13.
 
 The last version of Sherpa which supported Python 2.7 is
 [Sherpa 4.11.1](https://doi.org/10.5281/zenodo.3358134).
@@ -95,7 +95,7 @@ Using Conda
 --------------
 
 Sherpa is provided for both Linux and macOS operating systems running
-Python 3.10, 3.11, and (experimental) 3.12. It can be installed with the `conda`
+Python 3.10, 3.11, and 3.12. It can be installed with the `conda`
 package manager by saying
 
     $ conda install -c https://cxc.cfa.harvard.edu/conda/sherpa -c conda-forge sherpa

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ range of statistics and robust optimisers.
 Sherpa is released under the
 `GNU General Public License v3.0
 <https://github.com/sherpa/sherpa/blob/master/LICENSE>`_,
-and is compatible with Python versions 3.10 to 3.12.
+and is compatible with Python versions 3.10 to 3.13.
 Information on recent releases and citation information for
 Sherpa is available using the Digital Object Identifier (DOI)
 `10.5281/zenodo.593753 <https://doi.org/10.5281/zenodo.593753>`_.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,8 +33,8 @@ Requirements
 
 Sherpa has the following requirements:
 
-* Python 3.10 to 3.12
-* NumPy (version 2.0 should work but there has been limited testing)
+* Python 3.10 to 3.12, with experimental support for Python 3.13
+* NumPy
 * Linux or OS-X (patches to add Windows support are welcome)
 
 Sherpa can take advantage of the following Python packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Scientific/Engineering :: Astronomy",
   "Topic :: Scientific/Engineering :: Physics"


### PR DESCRIPTION
# Summary

Note that Sherpa can be used with Python 3.13.

# Details

We do not have a CI run using Python 3.13 but I have been using it to develop and test Sherpa, so note that we have "experimental" support for 3.13.

Drop the "experimental" label for Python 3.12.

Drop a NumPy version 2 comment as we have been using it for a while now.