### PR TITLE
TESTS: add a test used by the Chandra Source Catalog

### DIFF
--- a/sherpa/sim/tests/test_sim.py
+++ b/sherpa/sim/tests/test_sim.py
@@ -36,7 +36,7 @@ from sherpa.estmethods import Covariance
 from sherpa import sim
 from sherpa.utils.err import EstErr
 from sherpa.utils.logging import SherpaVerbosity
-from sherpa.utils.parallel import _multi, _ncpus
+from sherpa.utils.parallel import multi, ncpus
 
 
 _max = np.finfo(np.float32).max
@@ -432,7 +432,7 @@ def test_lrt_multicore(setup):
     # the _ncpus setting (although it appears that we still need to
     # check whether multi-processing is enabled or not).
     #
-    if _multi and _ncpus > 1:
+    if multi and ncpus > 1:
         expected = RATIOS_TWO
     else:
         expected = RATIOS_ONE


### PR DESCRIPTION
# Summary

Add a test from the CSC code to exercise #2201. There are no functional changes.

# Details

It is not-at-all clear what this test is exercising, but it appears to be involved with making sure that the minimum value for one of the parameters is never negative, but why this is and what it is for is not explained.

This test was taken from #2186 and has seen minimal changes

- rework to use "modern" Python code (e.g. we can use @ to do the matrix multiplication)
- rework to take advantage of changes made to Sherpa (explicit passing around of the random state)
- export symbols from the module that actually defines them rather than from a module that re-exports the symbol (this is purely a style change)
- avoid importing "private" variables from a module when there's a "global" variable (this is not related to this test, just something I noted when looking at the test code)

If I revert #2201 then the test fails, so this suggests it is a test of that change.