### PR TITLE
Disable ots

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@
 #fftw_libraries=fftw3
 
 # Region Library
+#disable_region=True
 # Uncomment to use a local installation
 #region=local
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@
 #region_use_cxc_parser=False
 
 # WCS Subroutines
+#disable_wcs=True
 # Uncomment to use a local installation
 #wcs=local
 

--- a/sherpa/astro/ui/tests/test_astro_session_image.py
+++ b/sherpa/astro/ui/tests/test_astro_session_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2022
+#  Copyright (C) 2022, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -44,7 +44,7 @@ from sherpa.astro.ui.utils import Session as AstroSession
 from sherpa.astro.data import DataIMG
 
 from sherpa.utils.err import ArgumentTypeErr
-from sherpa.utils.testing import requires_ds9
+from sherpa.utils.testing import requires_ds9, requires_region
 
 
 def example_data():
@@ -104,6 +104,7 @@ def test_image_xxx2d_not_sent_an_image(funcname, idval):
             func(idval)
 
 
+@requires_region
 @requires_ds9
 @pytest.mark.parametrize("funcname", ["notice", "ignore"])
 def test_xxx2d_image_no_region(funcname):
@@ -139,6 +140,7 @@ FILTER_A = "Circle(10,0,3)"
 FILTER_B = "RotBox(8,4,8,6,30)"
 
 
+@requires_region
 @requires_ds9
 def test_notice2d_image():
     """A valid region"""
@@ -165,6 +167,7 @@ def test_notice2d_image():
     assert d.mask.sum() == FILTER_NSET
 
 
+@requires_region
 @requires_ds9
 def test_ignore2d_image():
     """A valid region


### PR DESCRIPTION
This is similar to #2242 but for the region and wcssubs libraries. It is a bit easier as the code is already set up for these libraries (and the extensions built from them) to be optional.

It may allow building with gcc 15 - e.g. issue #2223 - but I haven't yet checked it out.

