### PR TITLE
ui: add more examples of using SherpaVerbosity

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015 - 2025
+#  Copyright (C) 2010, 2015-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -11399,6 +11399,9 @@ class Session(sherpa.ui.utils.Session):
         `fit_bkg` function can be used to fit models to just the
         background data.
 
+        The screen output from the fit can be controlled with the
+        `SherpaVerbosity` context manager, as shown in the examples.
+
         If outfile is sent a file handle then it is not closed by this
         routine.
 
@@ -11432,6 +11435,16 @@ class Session(sherpa.ui.utils.Session):
         >>> out = StringIO()
         >>> fit(outfile=out)
         >>> txt = out.getvalue()
+
+        The messages from `fit` use the standard Sherpa logging
+        infrastructure, and so can be ignored by using
+        `SherpaVerbosity`:
+
+        >>> from sherpa.utils.logging import SherpaVerbosity
+        >>> with SherpaVerbosity("WARN"):
+        ...     fit()
+        ...
+        >>> fres = get_fit_results()
 
         """
         kwargs['bkg_only'] = False
@@ -11490,6 +11503,9 @@ class Session(sherpa.ui.utils.Session):
         This is only for PHA data sets where the background is being
         modelled, rather than subtracted from the data.
 
+        The screen output from the fit can be controlled with the
+        `SherpaVerbosity` context manager, as shown in the examples.
+
         If outfile is sent a file handle then it is not closed by this
         routine.
 
@@ -11516,6 +11532,16 @@ class Session(sherpa.ui.utils.Session):
         >>> out = StringIO()
         >>> fit_bkg(outfile=out)
         >>> txt = out.getvalue()
+
+        The messages from `fit_bkg` use the standard Sherpa logging
+        infrastructure, and so can be ignored by using
+        `SherpaVerbosity`:
+
+        >>> from sherpa.utils.logging import SherpaVerbosity
+        >>> with SherpaVerbosity("WARN"):
+        ...     fit_bkg()
+        ...
+        >>> fres = get_fit_results()
 
         """
         kwargs['bkg_only'] = True

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015 - 2024
+#  Copyright (C) 2010, 2015-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -5681,7 +5681,7 @@ class Session(NoNewAttributesAfterInit):
 
         The report of the change in the filter expression can be
         controlled with the `SherpaVerbosity` context manager, as
-        shown in the examples below.
+        shown in the examples.
 
         Examples
         --------
@@ -5807,7 +5807,7 @@ class Session(NoNewAttributesAfterInit):
 
         The report of the change in the filter expression can be
         controlled with the `SherpaVerbosity` context manager, as
-        shown in the examples below.
+        shown in the examples.
 
         Examples
         --------
@@ -5917,7 +5917,7 @@ class Session(NoNewAttributesAfterInit):
 
         The report of the change in the filter expression can be
         controlled with the `SherpaVerbosity` context manager, as
-        shown in the examples below.
+        shown in the examples.
 
         Examples
         --------
@@ -9627,6 +9627,9 @@ class Session(NoNewAttributesAfterInit):
         If outfile is sent a file handle then it is not closed by this
         routine.
 
+        The screen output from the fit can be controlled with the
+        `SherpaVerbosity` context manager, as shown in the examples.
+
         Examples
         --------
 
@@ -9657,6 +9660,16 @@ class Session(NoNewAttributesAfterInit):
         >>> out = StringIO()
         >>> fit(outfile=out)
         >>> txt = out.getvalue()
+
+        The messages from `fit` use the standard Sherpa logging
+        infrastructure, and so can be ignored by using
+        `SherpaVerbosity`:
+
+        >>> from sherpa.utils.logging import SherpaVerbosity
+        >>> with SherpaVerbosity("WARN"):
+        ...     fit()
+        ...
+        >>> fres = get_fit_results()
 
         """
         ids, f = self._get_fit(id, otherids)
@@ -11098,6 +11111,10 @@ class Session(NoNewAttributesAfterInit):
         order is unimportant, since any argument that is not defined
         as a model parameter is assumed to be a data id.
 
+        The screen output from the error analysis can be controlled
+        with the `SherpaVerbosity` context manager, as shown in the
+        examples.
+
         The `covar` command is different to `conf`, in that in that
         all other thawed parameters are fixed, rather than being
         allowed to float to new best-fit values.  While `conf` is more
@@ -11178,6 +11195,16 @@ class Session(NoNewAttributesAfterInit):
 
         >>> covar(1, 3, 4, line, clus.kt)
 
+        The messages from `covar` use the standard Sherpa logging
+        infrastructure, and so can be ignored by using
+        `SherpaVerbosity`:
+
+        >>> from sherpa.utils.logging import SherpaVerbosity
+        >>> with SherpaVerbosity("WARN"):
+        ...     covar()
+        ...
+        >>> res = get_covar_results()
+
         """
         self._covariance_results = self._est_errors(args, 'covariance')
 
@@ -11230,6 +11257,10 @@ class Session(NoNewAttributesAfterInit):
         When called with multiple ``ids`` or ``parameters`` values, the
         order is unimportant, since any argument that is not defined
         as a model parameter is assumed to be a data id.
+
+        The screen output from the error analysis can be controlled
+        with the `SherpaVerbosity` context manager, as shown in the
+        examples.
 
         The `conf` function is different to `covar`, in that in that
         all other thawed parameters are allowed to float to new
@@ -11385,6 +11416,16 @@ class Session(NoNewAttributesAfterInit):
         3, and 4:
 
         >>> conf(1, 3, 4, line, clus.kt)
+
+        The messages from `conf` use the standard Sherpa logging
+        infrastructure, and so can be ignored by using
+        `SherpaVerbosity`:
+
+        >>> from sherpa.utils.logging import SherpaVerbosity
+        >>> with SherpaVerbosity("WARN"):
+        ...     conf()
+        ...
+        >>> res = get_conf_results()
 
         """
         self._confidence_results = self._est_errors(args, 'confidence')


### PR DESCRIPTION
# Summary

Point out the use of the sherpa.utils.logging.SherpaVerbosity context manager in the documentation of the fit and error-analysis UI routines.

# Details

The `SherpaVerbosity` context manager makes it easy to turn off the output from routines, but it is hard to find if you do not know it exists. So add some more examples to the UI code showing its use.

I looked to see if there were other places and the only other obvious place was `get_draws`, but the screen output from that is small. There may be some of the flux simulation/error analysis places that maybe it could be used, but again I think most of the time the screen output is only a few lines. We could add text, but I didn't want to waste the reader's time on stuff they do not need.