### PR TITLE
Update docstring for get_xsabundances

### DIFF
--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015 - 2025
+#  Copyright (C) 2010, 2015-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -242,8 +242,8 @@ def get_xsabundances(table: str | None = None) -> dict[str, float]:
 
     .. versionadded:: 4.17.0
 
-    Parameter
-    ---------
+    Parameters
+    ----------
     table : optional
         The table to use. Leave as None to use the selected abundance
         table.


### PR DESCRIPTION
# Summary

Correct the docstring for get_xsabundances so that it uses the term "Parameters" rather than "Parameter".

# Details

The singular form - "Parameter" - causes problems for the code used to create the Sherpa ahelp files for CIAO for reasons involving RST/Sphinx/past-my-pay-grade. You'll notice all the other docstrings use "Parameters".