### PR TITLE
Mark more session tests as optional

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -3027,7 +3027,7 @@ def test_pha1_get_foo_flux_hist_model(getfunc, ratio,
 
 
 @pytest.mark.parametrize("cls",
-                         [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
+                         [pytest.param(sherpa.ui.utils.Session, marks=pytest.mark.session), sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("plottype,extraargs,title,plotcls",
                          [("model", [], "Model",
                            sherpa.plot.ModelPlot),
@@ -3092,7 +3092,7 @@ def create_template():
 
 
 @pytest.mark.parametrize("cls",
-                         [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
+                         [pytest.param(sherpa.ui.utils.Session, marks=pytest.mark.session), sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("plottype,extraargs,title,plotcls",
                          [("model", [], "Model",
                            sherpa.plot.ModelPlot),
@@ -3151,7 +3151,7 @@ def test_data1d_get_model_plot_template(cls, plottype, extraargs, title, plotcls
 
 
 @pytest.mark.parametrize("cls",
-                         [sherpa.ui.utils.Session,
+                         [pytest.param(sherpa.ui.utils.Session, marks=pytest.mark.session),
                           sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("plottype,extraargs,title",
                          [("model", [], "Model"),
@@ -3210,7 +3210,7 @@ def test_data1d_plot_model(cls, plottype, extraargs, title,
 
 
 @pytest.mark.parametrize("cls",
-                         [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
+                         [pytest.param(sherpa.ui.utils.Session, marks=pytest.mark.session), sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("plottype,extraargs,title",
                          [("model", [], "Model"),
                           ("model_component", ['tmdl'],
@@ -3276,7 +3276,7 @@ def test_data1d_plot_model_template(cls, plottype, extraargs, title,
 
 
 @pytest.mark.parametrize("cls",
-                         [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
+                         [pytest.param(sherpa.ui.utils.Session, marks=pytest.mark.session), sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("plottype,extraargs,title,plotcls",
                          [("model", [], "Model",
                            sherpa.plot.ModelHistogramPlot),
@@ -3327,7 +3327,7 @@ def test_data1dint_get_model_plot(cls, plottype, extraargs, title, plotcls):
 
 
 @pytest.mark.parametrize("cls",
-                         [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
+                         [pytest.param(sherpa.ui.utils.Session, marks=pytest.mark.session), sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("plottype,extraargs,title",
                          [("model", [], "Model"),
                           ("model_component", ['mdl'],
@@ -3637,7 +3637,7 @@ def test_datapha_plot_after_clean():
 
 
 @pytest.mark.parametrize("cls",
-                         [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
+                         [pytest.param(sherpa.ui.utils.Session, marks=pytest.mark.session), sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("datafunc", [example_data1d,
                                       example_data1dint])
 @pytest.mark.parametrize("plotfunc",
@@ -3711,7 +3711,7 @@ def test_set_plot_opt_x(cls, datafunc, plotfunc, all_plot_backends):
 
 
 @pytest.mark.parametrize("cls",
-                         [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
+                         [pytest.param(sherpa.ui.utils.Session, marks=pytest.mark.session), sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("datafunc", [example_data1d,
                                       example_data1dint])
 @pytest.mark.parametrize("plotfunc,answer",
@@ -4013,7 +4013,7 @@ def test_set_plot_opt_with_plot_y(requires_pylab):
 
 
 @pytest.mark.parametrize("cls",
-                         [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
+                         [pytest.param(sherpa.ui.utils.Session, marks=pytest.mark.session), sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("name", [None, 1, {}])
 def test_set_opt_not_string(cls, name):
     """Check we error out if called with an argument that is not a string."""
@@ -4026,7 +4026,7 @@ def test_set_opt_not_string(cls, name):
 
 
 @pytest.mark.parametrize("cls",
-                         [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
+                         [pytest.param(sherpa.ui.utils.Session, marks=pytest.mark.session), sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("name", ["notdata",  "fit-allthe-things", " fi", "fi",
                                   # Comment-out those names which are currently aliases;
                                   # that is, they can be used in a call but are expected
@@ -4057,7 +4057,7 @@ def test_set_opt_invalid(cls, name):
 
 
 @pytest.mark.parametrize("cls",
-                         [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
+                         [pytest.param(sherpa.ui.utils.Session, marks=pytest.mark.session), sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("name", ["all", " all", "all ", "  all   ",
                                   "data", " data", "data ", " data   ",
                                   "source", "model",
@@ -4100,7 +4100,7 @@ def test_set_opt_valid_astro(name):
 
 
 @pytest.mark.parametrize("cls",
-                         [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
+                         [pytest.param(sherpa.ui.utils.Session, marks=pytest.mark.session), sherpa.astro.ui.utils.Session])
 def test_set_plot_opt_explicit(cls, requires_pylab):
     """Check we can call set_xlog('data').
 
@@ -4142,7 +4142,7 @@ def test_set_plot_opt_explicit(cls, requires_pylab):
 
 
 @pytest.mark.parametrize("cls",
-                         [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
+                         [pytest.param(sherpa.ui.utils.Session, marks=pytest.mark.session), sherpa.astro.ui.utils.Session])
 @pytest.mark.parametrize("name,extraargs",
                          [("data", []), ("model", []), ("source", []),
                           ("model_component", ["m1"]),
@@ -4256,7 +4256,7 @@ def test_set_plot_opt_explicit_astro(requires_pylab):
 
 
 @pytest.mark.parametrize("cls",
-                         [sherpa.ui.utils.Session, sherpa.astro.ui.utils.Session])
+                         [pytest.param(sherpa.ui.utils.Session, marks=pytest.mark.session), sherpa.astro.ui.utils.Session])
 def test_set_plot_opt_alias(cls, caplog):
     """Check that at least one alias works.
 

--- a/sherpa/astro/ui/tests/test_filtering.py
+++ b/sherpa/astro/ui/tests/test_filtering.py
@@ -298,6 +298,10 @@ def test_filter_bad_grouped(make_data_path, clean_astro_ui, caplog):
     assert pha.get_mask() == pytest.approx(expected)
 
 
+# Do not use pytest.param(Session, marks=pytest.mark.session) as these
+# tests are quick to run and historically there has been differences
+# to how the filtering works in the two session classes.
+#
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("expr,result",
                          [("4:13", "5:13"),
@@ -340,6 +344,10 @@ def test_notice_string_data1d(session, expr, result, caplog):
     clc_filter(caplog, expected)
 
 
+# Do not use pytest.param(Session, marks=pytest.mark.session) as these
+# tests are quick to run and historically there has been differences
+# to how the filtering works in the two session classes.
+#
 @pytest.mark.parametrize("session", [Session, AstroSession])
 @pytest.mark.parametrize("expr,result",
                          [("4:13", "5:13"),
@@ -422,6 +430,10 @@ def test_notice_string_datapha(expr, result, caplog):
     clc_filter(caplog, expected)
 
 
+# Do not use pytest.param(Session, marks=pytest.mark.session) as these
+# tests are quick to run and historically there has been differences
+# to how the filtering works in the two session classes.
+#
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_notice_reporting_data1d(session, caplog):
     """Unit-style test of logging of notice/ignore: Data1D"""
@@ -458,6 +470,10 @@ def test_notice_reporting_data1d(session, caplog):
     clc_filter(caplog, "dataset 1: no data (unchanged)")
 
 
+# Do not use pytest.param(Session, marks=pytest.mark.session) as these
+# tests are quick to run and historically there has been differences
+# to how the filtering works in the two session classes.
+#
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_notice_reporting_data1dint(session, caplog):
     """Unit-style test of logging of notice/ignore: Data1DInt"""
@@ -572,6 +588,10 @@ def test_notice_reporting_datapha_with_response(caplog):
     clc_filter(caplog, "dataset 1: 10:15 -> 1:19 Channel")
 
 
+# Do not use pytest.param(Session, marks=pytest.mark.session) as these
+# tests are quick to run and historically there has been differences
+# to how the filtering works in the two session classes.
+#
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_notice_reporting_data2d(session, caplog):
     """Unit-style test of logging of notice/ignore: Data2D

--- a/sherpa/models/tests/test_template_unit.py
+++ b/sherpa/models/tests/test_template_unit.py
@@ -54,6 +54,10 @@ def skip_if_no_io(request):
     pytest.skip(reason="FITS backend required")
 
 
+# Do not mark Session as marks=pytest.mark.session as the test is not
+# long and there are potential differences between the two cases (as
+# shown by skip_if_no_io).
+#
 @requires_data
 @pytest.mark.parametrize("session", [Session, AstroSession])
 def test_309(session, make_data_path, skip_if_no_io):
@@ -527,8 +531,12 @@ def test_template_with_different_independent_axes(pa, expected):
     assert got == pytest.approx(expected)
 
 
+# Although there are diffences in Session/AstroSession, assume this is
+# tested by test_309 so this can be marked as needing --runsession to
+# run.
+#
 @requires_data
-@pytest.mark.parametrize("session", [Session, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("method,nfev,statval",
                          [("neldermead", 68, 2.940358057485021),
                           ("NelderMead", 68, 2.940358057485021),

--- a/sherpa/plot/tests/test_plot.py
+++ b/sherpa/plot/tests/test_plot.py
@@ -477,7 +477,7 @@ def test_region_uncertainty(setup_confidence):
     # setup_confidence.ru.contour()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_source_component_arbitrary_grid(session, all_plot_backends):
     ui = session()
 
@@ -519,7 +519,7 @@ def test_source_component_arbitrary_grid(session, all_plot_backends):
     tst(x, y, re_x, [0,  0, 10, 10, 10,  0,  0,  0,  0,  0])
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_model_arbitrary_grid_integrated(session):
     ui = session()
     model = basic.Const1D('c')
@@ -560,7 +560,7 @@ def test_plot_model_arbitrary_grid_integrated(session):
     tst(x, y, re_x, yy)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_source_component_arbitrary_grid_int(session):
     ui = session()
 

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019 - 2022, 2024
+#  Copyright (C) 2019-2022, 2024-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1210,7 +1210,7 @@ def test_data_dep_any_obj_with_mask(Dataclass):
 
 
 # repeat set of tests except now by using ui
-# Results should be idendical, but tests are fast, so we just test again
+# Results should be identical, but tests are fast, so we just test again
 # To make sure that there is no heuristic in load_arrays or similar that
 # interferes with the logic
 @pytest.mark.parametrize('arrpos', [POS_X_ARRAY, POS_STATERR_ARRAY, POS_SYSERR_ARRAY])

--- a/sherpa/ui/tests/test_ui_image.py
+++ b/sherpa/ui/tests/test_ui_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2023
+#  Copyright (C) 2021, 2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -97,7 +97,7 @@ def example_psf():
     return psf
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("shape", [None, (9, 9)])
 def test_load_arrays2d(session, shape):
     """Does load_arrays work with 2D data?"""
@@ -126,7 +126,7 @@ def test_load_arrays2d(session, shape):
         assert got.shape == pytest.approx(shape)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_data_image(session):
     from sherpa.image import DataImage
 
@@ -147,7 +147,7 @@ def test_get_data_image(session):
     assert y[2, 5] == pytest.approx(100.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_model_image(session):
     from sherpa.image import ModelImage
 
@@ -170,7 +170,7 @@ def test_get_model_image(session):
     assert y[3, 3] == pytest.approx(102.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_model_component_image(session):
     from sherpa.image import ComponentModelImage
 
@@ -196,7 +196,7 @@ def test_get_model_component_image(session):
     assert y[3, 3] == pytest.approx(100.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_model_component_image_with_convolution(session):
     """What happens if there's a convolution component in play?"""
 
@@ -231,7 +231,7 @@ def test_get_model_component_image_with_convolution(session):
     assert y[3, 3] == pytest.approx(42.25302)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_source_image(session):
     """Note that here there's no difference of source and model"""
     from sherpa.image import SourceImage
@@ -255,7 +255,7 @@ def test_get_source_image(session):
     assert y[3, 3] == pytest.approx(102.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_source_component_image(session):
     """Note that here there's no difference of source and model"""
     from sherpa.image import ComponentSourceImage
@@ -279,7 +279,7 @@ def test_get_source_component_image(session):
     assert y[3, 3] == pytest.approx(100.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_source_component_image_with_convolution(session):
     """There is a difference thanks to the PSF"""
     from sherpa.image import ComponentSourceImage
@@ -307,7 +307,7 @@ def test_get_source_component_image_with_convolution(session):
     assert y[3, 3] == pytest.approx(100.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_resid_image(session):
     from sherpa.image import ResidImage
 
@@ -331,7 +331,7 @@ def test_get_resid_image(session):
     assert y[3, 3] == pytest.approx(-71.0983)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_ratio_image(session):
     from sherpa.image import RatioImage
 
@@ -355,7 +355,7 @@ def test_get_ratio_image(session):
     assert y[3, 3] == pytest.approx(0.302958)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_psf_image(session):
     from sherpa.image import PSFImage
 
@@ -379,7 +379,7 @@ def test_get_psf_image(session):
     assert obj.y == pytest.approx(y)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_kernel_image(session):
     from sherpa.image import PSFKernelImage
 
@@ -441,7 +441,7 @@ def check_xpa_resid(backend):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_image_data(session):
     from sherpa.image import backend
 
@@ -456,7 +456,7 @@ def test_image_data(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_image_model(session):
     from sherpa.image import backend
 
@@ -473,7 +473,7 @@ def test_image_model(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_image_model_component(session):
     from sherpa.image import backend
 
@@ -490,7 +490,7 @@ def test_image_model_component(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_image_model_component_with_convolution(session):
     """The convolution component changes the data."""
     from sherpa.image import backend
@@ -511,7 +511,7 @@ def test_image_model_component_with_convolution(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_image_source(session):
     from sherpa.image import backend
 
@@ -530,7 +530,7 @@ def test_image_source(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_image_source_component(session):
     from sherpa.image import backend
 
@@ -549,7 +549,7 @@ def test_image_source_component(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_image_source_component_with_convolution(session):
     """Unlike model, this does not change the component."""
     from sherpa.image import backend
@@ -570,7 +570,7 @@ def test_image_source_component_with_convolution(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_image_resid(session):
     from sherpa.image import backend
 
@@ -587,7 +587,7 @@ def test_image_resid(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_image_ratio(session):
     from sherpa.image import backend
 
@@ -606,7 +606,7 @@ def test_image_ratio(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_image_fit(session):
     from sherpa.image import backend
 
@@ -637,7 +637,7 @@ def test_image_fit(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_image_psf(session):
     from sherpa.image import backend
 
@@ -660,7 +660,7 @@ def test_image_psf(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_image_kernel(session):
     from sherpa.image import backend
 

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -129,7 +129,7 @@ def test_get_fit_plot(idval, clean_ui):
     assert mp.title == 'Model'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype", ["data", "model"])
 @pytest.mark.parametrize("arg", [None, 1, 'foo'])
 def test_plot_prefs_xxx(session, ptype, arg):
@@ -159,7 +159,7 @@ def test_plot_prefs_xxx(session, ptype, arg):
     assert not prefs3['xlog']
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype", ["data", "model"])
 def test_plot_prefs_xxx_data1dint(session, ptype):
     """Data1DInt is different to Data1D.
@@ -802,7 +802,7 @@ def test_prefs_change_session_objects_fit(clean_ui):
     assert plotobj.modelplot is ui.get_model_plot(id=12, recalc=False)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype", ["data", "kernel", "model" ,"psf", "ratio", "resid", "source"])
 def test_get_plot_prefs_returns_something(session, ptype):
     """Check this returns something.
@@ -817,7 +817,7 @@ def test_get_plot_prefs_returns_something(session, ptype):
     assert isinstance(p, dict)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_plot_prefs_does_not_like_fit(session):
     """Check this errors out.
 
@@ -833,7 +833,7 @@ def test_get_plot_prefs_does_not_like_fit(session):
         s.get_plot_prefs("fit")
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype", ["", "not-a-plot", None, 1])
 def test_get_plot_prefs_fails(session, ptype):
     """Check this call fails."""
@@ -844,7 +844,7 @@ def test_get_plot_prefs_fails(session, ptype):
         s.get_plot_prefs(ptype)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_plot_prefs_recognizes_datatype(session):
     """Check that get_plot_prefs recognizes the data type."""
 
@@ -882,7 +882,7 @@ def test_plot_xdf(plotfunc):
     plotfunc(pvals)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_psf(session):
     """Very basic check we can call plot_psf/get_psf_plot
 
@@ -917,7 +917,7 @@ def test_plot_psf(session):
     assert plotobj.y == pytest.approx(yexp)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_psf_plot_recalc(session):
     """get_psf_plot with recalc=False
 
@@ -958,7 +958,7 @@ def test_get_psf_plot_recalc(session):
     assert plotobj.y == pytest.approx(yexp2)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_kernel(session, caplog, plot_backends):
     """Very basic check we can call plot_kernel/get_kernel_plot
 
@@ -1002,7 +1002,7 @@ def test_plot_kernel(session, caplog, plot_backends):
     assert plotobj.y == pytest.approx(yexp)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_kernel_plot_recalc(session):
     """get_kernel_plot with recalc=False
 
@@ -1096,7 +1096,7 @@ def test_plot_fit_resid_ignores_ylog(getplot, plotfunc, clean_ui):
     assert dprefs['ylog']
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("plottype", ["plot", "contour"])
 def test_plot_contour_error_out_invalid(plottype, session):
     """plot()/contour() error out if argument name is invalid
@@ -1112,7 +1112,7 @@ def test_plot_contour_error_out_invalid(plottype, session):
         func("fooflan flim flam")
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_single(session, requires_pylab):
     """Can we call plot() with a single plot type?
 
@@ -1158,7 +1158,7 @@ def test_plot_single(session, requires_pylab):
     plt.close()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_multiple(session, requires_pylab):
     """Can we call plot() with multiple plot types?
 
@@ -1211,7 +1211,7 @@ def test_plot_multiple(session, requires_pylab):
     plt.close()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_contour_single(session, requires_pylab):
     """Can we call contour() with a single plot type?
 
@@ -1268,7 +1268,7 @@ def test_contour_single(session, requires_pylab):
     plt.close()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_contour_multiple(session, requires_pylab):
     """Can we call contour() with multiple plot types?
 
@@ -1313,7 +1313,7 @@ def test_contour_multiple(session, requires_pylab):
     plt.close()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("plotfunc,title,pcls",
                          [("data", "", sherpa.plot.DataContour),
                           ("model", "Model", sherpa.plot.ModelContour),
@@ -1385,7 +1385,7 @@ def test_contour_xxx(plotfunc, title, pcls, session, requires_pylab):
     plt.close()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ctype", ["data", "model"])
 def test_get_xxx_contour_prefs_pylab(ctype, session, requires_pylab):
 
@@ -1419,7 +1419,7 @@ def test_get_xxx_contour_prefs_behavior(ctype, clean_ui):
     assert getfunc("foo", recalc=False).contour_prefs["alpha"] == pytest.approx(0.5)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ctype", ["data", "kernel", "model" ,"psf", "ratio", "resid", "source"])
 def test_get_contour_prefs_returns_something(session, ctype):
     """Check this returns something.
@@ -1434,7 +1434,7 @@ def test_get_contour_prefs_returns_something(session, ctype):
     assert isinstance(p, dict)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_contour_prefs_does_not_like_fit(session):
     """Check this errors out.
 
@@ -1450,7 +1450,7 @@ def test_get_contour_prefs_does_not_like_fit(session):
         s.get_contour_prefs("fit")
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ctype", ["", "not-a-plot", None, 1])
 def test_get_contour_prefs_fails(session, ctype):
     """Check this call fails."""
@@ -1461,7 +1461,7 @@ def test_get_contour_prefs_fails(session, ctype):
         s.get_contour_prefs(ctype)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_scatter_plot_empty(session):
     """Very basic check we can call get_scatter_plot
 
@@ -1475,7 +1475,7 @@ def test_get_scatter_plot_empty(session):
         assert getattr(p, f) is None
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_scatter_plot(session):
     """Very basic check we can call plot_scatter/get_scatter_plot
 
@@ -1500,7 +1500,7 @@ def test_get_scatter_plot(session):
     assert p.title == 'Scatter: (x,y)'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_scatter_plot_labels_noname(session):
     """Very basic check we can call plot_scatter/get_scatter_plot
 
@@ -1525,7 +1525,7 @@ def test_get_scatter_plot_labels_noname(session):
     assert p.title == 'Scatter: (x,y)'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_scatter_plot_labels(session):
     """Very basic check we can call plot_scatter/get_scatter_plot
 
@@ -1550,7 +1550,7 @@ def test_get_scatter_plot_labels(session):
     assert p.title == 'Scatter: Fred Fred'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_trace_plot_empty(session):
     """Very basic check we can call get_trace_plot
 
@@ -1564,7 +1564,7 @@ def test_get_trace_plot_empty(session):
         assert getattr(p, f) is None
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_trace_plot(session):
     """Very basic check we can call get_trace_plot/plot_trace
 
@@ -1588,7 +1588,7 @@ def test_get_trace_plot(session):
     assert p.title == 'Trace: x'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_trace_plot_labels_noname(session):
     """Very basic check we can call get_trace_plot/plot_trace
 
@@ -1614,7 +1614,7 @@ def test_get_trace_plot_labels_noname(session):
     assert p.title == 'Trace: x'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_trace_plot_labels(session):
     """Very basic check we can call get_trace_plot/plot_trace
 
@@ -1641,7 +1641,7 @@ def test_get_trace_plot_labels(session):
     assert p.title == 'Trace: Awesome sauce'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_cdf_plot_empty(session):
 
     s = session()
@@ -1651,7 +1651,7 @@ def test_get_cdf_plot_empty(session):
         assert getattr(p, f) is None
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_cdf_replot_no_data(session, requires_pylab):
     """what does replot=True do for plot_cdf?
 
@@ -1668,7 +1668,7 @@ def test_plot_cdf_replot_no_data(session, requires_pylab):
         s.plot_cdf(x, replot=True)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_cdf_replot(session, requires_pylab):
     """what does replot=True do for plot_cdf?
 
@@ -1700,7 +1700,7 @@ def test_plot_cdf_replot(session, requires_pylab):
     plt.close()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_cdf(session):
 
     s = session()
@@ -1723,7 +1723,7 @@ def test_plot_cdf(session):
     assert p.title == 'CDF: x'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_cdf_labels_noname(session):
 
     s = session()
@@ -1739,7 +1739,7 @@ def test_plot_cdf_labels_noname(session):
     assert p.title == 'CDF: x'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_cdf_labels(session):
 
     s = session()
@@ -1755,7 +1755,7 @@ def test_plot_cdf_labels(session):
     assert p.title == 'CDF: b a'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_show_cdf_plot_empty(session):
 
     s = session()
@@ -1777,7 +1777,7 @@ def test_show_cdf_plot_empty(session):
     assert toks[8] == 'title  = None'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("use_numpy", [False, True])
 def test_show_cdf_plot(session, use_numpy):
     """This was to show issue #912 that has now been fixed.
@@ -1811,7 +1811,7 @@ def test_show_cdf_plot(session, use_numpy):
     assert toks[8] == 'title  = CDF: x'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_pdf_plot_empty(session):
 
     s = session()
@@ -1821,7 +1821,7 @@ def test_get_pdf_plot_empty(session):
         assert getattr(p, f) is None
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_pdf(session):
 
     s = session()
@@ -1851,7 +1851,7 @@ def test_plot_pdf(session):
     assert p.title == 'PDF: x'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_pdf_replot_no_data(session, requires_pylab):
     """what does replot=True do for plot_pdf?
 
@@ -1870,7 +1870,7 @@ def test_plot_pdf_replot_no_data(session, requires_pylab):
     assert "'NoneType' has no len" in str(exc.value)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_pdf_replot(session, requires_pylab):
     """what does replot=True do for plot_pdf?
 
@@ -1913,7 +1913,7 @@ def test_plot_pdf_replot(session, requires_pylab):
     plt.close()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_pdf_labels_noname(session):
 
     s = session()
@@ -1933,7 +1933,7 @@ def test_plot_pdf_labels_noname(session):
     assert p.title == 'PDF: x'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_pdf_labels(session):
 
     s = session()
@@ -1953,7 +1953,7 @@ def test_plot_pdf_labels(session):
     assert p.title == 'PDF: no name'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_show_pdf_plot_empty(session):
 
     s = session()
@@ -1973,7 +1973,7 @@ def test_show_pdf_plot_empty(session):
     assert toks[6] == 'title  = None'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_show_pdf_plot(session):
     """This is important as it also checks normed=False."""
 
@@ -1997,7 +1997,7 @@ def test_show_pdf_plot(session):
     assert toks[6] == 'title  = PDF: x'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_data_plot_recalc(session):
     """Basic testing of get_data_plot(recalc=False)"""
 
@@ -2020,7 +2020,7 @@ def test_data_plot_recalc(session):
     assert p.y == pytest.approx([10, 12, 14])
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype,extraargs",
                          [('model', []), ('model_component', ['mdl']),
                           ('source', []), ('source_component', ['mdl'])])
@@ -2040,7 +2040,7 @@ def test_xxx_plot_nodata(ptype, extraargs, session):
     assert retval.y is None
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype,extraargs",
                          [('model', []), ('model_component', ['mdl']),
                           ('source', []), ('source_component', ['mdl'])])
@@ -2060,7 +2060,7 @@ def test_xxx_plot_nodata_recalc(ptype, extraargs, session):
         func(*extraargs)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype,extraargs",
                          [('model', []), ('model_component', ['mdl']),
                           ('source', []), ('source_component', ['mdl'])])
@@ -2101,7 +2101,7 @@ def test_model_plot_recalc(ptype, extraargs, session):
     assert p.y == pytest.approx([162.5, 450, 1200])
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype,pclass,y1,y2",
                          [('resid', sherpa.plot.ResidPlot, [-10, -12], [-20, -28, -36]),
                           ('ratio', sherpa.plot.RatioPlot, [1/11, 0], [1/3, 12/40, 14/50]),
@@ -2146,7 +2146,7 @@ def test_xxx_plot_recalc(ptype, pclass, y1, y2, session):
     assert p.y == pytest.approx(y2)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_fit_plot_recalc(session):
     """Basic testing of get_fit_plot(recalc=False)"""
 
@@ -2212,7 +2212,7 @@ def check_pvalue(caplog, plot):
     assert plot.lr == pytest.approx(2.3637744995453147)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_pvalue_plot(session, caplog):
     """Basic testing of get_pvalue_plot
 
@@ -2246,7 +2246,7 @@ def test_get_pvalue_plot(session, caplog):
     check_pvalue(caplog, p)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_pvalue_requires_null_model(session):
     """We need a null_model argument"""
 
@@ -2259,7 +2259,7 @@ def test_plot_pvalue_requires_null_model(session):
     assert str(te.value) == 'null model cannot be None'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_pvalue_requires_alt_model(session):
     """We need a alt_model argument"""
 
@@ -2273,7 +2273,7 @@ def test_plot_pvalue_requires_alt_model(session):
     assert str(te.value) == 'alternative model cannot be None'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_pvalue(session, caplog, plot_backends):
     """Basic testing of plot_pvalue
 
@@ -2308,7 +2308,7 @@ def test_plot_pvalue(session, caplog, plot_backends):
     check_pvalue(caplog, p)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_split_plot(session):
     """Check we can call get_split_plot.
 
@@ -2322,7 +2322,7 @@ def test_get_split_plot(session):
     assert splot.cols == 1
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_model_component_plot_invalid(session):
     """invalid model argument for get_model_component_plot"""
 
@@ -2337,7 +2337,7 @@ def test_get_model_component_plot_invalid(session):
     assert str(exc.value) == emsg
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_model_component_plot_string(session):
     """Check we can call get_model_component_plot with string model"""
 
@@ -2357,7 +2357,7 @@ def test_get_model_component_plot_string(session):
     assert plot.title == 'Model component: const1d.gmdl'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_get_model_component_plot_model(session):
     """Check we can call get_model_component_plot with a model"""
 
@@ -2377,7 +2377,7 @@ def test_get_model_component_plot_model(session):
     assert plot.title == 'Model component: const1d.gmdl'
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_pylab_plot_scatter_empty_replot(session, requires_pylab):
     """plot_scatter with replot=False and no data
 
@@ -2410,7 +2410,7 @@ def test_pylab_plot_scatter_empty_replot(session, requires_pylab):
     plt.close()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_pylab_plot_scatter(session, requires_pylab):
     """Simple test of plot_scatter"""
 
@@ -2446,7 +2446,7 @@ def test_pylab_plot_scatter(session, requires_pylab):
     plt.close()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_pylab_plot_trace_empty_replot(session, requires_pylab):
     """plot_trace with replot=False and no data
 
@@ -2462,7 +2462,7 @@ def test_pylab_plot_trace_empty_replot(session, requires_pylab):
         s.plot_trace(y, replot=True)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_pylab_plot_trace(session, requires_pylab):
     """Simple test of plot_trace"""
 
@@ -2499,7 +2499,7 @@ def test_pylab_plot_trace(session, requires_pylab):
     plt.close()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_data_contour_recalc(session):
     """Basic testing of get_data_contour(recalc=False)"""
 
@@ -2536,7 +2536,7 @@ def test_data_contour_recalc(session):
     assert p.y == pytest.approx(ny)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_model_contour_recalc(session):
     """Basic testing of get_model_contour(recalc=False)"""
 
@@ -2582,7 +2582,7 @@ def test_model_contour_recalc(session):
     assert p.y.min() == p.y.max()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_source_contour_recalc(session):
     """Basic testing of get_source_contour(recalc=False)"""
 
@@ -2628,7 +2628,7 @@ def test_source_contour_recalc(session):
     assert p.y.min() == p.y.max()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_ratio_contour_recalc(session):
     """Basic testing of get_ratio_contour(recalc=False)"""
 
@@ -2676,7 +2676,7 @@ def test_ratio_contour_recalc(session):
     assert not ygood[40]
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_resid_contour_recalc(session):
     """Basic testing of get_resid_contour(recalc=False)"""
 
@@ -2724,7 +2724,7 @@ def test_resid_contour_recalc(session):
     assert not ygood[40]
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_fit_contour_recalc(session):
     """Basic testing of get_fit_contour(recalc=False)"""
 
@@ -2927,7 +2927,7 @@ def test_plot_fit_resid_handles_resid_log(idval, clean_ui, requires_pylab):
 
 
 @pytest.mark.xfail
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("label", ["source", "model"])
 @pytest.mark.parametrize("idval", [None, 1, "bob"])
 def test_get_foo_component_plot_recalc(session, label, idval):
@@ -2967,7 +2967,7 @@ def test_get_foo_component_plot_recalc(session, label, idval):
     assert plotobj.y == pytest.approx([9, 11, 12])
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype,mclass,label",
                          [("source", sherpa.plot.ComponentSourcePlot,
                            "Source model"),
@@ -3015,7 +3015,7 @@ def test_get_xxx_components_simple(session, ptype, mclass, label):
     assert out.plots[1].title == f"{label} component: scale1d.c1 * box1d.c3"
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype", ["source", "model"])
 def test_plot_xxx_components_simple_mpl(session, ptype, requires_pylab):
     """Simple check of plot_xxx_components using matpotlib"""
@@ -3060,7 +3060,7 @@ def test_plot_xxx_components_simple_mpl(session, ptype, requires_pylab):
     assert axes.lines[1].get_ydata() == pytest.approx([0, 2, 2])
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype", ["source", "model"])
 def test_plot_xxx_components_simple_bokeh(session, ptype):
     """Simple check of plot_xxx_components using bokeh"""
@@ -3105,7 +3105,7 @@ def test_plot_xxx_components_simple_bokeh(session, ptype):
     # Unlike the matplotlib case we do not check the plotted data.
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype", ["source", "model"])
 def test_plot_xxx_components_scalar_mpl(session, ptype, requires_pylab):
     """Can I set a kwarg to a scalar using matpotlib"""
@@ -3140,7 +3140,7 @@ def test_plot_xxx_components_scalar_mpl(session, ptype, requires_pylab):
         assert l.get_linestyle() == "--"
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype", ["source", "model"])
 def test_plot_xxx_components_scalar_bokeh(session, ptype):
     """Can I set a kwarg to a scalar using bokeh"""
@@ -3173,7 +3173,7 @@ def test_plot_xxx_components_scalar_bokeh(session, ptype):
     # For now there is no check the kwargs were used
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype", ["source", "model"])
 def test_plot_xxx_components_kwargs_mpl(session, ptype, requires_pylab):
     """Can we have per-plot kwargs? matplotlib"""
@@ -3208,7 +3208,7 @@ def test_plot_xxx_components_kwargs_mpl(session, ptype, requires_pylab):
     assert axes.lines[1].get_linestyle() == ":"
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype", ["source", "model"])
 def test_plot_xxx_components_kwargs_bokeh(session, ptype):
     """Can we have per-plot kwargs? bokeh"""
@@ -3237,7 +3237,7 @@ def test_plot_xxx_components_kwargs_bokeh(session, ptype):
     # For now there is no check the kwargs were used
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("ptype", ["source", "model"])
 @pytest.mark.parametrize("kwargs,badarg",
                          [({"color": ["orange", "black", "green"]}, "color"),
@@ -3269,7 +3269,7 @@ def test_plot_xxx_components_kwargs_mismatch(kwargs, badarg, session, ptype, plo
         pfunc(**kwargs)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("name,val",
                          [("rows", 0), ("cols", 0),
                           ("rows", 1.4), ("cols", 1.9)])
@@ -3286,7 +3286,7 @@ def test_plot_invalid_size(session, name, val):
         s.plot("data", "data", **kwargs)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("nplots", [1, 2, 3, 4, 5])
 def test_plot_overplot_too_many_plots(session, nplots):
     """Check we error out."""
@@ -3304,7 +3304,7 @@ def test_plot_overplot_too_many_plots(session, nplots):
         s.plot(*args2, overplot=True)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("nrows,ncols,nplots",
                          [(1, 1, 1),
                           (2, 1, 2),
@@ -3341,7 +3341,7 @@ def test_plot_check_default_size_pylab(session, nrows, ncols, nplots, requires_p
     plt.close()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("nrows,ncols,kwargs",
                          [(2, 3, {}),  # this is the default setting
                           (2, 3, {"rows": 1, "cols": 3}),  # also when requested nplots is too small
@@ -3385,7 +3385,7 @@ def test_plot_check_size_nrows_ncols_pylab(session, nrows, ncols, kwargs, requir
     plt.close()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 @pytest.mark.parametrize("rows,cols", [(None, 2), (1, 2),
                                        (2, None), (2, 1),
                                        (2, 2)])
@@ -3411,7 +3411,7 @@ def test_plot_singleton_ignores_sizes(session, rows, cols, requires_pylab):
     plt.close()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_uses_split_plot_prefs(session, requires_pylab):
     """Check we can use get_split_plot to change the size."""
 
@@ -3435,7 +3435,7 @@ def test_plot_uses_split_plot_prefs(session, requires_pylab):
     plt.close()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_overplot(session, requires_pylab):
     """What happens when overplot is set. See issue #2128.
 
@@ -3502,7 +3502,7 @@ def test_plot_overplot(session, requires_pylab):
     plt.close()
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session", [pytest.param(BaseSession, marks=pytest.mark.session), AstroSession])
 def test_plot_overplot_smaller(session, requires_pylab):
     """Check we can overplot less plots than the original.
 


### PR DESCRIPTION
# Summary

Mark more tests that check the Session class as being optional (run with --runsession) as in most cases there is no need to test both the sherpa.ui and sherpa.astro.ui cases. There are no functional changes in this request.

# Details

In #2271 I added the `--runsession` flag for tests to mark tests that are good to run occasionally but do not need to be run on every PR. This is used for tests which test both the sherpa.ui and sherpa.astro.ui `Session` classes.

There are a number of places where it can be added, which can reduce the runtime of the tests slightly. So this PR attempts to identify those places where requiring `--runsession` would be useful. There are some places where we either know there's potentially different paths being run on the two cases, or that the code is fast enough it isn't really worth opting out.

I want to check the codecov report just to check this doesn't reduce our test coverage significantly. **EDITED TO ADD** there are two lines that may have lost coverage, but they are not of a huge concern (since they are part of a common idiom in the UI layer and are only for sherpa.ui not sherpa.astro.ui so I think it's an okay change).
