### PR TITLE
Allow restoring of BinaryOpModels

### DIFF
--- a/sherpa/astro/ui/tests/test_session_copy.py
+++ b/sherpa/astro/ui/tests/test_session_copy.py
@@ -83,17 +83,16 @@ def test_save_restore(tmpdir):
 
 
 @requires_xspec
-def test_save_restore_composite_model_with_cache(tmpdir):
+def test_save_restore_composite_model_with_cache(tmp_path, xsmodel):
     """Test that the save/restore works with a composite model.
 
-    Specifically, we use a model form XSPEC that has a cache.
+    Specifically, we use a model from XSPEC that has a cache.
     Slightly expanded regression test for bug #2301.
     """
-    xspec = pytest.importorskip("sherpa.astro.xspec")
 
-    outfile = tmpdir.join("sherpa.save")
+    outfile = outfile = tmp_path / "sherpa.save"
     session = Session()
-    m1 = xspec.XSphabs() * xspec.XSvapec()
+    m1 = xsmodel("phabs") * xsmodel("vapec")
     session.set_source(1, m1)
     session.save(str(outfile), clobber=True)
     session.clean()

--- a/sherpa/astro/ui/tests/test_session_copy.py
+++ b/sherpa/astro/ui/tests/test_session_copy.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2017, 2022
+#  Copyright (C) 2016-2017, 2022, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -27,7 +27,9 @@ code and tests is likely needed.
 """
 
 from sherpa.astro.ui.utils import Session
+from sherpa.utils.testing import requires_xspec
 from numpy.testing import assert_array_equal
+import pytest
 
 TEST = [1, 2, 3]
 TEST2 = [4, 5, 6]
@@ -78,3 +80,29 @@ def test_save_restore(tmpdir):
     assert {1, } == set(session.list_data_ids())
     assert_array_equal(TEST, session.get_data(1).get_indep()[0])
     assert_array_equal(TEST2, session.get_data(1).get_dep())
+
+
+@requires_xspec
+def test_save_restore_composite_model_with_cache(tmpdir):
+    """Test that the save/restore works with a composite model.
+
+    Specifically, we use a model form XSPEC that has a cache.
+    Slightly expanded regression test for bug #2301.
+    """
+    xspec = pytest.importorskip("sherpa.astro.xspec")
+
+    outfile = tmpdir.join("sherpa.save")
+    session = Session()
+    m1 = xspec.XSphabs() * xspec.XSvapec()
+    session.set_source(1, m1)
+    session.save(str(outfile), clobber=True)
+    session.clean()
+    assert set() == set(session.list_model_ids())
+
+    session.restore(str(outfile))
+    assert {1, } == set(session.list_model_ids())
+    # We cannot use an identity check here since the model is
+    # reconstructed at a different memory location, but we can check
+    # that it is functionally the same, by checking the name
+    # which will contain the parts like 'phabs * vapec'
+    assert session.get_source(1).name == m1.name

--- a/sherpa/models/model.py
+++ b/sherpa/models/model.py
@@ -1617,11 +1617,6 @@ class ArithmeticModel(Model):
                                  strformat=strformat)
         return NotImplemented
 
-    def __setstate__(self, state):
-        # In case old pickle files do not have cache info
-        self.cache_clear()
-        self.__dict__.update(state)
-
     def startup(self, cache: bool = False) -> None:
         if cache:
             self.cache_clear()

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1282,11 +1282,8 @@ class Session(NoNewAttributesAfterInit):
         """
         _check_str_type(filename, "filename")
 
-        fin = open(filename, 'rb')
-        try:
+        with open(filename, 'rb') as fin:
             obj = pickle.load(fin)
-        finally:
-            fin.close()
 
         if not isinstance(obj, Session):
             raise ArgumentErr('nosession', filename)


### PR DESCRIPTION
## Summary
Fix #2301 (can't read saved sessions which contain  compsite models)

## Details

`CompositeModel` (one of the parent classes of `BinaryOpModel`) gains an attribute `parts` in their `__init__` function. However, when they are restored from a pickeled save, `__init__` is never called. Eventually, the `parts` attribute is taken from the pickle and added to the objects dict, but we can't access it before that is done.

fixes #2301

I believe that this regression was introduced in #2166, but I did not actually bisect it because that didn't seem necessary after I understood what causes the problem.

This commit also adds tests for the regression and a minor syntax clean-up that helped me with interactive debugging.

## Rejected alternatives

Here, I'm taking the appraoch to do the least extra work possible and let Python do its thing. There are alternatives that handle the cache in a differnet way that could be chosen instead:

- Create the "parts" attribute before resetting the Cache in a way that respects the `NoAtrtibuteAfterInit` (e.g. by directly changing the `__dict__`
- Not include the cache in the pickle at all (reduces file size and risk of stale cache values when files are loaded into different versions of Sherpa, but throws away time if the cache is build with long computations)

Both options are somewhat more complex. It's just just 2-5 lines of code, but I'm afraid that it will introduce other corner cases that are hard to predict.

On the other hand, the approach in this PR has a higher risk of failing on pickles created with different versions of Sherpa (when the code for caching changes). I think that's OK - we don't guarantee that pickles work for different versions and we don't change that code often (just recently, but probably not again any time soon).