### PR TITLE
Minor clean up of utility code

### DIFF
--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019 - 2024
+#  Copyright (C) 2019-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1395,6 +1395,28 @@ def test_get_xxx_contour_prefs_pylab(ctype, session, requires_pylab):
     assert p == {'xlog': False, 'ylog': False,
                  'alpha': None, 'linewidths': None, 'colors': None,
                  'label': None, 'levels': None, 'linestyles': 'solid'}
+
+
+@pytest.mark.parametrize("ctype", ["data", "model"])
+def test_get_xxx_contour_prefs_behavior(ctype, clean_ui):
+    """What happens with multiple id values.
+
+    This is a regression test.
+    """
+
+    preffunc = getattr(ui, f"get_{ctype}_contour_prefs")
+    getfunc = getattr(ui, f"get_{ctype}_contour")
+
+    got = preffunc()
+    assert got["alpha"] is None
+
+    assert getfunc(recalc=False).contour_prefs["alpha"] is None
+
+    got["alpha"] = 0.5
+
+    assert getfunc(recalc=False).contour_prefs["alpha"] == pytest.approx(0.5)
+    assert getfunc(2, recalc=False).contour_prefs["alpha"] == pytest.approx(0.5)
+    assert getfunc("foo", recalc=False).contour_prefs["alpha"] == pytest.approx(0.5)
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -2616,6 +2616,8 @@ def func_counter(func):
     warnings.warn("func_counter is deprecated in 4.17.0: use FuncCounter instead",
                   FutureWarning)
 
+    nfev = [0]
+
     def func_counter_wrapper(x, *args):
         nfev[0] += 1
         return func(x, *args)

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -2565,17 +2565,6 @@ def symmetric_to_low_triangle(matrix, num):
     return low_triangle
 
 
-############################### Root of all evil ##############################
-
-
-def printf(format, *args):
-    """Format args with the first argument as format string, and write.
-    Return the last arg, or format itself if there are no args."""
-    sys.stdout.write(str(format) % args)
-    # WARNING: where is if_ meant to be defined?
-    return if_(args, args[-1], format)
-
-
 # With ParamSpec, added in Python 3.10, we might be able to annotate
 # this so that we can match the arguments that `func` uses are the
 # same as are sent to the __call__ method, although it might be easier


### PR DESCRIPTION
# Summary

Ensure a deprecated routine can still be used and remove a routine that has never worked.

# Details

Pulled out of #2283 

- add a test for contour preference handling (just to cover a corner case)
- fix a bug, but it is in a deprecated routine (marked as such in 4.17.0, when the bug was introduced) which we do not use and I would be surprised if any external user does
- remove a routine that has been buggy (i.e. will always fail) for the entire time sherpa has been stored in git