### PR TITLE
Add option `record_steps` to `Fit.fit()` calls

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -53,7 +53,6 @@ doctest_norecursedirs =
     sherpa/astro/xspec
     sherpa/conftest.py
     sherpa/estmethods
-    sherpa/fit.py
     sherpa/image
     sherpa/include
     sherpa/io.py

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -11350,7 +11350,7 @@ class Session(sherpa.ui.utils.Session):
            file handle instead of a string.
 
         .. versionchanged:: 4.17.1
-           The parameters ``record_steps`` was added to keep parameter
+           The parameter ``record_steps`` was added to keep parameter
            values of each iteration with the fit results.
 
         Parameters

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -11349,6 +11349,10 @@ class Session(sherpa.ui.utils.Session):
            The outfile parameter can now be sent a Path object or a
            file handle instead of a string.
 
+        .. versionchanged:: 4.17.1
+           The parameters ``record_steps`` was added to keep parameter
+           values of each iteration with the fit results.
+
         Parameters
         ----------
         id : int or str, optional
@@ -11364,6 +11368,11 @@ class Session(sherpa.ui.utils.Session):
            overwritten (``True``) or if it raises an exception
            (``False``, the default setting). This is only used if
            `outfile` is set to a string or Path object.
+        record_steps : bool, optional
+            If `True`, then the parameter values and statistic value
+            are recorded at each iteration in an array in the
+            `~sherpa.fit.FitResults` object that you can obtain with
+            `get_fit_results`.
 
         Raises
         ------
@@ -11418,6 +11427,18 @@ class Session(sherpa.ui.utils.Session):
         Simultaneously fit data sets 1, 2, and 3:
 
         >>> fit(1, 2, 3)
+
+        Fit the dataset 'jet' and keep the values for each parameter in every
+        optimization step:
+
+         >>> fit('jet', record_steps=True)
+         >>> fres = get_fit_results()
+         >>> for row in fres.record_steps:
+         ...     print(f"{row['nfev']} {row['statistic']:8.6e} {row['const1d.c0']:6.4f}")
+         [... output here ...]
+
+        (This example assumes that the model for the data set 'jet' has a
+        parameter called 'const1d.c0'.)
 
         Fit data set 'jet' and write the fit results to the text file
         'jet.fit', over-writing it if it already exists:

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1313,7 +1313,7 @@ class Fit(NoNewAttributesAfterInit):
            file handle instead of a string.
 
         .. versionchanged:: 4.17.1
-           The parameters ``record_steps`` was added to keep parameter
+           The parameter ``record_steps`` was added to keep parameter
            values of each iteration in the `FitResults` object that is
            returned.
 

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -221,6 +221,10 @@ class FitResults(NoNewAttributesAfterInit):
        and now contains the covariance matrix estimated at the
        best-fit location, if provided by the optimiser.
 
+    .. versionchanged:: 4.17.1
+       The `record_steps` attribute has been added to the class.
+       If the fit recorded the parameter values of each step in the optimization,
+       this attribute will contain an array with the data.
     """
 
     # The fields to include in the __str__ output.
@@ -1307,6 +1311,11 @@ class Fit(NoNewAttributesAfterInit):
         .. versionchanged:: 4.17.0
            The outfile parameter can now be sent a Path object or a
            file handle instead of a string.
+
+        .. versionchanged:: 4.17.1
+           The parameters ``record_steps`` was added to keep parameter
+           values of each iteration in the `FitResults` object that is
+           returned.
 
         Parameters
         ----------

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -303,6 +303,10 @@ class FitResults(NoNewAttributesAfterInit):
         self.extra_output = results[4]
         """The ``extra_output`` field from the fit."""
 
+        self.record_steps: None | dict = results[4].get('record_steps')
+        """A record of all steps taken during the fit, if requested
+        with `record_steps=True`."""
+
         self.modelvals: np.ndarray = _vals
         """The values of the best-fit model evaluated for the data."""
 
@@ -615,19 +619,21 @@ class IterCallback:
 
     """
 
-    __slots__ = ("data", "model", "stat", "fh", "nfev")
+    __slots__ = ("data", "model", "stat", "fh", "nfev", "record_steps")
 
     def __init__(self,
                  data: DataSimulFit,
                  model: SimulFitModel,
                  stat: Stat,
-                 fh: WriteableTextFile | None = None
+                 fh: WriteableTextFile | None = None,
+                 record_steps: bool = False
                  ) -> None:
         self.data = data
         self.model = model
         self.stat = stat
         self.fh = fh
         self.nfev = 0
+        self.record_steps = [] if record_steps else None
 
     def __call__(self,
                  pars: np.ndarray
@@ -647,6 +653,10 @@ class IterCallback:
             vals = [f'{self.nfev:5e}', f'{output[0]:5e}']
             vals.extend([f'{val:5e}' for val in self.model.thawedpars])
             self.fh.write(' '.join(vals) + '\n')
+
+        if self.record_steps is not None:
+            # Store the current parameter values
+            self.record_steps.append((self.nfev, output[0], *self.model.thawedpars))
 
         # Update the counter and return the results
         self.nfev += 1
@@ -741,7 +751,8 @@ class IterFit:
         raise KeyboardInterrupt()
 
     def _get_callback(self,
-                      fh: WriteableTextFile | None = None
+                      fh: WriteableTextFile | None = None,
+                      record_steps: bool = False,
                       ) -> IterCallback:
         """Create the function that returns the statistic.
 
@@ -769,7 +780,8 @@ class IterFit:
             self.stat.calc_staterror)
 
         return IterCallback(data=self.data, model=self.model,
-                            stat=self.stat, fh=fh)
+                            stat=self.stat, fh=fh,
+                            record_steps=record_steps)
 
     # TODO: look at the cache argument
     def sigmarej(self,
@@ -996,7 +1008,7 @@ class IterFit:
             parmins: ArrayType,
             parmaxes: ArrayType,
             statargs: Sequence[Any] = (),
-            statkwargs: Mapping[str, Any] | None = None
+            statkwargs: Mapping[str, Any] | None = None,
             ) -> OptReturn:
 
         if statkwargs is None:
@@ -1287,7 +1299,8 @@ class Fit(NoNewAttributesAfterInit):
     def fit(self,
             outfile: str | Path | WriteableTextFile | None = None,
             clobber: bool = False,
-            numcores: int | None = 1
+            numcores: int | None = 1,
+            record_steps: bool = False,
             ) -> FitResults:
         """Fit the model to the data.
 
@@ -1298,14 +1311,19 @@ class Fit(NoNewAttributesAfterInit):
         Parameters
         ----------
         outfile : str, Path, IO object, or None, optional
-           If not `None` then information on the fit is written to
-           this file (as defined by a filename, path, or file
-           handle).
+            If not `None` then information on the fit is written to
+            this file (as defined by a filename, path, or file
+            handle).
         clobber : bool, optional
-           Determines if the output file can be overwritten. This is
-           only used when `outfile` is a string or `Path` object.
+            Determines if the output file can be overwritten. This is
+            only used when `outfile` is a string or `Path` object.
         numcores : int or None, optional
-           The number of cores to use in fitting simultaneous data.
+            The number of cores to use in fitting simultaneous data.
+            This argument is currently unused.
+        record_steps : bool, optional
+            If `True`, then the parameter values and statistic value
+            are recorded at each iteration in a dictionary in the
+            `FitResults` object that this method returns.
 
         Returns
         -------
@@ -1339,6 +1357,7 @@ class Fit(NoNewAttributesAfterInit):
         >>> from sherpa.data import Data1D
         >>> from sherpa.models.basic import Const1D
         >>> from sherpa.stats import LeastSq
+        >>> from sherpa.fit import Fit
         >>> d = Data1D("x", [-3, 5, 17, 22], [12, 3, 8, 5])
         >>> m = Const1D()
         >>> s = LeastSq()
@@ -1364,6 +1383,22 @@ class Fit(NoNewAttributesAfterInit):
         Repeat the fit, after resetting the model, so we can see how
         the optimiser searched the parameter space:
 
+        >>> m.reset()
+        >>> out = f.fit(record_steps=True)
+        >>> for row in out.record_steps:
+        ...     print(f"{row['nfev']} {row['statistic']:8.6e} {row['const1d.c0']:6.4f}")
+        0 1.900000e+02 1.0000
+        1 1.900000e+02 1.0000
+        2 1.899834e+02 1.0003
+        3 4.600000e+01 7.0000
+        4 4.600002e+01 7.0024
+        5 4.600000e+01 7.0000
+
+        This format is also easy to plot, e.g.
+        ``plt.plot(out.record_steps['nfev'], out.record_steps['statistic'])``.
+
+        Output could also be file-based or captured using `io.StringIO`:
+
         >>> from io import StringIO
         >>> m.reset()
         >>> optdata = StringIO()
@@ -1376,7 +1411,6 @@ class Fit(NoNewAttributesAfterInit):
         3.000000e+00 4.600000e+01 7.000000e+00
         4.000000e+00 4.600002e+01 7.002417e+00
         5.000000e+00 4.600000e+01 7.000000e+00
-
         """
 
         dep, staterror, _ = self.data.to_fit(self.stat.calc_staterror)
@@ -1400,7 +1434,8 @@ class Fit(NoNewAttributesAfterInit):
                  for par in self.model.get_thawed_pars()]
         cm = _add_fit_stats(outfile, clobber, names)
         with cm as fh:
-            cb = self._iterfit._get_callback(fh=fh)
+            cb = self._iterfit._get_callback(fh=fh,
+                                             record_steps=record_steps)
             output_orig = self._iterfit.fit(cb,
                                             self.model.thawedpars,
                                             self.model.thawedparmins,
@@ -1430,6 +1465,12 @@ class Fit(NoNewAttributesAfterInit):
                         param_warnings += f"WARNING: parameter value {par.fullname} is at its minimum boundary {par.min}\n"
                     if sao_fcmp(par.val, par.max, tol) == 0:
                         param_warnings += f"WARNING: parameter value {par.fullname} is at its maximum boundary {par.max}\n"
+            if record_steps:
+                extended_names = ['nfev', 'statistic'] + names
+                dtypes = [int] + [float] * (len(extended_names) - 1)
+                imap['record_steps'] = np.array(cb.record_steps,
+                                                dtype = [(n, d) for n, d in zip(extended_names, dtypes)])
+
 
         output = (status, newpars, fval_new, msg, imap)
         return FitResults(self, output, init_stat, param_warnings.strip("\n"))

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -3137,6 +3137,30 @@ def test_fit_outfile_simple_check_stringio(check_str):
                ""])
 
 
+def test_fit_record_steps():
+    """Check if we record the values of the parameters at each step.
+
+    """
+    data = make_data(Data1D)
+    mdl = Const1D("mx")
+    fit = Fit(data, mdl, stat=Cash())
+    fitres = fit.fit()
+    assert fitres.record_steps is None
+
+    mdl.reset()
+    fitres = fit.fit(record_steps=True)
+
+    expected_stat = [6.0, 6.0, 5.995167, -3.230695, -3.232515, -4.073187,
+                     -4.073357, -4.079456, -4.079455, -4.079456, -4.079456]
+    expected_c0 = [1.0, 1.0, 1.000345, 2.454143, 2.454991, 3.250567,
+                     3.251690, 3.333285, 3.334435, 3.333329, 3.333329]
+
+    assert fitres.record_steps['nfev'] == pytest.approx([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    assert fitres.record_steps['statistic'] == pytest.approx(expected_stat)
+    assert fitres.record_steps['mx.c0'] == pytest.approx(expected_c0)
+    assert len(fitres.record_steps.dtype) == 3
+
+
 @pytest.fixture
 def setup_ldata():
     """Create the data for the GAUSS1D linked-parameter test."""

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015 - 2024
+#  Copyright (C) 2010, 2015-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -9583,6 +9583,10 @@ class Session(NoNewAttributesAfterInit):
            The outfile parameter can now be sent a Path object or a
            file handle instead of a string.
 
+        .. versionchanged:: 4.17.1
+           The parameters ``record_steps`` was added to keep parameter
+           values of each iteration with the fit results.
+
         Parameters
         ----------
         id : int or str, optional
@@ -9598,6 +9602,11 @@ class Session(NoNewAttributesAfterInit):
            overwritten (``True``) or if it raises an exception
            (``False``, the default setting). This is only used if
            `outfile` is set to a string or Path object.
+        record_steps : bool, optional
+            If `True`, then the parameter values and statistic value
+            are recorded at each iteration in an array in the
+            `~sherpa.fit.FitResults` object that you can obtain with
+            `get_fit_results`.
 
         Raises
         ------

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -9584,7 +9584,7 @@ class Session(NoNewAttributesAfterInit):
            file handle instead of a string.
 
         .. versionchanged:: 4.17.1
-           The parameters ``record_steps`` was added to keep parameter
+           The parameter ``record_steps`` was added to keep parameter
            values of each iteration with the fit results.
 
         Parameters


### PR DESCRIPTION
## Summary
Add option `record_steps` to `Fit.fit()` calls, which will add a field `record_steps` to the `FitResults` object that the fitter returns. This can help to understand why a fit does not converge.

## Details
The fit function previously had an option to record statistic and parameter values for each step of a fit to a file. This is helpful to understand why a fit may not converge or does not find a global minimum.
However, the file loading and parsing (or capturing in a StringIO object) is somewhat cumbersome.
This commit adds a simpler way to have that information available in the `FitResults` object.

By default `record_steps=False` to match previous behavior and conserve memory.

fixes #2269