### PR TITLE
XSPEC: drop support for XSPEC 12.12.0 and 12.12.1

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -204,7 +204,7 @@ value) can be used. For most cases, the ``scripts/use_ciao_config``
 script can be used::
 
   % ./scripts/use_ciao_config
-  Found XSPEC version: 12.12.0
+  Found XSPEC version: 12.14.1
   Updating setup.cfg
   % git diff setup.cfg
   ...
@@ -213,7 +213,7 @@ Otherwise the file can be edited manually. First find out what
 XSPEC version is present with::
 
   % conda list xspec-modelsonly --json | grep version
-      "version": "12.12.0"
+      "version": "12.14.1"
 
 then change the ``setup.cfg`` to change the following lines, noting
 that the `${ASCDS_INSTALL}` environment variable **must** be
@@ -244,12 +244,12 @@ should be updated to match the output above::
     wcs_libraries=wcs
 
     with_xspec=True
-    xspec_version = 12.12.0
+    xspec_version = 12.14.1
     xspec_lib_dirs = ${ASCDS_INSTALL}/lib
     xspec_include_dirs = ${ASCDS_INSTALL}/include
 
 .. note::
-   The XSPEC version may include the patch level, such as ``12.12.0e``,
+   The XSPEC version may include the patch level, such as ``12.14.1d``,
    and this can be included in the configuration file.
 
 To avoid accidentally committing the modified ``setup.cfg`` into git,
@@ -345,8 +345,7 @@ Update the XSPEC bindings?
 --------------------------
 
 The :py:mod:`sherpa.astro.xspec` module currently supports
-:term:`XSPEC` versions 12.15.0, 12.14.1, 12.14.0, 12.13.1, 12.13.0, 12.12.1,
-and 12.12.0.
+:term:`XSPEC` versions 12.15.0, 12.14.1, 12.14.0, 12.13.1, and 12.13.0.
 It may build against newer versions, but if it does it will not provide
 access to any new models in the release. The following sections of the
 `XSPEC manual
@@ -475,8 +474,6 @@ noted as not being supported::
   #include <xsTypes.h>
   #include <XSFunctions/Utilities/funcType.h>
 
-  #define XSPEC_12_12_0
-  #define XSPEC_12_12_1
   #define XSPEC_12_13_0
 
   #include "sherpa/astro/xspec_extension.hh"

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -149,4 +149,4 @@ Glossary
        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html>`_.
 
        Sherpa can be built to use XSPEC versions 12.15.0, 12.14.1,
-       12.14.0, 12.13.1, 12.13.0, 12.12.1, and 12.12.0.
+       12.14.0, 12.13.1, and 12.13.0.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -216,7 +216,7 @@ made to the ``xspec_config`` section of the ``setup.cfg`` file. The
 available options (with default values) are::
 
     with_xspec = False
-    xspec_version = 12.12.0
+    xspec_version = 12.14.1
     xspec_lib_dirs = None
     xspec_include_dirs = None
     xspec_libraries = XSFunctions XSUtil XS
@@ -238,7 +238,7 @@ the XSPEC model library or the full XSPEC system has been installed.
 
 In the examples below, the ``$HEADAS`` value **must be replaced**
 by the actual path to the HEADAS installation, and the versions of
-the libraries - such as ``CCfits_2.6`` - may need to be changed to
+the libraries - such as ``CCfits_2.7`` - may need to be changed to
 match the contents of the XSPEC installation.
 
 1. If the full XSPEC 12.15.0 system has been built then use::
@@ -303,27 +303,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.6
        wcslib_libraries = wcs-7.7
 
-6. If the full XSPEC 12.12.1 system has been built then use::
-
-       with_xspec = True
-       xspec_version = 12.12.1
-       xspec_lib_dirs = $HEADAS/lib
-       xspec_include_dirs = $HEADAS/include
-       xspec_libraries = XSFunctions XSUtil XS hdsp_6.30
-       ccfits_libraries = CCfits_2.6
-       wcslib_libraries = wcs-7.7
-
-7. If the full XSPEC 12.12.0 system has been built then use::
-
-       with_xspec = True
-       xspec_version = 12.12.0
-       xspec_lib_dirs = $HEADAS/lib
-       xspec_include_dirs = $HEADAS/include
-       xspec_libraries = XSFunctions XSUtil XS hdsp_6.29
-       ccfits_libraries = CCfits_2.6
-       wcslib_libraries = wcs-7.3.1
-
-8. If the model-only build of XSPEC - created with the
+6. If the model-only build of XSPEC - created with the
    ``--enable-xs-models-only`` flag when building HEASOFT - has been
    installed, then the configuration is similar, but the library names
    may not need version numbers and locations, depending on how the

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -28,8 +28,7 @@ from .extensions import build_ext
 # major, minor, and micro. We drop the patch level - e.g.
 # "c" in "12.12.0c" as that is not helpful to track here.
 #
-SUPPORTED_VERSIONS = [(12, 12, 0), (12, 12, 1),
-                      (12, 13, 0), (12, 13, 1),
+SUPPORTED_VERSIONS = [(12, 13, 0), (12, 13, 1),
                       (12, 14, 0), (12, 14, 1),
                       (12, 15, 0)]
 
@@ -96,7 +95,7 @@ class xspec_config(Command):
 
     def initialize_options(self):
         self.with_xspec = False
-        self.xspec_version = '12.12.0'
+        self.xspec_version = '12.14.1'
         self.xspec_include_dirs = ''
         self.xspec_lib_dirs = ''
         # This is set up for how CIAO builds XSPEC; other users may require more libraries

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -20,10 +20,10 @@
 
 """Support for XSPEC models.
 
-Sherpa supports versions 12.15.0, 12.14.1, 12.14.0, 12.13.1, 12.13.0,
-12.12.1, and 12.12.0 of XSPEC [1]_, and can be built against the model
-library or the full application.  There is no guarantee of support for
-older or newer versions of XSPEC.
+Sherpa supports versions 12.15.0, 12.14.1, 12.14.0, 12.13.1, and
+12.13.0 of XSPEC [1]_, and can be built against the model library or
+the full application.  There is no guarantee of support for older or
+newer versions of XSPEC.
 
 To be able to use most routines from this module, the HEADAS environment
 variable must be set. The `get_xsversion` function can be used to return the
@@ -18113,14 +18113,12 @@ class XSclumin(XSConvolutionKernel):
         XSConvolutionKernel.__init__(self, name, pars)
 
 
-@version_at_least("12.13.0")
 class XScglumin(XSConvolutionKernel):
     """The XSPEC cglumin convolution model: calculate luminosity
 
     The model is described at [1]_.
 
     .. versionadded:: 4.15.1
-       This model requires XSPEC 12.13.0 or later.
 
     Attributes
     ----------
@@ -18145,8 +18143,6 @@ class XScglumin(XSConvolutionKernel):
     See [1]_ for the meaning and restrictions, in particular the
     necessity of freezing the amplitude, or normalization, of the
     emission component (or components) at 1.
-
-    This model is only available when used with XSPEC 12.13.0 or later.
 
     References
     ----------

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -877,13 +877,8 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT(xsphei, 3),                        // XSheilin
   XSPECMODELFCT(xshecu, 2),                        // XShighecut
   XSPECMODELFCT(xshrfl, 8),                        // XShrefl
-#ifdef XSPEC_12_12_1
   XSPECMODELFCT_DBL(ismabs, 31),                   // XSismabs
   XSPECMODELFCT_DBL(ismdust, 3),                   // XSismdust
-#else
-  XSPECMODELFCT(ismabs, 31),                       // XSismabs
-  XSPECMODELFCT(ismdust, 3),                       // XSismdust
-#endif
   XSPECMODELFCT_C(C_logconst, 1),                  // XSlogconst
   XSPECMODELFCT_C(C_log10con, 1),                  // XSlog10con
 #ifdef XSPEC_12_15_0
@@ -891,11 +886,7 @@ static PyMethodDef XSpecMethods[] = {
 #endif
   XSPECMODELFCT(xslyman, 4),                       // XSlyman
   XSPECMODELFCT(xsntch, 3),                        // XSnotch
-#ifdef XSPEC_12_12_1
   XSPECMODELFCT_DBL(olivineabs, 2),                // XSolivineabs
-#else
-  XSPECMODELFCT(olivineabs, 2),                    // XSolivineabs
-#endif
   XSPECMODELFCT(xsabsp, 2),                        // XSpcfabs
   XSPECMODELFCT(xsphab, 1),                        // XSphabs
   XSPECMODELFCT(xsplab, 2),                        // XSplabs
@@ -974,9 +965,7 @@ static PyMethodDef XSpecMethods[] = {
 
   XSPECMODELFCT_CON(C_cflux, 3),                   // XScflux
   XSPECMODELFCT_CON(C_clumin, 4),                  // XSclumin
-#ifdef XSPEC_12_13_0
   XSPECMODELFCT_CON(C_cglumin, 4),                 // XScglumin
-#endif
   XSPECMODELFCT_CON(C_cpflux, 3),                  // XScpflux
   XSPECMODELFCT_CON(C_gsmooth, 2),                 // XSgsmooth
   XSPECMODELFCT_CON(C_ireflct, 7),                 // XSireflect

--- a/sherpa/include/sherpa/astro/xspec_extension.hh
+++ b/sherpa/include/sherpa/astro/xspec_extension.hh
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2009, 2015, 2017, 2020 - 2024
+//  Copyright (C) 2009, 2015, 2017, 2020 - 2025
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -36,20 +36,6 @@
 
 #include <XSFunctions/Utilities/funcType.h>
 #include <XSFunctions/Utilities/xsFortran.h>
-
-// The table interface is defined in XSPEC 12.12.1 in xsFortran.h
-// (and uses const parameters) but it is not defined in 12.12.0.
-//
-#ifndef XSPEC_12_12_1
-extern "C" {
-
-  void tabint(float* ear, int ne, float* param,
-	      int npar, const char* filenm, int ifl,
-	      const char* tabtyp, float* photar, float* photer);
-
-}
-#endif
-
 
 namespace sherpa { namespace astro { namespace xspec {
 


### PR DESCRIPTION
# Summary

Drop support for XSPEC 12.12.0 and 12.12.1.

# Details

XSPEC 12.12.0 was released 2021-07 and XSPEC 12.12.1 in 2022-03. It would be nice to still support old code, but there is no test that we can still build with this old code, and dropping support cleans up the code base slightly.

We don't have an official policy on XSPEC support, but at some point we stop testing old versions (as shown by the fact none of the tests failed here and one XSPEC model here has been changed from optional to required (as it was added in 12.13.0) and so would have caused a built with xspec 12.12.0/1 to fail.

Release dates for XSPEC, from https://heasarc.gsfc.nasa.gov/xanadu/xspec/CHANGELOG.txt

| Version | Date |
| ------- | ---- |
| 12.12.0 | 2021-07 |
| 12.12.1 | 2022-03 |
| 12.13.0 | 2022-11 |
| 12.13.1 | 2023-07 |
| 12.14.0 | 2024-02 |
| 12.14.1 | 2024-08 |
| 12.15.0 | 2025-03 |
