### PR TITLE
Update Python version support: drop 3.10 and add 3.14

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -53,6 +53,7 @@ echo "dependencies: ${MATPLOTLIB} ${BOKEH} ${NUMPY} ${XSPEC} ${FITSBUILD}"
 echo "compilers:    ${compilers}"
 
 # Create and activate conda build environment
-conda create --yes -n build python"=${PYTHONVER}.*=*cpython*" pip ${MATPLOTLIB} ${BOKEH} ${NUMPY} ${XSPEC} ${FITSBUILD} ${compilers}
+# conda create --yes -n build python"=${PYTHONVER}.*=*cpython*" pip ${MATPLOTLIB} ${BOKEH} ${NUMPY} ${XSPEC} ${FITSBUILD} ${compilers}
+conda create --yes -n build python"=${PYTHONVER}.*" pip ${MATPLOTLIB} ${BOKEH} ${NUMPY} ${XSPEC} ${FITSBUILD} ${compilers}
 
 conda activate build

--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -69,7 +69,7 @@ jobs:
       matrix:
         image: ["redhat/ubi8"]
         os-dir: ["linux-64"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - name: Install git and diff
@@ -124,10 +124,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: MacOS (Intel) Python 3.10
-            os-type: "macos-15-intel"
-            os-dir: "osx-64"
-            python-version: "3.10"
           - name: MacOS (Intel) Python 3.11
             os-type: "macos-15-intel"
             os-dir: "osx-64"
@@ -136,10 +132,10 @@ jobs:
             os-type: "macos-15-intel"
             os-dir: "osx-64"
             python-version: "3.12"
-          - name: MacOS (ARM) Python 3.10
-            os-type: "macos-14"
-            os-dir: "osx-arm64"
-            python-version: "3.10"
+          - name: MacOS (Intel) Python 3.13
+            os-type: "macos-13"
+            os-dir: "osx-64"
+            python-version: "3.13"
           - name: MacOS (ARM) Python 3.11
             os-type: "macos-14"
             os-dir: "osx-arm64"
@@ -148,6 +144,10 @@ jobs:
             os-type: "macos-14"
             os-dir: "osx-arm64"
             python-version: "3.12"
+          - name: MacOS (ARM) Python 3.13
+            os-type: "macos-14"
+            os-dir: "osx-arm64"
+            python-version: "3.13"
 
     env:
       CONDA_BUILD_SYSROOT: /opt/MacOSX11.0.sdk
@@ -256,22 +256,28 @@ jobs:
       working-directory: ${{ github.workspace }}
       run: |
         source ${conda_loc}/etc/profile.d/conda.sh
-        curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/main.zip 
-        echo "conda create -n test310 --yes -q -c file://$(pwd)/packages python=3.10 astropy sherpa matplotlib"
-        conda create -n test310 --yes -q -c file://$(pwd)/packages python=3.10 astropy sherpa matplotlib
-        conda activate test310
-        pip install main.zip
-        sherpa_smoke -f astropy
-        sherpa_test
+        curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/main.zip
+        #
         echo "conda create -n test311 --yes -q -c file://$(pwd)/packages python=3.11 astropy sherpa matplotlib"
         conda create -n test311 --yes -q -c file://$(pwd)/packages python=3.11 astropy sherpa matplotlib
         conda activate test311
         pip install main.zip
         sherpa_smoke -f astropy
         sherpa_test
+        conda deactivate
+        #
         echo "conda create -n test312 --yes -q -c file://$(pwd)/packages python=3.12 astropy sherpa matplotlib"
         conda create -n test312 --yes -q -c file://$(pwd)/packages python=3.12 astropy sherpa matplotlib
         conda activate test312
         pip install main.zip
         sherpa_smoke -f astropy
         sherpa_test
+        conda deactivate
+        #
+        echo "conda create -n test313 --yes -q -c file://$(pwd)/packages python=3.13 astropy sherpa matplotlib"
+        conda create -n test313 --yes -q -c file://$(pwd)/packages python=3.13 astropy sherpa matplotlib
+        conda activate test313
+        pip install main.zip
+        sherpa_smoke -f astropy
+        sherpa_test
+        conda deactivate

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -97,7 +97,7 @@ jobs:
 
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.14"
             install-type: install
             test-data: package
             matplotlib-version: 3

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -32,9 +32,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: MacOS Intel Full Build (Python 3.11)
+          - name: MacOS Intel Full Build (Python 3.12)
             os: macos-15-intel
-            python-version: "3.11"
+            python-version: "3.12"
             install-type: develop
             fits: astropy
             test-data: submodule
@@ -42,9 +42,9 @@ jobs:
             bokeh-version: 3
             xspec-version: 12.14.0i
 
-          - name: MacOS ARM Full Build (Python 3.11)
+          - name: MacOS ARM Full Build (Python 3.12)
             os: macos-14
-            python-version: "3.11"
+            python-version: "3.12"
             install-type: develop
             fits: astropy
             test-data: submodule
@@ -52,19 +52,29 @@ jobs:
             bokeh-version: 3
             xspec-version: 12.13.1e
 
-          - name: Linux Minimum Setup (Python 3.10)
-            os: ubuntu-latest
-            python-version: "3.10"
-            numpy-version: "1.24"
-            install-type: develop
-            test-data: none
-
           - name: Linux Minimum Setup (Python 3.11)
             os: ubuntu-latest
             python-version: "3.11"
-            numpy-version: "1.24"
+            numpy-version: "2.3.2"
             install-type: develop
             test-data: none
+
+          - name: Linux Minimum Setup (Python 3.12)
+            os: ubuntu-latest
+            python-version: "3.12"
+            numpy-version: "2.3.2"
+            install-type: develop
+            test-data: none
+
+          - name: Linux Full Build (Python 3.13)
+            os: ubuntu-latest
+            python-version: "3.13"
+            install-type: develop
+            fits: astropy
+            test-data: submodule
+            matplotlib-version: 3
+            bokeh-version: 3
+            xspec-version: 12.14.0i
 
           - name: Linux Full Build (Python 3.12)
             os: ubuntu-latest
@@ -83,29 +93,19 @@ jobs:
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
-            bokeh-version: 3
-            xspec-version: 12.14.0i
-
-          - name: Linux Full Build (Python 3.10)
-            os: ubuntu-latest
-            python-version: "3.10"
-            install-type: develop
-            fits: astropy
-            test-data: submodule
-            matplotlib-version: 3
             xspec-version: 12.13.1
 
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             install-type: install
             test-data: package
             matplotlib-version: 3
 
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest
-            python-version: "3.12"
-            numpy-version: "1.26"
+            python-version: "3.13"
+            numpy-version: "2.3.2"
             install-type: develop
             fits: astropy
             test-data: none

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -27,14 +27,14 @@ jobs:
         include:
           - name: Linux Minimum Setup
             os: ubuntu-latest
-            python-version: "3.10"
-            numpy-pkg: 'numpy>=1.24,<1.25'
+            python-version: "3.11"
+            numpy-pkg: 'numpy>=2'
             install-type: develop
             test-data: none
 
-          - name: Linux Build (w/o Xspec; Python 3.11)
+          - name: Linux Build (w/o Xspec; Python 3.12)
             os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             numpy-pkg: 'numpy'
             install-type: install
             test-data: package
@@ -45,7 +45,7 @@ jobs:
 
           - name: Linux Build (w/o Matplotlib, Astropy or Xspec)
             os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             numpy-pkg: 'numpy'
             install-type: install
             test-data: package
@@ -53,7 +53,7 @@ jobs:
 
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
             os: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.11"
             numpy-pkg: 'numpy'
             install-type: develop
             fits-pkg: 'astropy'
@@ -61,7 +61,7 @@ jobs:
 
           - name: Linux Build (submodule data without Xspec)
             os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             numpy-pkg: 'numpy'
             install-type: develop
             matplotlib-pkg: 'matplotlib>=3,<4'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/sherpa/badge/)](https://sherpa.readthedocs.io/)
 [![DOI](https://zenodo.org/badge/683/sherpa/sherpa.svg)](https://zenodo.org/badge/latestdoi/683/sherpa/sherpa)
 [![GPLv3+ License](https://img.shields.io/badge/license-GPLv3+-blue.svg)](https://www.gnu.org/copyleft/gpl.html)
-![Python version](https://img.shields.io/badge/Python-3.10,3.11,3.12,3.13-green.svg?style=flat)
+![Python version](https://img.shields.io/badge/Python-3.11,3.12,3.13-green.svg?style=flat)
 
 <!-- TOC *generated with [DocToc](https://github.com/thlorenz/doctoc)* -->
 **Table of Contents**
@@ -86,7 +86,8 @@ documentation, and should be read if the following is not sufficient.
 It is strongly recommended that some form of *virtual environment* is
 used with Sherpa.
 
-Sherpa is tested against Python versions 3.10, 3.11, 3.12, and with experimental support for Python 3.13.
+Sherpa is tested against Python versions 3.11, 3.12, and 3.13. There
+is currently no support for the free-threaded version of Python.
 
 The last version of Sherpa which supported Python 2.7 is
 [Sherpa 4.11.1](https://doi.org/10.5281/zenodo.3358134).
@@ -95,8 +96,8 @@ Using Conda
 --------------
 
 Sherpa is provided for both Linux and macOS operating systems running
-Python 3.10, 3.11, and 3.12. It can be installed with the `conda`
-package manager by saying
+Python 3.11 to 3.13. It can be installed with the `conda` package
+manager by saying
 
     $ conda install -c https://cxc.cfa.harvard.edu/conda/sherpa -c conda-forge sherpa
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/sherpa/badge/)](https://sherpa.readthedocs.io/)
 [![DOI](https://zenodo.org/badge/683/sherpa/sherpa.svg)](https://zenodo.org/badge/latestdoi/683/sherpa/sherpa)
 [![GPLv3+ License](https://img.shields.io/badge/license-GPLv3+-blue.svg)](https://www.gnu.org/copyleft/gpl.html)
-![Python version](https://img.shields.io/badge/Python-3.11,3.12,3.13-green.svg?style=flat)
+![Python version](https://img.shields.io/badge/Python-3.11,3.12,3.13,3.14-green.svg?style=flat)
 
 <!-- TOC *generated with [DocToc](https://github.com/thlorenz/doctoc)* -->
 **Table of Contents**
@@ -86,8 +86,8 @@ documentation, and should be read if the following is not sufficient.
 It is strongly recommended that some form of *virtual environment* is
 used with Sherpa.
 
-Sherpa is tested against Python versions 3.11, 3.12, and 3.13. There
-is currently no support for the free-threaded version of Python.
+Sherpa is tested against Python versions 3.11 to 3.14. There is
+currently no support for the free-threaded version of Python.
 
 The last version of Sherpa which supported Python 2.7 is
 [Sherpa 4.11.1](https://doi.org/10.5281/zenodo.3358134).
@@ -96,7 +96,7 @@ Using Conda
 --------------
 
 Sherpa is provided for both Linux and macOS operating systems running
-Python 3.11 to 3.13. It can be installed with the `conda` package
+Python 3.11 to 3.14. It can be installed with the `conda` package
 manager by saying
 
     $ conda install -c https://cxc.cfa.harvard.edu/conda/sherpa -c conda-forge sherpa

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ range of statistics and robust optimisers.
 Sherpa is released under the
 `GNU General Public License v3.0
 <https://github.com/sherpa/sherpa/blob/master/LICENSE>`_,
-and is compatible with Python versions 3.11 to 3.13.
+and is compatible with Python versions 3.11 to 3.14.
 Information on recent releases and citation information for
 Sherpa is available using the Digital Object Identifier (DOI)
 `10.5281/zenodo.593753 <https://doi.org/10.5281/zenodo.593753>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ range of statistics and robust optimisers.
 Sherpa is released under the
 `GNU General Public License v3.0
 <https://github.com/sherpa/sherpa/blob/master/LICENSE>`_,
-and is compatible with Python versions 3.10 to 3.13.
+and is compatible with Python versions 3.11 to 3.13.
 Information on recent releases and citation information for
 Sherpa is available using the Digital Object Identifier (DOI)
 `10.5281/zenodo.593753 <https://doi.org/10.5281/zenodo.593753>`_.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,7 +33,7 @@ Requirements
 
 Sherpa has the following requirements:
 
-* Python 3.11 to 3.13 (there is no support for free-threaded Python)
+* Python 3.11 to 3.14 (there is no support for free-threaded Python)
 * NumPy
 * Linux or OS-X (patches to add Windows support are welcome)
 
@@ -143,7 +143,7 @@ Prerequisites
 
 The prerequisites for building from source are:
 
-* Python versions: 3.11 to 3.13 (there is no support for free-threaded Python)
+* Python versions: 3.11 to 3.14 (there is no support for free-threaded Python)
 * Python packages: ``setuptools``, ``numpy`` (these should be
   automatically installed by ``pip``)
 * System: ``gcc`` and ``g++`` or ``clang`` and ``clang++``, ``make``, ``flex``,

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,7 +33,7 @@ Requirements
 
 Sherpa has the following requirements:
 
-* Python 3.10 to 3.13 (there is no support for free-threaded Python)
+* Python 3.11 to 3.13 (there is no support for free-threaded Python)
 * NumPy
 * Linux or OS-X (patches to add Windows support are welcome)
 
@@ -143,7 +143,7 @@ Prerequisites
 
 The prerequisites for building from source are:
 
-* Python versions: 3.9 to 3.12
+* Python versions: 3.11 to 3.13 (there is no support for free-threaded Python)
 * Python packages: ``setuptools``, ``numpy`` (these should be
   automatically installed by ``pip``)
 * System: ``gcc`` and ``g++`` or ``clang`` and ``clang++``, ``make``, ``flex``,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
   "setuptools >= 77.0.3",  # minimum for PEP 639 - license identifiers
-  "numpy",
-  "tomli; python_version < '3.11'"
+  "numpy"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -24,7 +23,6 @@ authors = [
 classifiers = [
   "Intended Audience :: Science/Research",
   "Programming Language :: C",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -33,7 +31,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics"
 ]
 
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 dependencies = [
   "numpy"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Scientific/Engineering :: Astronomy",
   "Topic :: Scientific/Engineering :: Physics"


### PR DESCRIPTION
# Summary

Drop support for building with Python 3.10 and add support for building with Python 3.14.

# Details

At the moment there is only one change that we take advantage of, that we do not need to install the `tomli` package when building Sherpa. However, Python 3.10 is well into it's [only security fixes](https://devguide.python.org/versions/) phase, and we have historically only focused on supporting three versions. We could retain the 3.10 support but only test with 3.11 and above.

One of the CI runs is changed to build with Python 3.14 (one of the "minimal test" cases), to act as a canary ni case there are Python 3.14 issues, but so far it looks good for advertising 3.14 support.

The CI runs have been updated to use Python 3.11 to 3.14 but the choices made, in particular in the choice of versions of related code, such as NumPy, could do with a review.

There are no actual changes to code to add Python 3.11-only features in this PR.