### PR TITLE
Minor simplification of the extension code

### DIFF
--- a/sherpa/astro/models/src/_modelfcts.cc
+++ b/sherpa/astro/models/src/_modelfcts.cc
@@ -1,5 +1,6 @@
 //
-//  Copyright (C) 2007, 2020  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2020, 2025
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -17,17 +18,12 @@
 //  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 //
 
-// QUESTIONL is this used anywhere?
+// Override the default setting
 #define _MODELFCTPTR(name) \
   sherpa::astro::models::name< SherpaFloat, SherpaFloatArray >
 
 #include "sherpa/model_extension.hh"
 #include "sherpa/astro/models.hh"
-
-extern "C" {
-  void init_modelfcts();
-}
-
 
 static PyMethodDef ModelFcts[] = {
 

--- a/sherpa/astro/utils/src/_pileup.cc
+++ b/sherpa/astro/utils/src/_pileup.cc
@@ -1,5 +1,6 @@
-// 
-//  Copyright (C) 2009, 2021  Smithsonian Astrophysical Observatory
+//
+//  Copyright (C) 2009, 2021, 2025
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -21,12 +22,8 @@
 #include <sherpa/extension.hh>
 #include <memory>
 #include <iostream>
-#include "pileup.hh"	     
+#include "pileup.hh"
 #include "PyWrapper.hh"
-
-extern "C" {
-  void init_pileup();
-}
 
 static int pileup_model_func( double* x0, double* x1, double* res, int len,
 			      sherpa::PyWrapper* wrapper ) {
@@ -49,9 +46,9 @@ static int pileup_model_func( double* x0, double* x1, double* res, int len,
   dims[0] = npy_intp( len );
 
   DoubleArray n_x0, n_x1, n_res;
-  if ( EXIT_SUCCESS != n_x0.create( 1, dims, x0 ) )    
+  if ( EXIT_SUCCESS != n_x0.create( 1, dims, x0 ) )
     return EXIT_FAILURE;
-  
+
   if ( EXIT_SUCCESS != n_x1.create( 1, dims, x1 ) )
     return EXIT_FAILURE;
 
@@ -65,16 +62,16 @@ static int pileup_model_func( double* x0, double* x1, double* res, int len,
 		     (char*)"model evaluation failed\n");
     return EXIT_FAILURE;
   }
-  
+
   // convert pyobject into double array obj
   CONVERTME(DoubleArray)(rv_obj, &n_res);
 
   // fill res pointer
   for( int ii = 0; ii < len; ii++ )
     res[ii] = n_res[ii];
-  
+
   Py_DECREF( rv_obj );
-  
+
   return EXIT_SUCCESS;
 }
 
@@ -173,7 +170,7 @@ static PyObject* _apply_pileup( PyObject* self, PyObject* args )
 static PyMethodDef PileupFcts[] = {
 
   FCTSPEC( apply_pileup, _apply_pileup ),
-  
+
   { NULL, NULL, 0, NULL }
 
 };

--- a/sherpa/astro/utils/src/_utils.cc
+++ b/sherpa/astro/utils/src/_utils.cc
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2009, 2017, 2021, 2022, 2024
+//  Copyright (C) 2009, 2017, 2021-2022, 2024-2025
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -23,10 +23,6 @@
 #include <sstream>
 #include <iostream>
 #include <stdexcept>
-
-extern "C" {
-  void init_utils();
-}
 
 typedef sherpa::Array< npy_bool, NPY_BOOL > BoolArray;
 

--- a/sherpa/astro/utils/src/_wcs.cc
+++ b/sherpa/astro/utils/src/_wcs.cc
@@ -1,5 +1,6 @@
-// 
-//  Copyright (C) 2009  Smithsonian Astrophysical Observatory
+//
+//  Copyright (C) 2009, 2025
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -24,8 +25,6 @@
 
 extern "C" {
 #include "wcs.h"
-
-  void init_wcs();
 }
 
 static PyObject* pix2world( PyObject* self, PyObject* args )
@@ -37,7 +36,7 @@ static PyObject* pix2world( PyObject* self, PyObject* args )
   DoubleArray cdelt;
   double crota = 0.0, epoch = 0.0, equinox = 0.0;
   const char *ctype = NULL;
-  
+
   if ( !PyArg_ParseTuple( args, (char*)"sO&O&O&O&O&ddd",
 			  &ctype,
 			  CONVERTME(DoubleArray), &x0,
@@ -49,7 +48,7 @@ static PyObject* pix2world( PyObject* self, PyObject* args )
 			  &equinox,
 			  &epoch ) )
     return NULL;
-  
+
   if ( ( cdelt.get_size() != crpix.get_size() ) ||
        ( crpix.get_size() != crval.get_size() ) ) {
     std::ostringstream err;
@@ -66,7 +65,7 @@ static PyObject* pix2world( PyObject* self, PyObject* args )
 		     (char*)"input pixel arrays x0,x1 not of equal length" );
     return NULL;
   }
-  
+
   long nsets = long(x0.get_size());
 
   char    ct1[80] = "";
@@ -77,7 +76,7 @@ static PyObject* pix2world( PyObject* self, PyObject* args )
 		     (char*)"WCS params failed" );
     return NULL;
   }
-  
+
   if ( strcmp(ctype,"LINEAR") == 0 )
   {
     strcpy(ct1, "LINEAR");
@@ -133,16 +132,16 @@ static PyObject* pix2world( PyObject* self, PyObject* args )
       wcs->cel.ref[2] = wcs->longpole;
     if ( wcs->latpole != 0.0 )
       wcs->cel.ref[3] = wcs->latpole;
-  }  
+  }
 
   for (int ii = 0; ii < nsets; ii++)
   {
-    // Convert to world coords 
+    // Convert to world coords
     pix2wcs(wcs, x0[ii], x1[ii], &x0[ii], &x1[ii]);
-  }    
+  }
 
   wcsfree(wcs);
-  
+
   return Py_BuildValue( (char*)"(NN)",
 			x0.return_new_ref(),
 			x1.return_new_ref() );
@@ -158,7 +157,7 @@ static PyObject* world2pix( PyObject* self, PyObject* args )
   DoubleArray cdelt;
   double crota = 0.0, epoch = 0.0, equinox = 0.0;
   const char *ctype = NULL;
-  
+
   if ( !PyArg_ParseTuple( args, (char*)"sO&O&O&O&O&ddd",
 			  &ctype,
 			  CONVERTME(DoubleArray), &x0,
@@ -170,7 +169,7 @@ static PyObject* world2pix( PyObject* self, PyObject* args )
 			  &equinox,
 			  &epoch ) )
     return NULL;
-  
+
   if ( ( cdelt.get_size() != crpix.get_size() ) ||
        ( crpix.get_size() != crval.get_size() ) ) {
     std::ostringstream err;
@@ -187,7 +186,7 @@ static PyObject* world2pix( PyObject* self, PyObject* args )
 		     (char*)"input pixel arrays x0,x1 not of equal length" );
     return NULL;
   }
-  
+
   long nsets = long(x0.get_size());
 
   char    ct1[80] = "";
@@ -227,16 +226,16 @@ static PyObject* world2pix( PyObject* self, PyObject* args )
 			     int(equinox),
 			     epoch
 			     );
-  
+
   int scale;
   for (int ii = 0; ii < nsets; ii++)
   {
-    // Convert to world coords 
+    // Convert to world coords
     wcs2pix(wcs, x0[ii], x1[ii], &x0[ii], &x1[ii], &scale);
-  }    
+  }
 
   wcsfree(wcs);
-  
+
   return Py_BuildValue( (char*)"(NN)",
 			x0.return_new_ref(),
 			x1.return_new_ref() );
@@ -248,7 +247,7 @@ static PyMethodDef WcsFcts[] = {
     METH_VARARGS, (char*)"Pixel to World Coordinates" },
   { (char*)"world2pix", (PyCFunction)world2pix,
     METH_VARARGS, (char*)"World to Pixel Coordinates" },
-  
+
   { NULL, NULL, 0, NULL }
 
 };

--- a/sherpa/include/sherpa/extension.hh
+++ b/sherpa/include/sherpa/extension.hh
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2007, 2016, 2017, 2020, 2022, 2023
+//  Copyright (C) 2007, 2016-2017, 2020, 2022-2023, 2025
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -39,11 +39,11 @@ typedef int (*converter)( PyObject*, void* );
 
 #define CONVERTME(arg) ((converter) sherpa::convert_to_contig_array<arg>)
 
-#define SHERPAMOD(name, fctlist) \
+#define _SHERPAMOD(name, fctlist, doc)	   \
 static struct PyModuleDef module##name = { \
 PyModuleDef_HEAD_INIT, \
 #name, \
-NULL, \
+doc, \
 -1, \
 fctlist \
 }; \
@@ -53,19 +53,9 @@ PyMODINIT_FUNC PyInit_##name(void) { \
   return PyModule_Create(&module##name); \
 }
 
+#define SHERPAMOD(name, fctlist) _SHERPAMOD(name, fctlist, NULL)
 #define SHERPAMODDOC(name, fctlist, doc) \
-static struct PyModuleDef module##name = { \
-PyModuleDef_HEAD_INIT, \
-#name, \
-PyDoc_STR(doc), \
--1, \
-fctlist \
-}; \
-\
-PyMODINIT_FUNC PyInit_##name(void) { \
-  import_array(); \
-  return PyModule_Create(&module##name); \
-}
+  _SHERPAMOD(name, fctlist, PyDoc_STR(doc))
 
 #define FCTSPEC(name, func) \
  { (char*)#name, (PyCFunction)func, METH_VARARGS, NULL }

--- a/sherpa/include/sherpa/extension.hh
+++ b/sherpa/include/sherpa/extension.hh
@@ -39,6 +39,13 @@ typedef int (*converter)( PyObject*, void* );
 
 #define CONVERTME(arg) ((converter) sherpa::convert_to_contig_array<arg>)
 
+// Create the initialization for the module called name, with the
+// list of functions in fctlist, and the module documentation set
+// to doc (which can be NULL).
+//
+// The SHERPAMOD and SHERPAMODDOC defines are expected to be used
+// rather than this one.
+//
 #define _SHERPAMOD(name, fctlist, doc)	   \
 static struct PyModuleDef module##name = { \
 PyModuleDef_HEAD_INIT, \
@@ -53,16 +60,35 @@ PyMODINIT_FUNC PyInit_##name(void) { \
   return PyModule_Create(&module##name); \
 }
 
+// Create the initialization for the module called name, with the
+// list of functions in fctlist, and no module documentation.
+//
+// fctlist should be an array of PyMethodDef elements, which can
+// be constructed with FCTSPEC, FCTSPECDOC, and KWSPEC, or
+// created directly.
+//
 #define SHERPAMOD(name, fctlist) _SHERPAMOD(name, fctlist, NULL)
-#define SHERPAMODDOC(name, fctlist, doc) \
+
+// Similar to SHERMAMOD, but adds the ability to set the module
+// documentation (as a string).
+//
+#define SHERPAMODDOC(name, fctlist, doc)	\
   _SHERPAMOD(name, fctlist, PyDoc_STR(doc))
 
+// Create a function specification: name is the name for the
+// function (accessible from Python) and func is the function
+// to be called. The function will have no documentation.
+//
 #define FCTSPEC(name, func) \
  { (char*)#name, (PyCFunction)func, METH_VARARGS, NULL }
 
+// Add a docstring to FCTSPEC.
+//
 #define FCTSPECDOC(name, func, doc) \
   { (char*)#name, (PyCFunction)func, METH_VARARGS, PyDoc_STR(doc) }
 
+// Similar to FCTSPEC but allows the function to have keywords.
+//
 #define KWSPEC(name, func) \
   { (char*)#name, (PyCFunction)((PyCFunctionWithKeywords)func), \
       METH_VARARGS|METH_KEYWORDS, NULL }

--- a/sherpa/models/src/_modelfcts.cc
+++ b/sherpa/models/src/_modelfcts.cc
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2010, 2020, 2021
+//  Copyright (C) 2010, 2020, 2021, 2025
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -20,10 +20,6 @@
 
 #include "sherpa/model_extension.hh"
 #include "sherpa/models.hh"
-
-extern "C" {
-  void init_modelfcts();
-}
 
 static PyMethodDef ModelFcts[] = {
 

--- a/sherpa/stats/src/_statfcts.cc
+++ b/sherpa/stats/src/_statfcts.cc
@@ -1,5 +1,6 @@
-// 
-//  Copyright (C) 2007, 2015, 2016  Smithsonian Astrophysical Observatory
+//
+//  Copyright (C) 2007, 2015, 2016, 2025
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -20,10 +21,6 @@
 
 #include "sherpa/stat_extension.hh"
 #include "sherpa/stats.hh"
-
-extern "C" {
-	void init_statfcts();
-}
 
 static PyMethodDef StatFcts[] = {
 

--- a/sherpa/utils/src/_psf.cc
+++ b/sherpa/utils/src/_psf.cc
@@ -1,6 +1,6 @@
-// 
-//  Copyright (C) 2007, 2016, 2018, 2020, 2021
-//       Smithsonian Astrophysical Observatory
+//
+//  Copyright (C) 2007, 2016, 2018, 2020-2021, 2025
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -30,9 +30,7 @@ extern "C" {
 
 #include "structmember.h"
 #include "tcd/tcd.h"
-  //#include "fftw3.h"
 
-  void init_psf();
 }
 
 typedef sherpa::Array< long, NPY_LONG > LongArray;
@@ -80,7 +78,7 @@ static PyObject *tcdPyData_new(PyTypeObject *type, PyObject *args,
   tcdPyData *self = NULL;
   self = (tcdPyData*)type->tp_alloc(type, 0);
   return (PyObject*)self;
-  
+
 }
 
 static int tcdPyData_init(tcdPyData *self, PyObject *args, PyObject *kwds)
@@ -111,10 +109,10 @@ static int _pad(const long length, long& factor)
   long padding[num] =
       {   2,   3,   4,   5,   6,   8,   9,  10,  12,  15,  16,  18,  20,
          24,  25,  27,  30,  32,  36,  40,  45,  48,  50,  54,  60,  64,
-         72,  75,  80,  81,  90,  96, 100, 108, 120, 125, 128, 135, 144, 
-        150, 160, 162, 180, 192, 200, 216, 225, 240, 243, 250, 256, 270, 
-        288, 300, 320, 324, 360, 375, 384, 400, 405, 432, 450, 480, 486, 
-        500, 512, 540, 576, 600, 625, 640, 648, 675, 720, 729, 750, 768, 
+         72,  75,  80,  81,  90,  96, 100, 108, 120, 125, 128, 135, 144,
+        150, 160, 162, 180, 192, 200, 216, 225, 240, 243, 250, 256, 270,
+        288, 300, 320, 324, 360, 375, 384, 400, 405, 432, 450, 480, 486,
+        500, 512, 540, 576, 600, 625, 640, 648, 675, 720, 729, 750, 768,
         800, 810, 864, 900, 960, 972,1000,1024,1080,1125,1152,1200,1215,
        1250,1280,1296,1350,1440,1458,1500,1536,1600,1620,1728,1800,1875,
        1920,1944,2000,2025,2048,2160,2187,2250,2304,2400,2430,2500,2560,
@@ -172,7 +170,7 @@ static int _pad_data(const int dim, double* res, double* src,
         }
       }
     }
-    
+
     return EXIT_SUCCESS;
   }
 
@@ -216,11 +214,11 @@ static int _convolve( tcdPyData* self, double* source, double* kernel,
 		      long* dims_src, long* dims_kern,
 		      long* dOrigin, long* kOrigin,
 		      const long nAxes, double*& output ) {
-  
+
   // TCDlib variables
   tcdDComplex *fftData = NULL, *fftKern = NULL, *ffttemp = NULL;
   long  *newAxes = NULL, *newTemp = NULL;
-  
+
   if( self ) {
     ffttemp = (tcdDComplex*) self->kernel_fft;
     if( ffttemp ) fftKern = ffttemp;
@@ -228,7 +226,7 @@ static int _convolve( tcdPyData* self, double* source, double* kernel,
     newTemp = (long*) self->newAxes;
     if( newTemp ) newAxes = newTemp;
   }
-  
+
   if( fftKern && newAxes ) {
     if( tcdSUCCESS != tcdFFTConvolveD( tcdCONVOLVE, tcdDOUBLE, source,
   				       nAxes, dims_src, dOrigin, tcdDOUBLE,
@@ -243,7 +241,7 @@ static int _convolve( tcdPyData* self, double* source, double* kernel,
 				     &newAxes, &fftData, &fftKern ) )
     return EXIT_FAILURE;
   }
-  
+
   if ( tcdSUCCESS != tcdFreeTransformD( &fftData ) )
     return EXIT_FAILURE;
 
@@ -251,11 +249,11 @@ static int _convolve( tcdPyData* self, double* source, double* kernel,
   if( self ) {
     if(!self->kernel_fft)
       self->kernel_fft = fftKern;
-    
+
     if(!self->newAxes)
       self->newAxes = newAxes;
   }
-  
+
   return EXIT_SUCCESS;
 }
 
@@ -276,13 +274,13 @@ static bool same_size_arrays( npy_intp size1, npy_intp size2,
 
 static PyObject* tcdPyData_convolve( tcdPyData* self, PyObject* args )
 {
-  
+
   DoubleArray source;
   DoubleArray kernel;
   LongArray dims_src;
   LongArray dims_kern;
   LongArray center;
-  
+
   if ( !PyArg_ParseTuple( args, (char*)"O&O&O&O&O&",
 			  CONVERTME( DoubleArray ),
 			  &source,
@@ -295,7 +293,7 @@ static PyObject* tcdPyData_convolve( tcdPyData* self, PyObject* args )
 			  CONVERTME( LongArray ),
 			  &center) )
     return NULL;
-  
+
   if( !same_size_arrays( dims_src.get_size(), dims_kern.get_size(),
                          "dims_src", "dims_kern" ) )
     return NULL;
@@ -303,7 +301,7 @@ static PyObject* tcdPyData_convolve( tcdPyData* self, PyObject* args )
   if( !same_size_arrays( dims_kern.get_size(), center.get_size(),
                          "dims_kern", "center" ) )
     return NULL;
-  
+
   // src and kernel dims should be equal length
   long num = dims_kern.get_size();
   long kern_size = std::accumulate( &dims_kern[0],
@@ -312,15 +310,15 @@ static PyObject* tcdPyData_convolve( tcdPyData* self, PyObject* args )
   long src_size =  std::accumulate( &dims_src[0],
                                     &dims_src[0] + num,
                                     1, std::multiplies<long>() );
-  
+
   if( !same_size_arrays( source.get_size(), src_size,
                          "source size", "source dim", "dimensions" ) )
     return NULL;
-  
+
   if( !same_size_arrays( kernel.get_size(), kern_size,
                          "kernel size", "kernel dim",  "dimensions" ) )
     return NULL;
-  
+
   const long nAxes = (long) dims_kern.get_size();
   double* output = NULL;
   std::vector<long> dOrigin(nAxes, 0);
@@ -338,7 +336,7 @@ static PyObject* tcdPyData_convolve( tcdPyData* self, PyObject* args )
 
       if ( EXIT_SUCCESS != _pad(padSize, padfactor ) )
 	return NULL;
-      
+
       if (padfactor != dims_pad[ii]) need_to_pad = true;
       dims_pad[ii] = padfactor;
       padsize *= dims_pad[ii];
@@ -367,10 +365,10 @@ static PyObject* tcdPyData_convolve( tcdPyData* self, PyObject* args )
 		     (char*)"tcd convolution failed" );
     if(output) free(output);
     return NULL;
-  } 
-  
+  }
+
   DoubleArray result;
-  
+
   if (need_to_pad) {
 
     if( EXIT_SUCCESS != result.create(source.get_ndim(), source.get_dims() ) ) {
@@ -384,10 +382,10 @@ static PyObject* tcdPyData_convolve( tcdPyData* self, PyObject* args )
       std::ostringstream err;
       err << "Padding dimension not supported";
       PyErr_SetString( PyExc_TypeError, err.str().c_str() );
-      
+
       if(output) free(output);
       return NULL;
-      
+
     }
   } else {
 
@@ -395,7 +393,7 @@ static PyObject* tcdPyData_convolve( tcdPyData* self, PyObject* args )
     cdims[0] = 1;
     for(int ii = 0; ii < nAxes; ii++)
       cdims[0] *= (npy_intp) self->newAxes[ii];
-    
+
     if( EXIT_SUCCESS != result.create(source.get_ndim(), cdims ) ) {
       if(output) free(output);
       return NULL;
@@ -403,9 +401,9 @@ static PyObject* tcdPyData_convolve( tcdPyData* self, PyObject* args )
 
     std::copy( output, output + cdims[0], &result[0] );
   }
-  
-  if(output) free(output);  
-  
+
+  if(output) free(output);
+
   return result.return_new_ref();
 }
 
@@ -454,16 +452,16 @@ static PyMemberDef tcdPyData_members[] = {
   //{(char*)"datatype", T_INT, offsetof(tcdPyData, datatype), 0,
   // (char*)""},
 
-  {NULL}  // Sentinel 
+  {NULL}  // Sentinel
 };
 
 static PyMethodDef tcdPyData_methods[] = {
 
   { (char*) "clear_kernel_fft",(PyCFunction)tcdPyData_clear, METH_NOARGS, (char*) "clear cache"},
-  
+
   { (char*) "convolve",(PyCFunction)tcdPyData_convolve, METH_VARARGS, (char*) "convolve PSF"},
-  
-  {NULL, NULL, 0, NULL}  // Sentinel 
+
+  {NULL, NULL, 0, NULL}  // Sentinel
 };
 
 
@@ -491,23 +489,23 @@ static PyTypeObject tcdPyData_Type = {
   0,                                // tp_as_buffer
   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, //tp_flags
   (char*)"tcdPyData object",        // tp_doc, __doc__
-  0,		                    // tp_traverse 
-  0,		                    // tp_clear 
-  0,		                    // tp_richcompare 
-  0,		                    // tp_weaklistoffset 
+  0,		                    // tp_traverse
+  0,		                    // tp_clear
+  0,		                    // tp_richcompare
+  0,		                    // tp_weaklistoffset
   0,		                    // tp_iter, __iter__
-  0,		                    // tp_iternext 
-  tcdPyData_methods,              // tp_methods 
-  tcdPyData_members,              // tp_members 
-  0,                                // tp_getset 
-  0,                                // tp_base 
+  0,		                    // tp_iternext
+  tcdPyData_methods,              // tp_methods
+  tcdPyData_members,              // tp_members
+  0,                                // tp_getset
+  0,                                // tp_base
   0,                                // tp_dict, __dict__
-  0,                                // tp_descr_get 
-  0,                                // tp_descr_set 
-  0,                                // tp_dictoffset 
+  0,                                // tp_descr_get
+  0,                                // tp_descr_set
+  0,                                // tp_dictoffset
   (initproc)tcdPyData_init,         // tp_init, __init__
-  0,                                // tp_alloc 
-  tcdPyData_new,                    // tp_new 
+  0,                                // tp_alloc
+  tcdPyData_new,                    // tp_new
 };
 
 static void _normalize_kernel( double* res, long len ) {
@@ -521,7 +519,7 @@ static void _normalize_kernel( double* res, long len ) {
   if ((res_sum != 0.0) && ( std::fabs(res_sum - 1) > DBL_EPSILON ))
     for( ii = 0; ii < len; ii++ )
       res[ii] /= res_sum;
-  
+
 }
 
 
@@ -535,18 +533,18 @@ static int _extract_kernel( const double* psf, const long* dims,
   std::vector<long> nsize(ndims);
   //std::vector<long> xlo(ndims);
   //std::vector<long> xhi(ndims);
-  
+
   if( NULL == psf )
     return EXIT_FAILURE;
-  
+
   for(long ii = 0 ; ii < ndims ; ii++ ) {
 
     //If the "subregion" of the PSF to be extracted is actually
-    // bigger than the PSF, then reset the szs array to be of the 
+    // bigger than the PSF, then reset the szs array to be of the
     // size of the PSF.
     if( newdims[ii] > dims[ii] )
       newdims[ii] = dims[ii];
-    
+
     //
     // To try to eliminate algorithmic problems of 2D "centroid" PSFs and
     // 1D radial profile "one-sided" PSFs, I've implemented wrap-around in
@@ -558,7 +556,7 @@ static int _extract_kernel( const double* psf, const long* dims,
     //std::cout << "diff: " << diff << ", mid: " << mid << std::endl;
 
     //double mid = (xmin[ii]+xmax[ii])/2.0;
-    if( rad == 1) mid = 0.0; 
+    if( rad == 1) mid = 0.0;
 
     // Need to revisit--is size defined in image units, or number of bins?
     // (Moot for logical coord images.)
@@ -586,7 +584,7 @@ static int _extract_kernel( const double* psf, const long* dims,
     //size *= nsize[ii];
     nsize[ii] = newdims[ii];
     size *= newdims[ii];
-  
+
     //std::cout << "xlo[" << ii << "]: " << xlo[ii] << ", size[" << ii << "]: " << nsize[ii]
     //	      << std::endl;
 
@@ -596,15 +594,15 @@ static int _extract_kernel( const double* psf, const long* dims,
   npy_intp npydims[1];
   npydims[0] = size;
   if ( EXIT_SUCCESS != res.create( 1, npydims ) )
-    return EXIT_FAILURE;  
-  
+    return EXIT_FAILURE;
+
   // Extract y- and x-arrays from old PSF, centered on the
   // center position determined above.
   std::vector<long> coord(ndims);
   switch( ndims ) {
-    
+
   case 1:
-    
+
     for (long ii = 0 ; ii < nsize[0] ; ii++ ) {
       coord[0] = xlo[0] + ii;
       while ( coord[0] < 0 ) coord[0] += dims[0];
@@ -612,39 +610,39 @@ static int _extract_kernel( const double* psf, const long* dims,
       res[ ii ] = psf[ coord[0] ];
     }
     break;
-      
+
   case 2:
-    
+
     for (long jj = 0 ; jj < nsize[1] ; jj++ ) {
       coord[1] = xlo[1] + jj;
       while ( coord[1] < 0 ) coord[1] += dims[1];
       while ( coord[1] >= dims[1] ) coord[1] -= dims[1];
-      for (long ii = 0 ; ii < nsize[0] ; ii++ ) {    
+      for (long ii = 0 ; ii < nsize[0] ; ii++ ) {
 	coord[0] = xlo[0] + ii;
 	while ( coord[0] < 0 ) coord[0] += dims[0];
         while ( coord[0] >= dims[0] ) coord[0] -= dims[0];
-	
+
 	long newidx = jj * nsize[0] + ii;
 	// Find indices relevant for new bounds wrt old psf size (dims[0])
 	long oldidx = coord[1] * dims[0] + coord[0];
-	
+
 	res[ newidx  ] = psf[ oldidx ];
       }
     }
-    
+
     break;
-    
+
   default:
     return EXIT_FAILURE;
-    
+
   } // end switch
 
   // psffrac = std::accumulate( &res[0], &res[size], 0.0 );
   psffrac = 0.0;
   for(long ii = 0; ii < size; ii++ )
     psffrac += res[ii];
-  
-  return EXIT_SUCCESS;  
+
+  return EXIT_SUCCESS;
 }
 
 static void _set_origin( long* dims_kern, long* kOrigin, long max, long nAxes )
@@ -660,7 +658,7 @@ static void _set_origin( long* dims_kern, long* kOrigin, long max, long nAxes )
 	kOrigin[ii] = dims_kern[ii]/2;
     return;
   }
-  
+
   if ( nAxes == 1 ) {
     // Just in case, go back to the center ymaxpos is outside
     // the PSF data space for some reason.
@@ -672,11 +670,11 @@ static void _set_origin( long* dims_kern, long* kOrigin, long max, long nAxes )
     // Any bin number we get back is really the y-position * xsize +
     // x-position; therefore we must convert the bin number to x- and
     // y-positions.
-    
+
     // Can do this because it drops remainder
     long ybin = max / dims_kern[0];
     long xbin = max - (ybin * dims_kern[0]);
-    
+
     // Just in case, go back to the center if xbin, ybin turn out
     // to be outside the PSF data space for some reason.
     kOrigin[0] = ( xbin < 0 || xbin > dims_kern[0]-1 ) ? dims_kern[0]/2 : xbin;
@@ -688,7 +686,7 @@ static void _set_origin( long* dims_kern, long* kOrigin, long max, long nAxes )
 
 static PyObject* extract_kernel( PyObject* self, PyObject* args )
 {
-  
+
   DoubleArray kernel;
   DoubleArray res;
   DoubleArray xlo;
@@ -700,11 +698,11 @@ static PyObject* extract_kernel( PyObject* self, PyObject* args )
   LongArray hi;
   DoubleArray center;
   int radial;
-  
-  
+
+
   if ( !PyArg_ParseTuple( args, (char*)"O&O&O&O&O&O&O&i",
 			  CONVERTME( DoubleArray ),
-			  &kernel,			 
+			  &kernel,
 			  CONVERTME( LongArray ),
 			  &dims_kern,
 			  CONVERTME( LongArray ),
@@ -719,11 +717,11 @@ static PyObject* extract_kernel( PyObject* self, PyObject* args )
 			  &widths,
 			  &radial) )
     return NULL;
-  
+
   double frac = 0.0;
   const long nAxes = (long) dims_kern.get_size();
 
-  
+
   if( !same_size_arrays( dims_new.get_size(), nAxes,
                          "dims_new", "dims_kern" ) )
      return NULL;
@@ -758,7 +756,7 @@ static PyObject* extract_kernel( PyObject* self, PyObject* args )
 		     (char*)"kernel extraction failed" );
     return NULL;
   }
-  
+
   return Py_BuildValue( (char*)"(NNdNN)",
 			res.return_new_ref(),
 			dims_new.return_new_ref(),
@@ -770,48 +768,48 @@ static PyObject* extract_kernel( PyObject* self, PyObject* args )
 
 static PyObject* normalize( PyObject* self, PyObject* args )
 {
-  
+
   DoubleArray data;
-  
+
   if ( !PyArg_ParseTuple( args, (char*)"O&", CONVERTME(DoubleArray), &data) )
     return NULL;
-  
+
   _normalize_kernel( &data[0], (long) data.get_size() );
-  
+
   return data.return_new_ref();
 }
 
 
 static PyObject* set_origin( PyObject* self, PyObject* args )
 {
-  
+
   LongArray dims;
   LongArray res;
   long max=-1;
-  
+
   if ( !PyArg_ParseTuple( args, (char*)"O&|l", CONVERTME(LongArray), &dims,
 			  &max) )
     return NULL;
-  
+
   if( EXIT_SUCCESS != res.zeros( dims.get_ndim(), dims.get_dims() ) )
-    return NULL;      
-  
+    return NULL;
+
   _set_origin( &dims[0], &res[0], max, (long) dims.get_size() );
-  
+
   return res.return_new_ref();
 }
 
 
 static PyObject* get_padsize( PyObject* self, PyObject* args )
 {
-  
+
   long size, factor;
   if ( !PyArg_ParseTuple( args, (char*)"l", &size) )
     return NULL;
 
   if( EXIT_SUCCESS != _pad( size, factor  ) )
     return NULL;
-  
+
   return Py_BuildValue( (char*)"l", factor );
 }
 
@@ -832,12 +830,12 @@ static bool padshape_smaller_then_shape( npy_intp ii, long padshape,
 
 static PyObject* pad_data( PyObject* self, PyObject* args )
 {
-  
+
   DoubleArray kernel;
   LongArray shape;
   LongArray padshape;
   DoubleArray res;
-  
+
   if ( !PyArg_ParseTuple( args, (char*)"O&O&O&",
 			  CONVERTME(DoubleArray), &kernel,
 			  CONVERTME(LongArray), &shape,
@@ -847,21 +845,21 @@ static PyObject* pad_data( PyObject* self, PyObject* args )
   if( !same_size_arrays( shape.get_size(), padshape.get_size(),
                          "shape", "padshape" ) )
     return NULL;
-  
+
   long size=1, padsize=1;
   for( npy_intp ii = 0; ii < shape.get_size(); ii++ ) {
     size *= shape[ii];
 
     if( padshape_smaller_then_shape( ii, padshape[ii], shape[ii] ) )
       return NULL;
-    
+
     padsize *= padshape[ii];
   }
 
   if ( !same_size_arrays( kernel.get_size(), size,
                           "kernel size", "kernel dim", "dimensions" ) )
     return NULL;
-  
+
   npy_intp dims[1];
   dims[0] = padsize;
 
@@ -872,7 +870,7 @@ static PyObject* pad_data( PyObject* self, PyObject* args )
   if( EXIT_SUCCESS != _pad_data( (int)shape.get_size(), &res[0], &kernel[0],
 				 &padshape[0], &shape[0] ) )
     return NULL;
-  
+
   return res.return_new_ref();
 }
 
@@ -882,7 +880,7 @@ static PyObject* unpad_data( PyObject* self, PyObject* args )
   LongArray shape;
   LongArray padshape;
   DoubleArray res;
-  
+
   if ( !PyArg_ParseTuple( args, (char*)"O&O&O&",
 			  CONVERTME(DoubleArray), &kernel,
 			  CONVERTME(LongArray), &padshape,
@@ -892,21 +890,21 @@ static PyObject* unpad_data( PyObject* self, PyObject* args )
   if( !same_size_arrays( shape.get_size(), padshape.get_size(),
                         "shape", "padshape" ) )
     return NULL;
-  
+
   long size=1, padsize=1;
   for( npy_intp ii = 0; ii < shape.get_size(); ii++ ) {
     size *= shape[ii];
 
     if( padshape_smaller_then_shape( ii, padshape[ii], shape[ii] ) )
       return NULL;
-    
+
     padsize *= padshape[ii];
   }
 
   if ( !same_size_arrays( kernel.get_size(), padsize,
                           "kernel size",  "kernel dim",  "dimensions" ) )
     return NULL;
-  
+
   npy_intp dims[1];
   dims[0] = size;
 
@@ -919,8 +917,8 @@ static PyObject* unpad_data( PyObject* self, PyObject* args )
     PyErr_SetString( PyExc_TypeError,
 		     (char*)"unpadding kernel failed-dimension unsupported" );
     return NULL;
-  } 
-  
+  }
+
   return res.return_new_ref();
 }
 
@@ -932,11 +930,11 @@ static PyObject* unpad_data( PyObject* self, PyObject* args )
 //
 static PyObject* pad_bounding_box( PyObject* self, PyObject* args )
 {
-  
+
   DoubleArray kernel;
   DoubleArray res;
   IntArray mask;
-   
+
   if ( !PyArg_ParseTuple( args, (char*)"O&O&",
 			  CONVERTME(DoubleArray), &kernel,
 			  CONVERTME(IntArray), &mask) )
@@ -944,7 +942,7 @@ static PyObject* pad_bounding_box( PyObject* self, PyObject* args )
 
   int msize = mask.get_size();
   int ksize = kernel.get_size();
-  
+
   if ( ksize > msize ) {
     std::ostringstream err;
     err << "kernel size: " << ksize
@@ -956,7 +954,7 @@ static PyObject* pad_bounding_box( PyObject* self, PyObject* args )
   // Create a zeros array to padding size
   if( EXIT_SUCCESS != res.zeros( mask.get_ndim(), mask.get_dims() ) )
     return NULL;
-  
+
   int jj = 0;
   for( int ii = 0; ii < msize; ++ii ) {
     if( mask[ ii ] )
@@ -966,14 +964,14 @@ static PyObject* pad_bounding_box( PyObject* self, PyObject* args )
     if( jj >= ksize )
       break;
   }
-  
+
   return res.return_new_ref();
 }
 
 static PyMethodDef PsfFcts[] = {
 
   FCTSPEC(extract_kernel, extract_kernel),
- 
+
   FCTSPEC(normalize, normalize),
 
   FCTSPEC(set_origin, set_origin),
@@ -983,9 +981,9 @@ static PyMethodDef PsfFcts[] = {
   FCTSPEC(pad_data, pad_data),
 
   FCTSPEC(unpad_data, unpad_data),
-  
+
   FCTSPEC( pad_bounding_box, pad_bounding_box ),
-  
+
   { NULL, NULL, 0, NULL }
 
 };

--- a/sherpa/utils/src/_utils.cc
+++ b/sherpa/utils/src/_utils.cc
@@ -1,5 +1,6 @@
-// 
-//  Copyright (C) 2007, 2015, 2016, 2018, 2019  Smithsonian Astrophysical Observatory
+//
+//  Copyright (C) 2007, 2015-2016, 2018-2019, 2025
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -31,15 +32,12 @@
 extern "C" {
 
 #include "cephes.h"
-  //#include "fcmp.h"
-
-  void init_utils();
 
 }
 
 static PyObject* wofz( PyObject* self, PyObject* args )
 {
-  
+
   ComplexArray xxx;
   if( !PyArg_ParseTuple( args, (char*)"O&",
                          CONVERTME(ComplexArray), &xxx) )
@@ -59,7 +57,7 @@ static PyObject* wofz( PyObject* self, PyObject* args )
 
 static PyObject* ftest( PyObject* self, PyObject* args )
 {
-  
+
   DoubleArray dof_1;
   DoubleArray dof_2;
   DoubleArray chisq_1;
@@ -140,7 +138,7 @@ static PyObject* ftest( PyObject* self, PyObject* args )
                          (dof_2[ii] / ( tmp ) ) );
 
   }
-  
+
   return result.return_new_ref();
 
 }
@@ -158,7 +156,7 @@ static PyObject* mlr( PyObject* self, PyObject* args )
 			 (converter)sherpa::convert_to_array< DoubleArray >,
 			 &delta_chisq ) )
     return NULL;
-  
+
   npy_intp nelem = delta_dof.get_size();
 
   if ( delta_chisq.get_size() != nelem  ) {
@@ -176,8 +174,8 @@ static PyObject* mlr( PyObject* self, PyObject* args )
     return NULL;
 
   for ( npy_intp ii = 0; ii < nelem; ii++ )
-    result[ii] = igamc( delta_dof[ii] / 2.0, delta_chisq[ii] / 2.0 );  
- 
+    result[ii] = igamc( delta_dof[ii] / 2.0, delta_chisq[ii] / 2.0 );
+
   return result.return_new_ref();
 
 }
@@ -218,7 +216,7 @@ static PyObject* igam( PyObject* self, PyObject* args )
 			 (converter)sherpa::convert_to_array< DoubleArray >,
 			 &x ) )
     return NULL;
-  
+
   npy_intp asize = a.get_size();
   npy_intp xsize = x.get_size();
 
@@ -243,8 +241,8 @@ static PyObject* igam( PyObject* self, PyObject* args )
       return NULL;
     }
 
-    result[ii] = igam( a[ii], x[ii]);  
- 
+    result[ii] = igam( a[ii], x[ii]);
+
   }
   return result.return_new_ref();
 
@@ -262,7 +260,7 @@ static PyObject* igamc( PyObject* self, PyObject* args )
 			 (converter)sherpa::convert_to_array< DoubleArray >,
 			 &x ) )
     return NULL;
-  
+
   npy_intp asize = a.get_size();
   npy_intp xsize = x.get_size();
 
@@ -287,8 +285,8 @@ static PyObject* igamc( PyObject* self, PyObject* args )
       return NULL;
     }
 
-    result[ii] = igamc( a[ii], x[ii]);  
- 
+    result[ii] = igamc( a[ii], x[ii]);
+
   }
   return result.return_new_ref();
 
@@ -439,7 +437,7 @@ PyObject* _sherpa_fcmp( PyObject *self, PyObject *args )
 			 &x2,
 			 &epsilon ) )
     return NULL;
-  
+
   npy_intp n1 = x1.get_size();
   npy_intp n2 = x2.get_size();
 
@@ -473,14 +471,14 @@ PyObject* _sherpa_fcmp( PyObject *self, PyObject *args )
 template <typename ArrayType, typename DataType>
 PyObject* rebin( PyObject* self, PyObject* args )
 {
-  
+
   ArrayType x0;
   ArrayType x0lo;
   ArrayType x0hi;
   ArrayType x1;
   ArrayType x1lo;
   ArrayType x1hi;
-  
+
   if ( !PyArg_ParseTuple( args, (char*)"O&O&O&O&O&",
 			  (converter)sherpa::convert_to_array<ArrayType>,
 			  &x0,
@@ -492,9 +490,9 @@ PyObject* rebin( PyObject* self, PyObject* args )
 			  &x1lo,
 			  (converter)sherpa::convert_to_array<ArrayType>,
 			  &x1hi ))
-    
+
     return NULL;
-  
+
   if ( x0.get_size() != x0lo.get_size()  ) {
     std::ostringstream err;
     err << "input array sizes do not match, "
@@ -509,7 +507,7 @@ PyObject* rebin( PyObject* self, PyObject* args )
 	<< "x0hi: " << x0hi.get_size() << " vs x0lo: " << x0lo.get_size();
     PyErr_SetString( PyExc_TypeError, err.str().c_str() );
     return NULL;
-  }	 
+  }
 
   if ( x1hi.get_size() != x1lo.get_size() ) {
     std::ostringstream err;
@@ -531,16 +529,16 @@ PyObject* rebin( PyObject* self, PyObject* args )
     PyErr_SetString( PyExc_ValueError, (char*)"rebinning data failed" );
     return NULL;
   }
-  
+
   return x1.return_new_ref();
-  
+
 }
 
 template <typename ArrayType, typename DataType,
 	  typename IndexArrayType, typename IndexType>
 PyObject* histogram1d( PyObject* self, PyObject* args )
 {
-  
+
   ArrayType x;
   ArrayType x_lo;
   ArrayType x_hi;
@@ -562,7 +560,7 @@ PyObject* histogram1d( PyObject* self, PyObject* args )
     PyErr_SetString( PyExc_TypeError, err.str().c_str() );
     return NULL;
   }
-  
+
   if ( (x.get_size() < 1) || (x_lo.get_size() < 1) || (x_hi.get_size() < 1) ) {
     PyErr_SetString( PyExc_TypeError,
 		     (char*)"need at least one element for histogram");
@@ -578,7 +576,7 @@ PyObject* histogram1d( PyObject* self, PyObject* args )
     PyErr_SetString( PyExc_ValueError, (char*)"histogram1d failed" );
     return NULL;
   }
-  
+
   return res.return_new_ref();
 }
 
@@ -586,7 +584,7 @@ template <typename ArrayType, typename DataType,
 	  typename IndexArrayType, typename IndexType>
 PyObject* histogram2d( PyObject* self, PyObject* args )
 {
-  
+
   ArrayType x;
   ArrayType y;
   ArrayType x_grid;
@@ -603,7 +601,7 @@ PyObject* histogram2d( PyObject* self, PyObject* args )
 			  CONVERTME(ArrayType),
 			  &y_grid))
     return NULL;
-  
+
   if ( x.get_size() != y.get_size()  ) {
     std::ostringstream err;
     err << "input array sizes do not match, "
@@ -630,7 +628,7 @@ PyObject* histogram2d( PyObject* self, PyObject* args )
     PyErr_SetString( PyExc_ValueError, (char*)"histogram2d failed" );
     return NULL;
   }
-  
+
   return res.return_new_ref();
 }
 
@@ -639,7 +637,7 @@ template <typename FloatArrayType, typename IntArrayType,
 	  typename DataType, typename IntType, typename IndexType>
 PyObject* sum_intervals( PyObject* self, PyObject* args )
 {
-  
+
   FloatArrayType src;
   FloatArrayType model;
   IntArrayType indx0;
@@ -653,7 +651,7 @@ PyObject* sum_intervals( PyObject* self, PyObject* args )
 			  CONVERTME(IntArrayType),
 			  &indx1))
     return NULL;
-  
+
   if ( indx0.get_size() != indx1.get_size()  ) {
     std::ostringstream err;
     err << "input array sizes do not match, "
@@ -664,7 +662,7 @@ PyObject* sum_intervals( PyObject* self, PyObject* args )
 
   if ( EXIT_SUCCESS != model.zeros( indx0.get_ndim(), indx0.get_dims() ) )
     return NULL;
-  
+
   if ( EXIT_SUCCESS != (sherpa::utils::sum_intervals<DataType,
 			DataType, IntType, IndexType>
 			(&src[0], &indx0[0], &indx1[0], model.get_size(),
@@ -672,14 +670,14 @@ PyObject* sum_intervals( PyObject* self, PyObject* args )
     PyErr_SetString( PyExc_ValueError, (char*)"sum_intervals" );
     return NULL;
   }
-  
+
   return model.return_new_ref();
 }
 
 template <typename ArrayType, typename DataType>
 PyObject* neville( PyObject* self, PyObject* args )
 {
-  
+
   ArrayType xout;
   ArrayType xin;
   ArrayType yin;
@@ -693,7 +691,7 @@ PyObject* neville( PyObject* self, PyObject* args )
 			  CONVERTME(ArrayType),
 			  &yin))
     return NULL;
-  
+
   if ( xin.get_size() != yin.get_size()  ) {
     std::ostringstream err;
     err << "input array sizes do not match, "
@@ -704,7 +702,7 @@ PyObject* neville( PyObject* self, PyObject* args )
 
   if ( EXIT_SUCCESS != result.zeros( xout.get_ndim(), xout.get_dims() ) )
     return NULL;
-  
+
   int nin = (int) xin.get_size();
   int nout = (int) xout.get_size();
 
@@ -718,16 +716,16 @@ PyObject* neville( PyObject* self, PyObject* args )
 
       return NULL;
     }
-    
+
   }
-  
+
   return result.return_new_ref();
 }
 
 
 static PyObject* sao_arange( PyObject* self, PyObject* args )
 {
-  
+
   double start, stop, step = 1.0;
   DoubleArray result;
   std::vector<double> arr;
@@ -735,7 +733,7 @@ static PyObject* sao_arange( PyObject* self, PyObject* args )
 
   if ( !PyArg_ParseTuple( args, (char*)"dd|d", &start, &stop, &step ) )
     return NULL;
-  
+
   int count = 0;
   double bin = start;
   while( sao_fcmp(bin, stop, eps) < 0 ) {
@@ -743,16 +741,16 @@ static PyObject* sao_arange( PyObject* self, PyObject* args )
     arr.push_back(bin);
     ++count;
   }
-  
+
   npy_intp dim;
   dim = (npy_intp)arr.size();
 
   if ( EXIT_SUCCESS != result.create( 1, &dim ) )
     return NULL;
-  
+
   for(npy_intp ii = 0; ii < dim; ++ii)
     result[ii] = arr[ii];
-   
+
   return result.return_new_ref();
 }
 
@@ -763,7 +761,7 @@ static PyMethodDef UtilsFcts[] = {
 
   // F-Test
   FCTSPEC(calc_ftest, ftest),
-  
+
   // Maximum likelihood ratio
   FCTSPEC(calc_mlr, mlr),
 
@@ -775,10 +773,10 @@ static PyMethodDef UtilsFcts[] = {
 
   // Incomplete beta function
   FCTSPEC(incbet, incbet),
-  
+
   // Gamma function
   FCTSPEC(gamma, gamma),
-  
+
   // Log gamma function
   FCTSPEC(lgam, lgam),
 
@@ -790,7 +788,7 @@ static PyMethodDef UtilsFcts[] = {
 
   // This function determines whether x and y are approximately equal
   // to a relative accuracy epsilon.
-  FCTSPEC(gsl_fcmp, _sherpa_fcmp< gsl_fcmp >), 
+  FCTSPEC(gsl_fcmp, _sherpa_fcmp< gsl_fcmp >),
 
   //Same as gsl_fcmp, but also handles the case where one of the args is 0.
   FCTSPEC(sao_fcmp, _sherpa_fcmp< sao_fcmp >),
@@ -798,10 +796,10 @@ static PyMethodDef UtilsFcts[] = {
   //Rebin to new grid
   FCTSPEC(rebin, (rebin<SherpaFloatArray, SherpaFloat>)),
 
-  //Histogram1d 
+  //Histogram1d
   { (char*) "hist1d",(PyCFunction)(histogram1d<SherpaFloatArray, SherpaFloat, IntArray, int>), METH_VARARGS, (char*) " create 1D histogram\n\nExample:\nsherpa> histogram1d( x, xlo, xhi )"},
-  
-  //Histogram2d 
+
+  //Histogram2d
   { (char*) "hist2d",(PyCFunction)(histogram2d<SherpaFloatArray, SherpaFloat, IntArray, int>), METH_VARARGS, (char*) " create 2D histogram\n\nExample:\nsherpa> histogram2d( x, y, x_grid, y_grid )"},
 
   FCTSPEC(sum_intervals, (sum_intervals<SherpaFloatArray, IntArray,
@@ -811,7 +809,7 @@ static PyMethodDef UtilsFcts[] = {
   FCTSPEC(neville, (neville<SherpaFloatArray, SherpaFloat>)),
 
   FCTSPEC(sao_arange, sao_arange),
-  
+
   { NULL, NULL, 0, NULL }
 
 };

--- a/sherpa/utils/src/integration.cc
+++ b/sherpa/utils/src/integration.cc
@@ -1,5 +1,6 @@
-// 
-//  Copyright (C) 2007, 2016, 2020  Smithsonian Astrophysical Observatory
+//
+//  Copyright (C) 2007, 2016, 2020, 2025
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -27,15 +28,11 @@
 #include "adapt_integrate.h"
 #include "qng.h"
 
-extern "C" {
-  void initintegration();
-}
-
 namespace sherpa { namespace integration {
 
   static int gsl_int_flag = 1;
   static int sao_int_flag = 1;
-  
+
   int integrate_1d( integrand_1d fct, void* params,
 		    double xlo, double xhi,
 		    unsigned int maxeval, double epsabs, double epsrel,
@@ -53,20 +50,20 @@ namespace sherpa { namespace integration {
     size_t neval = size_t( maxeval );
 
     gsl_set_error_handler_off ();
- 
+
     retval = gsl_integration_qng( &func, xlo, xhi, epsabs, epsrel, &result,
 				  &abserr, &neval );
-    
+
     if (retval != EXIT_SUCCESS) {
       if( gsl_int_flag ) {
 	std::cerr << "WARNING: Gauss-Kronrod integration failed "
 		  << "with tolerance " << epsabs << ", trying lower tolerance..."
 		  << std::endl;
-	
+
 	double tol = std::numeric_limits< float >::epsilon();
 	retval = gsl_integration_qng( &func, xlo, xhi, tol, epsrel, &result,
 				      &abserr, &neval );
-	
+
 	if (retval != EXIT_SUCCESS) {
 	  std::cerr << "integration failed with tolerance " << tol
 		    << ", resorting to trapezoid method"
@@ -79,9 +76,9 @@ namespace sherpa { namespace integration {
 		    << std::endl;
 	}
 	gsl_int_flag = 0;
-      }      
+      }
     }
-    
+
     return EXIT_SUCCESS;
 
   }
@@ -119,37 +116,37 @@ namespace sherpa { namespace integration {
     size_t neval = size_t( maxeval );
 
     gsl_set_error_handler_off ();
- 
+
     retval = sao_integration_qng( fct, xlo, xhi, params, epsabs, epsrel,
 				  &result, &abserr, &neval );
-    
+
     if (retval == -1) {
       return EXIT_FAILURE;
     }
-    
+
     if (retval != EXIT_SUCCESS) {
       if (sao_int_flag) {
 	err << "Gauss-Kronrod integration failed "
 	    << "with tolerance " << epsabs << ", trying lower tolerance...";
-	
+
 	double tol = std::numeric_limits< float >::epsilon();
 	retval = sao_integration_qng( fct, xlo, xhi, params, tol, epsrel,
 				      &result, &abserr, &neval );
-	
+
 	if (retval != EXIT_SUCCESS) {
 	  err << std::endl << "integration failed with tolerance " << tol
 	      << ", resorting to trapezoid method";
 
-	  
+
 	  double loval[1], hival[1];
 	  loval[0] = xlo;
 	  hival[0] = xhi;
 	  if (-1 == fct(loval, 1, params) )
 	    return EXIT_FAILURE;
-	  
+
 	  if (-1 == fct(hival, 1, params) )
 	    return EXIT_FAILURE;
-	  
+
 	  result = 0.5 * ( xhi - xlo ) * ( loval[0] + hival[0] );
 	}
 	else {
@@ -159,9 +156,9 @@ namespace sherpa { namespace integration {
       sao_int_flag=0;
     }
     return EXIT_SUCCESS;
-    
+
   }
-    
+
 }  }  /* namespace integration, namespace sherpa */
 
 static struct PyModuleDef integration = {


### PR DESCRIPTION
# Summary

Minor clean up of the extension code. There should be no functional changes.

# Details

Developed as part of #2320 but is a separate clean-up item.

There are two changes

1. A minor simplification in the `SHERPAMOD` and `SHERPAMODDOC` templates as they can both be written calling a new template, to avoid dupllication (the two macros only differ on whether the documentation for the module is given, and the new code highlights this).
2. Avoid declaring a symbol - normally `init_<modname>` - which we don't actually provide or use in the extension modules.
