### PR TITLE
ptcat-3768 - removing max enforcement in sherpa for CAT processing

### DIFF
--- a/sherpa/models/parameter.py
+++ b/sherpa/models/parameter.py
@@ -368,25 +368,14 @@ hard_min
 
     # 'val' property
     #
-    # Note that _get_val has to check the parameter value when it
-    # is a link, to ensure that it isn't outside the parameter's
-    # min/max range. See issue #742.
-    #
     _val: SherpaFloat  # needed for typing
 
     def _get_val(self) -> SherpaFloat:
         if hasattr(self, 'eval'):
             return self.eval()
-        if self.link is None:
-            return self._val
-
-        val = self.link.val
-        if val < self.min:
-            raise ParameterErr('edge', self.fullname, 'minimum', self.min)
-        if val > self.max:
-            raise ParameterErr('edge', self.fullname, 'maximum', self.max)
-
-        return val
+        if self.link is not None:
+            return self.link.val
+        return self._val
 
     def _set_val(self, val: Union[Parameter, SupportsFloat]) -> None:
         if isinstance(val, Parameter):

--- a/sherpa/models/tests/test_model.py
+++ b/sherpa/models/tests/test_model.py
@@ -2340,6 +2340,7 @@ def test_model_can_not_change_pars():
         mdl.pars = [Parameter("x", "y", 2)]
 
 
+@pytest.mark.xfail
 def test_model_linked_par_outside_limit():
     """What happens if a linked par is outside it's limits"""
 

--- a/sherpa/models/tests/test_parameter.py
+++ b/sherpa/models/tests/test_parameter.py
@@ -496,7 +496,7 @@ def test_link_unlink_val_ui():
 
     tst_unlink(src1, src2)
 
-
+@pytest.mark.xfail
 def test_link_parameter_setting():
     """See https://github.com/sherpa/sherpa/issues/742
 
@@ -541,6 +541,7 @@ def test_link_parameter_setting():
     assert mdl.gamma.val == pytest.approx(-2)
 
 
+@pytest.mark.xfail
 def test_link_parameter_evaluation():
     """See also test_link_parameter_setting
 


### PR DESCRIPTION
removing max enforcement in sherpa as it causes aperture photometry to fail. Updated expected tests failures due to change