### PR TITLE
Improve docs for hard and soft limits

### DIFF
--- a/docs/models/index.rst
+++ b/docs/models/index.rst
@@ -227,7 +227,8 @@ During a fit the parameter values are bound by the soft limits,
 and a screen message will be displayed if an attempt to move
 outside this range was made. During error analysis the parameter
 values are allowed outside the soft limits, as long as they remain
-inside the hard limits.
+inside the hard limits. This helps with determining Uncertainties
+for parameters that are close to the soft limits.
 
 .. _params-guess:
 

--- a/docs/optimisers/index.rst
+++ b/docs/optimisers/index.rst
@@ -6,7 +6,7 @@ The optimiser varies the model parameters in an attempt to find
 the solution which minimises the chosen
 :doc:`statistic <../statistics/index>`.
 
-In general it is expected that the optimiser will be used by
+In general, it is expected that the optimiser will be used by
 a :py:class:`~sherpa.fit.Fit` object to
 :doc:`perform the fit <../fit/index>`, but
 it can be used directly using the
@@ -20,17 +20,18 @@ As an example, the default parameter values for the
 :py:class:`Levenberg-Marquardt <sherpa.optmethods.LevMar>`
 optimiser are::
 
-    >>> from sherpa.optmethods.LevMar
+    >>> from sherpa.optmethods import LevMar
     >>> lm = LevMar()
     >>> print(lm)
-    name    = levmar
-    ftol    = 1.19209289551e-07
-    xtol    = 1.19209289551e-07
-    gtol    = 1.19209289551e-07
-    maxfev  = None
-    epsfcn  = 1.19209289551e-07
-    factor  = 100.0
-    verbose = 0
+    name     = levmar
+    ftol     = 1.1920928955078125e-07
+    xtol     = 1.1920928955078125e-07
+    gtol     = 1.1920928955078125e-07
+    maxfev   = None
+    epsfcn   = 1.1920928955078125e-07
+    factor   = 100.0
+    numcores = 1
+    verbose  = 0
 
 These settings are available both as fields of the object and via
 the :py:attr:`~sherpa.optmethods.OptMethod.config` dictionary

--- a/docs/optimisers/optfcts.rst
+++ b/docs/optimisers/optfcts.rst
@@ -19,3 +19,6 @@ The sherpa.optmethods.optfcts module
      minim
      montecarlo
      neldermead
+     InfinitePotential
+     EPSILON
+     FUNC_MAX

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,9 +28,7 @@ doctest_norecursedirs =
     docs/fit
     docs/install.rst
     docs/model_classes
-    docs/optimisers
     docs/overview
-    #docs/plots
     docs/statistics
     docs/ui
     sherpa/__init__.py
@@ -54,7 +52,6 @@ doctest_norecursedirs =
     sherpa/image
     sherpa/include
     sherpa/io.py
-    sherpa/optmethods
     sherpa/sim
     sherpa/static
     sherpa/stats

--- a/sherpa/optmethods/optfcts.py
+++ b/sherpa/optmethods/optfcts.py
@@ -20,20 +20,23 @@
 
 """Optimizing functions.
 
-These functions take a callback, the current set of parameters, the
-minimum and maximum parameter ranges, along with optional arguments,
-and return a tuple containing
+As input, these functions take
+  - a callback function, which should return the current statistic value
+    and an array of the statistic value per bin.
+  - the current set of parameters (a numpy array)
+  - the minimum for each parameter (numpy array)
+  - the maximum for each parameter (numpy array)
+  - any optional arguments
 
-    status, parameters, statistic, message, dict
+The return a tuple containing
 
-where ``status`` is a boolean indicating whether the optimisation
-succeeded or not, parameters is the list of parameter values at the
-best-fit location, the statistic value at this location, a string
-message - when ``status`` is `False` this will give information on the
-failure - and a dictionary which depends on the optimiser.
+ - a boolean indicating whether the optimization succeeded or not
+ - the list of parameter values at the best-fit location
+ - the statistic value at this location
+ - a string message - when ``status`` is `False` this will give information
+   on the failure
+ - a dictionary which depends on the optimizer
 
-The callback should return the current statistic value and an array
-of the statistic value per bin.
 
 Notes
 -----
@@ -66,6 +69,16 @@ model value of 1 and bounded to the range 0 to 10000:
 >>> print(f"Best-fit value: {res[1][0]}")
 Best-fit value: 4.0
 
+How are parameter bounds implemented?
+-------------------------------------
+The optimizers in this module use a simple Infinite Potential
+approach, where the value of the statistic is set to a very large
+number defined by the module level variable `FUNC_MAX`
+if any of the parameter values is outside the limits.
+
+This approach is easy to implement and fast to evaluate, but it does
+introduce a discontinuity at the limits which can in some cases cause
+problems when the best-fit value is close to the limits.
 """
 
 from collections.abc import Sequence
@@ -85,20 +98,22 @@ from .ncoresnm import ncoresNelderMead
 
 
 __all__ = ('difevo', 'difevo_lm', 'difevo_nm', 'grid_search', 'lmdif',
-           'minim', 'montecarlo', 'neldermead')
+           'minim', 'montecarlo', 'neldermead',
+           'InfinitePotential', 'EPSILON', 'FUNC_MAX',
+           )
 
 
 warning = logging.getLogger(__name__).warning
 
-# Use FLT_EPSILON as default tolerance
-#
-EPSILON = np.float64(np.finfo(np.float32).eps)
 
-# Maximum callback function value, used to indicate that the optimizer
-# has exceeded parameter boundaries.  All the optimizers expect double
+EPSILON = np.float64(np.finfo(np.float32).eps)
+'''Use FLT_EPSILON as default tolerance'''
+
+# All the optimizers expect double
 # precision arguments, so we use np.float64 instead of SherpaFloat.
-#
 FUNC_MAX = np.finfo(np.float64).max
+"""Value used to indicate that the optimizer has exceeded parameter limits.
+"""
 
 
 def _check_args(x0: ArrayType,
@@ -234,6 +249,15 @@ class InfinitePotential:
     the statistic are not NaN and lie within the range
 
         minval <= pars <= maxval
+
+    Parameters
+    ----------
+    func : function
+        The function to be called to evaluate the statistic.
+    minval : array
+        The minimum value for each parameter.
+    maxval : array
+        The maximum value for each parameter.
 
     """
 


### PR DESCRIPTION
Hard and soft limits are already explained in the docs, but some details that might be useful for developers extending or building on Sherpa have been added. Since the audience of the added information are developers, and this is not typically an area that users need ot care about, the information has been added to a module docstring. I also made some of the relevant module level constants public - a developer might want to reset them.

closes #1480