### PR TITLE
Allow guess to be used with multiple datasets

### DIFF
--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -3923,8 +3923,8 @@ def test_eval_model_to_fit_when_all_ignored_dataimg():
                            "The size of 'empty' has not been set"),
                           (None, np.asarray([1, 2, 3]),
                            "data set 'empty' has no channel information"),
-                          pytest.param(np.asarray([1, 2, 3]), None,
-                                       "The dependent axis of 'empty' has not been set", marks=pytest.mark.xfail)
+                          (np.asarray([1, 2, 3]), None,
+                           "The dependent axis of 'empty' has not been set")
                           ])
 def test_to_guess_when_empty_datapha(chans, counts, emsg):
     """This is a regression test."""
@@ -3939,14 +3939,9 @@ def test_to_guess_when_empty_2d(data_class, args):
     """This is a regression test."""
 
     data = data_class("empty", *args)
-    resp = data.to_guess()
-
-    # Ensure there are n None values, where n is the number of
-    # independent + dependent axes - ie len(args)
-    #
-    assert len(resp) == len(args)
-    for r in resp:
-        assert r is None
+    with pytest.raises(DataErr,
+                       match="^The size of 'empty' has not been set$"):
+        _ = data.to_guess()
 
 
 def test_to_guess_when_all_ignored_datapha():

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -3918,12 +3918,19 @@ def test_eval_model_to_fit_when_all_ignored_dataimg():
         _ = data.eval_model_to_fit(Gauss2D())
 
 
-def test_to_guess_when_empty_datapha():
+@pytest.mark.parametrize("chans,counts,emsg",
+                         [(None, None,
+                           "The size of 'empty' has not been set"),
+                          (None, np.asarray([1, 2, 3]),
+                           "data set 'empty' has no channel information"),
+                          pytest.param(np.asarray([1, 2, 3]), None,
+                                       "The dependent axis of 'empty' has not been set", marks=pytest.mark.xfail)
+                          ])
+def test_to_guess_when_empty_datapha(chans, counts, emsg):
     """This is a regression test."""
 
-    data = DataPHA("empty", None, None)
-    with pytest.raises(DataErr,
-                       match="The size of 'empty' has not been set"):
+    data = DataPHA("empty", chans, counts)
+    with pytest.raises(DataErr, match=f"^{emsg}$"):
         _ = data.to_guess()
 
 

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -3430,7 +3430,6 @@ def test_pha_group_filter_ignore_bad_group(caplog, clean_astro_ui):
     assert r.getMessage() == "dataset 1: 1:4 -> 1:5 Channel"
 
 
-@pytest.mark.xfail
 @requires_data
 @requires_fits
 def test_multi_id_guess_pha(clean_astro_ui, make_data_path):

--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2020 - 2025
+#  Copyright (C) 2017, 2018, 2020-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -3428,3 +3428,62 @@ def test_pha_group_filter_ignore_bad_group(caplog, clean_astro_ui):
     assert r.name == "sherpa.ui.utils"
     assert r.levelname == "INFO"
     assert r.getMessage() == "dataset 1: 1:4 -> 1:5 Channel"
+
+
+@pytest.mark.xfail
+@requires_data
+@requires_fits
+def test_multi_id_guess_pha(clean_astro_ui, make_data_path):
+    """What happens with multiple datasets?"""
+
+    # This could be written to not require files, but it is
+    # based on a test case developed when writing the multi-id
+    # guess code, and it was not worth the time to simplify the
+    # code.
+    #
+    with SherpaVerbosity("ERROR"):
+        for idval in [1, 2, 3, 4]:
+            name = f"obs-{idval}"
+            ui.load_pha(name, make_data_path(f"obs{idval}.pi"))
+
+        ui.notice(0.5, 7)
+
+        for idval in [1, 2, 3, 4]:
+            name = f"obs-{idval}"
+            ui.group_counts(name, 5)
+
+        mdl = ui.create_model_component("powlaw1d", "mdl")
+        for idval in [1, 2, 3, 4]:
+            name = f"obs-{idval}"
+            ui.set_source(name, mdl)
+
+    assert mdl.gamma.val == pytest.approx(1.0)
+    assert mdl.ampl.val == pytest.approx(1.0)
+
+    ui.guess("obs-1")
+
+    expected1 = 9.18092e-7
+    expected2 = 1.725894e-5
+
+    # gamma is not expected to change, but the amplitude should
+    assert mdl.gamma.val == pytest.approx(1.0)
+    assert mdl.ampl.val == pytest.approx(expected1)
+
+    # The guess has set the amplitude max so that it is ~ 1e-3, hence
+    # the need to change it here.
+    #
+    mdl.ampl.set(1.0, max=10)
+    ui.guess("obs-2")
+
+    assert mdl.ampl.val == pytest.approx(expected2)
+
+    # How about all the data?
+    # Note that the current results are not actually correct.
+    #
+    mdl.ampl.set(1.0, max=10)
+    ui.guess("obs-1", otherids=["obs-2", "obs-3", "obs-4"])
+    assert mdl.ampl.val == pytest.approx(expected1)
+
+    mdl.ampl.set(1.0, max=10)
+    ui.guess("obs-2", otherids=["obs-1", "obs-3", "obs-4"])
+    assert mdl.ampl.val == pytest.approx(expected2)

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1511,20 +1511,49 @@ class Data(NoNewAttributesAfterInit, BaseData):
         self._can_apply_model(modelfunc)
         return modelfunc(*self.get_indep(filter=True))
 
-    def to_guess(self) -> tuple[np.ndarray | None, ...]:
+    def to_guess(self) -> tuple[np.ndarray, ...]:
+        """Return the dependent and independent axes for guessing.
 
-        # Should this also check whether the independent and dependent
-        # axes are set?
+        .. versionchanged:: 4.18.0
+           It is now an error to call this with either the independent
+           or dependent axes unset.
+
+        Return
+        ------
+        axes : tuple of ndarray
+           The dependent axis and then the independent axes, including
+           any data filtering.
+
+        """
+
+        # This check is technically not needed, as there are explicit
+        # checks for both indepedent and dependent axes below, but
+        # this attempts to remain as similar to the pre-4.18.0
+        # behaviour as possible.
         #
-        arrays: list[np.ndarray | None]
+        if self.size is None:
+            raise DataErr("sizenotset", self.name)
+
+        arrays: list[np.ndarray]
         arrays = [self.get_y(filter=True, yfunc=None)]
+        if arrays[0] is None:
+            raise DataErr("The dependent axis of "
+                          f"'{self.name}' has not been set")
+
+        # The check for each element not being None should not be
+        # needed with the check on self.size
         arrays.extend(self.get_indep(True))
+        for array in arrays[1:]:
+            if array is None:
+                raise DataErr("The independent axis of "
+                              f"'{self.name}' has not been set")
+
         return tuple(arrays)
 
     def to_fit(self,
                staterrfunc: StatErrFunc | None = None
                ) -> tuple[np.ndarray | None,
-                          ArrayType | None,
+                          ArrayType | None,  # should this be np.ndarray?
                           np.ndarray | None]:
         return (self.get_dep(True),
                 self.get_staterror(True, staterrfunc),

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -2705,14 +2705,9 @@ def test_to_guess_when_empty(data_class, args):
         pytest.xfail("test known to fail with Data1DInt")
 
     data = data_class("empty", *args)
-    resp = data.to_guess()
-
-    # Ensure there are n None values, where n is the number of
-    # independent + dependent axes - ie len(args)
-    #
-    assert len(resp) == len(args)
-    for r in resp:
-        assert r is None
+    with pytest.raises(DataErr,
+                       match="^The size of 'empty' has not been set$"):
+        _ = data.to_guess()
 
 
 @pytest.mark.parametrize("data_copy", ALL_DATA_CLASSES, indirect=True)

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -2762,7 +2762,6 @@ def test_get_filter_when_empty_1d(data_class, args):
         _ = data.get_filter()
 
 
-@pytest.mark.xfail
 def test_datasimulfit_to_guess_axis_difference():
     """Very basic check that this fails"""
 
@@ -2776,7 +2775,6 @@ def test_datasimulfit_to_guess_axis_difference():
         _ = d.to_guess()
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("d1,d2,emsg",
                          [ # First dataset has no data
                            (Data1D("d1", None, [3, 4, 5]),
@@ -2807,7 +2805,6 @@ def test_datasimulfit_to_guess_missing_axis(d1, d2, emsg):
         _ = d.to_guess()
 
 
-@pytest.mark.xfail
 def test_datasimulfit_to_guess():
     """Very basic check"""
 

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -313,7 +313,6 @@ def test_guess_single_dataset(caplog, clean_ui):
     assert len(caplog.records) == 0
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("id1,id2", [(10, 20), (20, 10)])
 def test_guess_multiple_datasets(id1, id2, caplog, clean_ui):
     """Do the different datasets change the guess?"""
@@ -342,7 +341,6 @@ def test_guess_multiple_datasets(id1, id2, caplog, clean_ui):
     assert len(caplog.records) == 0
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("id1,id2", [(10, 20), (20, 10)])
 def test_guess_multiple_datasets_single_component(id1, id2, caplog, clean_ui):
     """Guess a single component?"""

--- a/sherpa/utils/guess.py
+++ b/sherpa/utils/guess.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2018 - 2024
+#  Copyright (C) 2007, 2015-2016, 2018-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -26,7 +26,7 @@ Routines related to estimating initial parameter values and limits.
 
 """
 
-from typing import Any, Optional, Literal, TypedDict, cast, overload
+from typing import Any, Literal, TypedDict, cast, overload
 
 import numpy as np
 
@@ -45,8 +45,8 @@ __all__ = ("_guess_ampl_scale", "get_midpoint", "get_peak",
 class ValueAndRange(TypedDict):
     """Represent a value and range as a dict."""
     val: float
-    min: Optional[float]
-    max: Optional[float]
+    min: float | None
+    max: float | None
 
 
 _guess_ampl_scale: float = 1.e+3
@@ -94,7 +94,7 @@ def get_midpoint(a: np.ndarray) -> float:
 #
 def get_peak(y: np.ndarray,
              x: np.ndarray,
-             xhi: Optional[np.ndarray] = None) -> float:
+             xhi: np.ndarray | None = None) -> float:
     """Estimate the peak position of the data.
 
     Parameters
@@ -125,7 +125,7 @@ def get_peak(y: np.ndarray,
 
 def get_valley(y: np.ndarray,
                x: np.ndarray,
-               xhi: Optional[np.ndarray] = None) -> float:
+               xhi: np.ndarray | None = None) -> float:
     """Estimate the position of the minimum of the data.
 
     Parameters
@@ -155,7 +155,7 @@ def get_valley(y: np.ndarray,
 
 def get_fwhm(y: np.ndarray,
              x: np.ndarray,
-             xhi: Optional[np.ndarray] = None) -> float:
+             xhi: np.ndarray | None = None) -> float:
     """Estimate the width of the data.
 
     This is only valid for positive data values (``y``).
@@ -198,11 +198,11 @@ def get_fwhm(y: np.ndarray,
     # The x array is required to be ordered, so we can just
     # take the first and last points.
     #
-    guess_fwhm = (x[-1] - x[0]) / 2
+    fwhm_g = (x[-1] - x[0]) / 2
 
     y_argmax = y.argmax()
     if y[y_argmax] <= 0:
-        return guess_fwhm
+        return fwhm_g
 
     half_max_val = y[y_argmax] / 2.0
     x_max = x[y_argmax]
@@ -247,12 +247,12 @@ def get_fwhm(y: np.ndarray,
 
     # No value, so use the guess.
     #
-    return guess_fwhm
+    return fwhm_g
 
 
 def guess_fwhm(y: np.ndarray,
                x: np.ndarray,
-               xhi: Optional[np.ndarray] = None,
+               xhi: np.ndarray | None = None,
                scale: float = 1000) -> ValueAndRange:
     """Estimate the value and valid range for the FWHM of the data.
 
@@ -414,7 +414,7 @@ def get_amplitude_position(arr: np.ndarray,
 
 def guess_amplitude(y: np.ndarray,
                     x: np.ndarray,
-                    xhi: Optional[np.ndarray] = None
+                    xhi: np.ndarray | None = None
                     ) -> ValueAndRange:
     """
     Guess model parameter amplitude (val, min, max)
@@ -445,7 +445,7 @@ def guess_amplitude(y: np.ndarray,
 def guess_amplitude_at_ref(r: float,
                            y: np.ndarray,
                            x: np.ndarray,
-                           xhi: Optional[np.ndarray] = None
+                           xhi: np.ndarray | None = None
                            ) -> ValueAndRange:
     """
     Guess model parameter amplitude (val, min, max)
@@ -524,7 +524,7 @@ def guess_amplitude2d(y, x0lo, x1lo, x0hi=None, x1hi=None):
 def guess_reference(pmin: float,
                     pmax: float,
                     x: np.ndarray,
-                    xhi: Optional[np.ndarray] = None
+                    xhi: np.ndarray | None = None
                     ) -> ValueAndRange:
     """
     Guess model parameter reference (val, min, max)
@@ -553,7 +553,7 @@ def guess_reference(pmin: float,
 
 def get_position(y: np.ndarray,
                  x: np.ndarray,
-                 xhi: Optional[np.ndarray] = None
+                 xhi: np.ndarray | None = None
                  ) -> ValueAndRange:
     """
     Get 1D model parameter positions pos (val, min, max)


### PR DESCRIPTION
# Summary

Allow guess to run with multiple datasets. Fix #2284.

# Details

Adding a `to_guess` method to `DataSimulFit` is easy, apart from the fact that we allow `Data` objects to be "partially filled" - that is, the independent or dependent axes can be `None`. In this case it is not clear what to do - perhaps we should just drop that dataset - but for now we error out, as it is obviously not correct to use an empty or partially-empty dataset for the guess. This could be changed later once we have more experience.

Actually, I have now changed it so that guess (on a single dataset, not a simultaneous dataset) is now an error - this requires changing a few tests, but thet are obviously "check the behavior works as before"  so it makes sense they would need to be updated. This makes the handling consistent between the two cases (single vs multiple).

However, it now becomes unclear about how guess should work with multiple datasets, as the independent axis may not agree so we can't just sum the values (and it may not make sense to sum them). To think about. Hmm. The routines in `sherpa.utils.guess` kind-of assume the data is ordered (in the independent axis) so we either enforce this, require the guess routines to accept unordered data, or do something clever, such as send in multiple datasets separately, or run the guess routine on each dataset and "average" the results (but that's not statistically useful).

# Notes

The `ui.guess` routine adds the `otherids` argument, similar to other routines, but it adds it at the end (to avoid breaking other code) - that is

```python
    def guess(self,
              id=None,
              model=None,
              limits: bool = True,
              values: bool = True,
              otherids: Sequence[IdType] = ()
              ) -> None:
```

We could instead have

```python
    def guess(self,
              id=None,
              model=None,
              *,
              otherids: Sequence[IdType] = (),
              limits: bool = True,
              values: bool = True
              ) -> None:
```

which might be better but would be a breaking change. We could do it without the `*` which would also be a breaking change but probably a bit more "dangerous".

# Shelved

So, to do this would really require sending around `PointAxis`/`IntegratedAxis` objects rather than just `ndarray` values, so that we could work out how to "combine" multiple datasets - the existing `guess` routines may assume the data is ordered in the independent axis, and I haven't really thought through whether we need to add/average/whatever the dependent axis. This could just be done for the `to_guess` code, but it is a large change and I do not think it is feasible at this time. I have pulled out some code into

- #2323 

and will close this.