### PR TITLE
Provide access to XSPEC abundances

### DIFF
--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -35,6 +35,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
       get_xsabund
       get_xsabund_doc
       get_xsabundances
+      get_xsabundances_path
       get_xschatter
       get_xscosmo
       get_xspath_manager

--- a/docs/model_classes/xspec_model.rst
+++ b/docs/model_classes/xspec_model.rst
@@ -31,6 +31,7 @@ for a general description of the ``sherpa.astro.xspec`` module.
    .. autosummary::
       :toctree: api
 
+      clear_xsxset
       get_xsabund
       get_xsabund_doc
       get_xsabundances

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -818,7 +818,7 @@ def get_xsxset(name: str | None = None) -> str | dict[str, str]:
     Raises
     ------
     KeyError
-       When the name has not been set.
+       When the name passed is not set in X-Spec.
 
     See Also
     --------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -7721,7 +7721,7 @@ class XSeebremss(XSAdditiveModel):
     def __init__(self, name='eebremss'):
         self.T = XSParameter(name, 'T', 1.0, min=0.05, max=10000000000.0, hard_min=0.05, hard_max=10000000000.0, units='keV')
         self.eperh = XSParameter(name, 'eperh', 1.2, min=0.0, max=10.0, hard_min=0.0, hard_max=10.0, frozen=True)
-        self.Redshift = mkRedshift(0)
+        self.Redshift = mkRedshift(name)
 
         pars = (self.T, self.eperh, self.Redshift)
         XSAdditiveModel.__init__(self, name, pars)

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -232,16 +232,25 @@ def get_xsabund(element: str | None = None) -> str | float:
     return _xspec.get_xsabund(element)
 
 
-def get_xsabundances() -> dict[str, float]:
+def get_xsabundances(table: str | None = None) -> dict[str, float]:
     """Return the abundance settings used by X-Spec.
 
+    .. versionchanged:: 4.17.1
+       The optional table argument was added.
+
     .. versionadded:: 4.17.0
+
+    Parameter
+    ---------
+    table : optional
+        The table to use. Leave as None to use the selected abundance
+        table.
 
     Returns
     -------
     abundances : dict
-        The current set of abundances. The keys are the element names
-        (e.g. 'Fe') and the values are the abundances.
+        The keys are the element names (e.g. 'Fe') and the values are
+        the abundances.
 
     See Also
     --------
@@ -253,9 +262,16 @@ def get_xsabundances() -> dict[str, float]:
     >>> get_xsabundances()
     {'H': 1.0, 'He': ...}
 
+    >>> set_xsabud("angr")
+    >>> get_xsabundances()["Cu"]
+    1.619999956403717e-08
+    >>> get_xsabundances("felc")["Cu"]
+    0.0
+
     """
 
-    return {name: _xspec.get_xsabund(name)
+    tbl = get_xsabund() if table is None else table
+    return {name: _xspec.get_xsabund_table(tbl, name)
             for name in get_xselements().keys()}
 
 

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -319,8 +319,12 @@ static PyObject* set_cross( PyObject *self, PyObject *args )
 }
 
 
-// TODO: We could have a seperate "reset" command
-//
+static PyObject* clear_xset( PyObject *self )
+{
+  FunctionUtility::eraseModelStringDataBase();
+  Py_RETURN_NONE;
+}
+
 static PyObject* set_xset( PyObject *self, PyObject *args )
 {
 
@@ -330,6 +334,11 @@ static PyObject* set_xset( PyObject *self, PyObject *args )
   if ( !PyArg_ParseTuple( args, (char*)"ss", &str_name, &str_value ) )
     return NULL;
 
+  // Sending in INITIALIZE will reset the database but
+  // - users can now use the clear_xsxset() routine
+  // - using INITIALIZE for this has been marked as deprecated in
+  //   4.17.1
+  //
   string name = XSutility::upperCase(string(str_name));
   if (name == "INITIALIZE") {
     FunctionUtility::eraseModelStringDataBase();
@@ -345,13 +354,31 @@ static PyObject* get_xset( PyObject *self, PyObject *args  )
 
   char* str_name = NULL;
 
-  if ( !PyArg_ParseTuple( args, (char*)"s", &str_name ) )
+  if ( !PyArg_ParseTuple( args, (char*)"|s", &str_name ) )
     return NULL;
 
+  // If no argument is given then we return a dictonary
+  // of all items.
+  //
+  if ( str_name == NULL ) {
+
+    PyObject *d = PyDict_New();
+    for (const auto& item : FunctionUtility::modelStringDataBase()) {
+      PyObject *value = PyUnicode_FromString(item.second.c_str());
+      PyDict_SetItemString(d, item.first.c_str(), value);
+      Py_DECREF(value);
+    }
+
+    return d;
+  }
+
+  // Treat an unknown key as an error.
+  //
   static string value;
   value = FunctionUtility::getModelString(string(str_name));
   if (value == FunctionUtility::NOT_A_KEY()) {
-    value.erase();
+    PyErr_SetString( PyExc_KeyError, str_name );
+    return NULL;
   }
 
   return Py_BuildValue( (char*)"s", value.c_str() );
@@ -393,6 +420,7 @@ static PyMethodDef XSpecMethods[] = {
   NOARGSPEC(get_xsxsect, get_xspec_string<FunctionUtility::XSECT>),
 
   FCTSPEC(set_xsxsect, set_cross),
+  NOARGSPEC(clear_xsxset, clear_xset),
   FCTSPEC(set_xsxset, set_xset),
   FCTSPEC(get_xsxset, get_xset),
   NOARGSPEC(get_xspath_manager, get_xspec_string<FunctionUtility::managerPath>),

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -154,7 +154,7 @@ static PyObject* get_abund( PyObject *self, PyObject *args )
 
   // Was there an error?
   //
-  if( tmpStream.str().size() > 0 ) {
+  if( !tmpStream.str().empty() ) {
     return PyErr_Format( PyExc_TypeError, // TODO: change from TypeError to ValueError?
 			 (char*)"could not find element '%s'", element);
   }
@@ -194,6 +194,11 @@ static PyObject* get_abund_from_table( PyObject *self, PyObject *args )
     abundVal = FunctionUtility::getAbundance(string(table),
 					     string(element));
   } catch (FunctionUtility::NoInitializer&) {
+
+    IosHolder::setStreams(IosHolder::inHolder(),
+			  IosHolder::outHolder(),
+			  errStream);
+
     return PyErr_Format( PyExc_ValueError,
 			 "Unknown abundance table '%s'",
 			 table );
@@ -205,8 +210,8 @@ static PyObject* get_abund_from_table( PyObject *self, PyObject *args )
 
   // Was there an error?
   //
-  if( tmpStream.str().size() > 0 ) {
-    // No backwards compatability to worry about, so use the sensible
+  if( !tmpStream.str().empty() ) {
+    // No backwards compatibility to worry about, so use the sensible
     // error type (ValueError rather than TypeError as used by
     // get_abund).
     //
@@ -493,7 +498,7 @@ static PyObject* get_xset( PyObject *self, PyObject *args  )
   if ( !PyArg_ParseTuple( args, (char*)"|s", &str_name ) )
     return NULL;
 
-  // If no argument is given then we return a dictonary
+  // If no argument is given then we return a dictionary
   // of all items.
   //
   if ( str_name == NULL ) {

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -180,6 +180,17 @@ def test_abund_default():
 
 
 @requires_xspec
+def test_get_xsabundances_path():
+    """Minimal test of get_xsabundances_path"""
+
+    from sherpa.astro import xspec
+
+    # We assume the file must exist if we have got this far
+    path = xspec.get_xsabundances_path()
+    assert path.is_file()
+
+
+@requires_xspec
 def test_xset_default():
     """Check the expected default setting for the xset setting.
 
@@ -797,8 +808,11 @@ def test_set_xsstate_missing_key(miss_key):
 
     ostate = xspec.get_xsstate()
     assert miss_key in ostate
-    for val in ostate.values():
-        assert val is not None
+    for key, val in ostate.items():
+        if key == "abundances":
+            assert val is None
+        else:
+            assert val is not None
 
     def not_elem(value, vals):
         """Pick the first item in vals that is not value"""
@@ -815,6 +829,8 @@ def test_set_xsstate_missing_key(miss_key):
             'paths': {'manager': '/dev/null'}}
 
     del fake[miss_key]
+
+    assert xspec.get_xsabund() != 'file'
 
     try:
         xspec.set_xsstate(fake)
@@ -847,6 +863,11 @@ def test_set_xsstate_missing_key(miss_key):
         #
         for key in fake.get("modelstrings", {}).keys():
             xspec.set_xsxset(key, "")
+
+    # Safety check (this was not being reset correctly when working on
+    # using set_xsabund_vector and the abundances state setting).
+    #
+    assert xspec.get_xsabund() != 'file'
 
 
 @requires_xspec
@@ -956,7 +977,40 @@ def test_set_xsstate_path_manager():
     # assert xspec.get_xsstate() == ostate
 
     xspec.set_xspath_manager(opath)
-    # should really clear out xspec.xspecpaths
+    # should really clear out xspec.xsstate["paths"]
+
+
+@requires_xspec
+def test_set_xsstate_abundances():
+    """Check we can restore manually-created abundances.
+    """
+
+    from sherpa.astro import xspec
+
+    oabund = xspec.get_xsabund()
+    assert oabund != "file"
+
+    ostate = xspec.get_xsstate()
+
+    xspec.set_xsabundances({"H": 1, "He": 0.6, "C": 0.5, "Fe": 0.25, "Zn": 0.1})
+
+    nstate = xspec.get_xsstate()
+
+    # Change the abundances so we know the set_xsstate call works
+    xspec.set_xsabund("angr")
+    assert xspec.get_xsabund() == "angr"
+
+    xspec.set_xsstate(nstate)
+    assert xspec.get_xsabund() == "file"
+    assert xspec.get_xsabund("H") == pytest.approx(1)
+    assert xspec.get_xsabund("He") == pytest.approx(0.6)
+    assert xspec.get_xsabund("C") == pytest.approx(0.5)
+    assert xspec.get_xsabund("Fe") == pytest.approx(0.25)
+    assert xspec.get_xsabund("Cu") == pytest.approx(0.0)
+    assert xspec.get_xsabund("Zn") == pytest.approx(0.1)
+
+    xspec.set_xsstate(ostate)
+    assert xspec.get_xsabund() == oabund
 
 
 @requires_data

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -352,6 +352,37 @@ def test_abund_get_invalid_element(caplog):
 
 
 @requires_xspec
+@pytest.mark.parametrize("element,table,emsg",
+                         [("O3", "angr",
+                           "could not find element 'O3' in table 'angr'"),
+                          ("O", "foobar",
+                           "Unknown abundance table 'foobar'"),
+                          # It looks like XSPEC only throws the "unknown table"
+                          # error when the element is known, which means the
+                          # following error is not "Unknown abundance table".
+                          ("O3", "barfoo",
+                           "could not find element 'O3' in table 'barfoo'")
+                          ])
+def test_abund_get_invalid_element_table(element, table, emsg, caplog):
+    """Check what happens if sent the wrong element/table name.
+
+    Allow a combination of invalid/valid table and element names, as
+    long as at least one is invalid.
+
+    Users should never hit this case, as it requires explicit calls
+    to the _xspec.get_xsabund_table routine.
+
+    """
+
+    from sherpa.astro.xspec import _xspec
+
+    with pytest.raises(ValueError, match=f"^{emsg}$"):
+        _xspec.get_xsabund_table(table, element)
+
+    assert len(caplog.records) == 0
+
+
+@requires_xspec
 def test_abund_set_invalid_name(caplog):
     """Check what happens if sent an unknown table
 

--- a/sherpa/astro/xspec/tests/test_xspec_unit.py
+++ b/sherpa/astro/xspec/tests/test_xspec_unit.py
@@ -702,7 +702,7 @@ def test_get_xsabundances_table_name():
 def test_get_xsabundances_table_name_file():
     """Check we can get a different abundance table to the default.
 
-    Unlike test_get_xsabundances_table_name we load our own abnudances
+    Unlike test_get_xsabundances_table_name we load our own abundances
     so we can definitely check they are being used.
 
     """


### PR DESCRIPTION
# Summary

Minor improvements to the XSPEC interface: get_xsabundances now takes an optional table name, get_xsxset can be called with no argument, and clear_xsxset will clear the XSET database. Fix #2282.

# Details

Fix a minor error in the XSeebremss model (it just affects the string/print output of the model): issue #2282.

The rest are changes from #2216 without the problematic atomdb/nei version settings and some version string accessors that may suffer similar issues (e.g. you can change them but they don't seem to change anything if models have already run).

A number of routines have been added or changed in `sherpa.astro.xspec._xspec` as this is treated as an "internal" module (i.e. if users are calling this directly then they have to expect changes). The user-level changes in `sherpa.astro.xspec` are intended to be more backwards-compatible, as normally we have just added routines or added optional arguments. There is one breaking change however, noted below.

Changes are:

- added `clear_xsxset` as an "obvious" way to clear the XSXSET database (there was a hidden way to do this but you had to know XSPEC internals to do so, by setting the `"INITIALIZE"` key)
- `get_xsxset` can now be called with no name, in which case it returns a dict containing all the settings
- `get_xsxset` now raises a `KeyError` if given an invalid name (to make the dict-like behaviour cleaner) rather than returning an empty string
  - this is an explicit breaking change
- there have been internal changes to make `set_xsabundances` nicer, but it's not visible to the user, but it does mean that if you have set abundances from a file (or adjusted the values) then they will be recorded in the "xspec state"
- added `get_xsabundances_path` as a way to get the `Path` to the abundances file used by XSPEC
  - this is not exported by default as it is expected to be rarely used
- ensure you can't accidentally crash XSPEC by trying to set the abundances to "file" if you haven't actually loaded in any data (either from a file or by manual edits)
- the `set_xsabund` C++ implementation has added comments to explain why we don't use `FunctionUtility::readNewAbnudances()` but still keep the code from when we only were able to use the xsFORTRAN interface (which does not have a "read abundances from a file" routine); basically the error handling and behaviour of `readNewAbundances` mean it's not worth changing our existing code
- easy access to all the abundance tables, not just the currently loaded one, via `get_xsabundances("lodd")` etc
  - in earlier versions of this work I had many more ways to get this information, but for Sherpa users I think being able to just get all the abundances as a dict, labelled by element name, is all that we really need