### PR TITLE
Ensure the sample/normal/t_sample ui routines use the local RNG if set

### DIFF
--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -1498,11 +1498,11 @@ T_SAMPLE = np.asarray([[9.75190011, 6.69601813],
 
 @pytest.mark.parametrize("xxx,expected, setrng",
                          [("normal", N_SAMPLE, set_rng_global),
-                          pytest.param("normal", N_SAMPLE, set_rng_local, marks=pytest.mark.xfail),
+                          ("normal", N_SAMPLE, set_rng_local),
                           ("uniform", U_SAMPLE, set_rng_global),
-                          pytest.param("uniform", U_SAMPLE, set_rng_local, marks=pytest.mark.xfail),
+                          ("uniform", U_SAMPLE, set_rng_local),
                           ("t", T_SAMPLE, set_rng_global),
-                          pytest.param("t", T_SAMPLE, set_rng_local, marks=pytest.mark.xfail),
+                          ("t", T_SAMPLE, set_rng_local),
                          ])
 def test_xxx_sample_random(xxx, expected, setrng, clean_ui):
     """Check if xxx_sample is repeatable.
@@ -1528,7 +1528,7 @@ def test_xxx_sample_random(xxx, expected, setrng, clean_ui):
     assert answer == pytest.approx(expected)
 
 
-@pytest.mark.parametrize("setrng", [set_rng_global, pytest.param(set_rng_local, marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("setrng", [set_rng_global, set_rng_local])
 def test_normal_sample_correlate(setrng, clean_ui):
     """Does the correlate setting change anything with normal_sample?"""
 

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2020 - 2025
+#  Copyright (C) 2017, 2018, 2020-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1466,3 +1466,116 @@ def test_num_pars_links(clean_ui):
     assert ui.get_num_par() == 5
     assert ui.get_num_par_thawed() == 3
     assert ui.get_num_par_frozen() == 2
+
+
+SEEDVAL = 1327
+
+def set_rng_global():
+    # Ensure no RNG is set
+    ui.set_rng(None)
+    np.random.seed(SEEDVAL)
+
+
+def set_rng_local():
+    # Set the global RNG state to a random state to make sure it isn't
+    # being used (the assumption is that this will not match SEEDVAL).
+    np.random.seed()
+    ui.set_rng(np.random.RandomState(SEEDVAL))
+
+
+# The uniform sampling creates a model value < 0 which is allowed,
+# but unphysical. Really should have changed the parameter range.
+#
+N_SAMPLE = np.asarray([[2.9013215,  4.4862895 ],
+                       [1.55735165, 3.86432178],
+                       [0.42363933, 2.35716076]])
+U_SAMPLE = np.asarray([[ 5.97118671e-01,  3.20748789e+00],
+                       [ 9.39240153e-01,  3.48835118e+00],
+                       [ 9.21034037e+02, -2.67949604e-01]])
+T_SAMPLE = np.asarray([[9.75190011, 6.69601813],
+                       [8.60285233, 6.37242034],
+                       [0.46611989, 2.30776257]])
+
+@pytest.mark.parametrize("xxx,expected, setrng",
+                         [("normal", N_SAMPLE, set_rng_global),
+                          pytest.param("normal", N_SAMPLE, set_rng_local, marks=pytest.mark.xfail),
+                          ("uniform", U_SAMPLE, set_rng_global),
+                          pytest.param("uniform", U_SAMPLE, set_rng_local, marks=pytest.mark.xfail),
+                          ("t", T_SAMPLE, set_rng_global),
+                          pytest.param("t", T_SAMPLE, set_rng_local, marks=pytest.mark.xfail),
+                         ])
+def test_xxx_sample_random(xxx, expected, setrng, clean_ui):
+    """Check if xxx_sample is repeatable.
+
+    At the moment we allow the global RNG (np.random.seed)
+
+    """
+
+    ui.load_arrays(1, [2, 3, 10], [3, 4, 1])
+    ui.set_stat('cash')
+    ui.set_source(ui.const1d.mdl)
+    ui.fit()
+
+    setrng()
+
+    func = getattr(ui, f"{xxx}_sample")
+    answer = func(num=3)
+
+    # clear out the RNG state
+    np.random.seed()
+    ui.set_rng(None)
+
+    assert answer == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("setrng", [set_rng_global, pytest.param(set_rng_local, marks=pytest.mark.xfail)])
+def test_normal_sample_correlate(setrng, clean_ui):
+    """Does the correlate setting change anything with normal_sample?"""
+
+    ui.load_arrays(1, [1, 2, 3, 4, 5], [2, 4, 7, 15, 19])
+    ui.set_source(ui.polynom1d.mdl)
+    mdl.c1.thaw()
+    ui.fit()
+
+    bestfit = np.asarray([mdl.c0.val, mdl.c1.val])
+
+    setrng()
+    e1t = ui.normal_sample(num=3, sigma=1, correlate=True)
+
+    setrng()
+    e1f = ui.normal_sample(num=3, sigma=1, correlate=False)
+
+    setrng()
+    e2t = ui.normal_sample(num=3, sigma=2, correlate=True)
+
+    setrng()
+    e2f = ui.normal_sample(num=3, sigma=2, correlate=False)
+
+    # Are the sigma=2 values twice those of sigma=1, after subtracting
+    # off the best-fit? The first column is dropped as it is the
+    # statistic column.
+    #
+    # The scalevalue should be 2.0, but at present the sigma value
+    # does not get sent through to the correct classes, so it is
+    # actually unused (at least in some cases).
+    #
+    scalevalue = 1.0
+    expected = np.full((3, 2), scalevalue)
+
+    def check_ratio(v1, v2):
+        """Check sigma=1 and sigma=2 results scale"""
+
+        d1 = v1 - bestfit
+        d2 = v2 - bestfit
+        r = d2 / d1
+        assert r == pytest.approx(expected)
+
+    check_ratio(e1t[:, 1:], e2t[:, 1:])
+    check_ratio(e1f[:, 1:], e2f[:, 1:])
+
+    # Assume that the correlated=true/false results are different,
+    # which can be checked by comparing the statistic columns.
+    #
+    stat_t = e1t[:, 0]
+    stat_f = e1f[:, 0]
+    assert not stat_f == pytest.approx(stat_t)

--- a/sherpa/ui/tests/test_ui_unit.py
+++ b/sherpa/ui/tests/test_ui_unit.py
@@ -1496,7 +1496,7 @@ T_SAMPLE = np.asarray([[9.75190011, 6.69601813],
                        [8.60285233, 6.37242034],
                        [0.46611989, 2.30776257]])
 
-@pytest.mark.parametrize("xxx,expected, setrng",
+@pytest.mark.parametrize("xxx,expected,setrng",
                          [("normal", N_SAMPLE, set_rng_global),
                           ("normal", N_SAMPLE, set_rng_local),
                           ("uniform", U_SAMPLE, set_rng_global),

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -10067,16 +10067,24 @@ class Session(NoNewAttributesAfterInit):
     # Unfortunately not quite a direct copy, so hard
     # to see how to do
 
-    def normal_sample(self, num=1, sigma=1, correlate=True,
+    def normal_sample(self,
+                      num: int = 1,
+                      sigma: float = 1,
+                      correlate: bool = True,
                       id: IdType | None = None,
                       otherids: IdTypes = (),
-                      numcores=None):
+                      numcores: int | None = None
+                      ) -> np.ndarray:
         """Sample the fit statistic by taking the parameter values
         from a normal distribution.
 
         For each iteration (sample), change the thawed parameters by
         drawing values from a uni- or multi-variate normal (Gaussian)
         distribution, and calculate the fit statistic.
+
+        ..versionchanged:: 4.18.0
+          The random state returned by get_rng is now used for the
+          sampling.
 
         Parameters
         ----------
@@ -10136,19 +10144,29 @@ class Session(NoNewAttributesAfterInit):
 
         """
         ids, fit = self._get_fit(id, otherids)
-        return sherpa.sim.normal_sample(fit, num, sigma, correlate, numcores)
+        rng = self.get_rng()
+        return sherpa.sim.normal_sample(fit, num=num, sigma=sigma,
+                                        correlate=correlate,
+                                        numcores=numcores, rng=rng)
 
     # DOC-TODO: improve the description of factor parameter
-    def uniform_sample(self, num=1, factor=4,
+    def uniform_sample(self,
+                       num: int = 1,
+                       factor: float = 4,
                        id: IdType | None = None,
                        otherids: IdTypes = (),
-                       numcores=None):
+                       numcores: int | None = None
+                       ) -> np.ndarray:
         """Sample the fit statistic by taking the parameter values
         from an uniform distribution.
 
         For each iteration (sample), change the thawed parameters by
         drawing values from a uniform distribution, and calculate the
         fit statistic.
+
+        ..versionchanged:: 4.18.0
+          The random state returned by get_rng is now used for the
+          sampling.
 
         Parameters
         ----------
@@ -10194,18 +10212,27 @@ class Session(NoNewAttributesAfterInit):
 
         """
         ids, fit = self._get_fit(id, otherids)
-        return sherpa.sim.uniform_sample(fit, num, factor, numcores)
+        rng = self.get_rng()
+        return sherpa.sim.uniform_sample(fit, num=num, factor=factor,
+                                         numcores=numcores, rng=rng)
 
-    def t_sample(self, num=1, dof=None,
+    def t_sample(self,
+                 num: int = 1,
+                 dof: int | None = None,
                  id: IdType | None = None,
                  otherids: IdTypes = (),
-                 numcores=None):
+                 numcores: int | None = None
+                 ) -> np.ndarray:
         """Sample the fit statistic by taking the parameter values from
         a Student's t-distribution.
 
         For each iteration (sample), change the thawed parameters
         by drawing values from a Student's t-distribution, and
         calculate the fit statistic.
+
+        ..versionchanged:: 4.18.0
+          The random state returned by get_rng is now used for the
+          sampling.
 
         Parameters
         ----------
@@ -10253,9 +10280,12 @@ class Session(NoNewAttributesAfterInit):
         """
         ids, fit = self._get_fit(id, otherids)
         if dof is None:
-            dof = (len(fit.data.eval_model_to_fit(fit.model)) -
-                   len(fit.model.thawedpars))
-        return sherpa.sim.t_sample(fit, num, dof, numcores)
+            dof = len(fit.data.eval_model_to_fit(fit.model)) - \
+                len(fit.model.thawedpars)
+
+        rng = self.get_rng()
+        return sherpa.sim.t_sample(fit, num=num, dof=dof,
+                                   numcores=numcores, rng=rng)
 
     ###########################################################################
     # Error estimation


### PR DESCRIPTION
# Summary

Ensure that local generators sent to set_rng are used in the normal_sample, uniform_sample, and t_sample routines. Fix #2314.

# Details

This is fall-out from #1735, which added the `set_rng/get_rng` calls to the UI code. The `normal_sample`, `uniform_sample`, and `t_sample` routines missed out on this, so fix this. 

As part of this, add some limited typing rules to these methods.

This has been taken out of

- #2211