### PR TITLE
Docs for Cash and CStat are wrong about truncate_value

### DIFF
--- a/sherpa/stats/__init__.py
+++ b/sherpa/stats/__init__.py
@@ -455,7 +455,7 @@ class Cash(Likelihood):
     .sherpa.rc file:
 
     - if `truncate` is `True` (the default value), then
-      `log(trunc_value)` is used whenever the data value is <= 0.  The
+      `log(trunc_value)` is used whenever the model value is <= 0.  The
       default is `trunc_value=1.0e-25`.
 
     - when `truncate` is `False` an error is raised.
@@ -528,7 +528,7 @@ class CStat(Likelihood):
     .sherpa.rc file:
 
     - if `truncate` is `True` (the default value), then
-      `log(trunc_value)` is used whenever the data value is <= 0.  The
+      `log(trunc_value)` is used whenever the model value is <= 0.  The
       default is `trunc_value=1.0e-25`.
 
     - when `truncate` is `False` an error is raised.


### PR DESCRIPTION
`stats.hh` contains the following lines for both CStat and Cash:
```
    for ( IndexType ii = num - 1; ii >= 0; --ii ) {

      if ( model[ ii ] > 0.0)
	mymodel = model[ ii ];
      else {
	if (trunc_value > 0)
	  mymodel = trunc_value;
	else
	  return EXIT_FAILURE;
      }
```
Clearly, the truncate_value is applied when the MODEL (not the DATA, as the docs state before this PR) is <=0.
(The data in fact has to be >=0, otherwise the likelihood makes no sense anyway.)