### PR TITLE
ptcat-3959 - add est_method_args back to sample function in sherpa

### DIFF
--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -137,7 +137,7 @@ def calc_flux(data, src, samples, method=calc_energy_flux,
 
 
 def _sample_flux_get_samples_with_scales(fit, src, correlated, scales,
-                                         num, clip='hard', rng=None):
+                                         num, clip='hard', rng=None, est_method_args=None):
     """Return the parameter samples given the parameter scales.
 
     Parameters
@@ -258,16 +258,16 @@ def _sample_flux_get_samples_with_scales(fit, src, correlated, scales,
 
     if correlated:
         sampler = NormalParameterSampleFromScaleMatrix()
-        samples = sampler.get_sample(fit, mycov=scales, num=num, rng=rng)
+        samples = sampler.get_sample(fit, mycov=scales, num=num, rng=rng, est_method_args=est_method_args)
     else:
         sampler = NormalParameterSampleFromScaleVector()
-        samples = sampler.get_sample(fit, myscales=scales, num=num, rng=rng)
+        samples = sampler.get_sample(fit, myscales=scales, num=num, rng=rng, est_method_args=est_method_args)
 
     clipped = sampler.clip(fit, samples, clip=clip)
     return samples, clipped
 
 
-def _sample_flux_get_samples(fit, src, correlated, num, clip='hard', rng=None):
+def _sample_flux_get_samples(fit, src, correlated, num, clip='hard', rng=None, est_method_args=None):
     """Return the parameter samples, using fit to define the scales.
 
     The covariance method is used to estimate the errors for the
@@ -326,7 +326,7 @@ def _sample_flux_get_samples(fit, src, correlated, num, clip='hard', rng=None):
     else:
         sampler = NormalParameterSampleFromScaleVector()
 
-    samples = sampler.get_sample(fit, num=num, rng=rng)
+    samples = sampler.get_sample(fit, num=num, rng=rng, est_method_args=est_method_args)
     clipped = sampler.clip(fit, samples, clip=clip)
     return samples, clipped
 
@@ -377,7 +377,7 @@ def decompose(mdl):
 def sample_flux(fit, data, src,
                 method=calc_energy_flux, correlated=False,
                 num=1, lo=None, hi=None, numcores=None, samples=None,
-                clip='hard', rng=None):
+                clip='hard', rng=None, est_method_args=None):
     """Calculate model fluxes from a sample of parameter values.
 
     Draw parameter values from a normal distribution and then calculate
@@ -505,11 +505,11 @@ def sample_flux(fit, data, src,
     scales = samples
     if scales is None:
         samples, clipped = _sample_flux_get_samples(fit, src, correlated,
-                                                    num, clip=clip, rng=rng)
+                                                    num, clip=clip, rng=rng, est_method_args=est_method_args)
     else:
         samples, clipped = _sample_flux_get_samples_with_scales(fit, src, correlated,
                                                                 scales, num, clip=clip,
-                                                                rng=rng)
+                                                                rng=rng, est_method_args=est_method_args)
 
     # When a subset of the full model is used we need to know how
     # to select which rows in the samples array refer to the

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -14874,7 +14874,7 @@ class Session(sherpa.ui.utils.Session):
                            bkg_id: IdType | None = None,
                            model=None,
                            otherids: Sequence[IdType] = (),
-                           clip='hard'):
+                           clip='hard', est_method_args = None):
         """Return the energy flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -15105,14 +15105,14 @@ class Session(sherpa.ui.utils.Session):
                                              num=num, lo=lo, hi=hi,
                                              numcores=numcores,
                                              samples=scales, clip=clip,
-                                             rng=self.get_rng())
+                                             rng=self.get_rng(), est_method_args=est_method_args)
 
     def sample_flux(self, modelcomponent=None, lo=None, hi=None,
                     id: IdType | None = None,
                     num=1, scales=None, correlated=False,
                     numcores=None,
                     bkg_id: IdType | None = None,
-                    Xrays=True, confidence=68):
+                    Xrays=True, confidence=68, est_method_args=None):
         """Return the flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -15325,7 +15325,7 @@ class Session(sherpa.ui.utils.Session):
                                               scales=scales, clip='soft',
                                               correlated=correlated,
                                               numcores=numcores,
-                                              bkg_id=bkg_id)
+                                              bkg_id=bkg_id, est_method_args=est_method_args)
 
         return sherpa.astro.flux.calc_sample_flux(lo=lo, hi=hi,
                                                   fit=fit, data=data, samples=samples,

--- a/sherpa/sim/sample.py
+++ b/sherpa/sim/sample.py
@@ -148,7 +148,7 @@ class ParameterScaleVector(ParameterScale):
 
     """
 
-    def get_scales(self, fit, myscales=None):
+    def get_scales(self, fit, myscales=None, est_method_args=None):
         """Return the samples.
 
         Parameters
@@ -170,6 +170,9 @@ class ParameterScaleVector(ParameterScale):
 
         """
 
+        if est_method_args is None:
+            est_method_args = {}
+
         scales = []
         thawedpars = [par for par in fit.model.pars if not par.frozen]
 
@@ -179,7 +182,8 @@ class ParameterScaleVector(ParameterScale):
 
             covar = Covariance()
             covar.config['sigma'] = self.sigma
-            fit.estmethod = Covariance()
+            covar.config.update(est_method_args)
+            fit.estmethod = covar
 
             try:
                 r = fit.est_errors()
@@ -196,6 +200,7 @@ class ParameterScaleVector(ParameterScale):
 
                     conf = Confidence()
                     conf.config['sigma'] = self.sigma
+                    conf.config.update(est_method_args)
                     fit.estmethod = conf
                     try:
                         t = fit.est_errors(parlist=(par,))
@@ -237,7 +242,7 @@ class ParameterScaleMatrix(ParameterScale):
 
     """
 
-    def get_scales(self, fit, myscales=None):
+    def get_scales(self, fit, myscales=None, **est_method_args):
         """Return the samples.
 
         Parameters
@@ -263,6 +268,7 @@ class ParameterScaleMatrix(ParameterScale):
         if myscales is None:
             oldestmethod = fit.estmethod
             fit.estmethod = Covariance()
+            fit.estmethod.config.update(est_method_args)
 
             try:
                 r = fit.est_errors()
@@ -414,7 +420,7 @@ class UniformParameterSampleFromScaleVector(ParameterSampleFromScaleVector):
     but the upper bound is not).
     """
 
-    def get_sample(self, fit, *, factor=4, num=1, rng=None):
+    def get_sample(self, fit, *, factor=4, num=1, rng=None, est_method_args=None):
         """Return the parameter samples.
 
         .. versionchanged:: 4.16.0
@@ -444,7 +450,7 @@ class UniformParameterSampleFromScaleVector(ParameterSampleFromScaleVector):
 
         """
         vals = numpy.array(fit.model.thawedpars)
-        scales = self.scale.get_scales(fit)
+        scales = self.scale.get_scales(fit, est_method_args=est_method_args)
         size = int(num)
         samples = [random.uniform(rng,
                                   val - factor * abs(scale),
@@ -464,7 +470,7 @@ class NormalParameterSampleFromScaleVector(ParameterSampleFromScaleVector):
 
     """
 
-    def get_sample(self, fit, *, myscales=None, num=1, rng=None):
+    def get_sample(self, fit, *, myscales=None, num=1, rng=None, est_method_args=None):
         """Return the parameter samples.
 
         .. versionchanged:: 4.16.0
@@ -494,7 +500,7 @@ class NormalParameterSampleFromScaleVector(ParameterSampleFromScaleVector):
 
         """
         vals = numpy.array(fit.model.thawedpars)
-        scales = self.scale.get_scales(fit, myscales)
+        scales = self.scale.get_scales(fit, myscales, est_method_args=est_method_args)
         size = int(num)
 
         samples = [random.normal(rng, val, scale, size=size)
@@ -512,7 +518,7 @@ class NormalParameterSampleFromScaleMatrix(ParameterSampleFromScaleMatrix):
 
     """
 
-    def get_sample(self, fit, *, mycov=None, num=1, rng=None):
+    def get_sample(self, fit, *, mycov=None, num=1, rng=None, est_method_args=None):
         """Return the parameter samples.
 
         .. versionchanged:: 4.16.0
@@ -542,7 +548,7 @@ class NormalParameterSampleFromScaleMatrix(ParameterSampleFromScaleMatrix):
 
         """
         vals = numpy.array(fit.model.thawedpars)
-        cov = self.scale.get_scales(fit, mycov)
+        cov = self.scale.get_scales(fit, mycov, est_method_args=est_method_args)
         return random.multivariate_normal(rng, vals, cov, size=int(num))
 
 
@@ -556,7 +562,7 @@ class StudentTParameterSampleFromScaleMatrix(ParameterSampleFromScaleMatrix):
 
     """
 
-    def get_sample(self, fit, *, dof, num=1, rng=None):
+    def get_sample(self, fit, *, dof, num=1, rng=None, est_method_args=None):
         """Return the parameter samples.
 
         .. versionchanged:: 4.16.0
@@ -585,7 +591,7 @@ class StudentTParameterSampleFromScaleMatrix(ParameterSampleFromScaleMatrix):
 
         """
         vals = numpy.array(fit.model.thawedpars)
-        cov = self.scale.get_scales(fit)
+        cov = self.scale.get_scales(fit, est_method_args=None)
         return multivariate_t(vals, cov, dof, int(num), rng=rng)
 
 


### PR DESCRIPTION
In CAT 5.5 we added est_method_args option to the sample function. The argument needs to be added back for specfit to work properly. 