### PR TITLE
Start free threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/sherpa/badge/)](https://sherpa.readthedocs.io/)
 [![DOI](https://zenodo.org/badge/683/sherpa/sherpa.svg)](https://zenodo.org/badge/latestdoi/683/sherpa/sherpa)
 [![GPLv3+ License](https://img.shields.io/badge/license-GPLv3+-blue.svg)](https://www.gnu.org/copyleft/gpl.html)
-![Python version](https://img.shields.io/badge/Python-3.10,3.11,3.12,3.13-green.svg?style=flat)
+![Python version](https://img.shields.io/badge/Python-3.10,3.11,3.12,3.13,3.14-green.svg?style=flat)
 
 <!-- TOC *generated with [DocToc](https://github.com/thlorenz/doctoc)* -->
 **Table of Contents**
@@ -86,7 +86,7 @@ documentation, and should be read if the following is not sufficient.
 It is strongly recommended that some form of *virtual environment* is
 used with Sherpa.
 
-Sherpa is tested against Python versions 3.10, 3.11, 3.12, and with experimental support for Python 3.13.
+Sherpa is tested against Python versions 3.10, 3.11, 3.12, 3.13, and 3.14.
 
 The last version of Sherpa which supported Python 2.7 is
 [Sherpa 4.11.1](https://doi.org/10.5281/zenodo.3358134).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ range of statistics and robust optimisers.
 Sherpa is released under the
 `GNU General Public License v3.0
 <https://github.com/sherpa/sherpa/blob/master/LICENSE>`_,
-and is compatible with Python versions 3.10 to 3.13.
+and is compatible with Python versions 3.10 to 3.14.
 Information on recent releases and citation information for
 Sherpa is available using the Digital Object Identifier (DOI)
 `10.5281/zenodo.593753 <https://doi.org/10.5281/zenodo.593753>`_.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,7 +33,7 @@ Requirements
 
 Sherpa has the following requirements:
 
-* Python 3.10 to 3.13 (there is no support for free-threaded Python)
+* Python 3.10 to 3.14 (there is no support for free-threaded Python)
 * NumPy
 * Linux or OS-X (patches to add Windows support are welcome)
 
@@ -143,7 +143,7 @@ Prerequisites
 
 The prerequisites for building from source are:
 
-* Python versions: 3.9 to 3.12
+* Python versions: 3.9 to 3.14
 * Python packages: ``setuptools``, ``numpy`` (these should be
   automatically installed by ``pip``)
 * System: ``gcc`` and ``g++`` or ``clang`` and ``clang++``, ``make``, ``flex``,

--- a/extern/stklib-4.18/src/pystk.c
+++ b/extern/stklib-4.18/src/pystk.c
@@ -26,33 +26,6 @@
 #include <unistd.h>
 #include <stdio.h>
 
-/** 
- * For supporting both python 2 and 3, we include macros that abstract out
- * differences in module initialization and other issues described in:
- * 
- * http://python3porting.com/cextensions.html
- */
-#if PY_MAJOR_VERSION >= 3
-#define MOD_ERROR_VAL NULL
-#define MOD_SUCCESS_VAL(val) val
-#define MOD_INIT(name) PyMODINIT_FUNC PyInit_##name(void)
-#define MOD_DEF(ob, name, doc, methods) \
-        static struct PyModuleDef moduledef = { \
-          PyModuleDef_HEAD_INIT, name, doc, -1, methods, NULL, NULL, NULL, NULL }; \
-        ob = PyModule_Create(&moduledef);
-#define MOD_NEWOBJ(newval, val) newval = PyCapsule_New((void *)val, NULL, NULL);
-#define PyString_FromString PyUnicode_FromString
-#else
-#define MOD_ERROR_VAL
-#define MOD_SUCCESS_VAL(val)
-#define MOD_INIT(name) PyMODINIT_FUNC init##name(void)
-#define MOD_DEF(ob, name, doc, methods) \
-        ob = Py_InitModule3(name, methods, doc);
-#define MOD_NEWOBJ(newval, val) newval = PyCObject_FromVoidPtr((void*)val, NULL);
-#endif
-
-MOD_INIT(stk);
-
 static PyMethodDef stkMethods[] =
 {
   /* Each entry in the groupMethods array is a PyMethodDef structure containing
@@ -61,7 +34,7 @@ static PyMethodDef stkMethods[] =
    * 3) flags indicating whether or not keywords are accepted for this function,
    * and 4) The docstring for the function.
    */
-  { "build", (PyCFunction)_stk_build, METH_VARARGS, 
+  { "build", (PyCFunction)_stk_build, METH_VARARGS,
     "Example: \n"
     ">>> foo = build(\"a,b,c,d\")\n"
     ">>> foo\n"
@@ -73,16 +46,29 @@ static PyMethodDef stkMethods[] =
 /*
  * Initialize the module
  * */
-MOD_INIT(stk)
+#if PY_MAJOR_VERSION >= 3
+#define MOD_DEF(ob, name, doc, methods) \
+        static struct PyModuleDef moduledef = { \
+          PyModuleDef_HEAD_INIT, name, doc, -1, methods }; \
+        ob = PyModule_Create(&moduledef);
+#endif
+
+PyMODINIT_FUNC PyInit_stk(void)
 {
-  PyObject *mod = NULL;
-  
-  MOD_DEF(mod, "stk", "stk", stkMethods)
+
+  static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT, "stk", "stk", -1, stkMethods };
+
+  PyObject *mod = PyModule_Create(&moduledef);
   if (mod == NULL) {
-    return MOD_ERROR_VAL;
+    return NULL;
   }
-  
-  return MOD_SUCCESS_VAL(mod);
+
+#ifdef Py_GIL_DISABLED
+  PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+#endif
+
+  return mod;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * *
@@ -95,12 +81,12 @@ MOD_INIT(stk)
  *   Uses stk library to open and process the provided stack list
  *   generating a List of the stack contents.
  *
- * Returns 
+ * Returns
  *   Python List containing all stack entries.
  */
 static PyObject* _stk_build(PyObject *self, PyObject *args)
 {
-  char *buff; 
+  char *buff;
   int  status = 0;
   (void)self; /* avoid compiler warning */
 
@@ -118,7 +104,7 @@ static PyObject* _stk_build(PyObject *self, PyObject *args)
       PyErr_Restore(type, value, traceback);
       status = 1;
     }
-  } 
+  }
 #else
   if (!PyArg_ParseTuple(args, "s", &buff))
     status = 1;
@@ -131,14 +117,14 @@ static PyObject* _stk_build(PyObject *self, PyObject *args)
     return NULL;
   }
 
-  if ( ( NULL == buff ) || ( 0 == strlen( buff ) ) ) 
+  if ( ( NULL == buff ) || ( 0 == strlen( buff ) ) )
   {
     PyErr_SetString(PyExc_Exception, "Empty stack string.");
     return NULL;
   }
 
   Stack *stk;
-  
+
   /* We trash stk_lib's stdout/stderr and issue our own exception */
 
   int pipe_fild[2];
@@ -146,10 +132,10 @@ static PyObject* _stk_build(PyObject *self, PyObject *args)
   int orig_err = dup( fileno(stderr ));
   fflush(stderr);
   dup2( pipe_fild[1], fileno(stderr));
-  
+
   /* Open the stack */
   stk = stk_build( buff );
-  
+
   /* Return stderr */
   fflush(stderr);
   dup2( orig_err, fileno(stderr));
@@ -158,7 +144,7 @@ static PyObject* _stk_build(PyObject *self, PyObject *args)
   close(orig_err);
 
   /* Check stack opened OK */
-  if ( NULL == stk ) 
+  if ( NULL == stk )
   {
     long maxl = strlen( buff ) + 100;
     char *ibuff = ( char*) calloc( maxl, sizeof(char));
@@ -175,8 +161,8 @@ static PyObject* _stk_build(PyObject *self, PyObject *args)
     PyErr_SetString(PyExc_ValueError, "Stack has 0 elements");
     return NULL;
   }
-  
-  if ( (1 == num_elem ) && (0 == strlen( stk_read_num( stk, 1 )) )) 
+
+  if ( (1 == num_elem ) && (0 == strlen( stk_read_num( stk, 1 )) ))
   {
     PyErr_SetString(PyExc_ValueError, "Stack has only 1 element and it is blank");
     return NULL;
@@ -184,7 +170,7 @@ static PyObject* _stk_build(PyObject *self, PyObject *args)
 
   /* Create output List */
   PyObject *pylist;
-  if ( NULL == (pylist = PyList_New(  (Py_ssize_t) 0 ))) 
+  if ( NULL == (pylist = PyList_New(  (Py_ssize_t) 0 )))
   {
     PyErr_SetString(PyExc_Exception, "Failed to create new list");
     return NULL;
@@ -192,19 +178,19 @@ static PyObject* _stk_build(PyObject *self, PyObject *args)
 
   /* Transfer Stack content to List */
   int ii;
-  for ( ii = 1; ii <= num_elem; ii++ ) 
+  for ( ii = 1; ii <= num_elem; ii++ )
   {
     /* get stack record */
     char *ibuff = stk_read_num( stk, ii );
-    if ( NULL == ibuff ) 
-    {	
+    if ( NULL == ibuff )
+    {
       PyErr_SetString(PyExc_IndexError, "Invalid stack_read_num");
       return NULL;
     }
-    
+
     /* Convert to python string object */
-    PyObject *pstr = PyString_FromString( ibuff );
-    if ( NULL == pstr ) 
+    PyObject *pstr = PyUnicode_FromString( ibuff );
+    if ( NULL == pstr )
     {
       PyErr_SetString(PyExc_ValueError, "Cannot convert to python string");
       return NULL;
@@ -216,12 +202,12 @@ static PyObject* _stk_build(PyObject *self, PyObject *args)
       PyErr_SetString( PyExc_Exception, "Failed to append string to list");
       return NULL;
     }
-    
+
     stk_read_free( ibuff );
 
   } /* End for ii */
 
   stk_close( stk );
-  
+
   return( pylist );
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Free Threading :: 1 - Unstable",
   "Topic :: Scientific/Engineering :: Astronomy",
   "Topic :: Scientific/Engineering :: Physics"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Scientific/Engineering :: Astronomy",
   "Topic :: Scientific/Engineering :: Physics"

--- a/sherpa/include/sherpa/extension.hh
+++ b/sherpa/include/sherpa/extension.hh
@@ -46,6 +46,31 @@ typedef int (*converter)( PyObject*, void* );
 // The SHERPAMOD and SHERPAMODDOC defines are expected to be used
 // rather than this one.
 //
+// fctlist should be an array of PyMethodDef elements, which can
+// be constructed with FCTSPEC, FCTSPECDOC, and KWSPEC, or
+// created directly.
+//
+#ifdef Py_GIL_DISABLED
+
+#define _SHERPAMOD(name, fctlist, doc)	   \
+static struct PyModuleDef module##name = { \
+PyModuleDef_HEAD_INIT, \
+#name, \
+doc, \
+-1, \
+fctlist \
+}; \
+\
+PyMODINIT_FUNC PyInit_##name(void) { \
+  import_array(); \
+  PyObject *m = PyModule_Create(&module##name); \
+  if (m == NULL) return NULL; \
+  PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED); \
+  return m; \
+}
+
+#else
+
 #define _SHERPAMOD(name, fctlist, doc)	   \
 static struct PyModuleDef module##name = { \
 PyModuleDef_HEAD_INIT, \
@@ -60,13 +85,8 @@ PyMODINIT_FUNC PyInit_##name(void) { \
   return PyModule_Create(&module##name); \
 }
 
-// Create the initialization for the module called name, with the
-// list of functions in fctlist, and no module documentation.
-//
-// fctlist should be an array of PyMethodDef elements, which can
-// be constructed with FCTSPEC, FCTSPECDOC, and KWSPEC, or
-// created directly.
-//
+#endif
+
 #define SHERPAMOD(name, fctlist) _SHERPAMOD(name, fctlist, NULL)
 
 // Similar to SHERMAMOD, but adds the ability to set the module

--- a/sherpa/include/sherpa/model_extension.hh
+++ b/sherpa/include/sherpa/model_extension.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007, 2016, 2019, 2020, 2023
+//  Copyright (C) 2007, 2016, 2019-2020, 2023, 2025
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -430,6 +430,29 @@ namespace sherpa { namespace models {
 
 }  }  /* namespace models, namespace sherpa */
 
+#ifdef Py_GIL_DISABLED
+
+#define SHERPAMODELMOD(name, fctlist) \
+static struct PyModuleDef module##name = {\
+PyModuleDef_HEAD_INIT, \
+#name, \
+NULL, \
+-1, \
+fctlist \
+}; \
+\
+PyMODINIT_FUNC PyInit_##name(void) { \
+  import_array(); \
+  if ( -1 == import_integration() ) \
+    return NULL; \
+  PyObject *m = PyModule_Create(&module##name); \
+  if (m == NULL) return NULL; \
+  PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED); \
+  return m; \
+}
+
+#else
+
 #define SHERPAMODELMOD(name, fctlist) \
 static struct PyModuleDef module##name = {\
 PyModuleDef_HEAD_INIT, \
@@ -445,6 +468,8 @@ PyMODINIT_FUNC PyInit_##name(void) { \
     return NULL; \
   return PyModule_Create(&module##name); \
 }
+
+#endif
 
 // Allow this to be customized on a per-file basis
 

--- a/sherpa/utils/src/_psf.cc
+++ b/sherpa/utils/src/_psf.cc
@@ -1000,20 +1000,22 @@ static struct PyModuleDef psf = {
 };
 
 PyMODINIT_FUNC PyInit__psf(void) {
-  if( PyType_Ready(&tcdPyData_Type) < 0 )
+  if( PyType_Ready(&tcdPyData_Type) < 0 ) {
     return NULL;
+  }
 
-   import_array();
+  import_array();
 
-   PyObject* m;
-   m = PyModule_Create(&psf);
-
-  if( m == NULL )
-    return NULL;
+  PyObject* m = PyModule_Create(&psf);
+  if( m == NULL ) { return NULL; }
 
   Py_INCREF(&tcdPyData_Type);
 
   PyModule_AddObject(m, (char*)"tcdData", (PyObject*)&tcdPyData_Type);
+
+#ifdef Py_GIL_DISABLED
+  PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
 
   return m;
 }

--- a/sherpa/utils/src/integration.cc
+++ b/sherpa/utils/src/integration.cc
@@ -191,5 +191,9 @@ PyMODINIT_FUNC PyInit_integration(void) {
   // steal the reference
   PyModule_AddObject( m, (char*)"_C_API", api_cobject );
 
+#ifdef Py_GIL_DISABLED
+  PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
   return m;
 }


### PR DESCRIPTION
This is **very** early days.

Uses

- #2319 
- #2321 

Note that Sherpa is designed to be very thread-unfriendly, so it's not clear how useful the free-threaded build will be. For instance, something like

```python
data = Data1D('x', x, y)
model = Polynom1D('mdl')
model.c1.thaw()
f = Fit(data, model)
```

is tricky to use in a free-threaded world because `data` and `model` are mutable and so changing them can change the result of `f.fit()` - and vice-versa.