### PR TITLE
CI: add an  aarch64 workflow

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -5,12 +5,12 @@ echo "** uname -s: `uname -s`"
 echo "** uname -m: `uname -m`"
 
 if [ "`uname -s`" == "Darwin" ] ; then
-
     if [ "`uname -m`" == "x86_64" ]; then
-	sys="64"
+       sys="64"
     else
-	sys="arm64"
+       sys="arm64"
     fi
+
     compilers="clang_osx-${sys} clangxx_osx-${sys} gfortran_osx-${sys}"
 
     #Download the macOS 11.0 SDK to the CONDA_BUILD_SYSROOT location for the Conda Compilers to work
@@ -22,7 +22,13 @@ if [ "`uname -s`" == "Darwin" ] ; then
     tar -C ${GITHUB_WORKSPACE}/../11.0SDK -xf MacOSX11.0.sdk.tar.xz
 
 else
-    compilers="gcc_linux-64=14.2 gxx_linux-64=14.2 gfortran_linux-64"
+    if [ "`uname -m`" == "x86_64" ]; then
+        sys="64"
+    else
+        sys="aarch64"
+    fi
+
+    compilers="gcc_linux-${sys}=14.2 gxx_linux-${sys}=14.2 gfortran_linux-${sys}"
 
     if [ -n "${MATPLOTLIBVER}" ]; then
         #Installed for qt-main deps which is needed for the QtAgg backend to work for matplotlib

--- a/.github/scripts/setup_ds9.sh
+++ b/.github/scripts/setup_ds9.sh
@@ -29,7 +29,12 @@ else
 
     # set os-specific variables
     ds9_os=ubuntu24
-    ds9_platform=x86
+    if [ "`uname -m`" == "x86_64" ] ; then
+      ds9_platform=x86
+    else
+      # Assume this is aarch64 for now
+      ds9_platform=arm64
+    fi
 fi
 
 echo "* ds9_os=$ds9_os"

--- a/.github/workflows/ci-pip-arch.yml
+++ b/.github/workflows/ci-pip-arch.yml
@@ -17,68 +17,76 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-22.04
     if: (github.repository == 'sherpa/sherpa' && (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'CI arch')))
 
+    defaults:
+      run:
+        shell: bash
+
+    name: ${{ matrix.name }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.arch }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - arch: aarch64
-          - arch: ppc64le
-
-          # We currently do not have any user requests for this
-          # architecture.
-          #
-          # - arch: s390x
+          - name: Python 3.13
+            arch: ubuntu-24.04-arm
+            python-version: "3.13"
+            numpy-pkg: 'numpy'
+            fits-pkg: 'astropy'
+            matplotlib-pkg: 'matplotlib>=3,<4'
+            bokeh-pkg: 'bokeh>=3,<4'
+            # arviz-pkg: 'arviz'  wait until #2457 has landed
 
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6
-      # As we do not include an I/O backend it is not worth checking out the data submodule.
-      #
-      # with:
-      #   submodules: 'True'
-
-    - name: Build and test
-      uses: uraimo/run-on-arch-action@v2
       with:
-        arch: ${{ matrix.arch }}
-        # use the latest LTS version
-        distro: ubuntu_latest
+        submodules: 'True'
 
-        shell: /bin/bash
+    - name: "Setup: Python"
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
 
-        # Based on AstroPy
-        install: |
-          apt-get update -q -y
-          apt-get install -q -y \
-                                g++ \
-                                gfortran \
-                                flex \
-                                bison \
-                                make \
-                                file \
-                                pkg-config \
-                                python3 \
-                                python3-dev \
-                                python3-configobj \
-                                python3-numpy \
-                                python3-venv
+    - name: "Setup: Dependencies"
+      env:
+        NUMPYVER: ${{ matrix.numpy-pkg }}
+        FITSBUILD: ${{ matrix.fits-pkg }}
+        MATPLOTLIBVER: ${{ matrix.matplotlib-pkg }}
+        BOKEHVER: ${{ matrix.bokeh-pkg }}
+        ARVIZVER: ${{ matrix.arviz-pkg }}
+      run: |
+        pip install ${NUMPYVER} ${FITSBUILD} ${MATPLOTLIBVER} ${BOKEHVER} ${ARVIZVER} pytest-xvfb
 
-        # Follow AstroPy for now and do not install any external packages
-        # (I/O, plotting, or DS9).
+    - name: "Setup: DS9"
+      run: |
+        # Setup CONDA_PREFIX so that it maps to a location which
+        # contains a bin directory which is in the PATH (or will be).
         #
-        run: |
-          python3 -m venv --system-site-packages tests
-          source tests/bin/activate
+        mkdir $HOME/bin
+        CONDA_PREFIX=$HOME source .github/scripts/setup_ds9.sh
 
-          # without this we get configure errors when building fftw and I don't know why
-          # (this adds the --disable-dependency-tracking option). A google suggests it
-          # could be a make vs gmake issue but we can't easily change this (and it may
-          # not be the actual problem).
-          #
-          sed -i.orig "s|#configure=None|configure=--disable-maintainer-mode --enable-stuberrorlib --disable-shared --enable-shared=libgrp,stklib --disable-dependency-tracking|" setup.cfg
+    - name: "Install Sherpa"
+      run: |
+        pip install . --verbose
 
-          pip3 install -e .[test]
-          python3 -m pytest
+    - name: "sherpa_test"
+      run: |
+        data_dir=`pwd`
+        cd $HOME
+        PATH=$HOME/bin:$PATH
+        sherpa_test -D ${data_dir}/sherpa-test-data/sherpatest
+
+    - name: "Smoke Test"
+      env:
+        FITS: ${{ matrix.fits-pkg }}
+      run: |
+        smokevars="-d -v 3"
+        if [ ${FITS} != '' ] ; then
+            smokevars="-f ${FITS} ${smokevars}"
+        fi
+        echo "** smoke test: ${smokevars}"
+        cd ${HOME}
+        PATH=$HOME/bin:$PATH
+        sherpa_smoke ${smokevars}

--- a/.github/workflows/ci-pip-arch.yml
+++ b/.github/workflows/ci-pip-arch.yml
@@ -17,68 +17,83 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-22.04
     if: (github.repository == 'sherpa/sherpa' && (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'CI arch')))
 
+    defaults:
+      run:
+        shell: bash
+
+    name: ${{ matrix.name }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.arch }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - arch: aarch64
-          - arch: ppc64le
-
-          # We currently do not have any user requests for this
-          # architecture.
-          #
-          # - arch: s390x
+          - name: Python 3.13
+            arch: ubuntu-24.04-arm
+            python-version: "3.13"
+            numpy-pkg: 'numpy'
+            fits-pkg: 'astropy'
+            matplotlib-pkg: 'matplotlib>=3,<4'
+            bokeh-pkg: 'bokeh>=3,<4'
+            arviz-pkg: 'arviz'
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v6
-      # As we do not include an I/O backend it is not worth checking out the data submodule.
-      #
-      # with:
-      #   submodules: 'True'
-
-    - name: Build and test
-      uses: uraimo/run-on-arch-action@v2
+      uses: actions/checkout@v7
       with:
-        arch: ${{ matrix.arch }}
-        # use the latest LTS version
-        distro: ubuntu_latest
+        submodules: 'True'
 
-        shell: /bin/bash
+    - name: "Setup: Python"
+      uses: actions/setup-python@v7
+      with:
+        python-version: ${{ matrix.python-version }}
 
-        # Based on AstroPy
-        install: |
-          apt-get update -q -y
-          apt-get install -q -y \
-                                g++ \
-                                gfortran \
-                                flex \
-                                bison \
-                                make \
-                                file \
-                                pkg-config \
-                                python3 \
-                                python3-dev \
-                                python3-configobj \
-                                python3-numpy \
-                                python3-venv
+    - name: "Setup: Dependencies (system)"
+      run: |
+        # Assume that pkg-config is installed
+        sudo apt-get install -y libfftw3-dev
+        echo "** fftw3"
+        pkg-config fftw3 --cflags --libs
 
-        # Follow AstroPy for now and do not install any external packages
-        # (I/O, plotting, or DS9).
+    - name: "Setup: Dependencies (pip)"
+      env:
+        NUMPYVER: ${{ matrix.numpy-pkg }}
+        FITSBUILD: ${{ matrix.fits-pkg }}
+        MATPLOTLIBVER: ${{ matrix.matplotlib-pkg }}
+        BOKEHVER: ${{ matrix.bokeh-pkg }}
+        ARVIZVER: ${{ matrix.arviz-pkg }}
+      run: |
+        pip install ${NUMPYVER} ${FITSBUILD} ${MATPLOTLIBVER} ${BOKEHVER} ${ARVIZVER} pytest-xvfb
+
+    - name: "Setup: DS9"
+      run: |
+        # Setup CONDA_PREFIX so that it maps to a location which
+        # contains a bin directory which is in the PATH (or will be).
         #
-        run: |
-          python3 -m venv --system-site-packages tests
-          source tests/bin/activate
+        mkdir $HOME/bin
+        CONDA_PREFIX=$HOME source .github/scripts/setup_ds9.sh
 
-          # without this we get configure errors when building fftw and I don't know why
-          # (this adds the --disable-dependency-tracking option). A google suggests it
-          # could be a make vs gmake issue but we can't easily change this (and it may
-          # not be the actual problem).
-          #
-          sed -i.orig "s|#configure=None|configure=--disable-maintainer-mode --enable-stuberrorlib --disable-shared --enable-shared=libgrp,stklib --disable-dependency-tracking|" setup.cfg
+    - name: "Install Sherpa"
+      run: |
+        pip install . --verbose
 
-          pip3 install -e .[test]
-          python3 -m pytest
+    - name: "sherpa_test"
+      run: |
+        data_dir=`pwd`
+        cd $HOME
+        PATH=$HOME/bin:$PATH
+        sherpa_test -D ${data_dir}/sherpa-test-data/sherpatest
+
+    - name: "Smoke Test"
+      env:
+        FITS: ${{ matrix.fits-pkg }}
+      run: |
+        smokevars="-d -v 3"
+        if [ ${FITS} != '' ] ; then
+            smokevars="-f ${FITS} ${smokevars}"
+        fi
+        echo "** smoke test: ${smokevars}"
+        cd ${HOME}
+        PATH=$HOME/bin:$PATH
+        sherpa_smoke ${smokevars}

--- a/sherpa/astro/ui/tests/test_eqwidth_err.py
+++ b/sherpa/astro/ui/tests/test_eqwidth_err.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2018, 2021, 2023, 2025
+#  Copyright (C) 2018, 2021, 2023, 2025-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -397,7 +397,8 @@ def test_eqwidth_multi_id_poisson(clean_astro_ui):
 
     # A regression to check if the calculation changes.
     #
-    assert val1 == pytest.approx(0.0409343934694133)
+    tol = 1e-5
+    assert val1 == pytest.approx(0.0409343934694133, rel=tol)
 
     # Check the error results. This is calculated via get_draws,
     # which handles the multiple-id case.
@@ -425,9 +426,9 @@ def test_eqwidth_multi_id_poisson(clean_astro_ui):
     # be approximated by a "smaller" sigma limits range, and the
     # "a + b" and "b + a" give the same results.
     #
-    assert resa[0] == pytest.approx(0.04259715629705425)
-    assert resb[0] == pytest.approx(0.043209134605777154)
-    assert resab[0] == pytest.approx(0.04104216531226462)
+    assert resa[0] == pytest.approx(0.04259715629705425, rel=tol)
+    assert resb[0] == pytest.approx(0.043209134605777154, rel=tol)
+    assert resab[0] == pytest.approx(0.04104216531226462, rel=tol)
 
     # The resba results are identical to resab
     assert resba[4] == pytest.approx(resab[4])


### PR DESCRIPTION
# Summary

Add an aarch64 CI run. Fix #2338.

# Details

I just want to make sure we have an aarch64 build being tested. I do not think  it worth adding a full set of tests for this platform. This replaces the "arch" workflow, which used emulation, with the new Linux aarch64 runner.

As part of this work two of the scripts used in the conda GitHub workflows have been reworked to also work when run on the aarch64 platform. The conda setup is currently not used (but is there if we decide to add a conda test) and the ds9 setup is used here (as the workflow is written to emulate the conda setup required by the script).