### PR TITLE
Ensure `Fit.method` gives the same answer as `Fit._iterfit.method`

### DIFF
--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1145,13 +1145,6 @@ class Fit(NoNewAttributesAfterInit):
         self.data = data
         self.model = model
 
-        # It is not clear why this can not just set self.stat but
-        # there is a comment below that suggests it should not be done
-        # here.
-        #
-        statobj = Chi2Gehrels() if stat is None else stat
-
-        self.method = LevMar() if method is None else method
         self.estmethod = Covariance() if estmethod is None else estmethod
         self.current_frozen = -1
 
@@ -1163,26 +1156,33 @@ class Fit(NoNewAttributesAfterInit):
 
         # Set up an IterFit object, so that the user can select
         # an iterative fitting option.
-        self._iterfit = IterFit(self.data, self.model, statobj,
-                                self.method, iopts)
-
-        # We need to set the statistic *after* creating the _iterfit
-        # attribute
-        #
-        self.stat = statobj
+        self._iterfit = IterFit(self.data,
+                                self.model,
+                                Chi2Gehrels() if stat is None else stat,
+                                LevMar() if method is None else method,
+                                iopts)
 
         super().__init__()
 
     @property
     def stat(self) -> Stat:
-        """Return the statistic value"""
-        return self._stat
+        """Return the statistic object"""
+        return self._iterfit.stat
 
     @stat.setter
     def stat(self, stat: Stat) -> None:
         """Ensure that we use a consistent stat object."""
-        self._stat = stat
         self._iterfit.stat = stat
+
+    @property
+    def method(self) -> OptMethod:
+        """Return the method object"""
+        return self._iterfit.method
+
+    @method.setter
+    def method(self, method: OptMethod) -> None:
+        """Ensure that we use a consistent method object."""
+        self._iterfit.method = method
 
     def __setstate__(self, state):
         self.__dict__.update(state)

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1090,6 +1090,10 @@ def _check_length(dep) -> int:
 class Fit(NoNewAttributesAfterInit):
     """Fit a model to a data set.
 
+    .. versionchanged:: 4.18.0
+       Prior to 4.18.0 changing the method field would not change the method used
+       by fit and esterrors, just the label shown when a ``Fit`` object is printed.
+
     .. versionchanged:: 4.17.0
        Changing the stat field now changes the internal IterFit
        object as well.
@@ -1166,22 +1170,20 @@ class Fit(NoNewAttributesAfterInit):
 
     @property
     def stat(self) -> Stat:
-        """Return the statistic object"""
+        """Set or get the statistic object"""
         return self._iterfit.stat
 
     @stat.setter
     def stat(self, stat: Stat) -> None:
-        """Ensure that we use a consistent stat object."""
         self._iterfit.stat = stat
 
     @property
     def method(self) -> OptMethod:
-        """Return the method object"""
+        """Set or get the method object"""
         return self._iterfit.method
 
     @method.setter
     def method(self, method: OptMethod) -> None:
-        """Ensure that we use a consistent method object."""
         self._iterfit.method = method
 
     def __setstate__(self, state):

--- a/sherpa/sim/tests/test_sim.py
+++ b/sherpa/sim/tests/test_sim.py
@@ -456,25 +456,26 @@ def test_mh(setup, caplog):
     # Note when the covariance changes; this is more just as a check
     # hence not a full check.
     #
-    diag = np.asarray([1.68857268e-03, 6.48507899e-01,
-                       9.22029508e-03, 1.88340111e-03,
-                       3.22767792e+00])
+    diag = np.asarray([1.68861299e-03, 6.48511837e-01,
+                       9.22037431e-03, 1.88340729e-03,
+                       3.22766923e+00])
     assert np.diag(cov) == pytest.approx(diag)
 
     # Check outfile; expect
     #     nfev statistic pl.gamma pl.ampl g1.fwhm g1.pos g1.ampl
     #
     row0 = np.asarray([0, -8975.692, 1.070194, 9.182625, 2.586208, 2.601620, 47.26266])
-    row19 = np.asarray([19, -8975.953, 1.069763, 9.219122,  2.570933, 2.586584,  47.36504])
-    row20 = row19.copy()
-    row20[0] = 20
+    row551 = np.asarray([551, -8975.953,  1.069770,  9.219028,
+                         2.570941,  2.586583,  47.36505])
+    row552 = row551.copy()
+    row552[0] = 552
 
     out.seek(0)
     fitvals = np.loadtxt(out)
-    assert fitvals.shape == (21, 7)
+    assert fitvals.shape == (553, 7)
     assert fitvals[0] == pytest.approx(row0)
-    assert fitvals[19] == pytest.approx(row19)
-    assert fitvals[20] == pytest.approx(row20)
+    assert fitvals[551] == pytest.approx(row551)
+    assert fitvals[552] == pytest.approx(row552)
 
     mcmc = sim.MCMC()
     for par in setup.fit.model.pars:
@@ -503,7 +504,7 @@ def test_mh(setup, caplog):
     assert accept.min() == 0
     assert accept.max() == 1
 
-    means = np.asarray([1.06497461, 9.2188531, 2.58191838, 2.57882817, 47.5158447])
+    means = np.asarray([1.064982272, 9.2187596738, 2.581926009, 2.57882817, 47.5158447])
     assert params.mean(axis=1) == pytest.approx(means)
 
 
@@ -522,25 +523,25 @@ def test_metropolisMH(setup, caplog):
     # Note when the covariance changes; this is more just as a check
     # hence not a full check.
     #
-    diag = np.asarray([1.68857268e-03, 6.48507899e-01,
-                       9.22029508e-03, 1.88340111e-03,
-                       3.22767792e+00])
+    diag = np.asarray([1.68861300e-03, 6.48511828e-01,
+                       9.22037429e-03, 1.88340729e-03,
+                       3.22766923e+00])
     assert np.diag(cov) == pytest.approx(diag)
 
     # Check outfile; expect
     #     nfev statistic pl.gamma pl.ampl g1.fwhm g1.pos g1.ampl
     #
     row0 = np.asarray([0, 98.83959, 1.070194, 9.182625, 2.586208, 2.601620, 47.26266])
-    row19 = np.asarray([19, 98.5784, 1.069763, 9.219122, 2.570933, 2.586584, 47.36504])
-    row20 = row19.copy()
-    row20[0] = 20
+    row602 = np.asarray([602., 98.5784, 1.06977, 9.219028, 2.570941, 2.586583, 47.36505])
+    row603 = row602.copy()
+    row603[0] = 603
 
     out.seek(0)
     fitvals = np.loadtxt(out)
-    assert fitvals.shape == (21, 7)
+    assert fitvals.shape == (604, 7)
     assert fitvals[0] == pytest.approx(row0)
-    assert fitvals[19] == pytest.approx(row19)
-    assert fitvals[20] == pytest.approx(row20)
+    assert fitvals[602] == pytest.approx(row602)
+    assert fitvals[603] == pytest.approx(row603)
 
     mcmc = sim.MCMC()
     mcmc.set_sampler('MetropolisMH')
@@ -561,7 +562,7 @@ def test_metropolisMH(setup, caplog):
     assert accept.min() == 0
     assert accept.max() == 1
 
-    means = np.asarray([1.06278015, 9.21533855, 2.5736483, 2.5853907, 47.27058904])
+    means = np.asarray([1.06278784, 9.2152448, 2.573655956, 2.5853907, 47.27058904])
     assert params.mean(axis=1) == pytest.approx(means)
 
 

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -3414,3 +3414,55 @@ def test_sigmarej_invalid_argument(arg, value):
     with pytest.raises(SherpaErr,
                        match="^Generic Error$"):
         f.fit()
+
+
+def test_change_opt_method_after_fit_object_creation():
+    """Check we can change the method after creating the fit object?
+
+    This is a regression test for issue #2296.
+
+    """
+    data = Data1D('data1', x=np.arange(5),
+                  y=[3.4, 3.6, 3.3, 3.5, 3.4],
+                  staterror=[0.1, 0.2, 0.14, 0.09, 0.1])
+    model = Const1D('model')
+
+    fitter = Fit(data=data, model=model, method=NelderMead())
+    res_nm = fitter.fit()
+    assert fitter.method == fitter._iterfit.method
+
+    fitter.method = MonCar()
+    model.reset()
+    res_mc = fitter.fit()
+    assert fitter.method == fitter._iterfit.method
+    # While both converge, the output message is different.
+    assert res_nm != res_mc
+    assert res_nm.nfev != res_mc.nfev
+
+
+def test_change_stat_after_fit_object_creation():
+    """Check we can change the method after creating the fit object?
+
+    This is a regression test for issue #2063.
+
+    """
+    data = Data1D('data1', x=np.arange(5),
+                  y=[4,5,2,3,5],
+                  staterror=[0.1, 0.2, 0.14, 0.09, 0.1])
+    model = Const1D('model')
+
+    lsstat = LeastSq()
+    fitter = Fit(data=data, model=model, stat=lsstat)
+    res_ls = fitter.fit()
+    assert fitter.stat == lsstat
+    assert fitter.stat == fitter._iterfit.stat
+
+    chigstat = Chi2Gehrels()
+    fitter.stat = chigstat
+    model.reset()
+    res_chig = fitter.fit()
+    assert fitter.stat == chigstat
+    assert fitter.stat == fitter._iterfit.stat
+    # While both converge, the statval is obviously different.
+    assert res_ls.statval != res_chig.statval
+    assert res_ls.statname != res_chig.statname

--- a/sherpa/tests/test_fit_unit.py
+++ b/sherpa/tests/test_fit_unit.py
@@ -1876,22 +1876,22 @@ def test_fit_single(stat, usestat, usesys, finalstat):
     assert fr.statval == pytest.approx(finalstat, rel=7e-5)
 
 
-@pytest.mark.parametrize("stat,usestat,usesys,finalstat", [
-    (LeastSq, False, False, fit_lsq),
-    (Chi2, True, True, fit_chi2_tt),
-    (Chi2Gehrels, True, True, fit_chi2_tt),
-    (Chi2Gehrels, False, False, fit_gehrels_ff),
-    (Chi2XspecVar, False, True, fit_xvar_ft),
-    (Chi2ConstVar, False, True, fit_cvar_ft),
-    (Chi2ModVar, True, True, fit_mvar_xt),
-    (Chi2ModVar, True, False, fit_mvar_xf),
-    (Chi2ModVar, False, False, fit_mvar_xf),
-    (Chi2ModVar, False, True, fit_mvar_xt),
+@pytest.mark.parametrize("stat,usestat,usesys,finalstat,rel", [
+    (LeastSq, False, False, fit_lsq, 1e-6),
+    (Chi2, True, True, fit_chi2_tt, 1e-6),
+    (Chi2Gehrels, True, True, fit_chi2_tt, 1e-6),
+    (Chi2Gehrels, False, False, fit_gehrels_ff, 1e-6),
+    (Chi2XspecVar, False, True, fit_xvar_ft, 1e-6),
+    (Chi2ConstVar, False, True, fit_cvar_ft, 1e-6),
+    (Chi2ModVar, True, True, fit_mvar_xt, 1e-6),
+    (Chi2ModVar, True, False, fit_mvar_xf, 1e-6),
+    (Chi2ModVar, False, False, fit_mvar_xf, 1e-6),
+    (Chi2ModVar, False, True, fit_mvar_xt, 1e-6),
 
-    (Cash, True, True, fit_cash),
-    (CStat, True, True, fit_cstat),
+    (Cash, True, True, fit_cash, 1e-6),
+    (CStat, True, True, fit_cstat, 2e-4),  # This tests gives different results on Linux and ARM
 ])
-def test_fit_single_nm(stat, usestat, usesys, finalstat):
+def test_fit_single_nm(stat, usestat, usesys, finalstat, rel):
     """Check that the fit method works: single dataset, successful fit, simplex
 
     Test several cases from test_fit_single but using the
@@ -1903,7 +1903,7 @@ def test_fit_single_nm(stat, usestat, usesys, finalstat):
     fit.method = NelderMead()
     fr = fit.fit()
     assert fr.succeeded
-    assert fr.statval == pytest.approx(finalstat)
+    assert fr.statval == pytest.approx(finalstat, rel=rel)
 
 
 # Since the background is being ignored in this fit (except for


### PR DESCRIPTION
## Summary
Ensure `Fit.method` gives the same answer as `Fit._iterfit.method`. FIxes #2296

## Details
Previously, those objects could be different, leading to inconsistent results when a user though that the optimization method had been changed when in reality the previous setting was still active.
One optimization method would be reported in printing, while in practice a different method was used.

This PR changes some of the tests, because the tests contain hardcoded expected values that were actually run with the wong method.
