### PR TITLE
Allow Sherpa to be built with lib64 or free-threading

### DIFF
--- a/helpers/sherpa_config.py
+++ b/helpers/sherpa_config.py
@@ -79,7 +79,6 @@ class sherpa_config(Command):
     def finalize_options(self):
         incdir = os.path.join(self.install_dir, 'include')
         libdir = os.path.join(self.install_dir, 'lib')
-        pydir = os.path.join(libdir, f'python{version}', 'site-packages')
 
         if self.fftw_include_dirs is None:
             self.fftw_include_dirs = incdir
@@ -104,6 +103,12 @@ class sherpa_config(Command):
 
         if self.wcs_lib_dirs is None:
             self.wcs_lib_dirs = libdir
+
+        # Note that the directory is not assumed to be called
+        # "lib", unlike libdir above.
+        #
+        pydir = os.path.join(self.install_dir, sys.platlibdir,
+                             f'python{version}', 'site-packages')
 
         if self.group_location is None:
             self.group_location = os.path.join(pydir, 'group.so')

--- a/helpers/sherpa_config.py
+++ b/helpers/sherpa_config.py
@@ -22,6 +22,7 @@
 from setuptools import Command
 import os
 import sys
+from sysconfig import get_config_var
 
 from .extensions import build_ext
 from .deps import build_deps
@@ -104,11 +105,14 @@ class sherpa_config(Command):
         if self.wcs_lib_dirs is None:
             self.wcs_lib_dirs = libdir
 
-        # Note that the directory is not assumed to be called
-        # "lib", unlike libdir above.
+        # Is there documentation to explain how this path is
+        # created (to make sure this is correct)?
         #
+        abi_thread = 't' if get_config_var("Py_GIL_DISABLED") else ''
+        pyname = f'python{version}{abi_thread}'
+
         pydir = os.path.join(self.install_dir, sys.platlibdir,
-                             f'python{version}', 'site-packages')
+                             pyname, 'site-packages')
 
         if self.group_location is None:
             self.group_location = os.path.join(pydir, 'group.so')


### PR DESCRIPTION
# Summary

Allow Sherpa to be built with the free-threading build or on a platform that uses the lib64 rather than lib as a directory name (e.g. Fedora 42). There is no promise at this time that the resulting code is correct.

# Details

These were found when trying to build Sherpa with Fedora 42 and with the python 3.13 free-threading conda-forge version. Ideally we could just ask sys/sysconfig/somewhere for the correct name to use, but it's not clear from the documentation what that would be, and I still aim for all this code to be swept away with the meson broom in the future, but this at least allows the build to complete.

This does not guarantee that the build works correctly (I would hope it does on Fedora 42 but there has been no attempt yet to support the free-threaded build, as this requires a lot of work; e.g.

- #2062 
- #2291 
)