### PR TITLE
Address documentation errors in normal/uniform/t_sample

### DIFF
--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -10082,9 +10082,9 @@ class Session(NoNewAttributesAfterInit):
         drawing values from a uni- or multi-variate normal (Gaussian)
         distribution, and calculate the fit statistic.
 
-        ..versionchanged:: 4.18.0
-          The random state returned by get_rng is now used for the
-          sampling.
+        .. versionchanged:: 4.18.0
+           The random state returned by get_rng is now used for the
+           sampling.
 
         Parameters
         ----------
@@ -10164,9 +10164,9 @@ class Session(NoNewAttributesAfterInit):
         drawing values from a uniform distribution, and calculate the
         fit statistic.
 
-        ..versionchanged:: 4.18.0
-          The random state returned by get_rng is now used for the
-          sampling.
+        .. versionchanged:: 4.18.0
+           The random state returned by get_rng is now used for the
+           sampling.
 
         Parameters
         ----------
@@ -10230,9 +10230,9 @@ class Session(NoNewAttributesAfterInit):
         by drawing values from a Student's t-distribution, and
         calculate the fit statistic.
 
-        ..versionchanged:: 4.18.0
-          The random state returned by get_rng is now used for the
-          sampling.
+        .. versionchanged:: 4.18.0
+           The random state returned by get_rng is now used for the
+           sampling.
 
         Parameters
         ----------


### PR DESCRIPTION
# Summary

Fix up a typo in the docstrings for the normal_sample, uniform_sample, and t_sample routines.

# Details

Fix up incorrect markup ("..versionchanged::" should be ".. versionchanged::") added in #2331.