### PR TITLE
ui: explicit imports - no functional change

### DIFF
--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -35,17 +35,35 @@ from typing import Any, Literal, TypeVar, overload
 import numpy as np
 
 from sherpa import get_config
+
+# This provides warning messages to the user when optional parts of
+# the system are not available, such as plotting and I/O backends. The
+# required modules are "re-loaded" below.
+#
 import sherpa.all
+
+import sherpa.data
 from sherpa.data import Data, DataSimulFit
+import sherpa.estmethods
 from sherpa.estmethods import EstMethod
 from sherpa.fit import Fit, FitResults
+import sherpa.instrument
+import sherpa.io
+import sherpa.image
+import sherpa.models
 from sherpa.models.basic import TableModel
+import sherpa.models.model
 from sherpa.models.model import Model, SimulFitModel
 from sherpa.models.template import add_interpolator, create_template_model, \
     reset_interpolators
+import sherpa.optmethods
 from sherpa.optmethods import OptMethod
+import sherpa.plot
 from sherpa.plot import Plot, MultiPlot, set_backend, get_per_plot_kwargs
+import sherpa.sim
+import sherpa.stats
 from sherpa.stats import Stat, UserStat
+import sherpa.utils
 from sherpa.utils import NoNewAttributesAfterInit, is_subclass, \
     export_method, send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \


### PR DESCRIPTION
The use of sherpa.all has, over the years, annoyed me, as it makes it hard to track down what is being used, and linting tools do not seem to like it. So, move to explicitly import the modules rather than rely on sherpa.all, which is somewhat un-pythonic.

However, we do not remove sherpa.all since it does provide the user with information about what optional parts of the system - such as the plotting backend - are available. There may be a "better" approach, but it does not seem worth changing it here.