### PR TITLE
Improve documentation on parallel and thread support

### DIFF
--- a/docs/overview/utilities.rst
+++ b/docs/overview/utilities.rst
@@ -12,6 +12,46 @@ There are a number of utility routines provided by Sherpa that may
 be useful. Unfortunately it is not always obvious whether a routine is for use
 with the Object-Oriented API or the Session API.
 
+.. _resource-file:
+
+The Sherpa resource file
+========================
+
+The `sherpa.get_config` routine returns the location of the default
+resource file used to configure Sherpa. The location of this file is
+taken from (in order):
+
+  1. the ``SHERPARC`` environment file,
+
+  2. the file ``.sherpa.rc`` in the user's home directory,
+
+  3. and the file returned by `~sherpa.get_config`.
+
+.. _multi-core:
+
+Taking advantage of multiple CPUs
+=================================
+
+The `sherpa.utils.parallel` module provides code to run code on
+multiple CPUs. There are two settings in the Sherpa resource file
+that can be changed:
+
+- ``parallel.numcores``
+- ``multiprocessing.multiprocessing_start_method``
+
+If ``parallel.numcores`` is set to 1 then the code will run in serial
+and not parallel.
+
+The ``multiprocessing.multiprocessing_start_method`` field controls
+how the parallel code is run. Using methods other than "fork" are
+unlikely to provide any benefit, and it is probably better to set
+``parallel.numcores`` to 1 if the "fork" method can not be used.
+
+Sherpa relies on mutable state, in particular for handling parameter
+values, and so is unlikely to benefit from using threads.
+
+.. _verbosity:
+
 Controlling the verbosity of Sherpa
 ===================================
 

--- a/docs/overview/utilities.rst
+++ b/docs/overview/utilities.rst
@@ -44,8 +44,10 @@ and not parallel.
 
 The ``multiprocessing.multiprocessing_start_method`` field controls
 how the parallel code is run. Using methods other than "fork" are
-unlikely to provide any benefit, and it is probably better to set
+unlikely to provide any benefit for Sherpa, and it is probably better to set
 ``parallel.numcores`` to 1 if the "fork" method can not be used.
+The `Python documentation on multiprocessing <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_
+explains the methods that Python offers and discusses some pitfalls.
 
 Sherpa relies on mutable state, in particular for handling parameter
 values, and so is unlikely to benefit from using threads.

--- a/sherpa/utils/parallel.py
+++ b/sherpa/utils/parallel.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2018 - 2025
+#  Copyright (C) 2007, 2015, 2016, 2018-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -19,6 +19,15 @@
 #
 
 """Routines for running code in parallel.
+
+The Sherpa configuration file contains two settings that control how
+code can be run in parallel:
+
+- parallel.numcores
+- multiprocessing.multiprocessing_start_method
+
+Sherpa relies on mutable state, in particular for handling parameter
+values, and so is unlikely to benefit from using threads.
 
 .. versionchanged:: 4.16.1
    All `multiprocessing` calls are now done using an explicit context,


### PR DESCRIPTION
# Summary

Add minimal documentation about parallel and thread support.

# Details

One of the suggestions about support Python free threading is to document the thread support. At this time we do not support the free-threading build of Python, and it is not obvious, even when we do, if it would provide much benefit given that Sherpa relies on a lot of mutable state (in particular, parameter objects). So we add a minimal amount of documentation, and improve some related documentation as part of this work.

This has been written after working on

- #2309 

but can be merged now (although maybe we should say something like "fork" is the only supported method here?)