### PR TITLE
CI: add a test-run with ncores=1 (pip)

### DIFF
--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -41,6 +41,7 @@ jobs:
             fits-pkg: 'astropy'
             matplotlib-pkg: 'matplotlib>=3,<4'
             bokeh-pkg: 'bokeh>=3,<4'
+            ncores: 1
 
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
@@ -103,20 +104,41 @@ jobs:
       run: |
         pip install -e . --verbose
 
-    - name: install pytest-xvfb
-      if: matrix.test-data == 'package'
+    # This isn't always going to be used, but it is easiest to
+    # always create it.
+    #
+    - name: setup sherpa rc file
+      env:
+        NCORES: ${{ matrix.ncores }}
       run: |
-        pip install pytest-xvfb
+        cd $HOME
+        orig=`python -c 'import sherpa; print(sherpa.get_config())'`
+        if [ "${NCORES}" == "1" ]; then
+          sed -e "s/numcores : None/numcores : 1/" $orig > sherpa.rc
+        else
+          cp $orig sherpa.rc
+        fi
+        echo "** check multiprocessing setting"
+        python -c 'from sherpa.utils import parallel; print(f"default={parallel.ncpus}");'
+        SHERPARC=sherpa.rc python -c 'from sherpa.utils import parallel; print(f"rcfile ={parallel.ncpus}");'
+        echo "** end check"
+
+    - name: setup
+      if: matrix.test-data == 'package' || matrix.test-data == 'none'
+      run: |
+        # These packages are not always needed, but the install should
+        # be relatively quick.
+        pip install pytest-xvfb pytest-cov
+        # Remove the submodule.
+        git submodule deinit -f .
 
     - name: sherpa_test with test-data=${{ matrix.test-data }}
       if: matrix.test-data == 'package' || matrix.test-data == 'none'
       env:
         TEST: ${{ matrix.test-data }}
       run: |
-        git submodule deinit -f .
-        pip install pytest-cov
         cd $HOME
-        sherpa_test --cov=sherpa --cov-report=xml:${{ github.workspace }}/coverage.xml
+        SHERPARC=sherpa.rc sherpa_test --cov=sherpa --cov-report=xml:${{ github.workspace }}/coverage.xml
 
     - name: Submodule test with pytest
       if: matrix.test-data == 'submodule'


### PR DESCRIPTION
# Summary

Enhance the CI test suite to include an explicit test of the "ncores: 1" case in the sherpa.rc (rather than the default "ncores: None" value). This will improve the apparent reported test coverage, since the use of the multiprocessing code (with the default values) confuses the system. It may improve the actual test coverage as there are a few hidden-away cases which may not have been exercised before. There is no functional change to Sherpa.

# Details

In looking at the multiprocessing code it is obvious that there are potentially-subtle differences in the code paths when the ncpus is 1 rather than None (as nowadays most machines, even on CI, have multiple CPUs).

So, make sure one test is run with the "ncores: 1" setting in the configuratuion file (sherpa.rc) rather than the default of "ncores: None".

There are a number of ways this could be done, such as adding an extra run of the tests after a successful standard run, which has the advantage of ensuring "the best" test coverage (since coverage can not easily handle the multiprocessing code) but at the expense of time/computation.

This is only done for the pip case at present.

As part of this, simplify test_lrt/test_lrt_multicore in test_sim.py, as this can be done with a single parametrized test rather than two essentially-identical tests. However, the previous test included checks for multi/ncpus which appear to no-longer be needed. Is this because the code has changed - to somehow allow the "ncores > 2" version to use two generators even when no multiprocessing is selected - or because there is a subtle bug in the multi-core case when only a single core is requested?

Note that without this test change the tests would fail with the new ncores=1 CI run.