### PR TITLE
Reorganize class hierarchy for Dataclasses and EvaluationSpaces

### DIFF
--- a/docs/fit/index.rst
+++ b/docs/fit/index.rst
@@ -119,11 +119,12 @@ unless explicitly over-riden with the ``stat`` and
     method    = LevMar
     estmethod = Covariance
     >>> print(f.data)
-    name      = fit example
-    x         = Int64[6]
-    y         = Float64[6]
-    staterror = Float64[6]
-    syserror  = None
+    name       = fit example
+    x          = Int64[6]
+    y          = Float64[6]
+    staterror  = Float64[6]
+    syserror   = None
+    integrated = False
     >>> print(f.model)
     polynom1d
        Param        Type          Value          Min          Max      Units

--- a/docs/quick.rst
+++ b/docs/quick.rst
@@ -91,11 +91,12 @@ axis, and then dependent axis:
     >>> from sherpa.data import Data1D
     >>> d = Data1D('example', x, y)
     >>> print(d)
-    name      = example
-    x         = Float64[200]
-    y         = Float64[200]
-    staterror = None
-    syserror  = None
+    name       = example
+    x          = Float64[200]
+    y          = Float64[200]
+    staterror  = None
+    syserror   = None
+    integrated = False
 
 At this point no errors are being used in the fit, so the ``staterror``
 and ``syserror`` fields are empty. They can be set either when the
@@ -477,11 +478,12 @@ the same, and equal to the true error:
     >>> dy = np.full(x.size, err_true)
     >>> de = Data1D('with-errors', x, y, staterror=dy)
     >>> print(de)
-    name      = with-errors
-    x         = Float64[200]
-    y         = Float64[200]
-    staterror = Float64[200]
-    syserror  = None
+    name       = with-errors
+    x          = Float64[200]
+    y          = Float64[200]
+    staterror  = Float64[200]
+    syserror   = None
+    integrated = False
 
 The statistic is changed from least squares to
 chi-square (:py:class:`~sherpa.stats.Chi2`), to take advantage
@@ -897,13 +899,14 @@ For example, the following code creates a
     >>> yaxis = y.ravel()
     >>> d2 = Data2D('img', x0axis, x1axis, yaxis, shape=(128, 128))
     >>> print(d2)
-    name      = img
-    x0        = Int64[16384]
-    x1        = Int64[16384]
-    y         = Float64[16384]
-    shape     = (128, 128)
-    staterror = None
-    syserror  = None
+    name       = img
+    x0         = Int64[16384]
+    x1         = Int64[16384]
+    y          = Float64[16384]
+    shape      = (128, 128)
+    staterror  = None
+    syserror   = None
+    integrated = False
 
 Define the model
 ----------------

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -5506,7 +5506,8 @@ class DataIMG(Data2D):
         #
         self._orig_indep_axis = (self.coord, x0, x1)
 
-        super().__init__(name, x0, x1, y, shape, staterror, syserror)
+        super().__init__(name, x0, x1, y,
+                         shape=shape, staterror=staterror, syserror=syserror)
 
         # special case the x-axis labels
         self._x0label = None
@@ -6164,19 +6165,19 @@ class DataIMGInt(DataIMG):
                  staterror=None, syserror=None, sky=None, eqpos=None,
                  coord='logical', header=None):
 
-        # Note: we do not call the superclass here.
         self._region = None
         self.sky = sky
         self.eqpos = eqpos
         self._set_coord(coord)
         self.header = {} if header is None else header
-        self.shape = shape
 
         self._x0label = 'x0'
         self._x1label = 'x1'
         self._ylabel = 'y'
 
-        Data.__init__(self, name, (x0lo, x1lo, x0hi, x1hi), y, staterror, syserror)
+        # Note that we are not calling the direct superclass here
+        Data.__init__(self, name, (x0lo, x1lo, x0hi, x1hi), y, staterror, syserror,
+                      integrated=True, shape=shape)
 
     # This could be moved up Data2D, but the inheritance pathway of the
     # DataIMG classes makes that a bit awkward, since DataIMG and DataIMGInt

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -129,17 +129,18 @@ this range to have at least 20 counts per group:
 
 from __future__ import annotations
 
+from abc import ABC
 from collections.abc import Callable, Mapping
 import logging
 import os
-from typing import Any, Literal, cast, overload, TYPE_CHECKING
+from typing import Any, Literal, Self, cast, overload, TYPE_CHECKING
 import warnings
 
 import numpy as np
 import numpy.typing as npt
 
 from sherpa.astro import hc
-from sherpa.data import Data1DInt, Data2D, Data, Data1D, \
+from sherpa.data import Data1DInt, Data2D, Data, Data1D, Data2DInt, FieldsType, \
     IntegratedDataSpace2D, _check
 from sherpa.models.regrid import EvaluationSpace1D
 from sherpa.stats import Chi2XspecVar
@@ -1606,17 +1607,18 @@ class DataPHA(Data1D):
 
         # Assert types: is there a better way to do this?
         #
-        self._grouping: np.ndarray | None
-        self._quality: np.ndarray | None
-        self._quality_filter: np.ndarray | None
+        self._grouping: np.ndarray | None = None
+        self._quality: np.ndarray | None = None
+        self._quality_filter: np.ndarray | None = None
 
         self.bin_lo = None
         self.bin_hi = None
-        self.quality = _check(quality)
-        self.grouping = _check(grouping)
         self.exposure = exposure
-        self.backscal = backscal
-        self.areascal = areascal
+        # Can't set to array yet, because independent dataspace has not been set
+        # But need to set to something before calling __init__ because of
+        # NoNewAttributesAfterInit
+        self.backscal = None
+        self.areascal = None
         if header is None:
             header = {"HDUCLASS": "OGIP", "HDUCLAS1": "SPECTRUM",
                       "HDUCLAS2": "TOTAL", "HDUCLAS3": "TYPE:I",
@@ -1652,6 +1654,10 @@ class DataPHA(Data1D):
         self.units = "channel"
         self.quality_filter = None
         super().__init__(name, channel, counts, staterror, syserror)
+        self.quality = _check(quality)
+        self.grouping = _check(grouping)
+        self.backscal = backscal
+        self.areascal = areascal
 
         # special-case the labels
         self._xlabel = None
@@ -3274,7 +3280,7 @@ It is an integer or string.
             return None
 
         nelem = self.size
-        if nelem is None:
+        if nelem == 0:
             raise DataErr("sizenotset", self.name)
 
         data = _check(data)
@@ -3444,7 +3450,7 @@ It is an integer or string.
             return None
 
         nelem = self.size
-        if nelem is None:
+        if nelem == 0:
             raise DataErr("sizenotset", self.name)
 
         data = _check(data)
@@ -4707,7 +4713,7 @@ It is an integer or string.
 
         """
 
-        if self.size is None:
+        if self.size == 0:
             raise DataErr("sizenotset", self.name)
 
         # I am not convinced that self.mask will always be an array if
@@ -5346,105 +5352,11 @@ It is an integer or string.
         self.subtracted = False
 
 
-class DataIMG(Data2D):
-    '''Image data set
-
-    This class builds on `sherpa.data.Data2D` to add support for
-    region filters and the ability to describe the data in different coordinate
-    systems, such as the "logical" coordinates (pixels of the image),
-    the "physical" coordinates (e.g. detector coordinates), and the "world"
-    coordinates (e.g. Ra/Dec on the sky).
-
-    .. note::
-
-       In principle, this class can deal with any shape of data, even with
-       sparse data. However, the added functionality over the base class
-       is most useful for regularly gridded images. In that case, that data
-       should be ordered as in the FITS image conventions, i.e. [column, row];
-       in other words `x0` is the x-axis of the image and `x1` is the y-axis in
-       an x-y-plot.
-       (Sherpa uses `y` for the dependent variable and calls the axes `x0` and `x1`.)
-
-       Only with this convention will the routines that return a 2D
-       array (e.g. for plotting) work correctly. Fitting is done on the flattened
-       1D arrays and will work for any ordering.
+class IMGMixIn(ABC):
+    """Mix-in class to add WCS support and 2D imagane filtering to 2D data classes."""
 
 
-
-    Parameters
-    ----------
-    name : string
-        name of this dataset
-    x0 : array-like
-        Independent coordinate values for the first dimension
-    x1 : array-like
-        Independent coordinate values for the second dimension
-    y : array-like
-        The values of the dependent observable.
-    shape : tuple
-        Shape of the data grid (optional). This is
-        used return the data as an image e.g. for display,
-        but it not needed for fitting and modelling.
-    staterror : array-like
-        the statistical error associated with the data
-    syserror : array-like
-        the systematic error associated with the data
-    sky : `sherpa.astro.io.wcs.WCS`
-        The optional WCS object that converts to the physical coordinate system.
-    eqpos : `sherpa.astro.io.wcs.WCS`
-        The optional WCS object that converts to the world coordinate system.
-    coord : string
-        The coordinate system of the data. This can be one of 'logical',
-        'physical', or 'world'.
-        'image' is an alias for 'logical' and 'wcs' is an alias for 'world'.
-    header : dict
-        The FITS header associated with the data to store meta data.
-
-    Examples
-    --------
-    In this example, we create an image data set, but do not specify the
-    coordinate system. This means that the coordinates are expressed in
-    the logical coordinates of the image, i.e. in pixels::
-
-        >>> from sherpa.astro.data import DataIMG
-        >>> import numpy as np
-        >>> # Note ordering of x1, x0 here
-        >>> x1, x0 = np.mgrid[20:30, 5:20]
-        >>> datashape = x0.shape
-        >>> y = np.sqrt((x0 - 10)**2 + (x1 - 31)**2)
-        >>> x0flat = x0.flatten()
-        >>> x1flat = x1.flatten()
-        >>> yflat = y.flatten()
-        >>> image = DataIMG("bimage", x0=x0flat, x1=x1flat, y=yflat, shape=datashape)
-
-    In this example, we end up with a "logical" coordinate system
-    in ``image`` and no WCS system to convert it to anything else. On the other hand,
-    in FITS standard terminology, the "logical" coordinate system is the
-    "image", counting pixels starting at 1, while here the ``x0lo``` and ``x1lo``
-    actually start at 20 and 5, respectively.
-    This behavior works for now, but might be revisited.
-
-    For the common case of creating an image data set from a 2D array,
-    the `from_2d_array` class method can be used. In this case,
-    the length of ``x0`` and ``x1`` must match the shape of the 2D numpy array and
-    Sherpa will take care of transforming it from numpy [row, column] ordering
-    to the [column, row] ordering::
-
-        >>> x0 = np.arange(20, 30)
-        >>> x1 = np.arange(5, 20)
-        >>> print(y.shape, x0.shape, x1.shape)
-        (10, 15) (10,) (15,)
-        >>> image = DataIMG.from_2d_array("bimage", y=y, x0=x0, x1=x1)
-
-    It's even easier if no particular coordinate system is needed for ``x0``
-    and ``x1`` and the coordinates are simply pixel indices, which can be generated
-    automatically (starting at 1)::
-
-        >>> image = DataIMG.from_2d_array("bimage", y=y)
-
-    '''
-
-    _extra_fields = ("sky", "eqpos", "coord")
+    _extra_fields: FieldsType = ("sky", "eqpos", "coord")
 
     sky = None
     """The optional WCS object that converts to the physical coordinate system."""
@@ -5483,9 +5395,10 @@ class DataIMG(Data2D):
 
         self._coord = coord
 
-    def __init__(self, name, x0, x1, y, shape=None, staterror=None,
+
+    def __init__(self, name, *args, shape=None, staterror=None,
                  syserror=None, sky=None, eqpos=None, coord='logical',
-                 header=None):
+                 header=None, **kwargs):
         self.name = name  # needed by transform checks
         self.sky = sky
         self.eqpos = eqpos
@@ -5493,105 +5406,13 @@ class DataIMG(Data2D):
         self.header = {} if header is None else header
         self._region = None
 
-        # Store the original axes so we can always recreate the other
-        # systems without having to worry about numerical differences
-        # from switching between systems. This is an explicit decision
-        # to go for repeatable behavior at the expense of using more
-        # memory. See #1380 for more information.
-        #
-        self._orig_indep_axis = (self.coord, x0, x1)
-
-        super().__init__(name, x0, x1, y,
-                         shape=shape, staterror=staterror, syserror=syserror)
+        super().__init__(name, *args,
+                         shape=shape, staterror=staterror, syserror=syserror,
+                         **kwargs)
 
         # special case the x-axis labels
         self._x0label = None
         self._x1label = None
-
-
-    # This could be moved up Data2D, but the inheritance pathway of the
-    # DataIMG classes makes that a bit awkward, since DataIMG and DataIMGInt
-    # both inherit from Data2D, but DataIMGInt does not inherit from Data2DInt.
-    @classmethod
-    def from_2d_array(cls,
-                     name: str,
-                     *,
-                     y: npt.NDArray[np.floating],
-                     x0: npt.NDArray[np.floating] | None = None,
-                     x1: npt.NDArray[np.floating] | None = None,
-                     staterror: npt.NDArray[np.floating] | None = None,
-                     syserror: npt.NDArray[np.floating] | None = None,
-                     header: Mapping[str, Any] | None = None
-                     ) -> "DataIMG":   # change to Self once Python 3.10 support has been dropped
-        '''Create a `DataIMG` instance from a 2-dimensional array.
-
-        Parameters
-        ----------
-        name : str
-            The name of the dataset.
-        y : ndarray with 2 dimensions
-            The dependent variable array.
-        x0, x1: ndarray, optional
-            The independent variable arrays; the length of x0 must match
-            y's first dimension, and the length of x1 must match y's second dimension.
-            If not provided, they will be generated, starting at 1.
-
-            .. note::
-
-                This does **not** follow the usual Python conventions to start
-                enumerations at 0, instead, it follows the fits conventions where the first
-                pixel has the coordinate (1, 1).
-
-        staterror : ndarray with 2 dimensions, optional
-            The statistical error array.
-        syserror : ndarray with 2 dimensions, optional
-            The systematic error array.
-        header : dict, optional
-            The header information for the data.
-
-        Returns
-        -------
-        dataimg : DataIMG
-            A DataIMG instance.
-
-        Examples
-        --------
-        Create a DataIMG instance from 2D data. Here, we first create
-        a 2-D array of values y, but in practice this might be read in
-        from a file, from the output of a simulation, or as a result of
-        some other computation.
-
-            >>> import numpy as np
-            >>> from sherpa.astro.data import DataIMG
-            >>> x1 = np.arange(20, 30, 2)
-            >>> x0 = np.arange(5, 20, 2)
-            >>> y = np.sqrt((x0[:, np.newaxis] - 10)**2 + (x1[np.newaxis, :] - 31)**2)
-            >>> reg2d = DataIMG.from_2d_array("regular2d", x0=x0, x1=x1, y=y)
-
-        '''
-        if y.ndim != 2:
-            raise ValueError(f"Expected 2D array for y, got {y.ndim}D array instead.")
-        if staterror is not None and staterror.shape != y.shape:
-            raise ValueError(f"staterror shape {staterror.shape} does not match y's shape {y.shape}")
-        if syserror is not None and syserror.shape != y.shape:
-            raise ValueError(f"syserror shape {syserror.shape} does not match y's shape {y.shape}")
-
-        if x0 is None:
-            x0 = np.arange(y.shape[0], dtype=SherpaFloat) + 1.
-        if x1 is None:
-            x1 = np.arange(y.shape[1], dtype=SherpaFloat) + 1.
-
-        if len(x0) != y.shape[0]:
-            raise ValueError(f"Length of x0 ({len(x0)}) must match y's first dimension ({y.shape[0]})")
-        if len(x1) != y.shape[1]:
-            raise ValueError(f"Length of x1 ({len(x1)}) must match y's second dimension ({y.shape[1]})")
-
-        x0, x1 = np.meshgrid(x0, x1)
-        return cls(name, x0=x0.ravel(), x1=x1.ravel(),
-                   y=y.T.ravel(), shape=y.T.shape,
-                   staterror=staterror.T.ravel() if staterror is not None else None,
-                   syserror=syserror.T.ravel() if syserror is not None else None,
-                   header=header)
 
     @classmethod
     def from_2d_array_with_wcs(cls,
@@ -5604,8 +5425,8 @@ class DataIMG(Data2D):
                      eqpos: WCS,
                      coord: Literal["logical", "image", "physical", "world", "wcs"] = 'logical',
                      header: Mapping[str, Any] | None = None
-                     ) -> "DataIMG":   # change to Self once Python 3.10 support has been dropped
-        '''Create a DataIMG instance from 2D data and WCS information.
+                     ) -> Self:
+        '''Create a DataIMGInt instance from 2D data and WCS information.
 
         '''
         img = cls.from_2d_array(name, y=y,
@@ -5797,21 +5618,27 @@ class DataIMG(Data2D):
 
         return (x0, x1)
 
-    # Convert from the _orig_indep_axis tuple (coord, x0, x1) to the
+    # Convert from the _orig_indep_axis tuple
+    # (coord, ((x0, x1),)) or
+    # (coord, ((x0lo, x1lo), (x0hi, x1hi)))
+    # to the
     # required data system (if it isn't already set).
     #
     def _get_coordsys(self, coord):
         if self.coord == coord:
             return self.get_indep()
 
-        (base, x0, x1) = self._orig_indep_axis
-        x0 = x0.copy()
-        x1 = x1.copy()
+        (base, axes) = self._orig_indep_axis
+        axes = tuple(tuple(ax.copy() for ax in axesset) for axesset in axes)
+
         if base == coord:
-            return (x0, x1)
+            # The sum() with () is a neat trick to flatten the list of tuples
+            return sum(axes, ())
 
         conv = getattr(self, f'_{base}_to_{coord}')
-        return conv(x0, x1)
+        nested_tuple = (conv(x0, x1) for x0, x1 in axes)
+        # The sum() with () is a neat trick to flatten the list of tuples
+        return sum(nested_tuple, ())
 
     def get_logical(self):
         return self._get_coordsys("logical")
@@ -5857,6 +5684,90 @@ class DataIMG(Data2D):
         func = getattr(self, f'get_{coord}')
         self.indep = func()
         self._set_coord(coord)
+
+    def _get_axes(self, offset):
+        axis0 = np.arange(self.shape[1], dtype=float) + offset
+        axis1 = np.arange(self.shape[0], dtype=float) + offset
+
+        # dummy placeholders needed b/c img shape may not be square!
+        dummy0 = np.ones(axis0.size, dtype=float)
+        dummy1 = np.ones(axis1.size, dtype=float)
+
+        if self.coord == 'logical':
+            return (axis0, axis1)
+
+        if self.coord == 'physical':
+            axis0, dummy = self._logical_to_physical(axis0, dummy0)
+            dummy, axis1 = self._logical_to_physical(dummy1, axis1)
+        else:
+            axis0, dummy = self._logical_to_world(axis0, dummy0)
+            dummy, axis1 = self._logical_to_world(dummy1, axis1)
+        return (axis0, axis1)
+
+    def get_axes(self):
+        # FIXME: how to filter an axis when self.mask is size of self.y?
+        self._check_shape()
+
+        if self.integrated:
+            # Integrated datasets start with pixels are 0
+            return self._get_axes(offset=-0.5) + self._get_axes(offset=0.5)
+        else:
+            # but non-integrated datasets start with pixels at 1
+            # FIXME: is this correct?
+            return self._get_axes(offset=1.0)
+
+
+        # Sum with () flattens the tuple of arrays
+        return sum(out, ())
+
+    def get_x0label(self) -> str:
+        """Return the label for the first independent axis.
+
+        If set_x0label has been called then the label used in that call
+        will be used, otherwise the label will change depending on the
+        coordinate setting.
+
+        .. versionchanged:: 4.17.0
+           The return value depends on if set_x0label has been called.
+
+        See Also
+        --------
+        get_x1label, set_coord, set_x0label
+
+        """
+
+        if self._x0label is not None:
+            return self._x0label
+        if self.coord == 'physical':
+            return 'x0 (pixels)'
+        if self.coord == 'world':
+            return 'RA (deg)'
+        return 'x0'
+
+    def get_x1label(self) -> str:
+        """Return the label for the second independent axis.
+
+        If set_x1label has been called then the label used in that call
+        will be used, otherwise the label will change depending on the
+        coordinate setting.
+
+        .. versionchanged:: 4.17.0
+           The return value depends on if set_x1label has been called.
+
+        See Also
+        --------
+        get_x0label, set_coord, set_x1label
+
+        """
+
+        if self._x1label is not None:
+            return self._x1label
+        if self.coord == 'physical':
+            return 'x1 (pixels)'
+        if self.coord == 'world':
+            return 'DEC (deg)'
+
+        return 'x1'
 
     def get_filter_expr(self):
         if self._region is None:
@@ -5968,78 +5879,6 @@ class DataIMG(Data2D):
         return (y_img,
                 self.filter_region(m).reshape(*self.shape))
 
-    def get_axes(self):
-        # FIXME: how to filter an axis when self.mask is size of self.y?
-        self._check_shape()
-
-        # dummy placeholders needed b/c img shape may not be square!
-        axis0 = np.arange(self.shape[1], dtype=float) + 1.
-        axis1 = np.arange(self.shape[0], dtype=float) + 1.
-        if self.coord == 'logical':
-            return (axis0, axis1)
-
-        dummy0 = np.ones(axis0.size, dtype=float)
-        dummy1 = np.ones(axis1.size, dtype=float)
-
-        if self.coord == 'physical':
-            axis0, dummy = self._logical_to_physical(axis0, dummy0)
-            dummy, axis1 = self._logical_to_physical(dummy1, axis1)
-
-        else:
-            axis0, dummy = self._logical_to_world(axis0, dummy0)
-            dummy, axis1 = self._logical_to_world(dummy1, axis1)
-
-        return (axis0, axis1)
-
-    def get_x0label(self) -> str:
-        """Return the label for the first independent axis.
-
-        If set_x0label has been called then the label used in that call
-        will be used, otherwise the label will change depending on the
-        coordinate setting.
-
-        .. versionchanged:: 4.17.0
-           The return value depends on if set_x0label has been called.
-
-        See Also
-        --------
-        get_x1label, set_coord, set_x0label
-
-        """
-
-        if self._x0label is not None:
-            return self._x0label
-        if self.coord == 'physical':
-            return 'x0 (pixels)'
-        if self.coord == 'world':
-            return 'RA (deg)'
-        return 'x0'
-
-    def get_x1label(self) -> str:
-        """Return the label for the second independent axis.
-
-        If set_x1label has been called then the label used in that call
-        will be used, otherwise the label will change depending on the
-        coordinate setting.
-
-        .. versionchanged:: 4.17.0
-           The return value depends on if set_x1label has been called.
-
-        See Also
-        --------
-        get_x0label, set_coord, set_x1label
-
-        """
-
-        if self._x1label is not None:
-            return self._x1label
-        if self.coord == 'physical':
-            return 'x1 (pixels)'
-        if self.coord == 'world':
-            return 'DEC (deg)'
-
-        return 'x1'
-
     def to_contour(self, yfunc=None):
         y = self.filter_region(self.get_dep(False))
         if yfunc is not None:
@@ -6068,8 +5907,209 @@ class DataIMG(Data2D):
         out[~self.mask] = np.nan
         return out
 
+class DataIMG(IMGMixIn, Data2D):
+    '''Image data set
 
-class DataIMGInt(DataIMG):
+    This class builds on `sherpa.data.Data2D` to add support for
+    region filters and the ability to describe the data in different coordinate
+    systems, such as the "logical" coordinates (pixels of the image),
+    the "physical" coordinates (e.g. detector coordinates), and the "world"
+    coordinates (e.g. Ra/Dec on the sky).
+
+    .. note::
+
+       In principle, this class can deal with any shape of data, even with
+       sparse data. However, the added functionality over the base class
+       is most useful for regularly gridded images. In that case, that data
+       should be ordered as in the FITS image conventions, i.e. [column, row];
+       in other words `x0` is the x-axis of the image and `x1` is the y-axis in
+       an x-y-plot.
+       (Sherpa uses `y` for the dependent variable and calls the axes `x0` and `x1`.)
+
+       Only with this convention will the routines that return a 2D
+       array (e.g. for plotting) work correctly. Fitting is done on the flattened
+       1D arrays and will work for any ordering.
+
+
+
+    Parameters
+    ----------
+    name : string
+        name of this dataset
+    x0 : array-like
+        Independent coordinate values for the first dimension
+    x1 : array-like
+        Independent coordinate values for the second dimension
+    y : array-like
+        The values of the dependent observable.
+    shape : tuple
+        Shape of the data grid (optional). This is
+        used return the data as an image e.g. for display,
+        but it not needed for fitting and modelling.
+    staterror : array-like
+        the statistical error associated with the data
+    syserror : array-like
+        the systematic error associated with the data
+    sky : `sherpa.astro.io.wcs.WCS`
+        The optional WCS object that converts to the physical coordinate system.
+    eqpos : `sherpa.astro.io.wcs.WCS`
+        The optional WCS object that converts to the world coordinate system.
+    coord : string
+        The coordinate system of the data. This can be one of 'logical',
+        'physical', or 'world'.
+        'image' is an alias for 'logical' and 'wcs' is an alias for 'world'.
+    header : dict
+        The FITS header associated with the data to store meta data.
+
+    Examples
+    --------
+    In this example, we create an image data set, but do not specify the
+    coordinate system. This means that the coordinates are expressed in
+    the logical coordinates of the image, i.e. in pixels::
+
+        >>> from sherpa.astro.data import DataIMG
+        >>> import numpy as np
+        >>> # Note ordering of x1, x0 here
+        >>> x1, x0 = np.mgrid[20:30, 5:20]
+        >>> datashape = x0.shape
+        >>> y = np.sqrt((x0 - 10)**2 + (x1 - 31)**2)
+        >>> x0flat = x0.flatten()
+        >>> x1flat = x1.flatten()
+        >>> yflat = y.flatten()
+        >>> image = DataIMG("bimage", x0=x0flat, x1=x1flat, y=yflat, shape=datashape)
+
+    In this example, we end up with a "logical" coordinate system
+    in ``image`` and no WCS system to convert it to anything else. On the other hand,
+    in FITS standard terminology, the "logical" coordinate system is the
+    "image", counting pixels starting at 1, while here the ``x0lo``` and ``x1lo``
+    actually start at 20 and 5, respectively.
+    This behavior works for now, but might be revisited.
+
+    For the common case of creating an image data set from a 2D array,
+    the `from_2d_array` class method can be used. In this case,
+    the length of ``x0`` and ``x1`` must match the shape of the 2D numpy array and
+    Sherpa will take care of transforming it from numpy [row, column] ordering
+    to the [column, row] ordering::
+
+        >>> x0 = np.arange(20, 30)
+        >>> x1 = np.arange(5, 20)
+        >>> print(y.shape, x0.shape, x1.shape)
+        (10, 15) (10,) (15,)
+        >>> image = DataIMG.from_2d_array("bimage", y=y, x0=x0, x1=x1)
+
+    It's even easier if no particular coordinate system is needed for ``x0``
+    and ``x1`` and the coordinates are simply pixel indices, which can be generated
+    automatically (starting at 1)::
+
+        >>> image = DataIMG.from_2d_array("bimage", y=y)
+
+    '''
+    _fields: FieldsType = ("name", "x0", "x1", "y", "shape", "staterror", "syserror")
+
+    def __init__(self, name, x0, x1, y, shape=None, staterror=None,
+                 syserror=None, sky=None, eqpos=None, coord='logical',
+                 header=None):
+
+        # Store the original axes so we can always recreate the other
+        # systems without having to worry about numerical differences
+        # from switching between systems. This is an explicit decision
+        # to go for repeatable behavior at the expense of using more
+        # memory. See #1380 for more information.
+        #
+        self._orig_indep_axis = (coord, ((x0, x1),))
+
+        super().__init__(name, x0, x1, y,
+                         shape=shape,
+                         staterror=staterror, syserror=syserror,
+                         sky=sky, eqpos=eqpos, coord=coord, header=header)
+
+
+    # This could be moved up Data2D, but the inheritance pathway of the
+    # DataIMG classes makes that a bit awkward, since DataIMG and DataIMGInt
+    # both inherit from Data2D, but DataIMGInt does not inherit from Data2DInt.
+    @classmethod
+    def from_2d_array(cls,
+                     name: str,
+                     *,
+                     y: npt.NDArray[np.floating],
+                     x0: npt.NDArray[np.floating] | None = None,
+                     x1: npt.NDArray[np.floating] | None = None,
+                     staterror: npt.NDArray[np.floating] | None = None,
+                     syserror: npt.NDArray[np.floating] | None = None,
+                     header: Mapping[str, Any] | None = None
+                     ) -> "DataIMG":   # change to Self once Python 3.10 support has been dropped
+        '''Create a `DataIMG` instance from a 2-dimensional array.
+
+        Parameters
+        ----------
+        name : str
+            The name of the dataset.
+        y : ndarray with 2 dimensions
+            The dependent variable array.
+        x0, x1: ndarray, optional
+            The independent variable arrays; the length of x0 must match
+            y's first dimension, and the length of x1 must match y's second dimension.
+            If not provided, they will be generated, starting at 1.
+
+            .. note::
+
+                This does **not** follow the usual Python conventions to start
+                enumerations at 0, instead, it follows the fits conventions where the first
+                pixel has the coordinate (1, 1).
+
+        staterror : ndarray with 2 dimensions, optional
+            The statistical error array.
+        syserror : ndarray with 2 dimensions, optional
+            The systematic error array.
+        header : dict, optional
+            The header information for the data.
+
+        Returns
+        -------
+        dataimg : DataIMG
+            A DataIMG instance.
+
+        Examples
+        --------
+        Create a DataIMG instance from 2D data. Here, we first create
+        a 2-D array of values y, but in practice this might be read in
+        from a file, from the output of a simulation, or as a result of
+        some other computation.
+
+            >>> import numpy as np
+            >>> from sherpa.astro.data import DataIMG
+            >>> x1 = np.arange(20, 30, 2)
+            >>> x0 = np.arange(5, 20, 2)
+            >>> y = np.sqrt((x0[:, np.newaxis] - 10)**2 + (x1[np.newaxis, :] - 31)**2)
+            >>> reg2d = DataIMG.from_2d_array("regular2d", x0=x0, x1=x1, y=y)
+
+        '''
+        if y.ndim != 2:
+            raise ValueError(f"Expected 2D array for y, got {y.ndim}D array instead.")
+        if staterror is not None and staterror.shape != y.shape:
+            raise ValueError(f"staterror shape {staterror.shape} does not match y's shape {y.shape}")
+        if syserror is not None and syserror.shape != y.shape:
+            raise ValueError(f"syserror shape {syserror.shape} does not match y's shape {y.shape}")
+
+        if x0 is None:
+            x0 = np.arange(y.shape[0], dtype=SherpaFloat) + 1.
+        if x1 is None:
+            x1 = np.arange(y.shape[1], dtype=SherpaFloat) + 1.
+
+        if len(x0) != y.shape[0]:
+            raise ValueError(f"Length of x0 ({len(x0)}) must match y's first dimension ({y.shape[0]})")
+        if len(x1) != y.shape[1]:
+            raise ValueError(f"Length of x1 ({len(x1)}) must match y's second dimension ({y.shape[1]})")
+
+        x0, x1 = np.meshgrid(x0, x1)
+        return cls(name, x0=x0.ravel(), x1=x1.ravel(),
+                   y=y.T.ravel(), shape=y.T.shape,
+                   staterror=staterror.T.ravel() if staterror is not None else None,
+                   syserror=syserror.T.ravel() if syserror is not None else None,
+                   header=header)
+
+
+class DataIMGInt(IMGMixIn, Data2DInt):
     '''Binned image data set
 
     This class is very similar to `sherpa.data.DataIMG`, but it stores integrated
@@ -6155,24 +6195,18 @@ class DataIMGInt(DataIMG):
         ...                    x0_bounds=x0edges, x1_bounds=x1edges)
 
     '''
+    _fields: FieldsType = ("name", "x0lo", "x1lo", "x0hi", "x1hi", "y", "shape", "staterror", "syserror")
 
     def __init__(self, name, x0lo, x1lo, x0hi, x1hi, y, shape=None,
                  staterror=None, syserror=None, sky=None, eqpos=None,
                  coord='logical', header=None):
 
-        self._region = None
-        self.sky = sky
-        self.eqpos = eqpos
-        self._set_coord(coord)
-        self.header = {} if header is None else header
+        self._orig_indep_axis = (coord, ((x0lo, x1lo), (x0hi, x1hi)))
 
-        self._x0label = 'x0'
-        self._x1label = 'x1'
-        self._ylabel = 'y'
-
-        # Note that we are not calling the direct superclass here
-        Data.__init__(self, name, (x0lo, x1lo, x0hi, x1hi), y, staterror, syserror,
-                      integrated=True, shape=shape)
+        super().__init__(name, x0lo, x1lo, x0hi, x1hi, y,
+                         shape=shape,
+                         staterror=staterror, syserror=syserror,
+                         sky=sky, eqpos=eqpos, coord=coord, header=header)
 
     # This could be moved up Data2D, but the inheritance pathway of the
     # DataIMG classes makes that a bit awkward, since DataIMG and DataIMGInt
@@ -6267,159 +6301,3 @@ class DataIMGInt(DataIMG):
                    syserror=syserror.T.ravel() if syserror is not None else None,
                    header=header)
 
-
-    @classmethod
-    def from_2d_array_with_wcs(cls,
-                     name: str,
-                     *,
-                     y: npt.NDArray[np.floating],
-                     staterror: npt.NDArray[np.floating] | None = None,
-                     syserror: npt.NDArray[np.floating] | None = None,
-                     sky: WCS,
-                     eqpos: WCS,
-                     coord: Literal["logical", "image", "physical", "world", "wcs"] = 'logical',
-                     header: Mapping[str, Any] | None = None
-                     ) -> "DataIMGInt":   # change to Self once Python 3.10 support has been dropped
-        '''Create a DataIMGInt instance from 2D data and WCS information.
-
-        '''
-        img = cls.from_2d_array(name, y=y,
-                               staterror=staterror, syserror=syserror,
-                               header=header)
-        img.sky = sky
-        img.eqpos = eqpos
-        img._set_coord(coord)
-        return img
-
-    def _init_data_space(self, filter, *data):
-        ndata = len(data)
-        if ndata != 4:
-            raise DataErr("wrongaxiscount", self.name, 4, ndata)
-
-        ds = IntegratedDataSpace2D(filter, *data)
-        self._check_data_space(ds)
-        return ds
-
-    def get_x0(self, filter=False):
-        if self.size is None:
-            return None
-        indep = self._data_space.get(filter)
-        return (indep.x0lo + indep.x0hi) / 2.0
-
-    def get_x1(self, filter=False):
-        if self.size is None:
-            return None
-        indep = self._data_space.get(filter)
-        return (indep.x1lo + indep.x1hi) / 2.0
-
-    @property
-    def x0lo(self):
-        """
-        Property kept for compatibility
-        """
-        return self._data_space.x0lo
-
-    @property
-    def x0hi(self):
-        """
-        Property kept for compatibility
-        """
-        return self._data_space.x0hi
-
-    @property
-    def x1lo(self):
-        """
-        Property kept for compatibility
-        """
-        return self._data_space.x1lo
-
-    @property
-    def x1hi(self):
-        """
-        Property kept for compatibility
-        """
-        return self._data_space.x1hi
-
-    def get_logical(self):
-        coord = self.coord
-        x0lo, x1lo, x0hi, x1hi = self.get_indep()
-        if coord == 'logical':
-            return (x0lo, x1lo, x0hi, x1hi)
-
-        x0lo = x0lo.copy()
-        x1lo = x1lo.copy()
-        convert = getattr(self, f'_{coord}_to_logical')
-        x0lo, x1lo = convert(x0lo, x1lo)
-
-        x0hi = x0hi.copy()
-        x1hi = x1hi.copy()
-        x0hi, x1hi = convert(x0hi, x1hi)
-
-        return (x0lo, x1lo, x0hi, x1hi)
-
-    def get_physical(self):
-        coord = self.coord
-        x0lo, x1lo, x0hi, x1hi = self.get_indep()
-        if coord == 'physical':
-            return (x0lo, x1lo, x0hi, x1hi)
-
-        x0lo = x0lo.copy()
-        x1lo = x1lo.copy()
-        convert = getattr(self, f'_{coord}_to_physical')
-        x0lo, x1lo = convert(x0lo, x1lo)
-
-        x0hi = x0hi.copy()
-        x1hi = x1hi.copy()
-        x0hi, x1hi = convert(x0hi, x1hi)
-
-        return (x0lo, x1lo, x0hi, x1hi)
-
-    def get_world(self):
-        coord = self.coord
-        x0lo, x1lo, x0hi, x1hi = self.get_indep()
-        if coord == 'world':
-            return (x0lo, x1lo, x0hi, x1hi)
-
-        x0lo = x0lo.copy()
-        x1lo = x1lo.copy()
-        convert = getattr(self, f'_{coord}_to_world')
-        x0lo, x1lo = convert(x0lo, x1lo)
-
-        x0hi = x0hi.copy()
-        x1hi = x1hi.copy()
-        x0hi, x1hi = convert(x0hi, x1hi)
-
-        return (x0lo, x1lo, x0hi, x1hi)
-
-    def get_axes(self):
-        # FIXME: how to filter an axis when self.mask is size of self.y?
-        self._check_shape()
-
-        # dummy placeholders needed b/c img shape may not be square!
-        axis0lo = np.arange(self.shape[1], dtype=float) - 0.5
-        axis1lo = np.arange(self.shape[0], dtype=float) - 0.5
-
-        axis0hi = np.arange(self.shape[1], dtype=float) + 0.5
-        axis1hi = np.arange(self.shape[0], dtype=float) + 0.5
-
-        if self.coord == 'logical':
-            return (axis0lo, axis1lo, axis0hi, axis1hi)
-
-        dummy0 = np.ones(axis0lo.size, dtype=float)
-        dummy1 = np.ones(axis1lo.size, dtype=float)
-
-        if self.coord == 'physical':
-            axis0lo, dummy = self._logical_to_physical(axis0lo, dummy0)
-            axis0hi, dummy = self._logical_to_physical(axis0hi, dummy0)
-
-            dummy, axis1lo = self._logical_to_physical(dummy1, axis1lo)
-            dummy, axis1hi = self._logical_to_physical(dummy1, axis1hi)
-
-        else:
-            axis0lo, dummy = self._logical_to_world(axis0lo, dummy0)
-            axis0hi, dummy = self._logical_to_world(axis0hi, dummy0)
-
-            dummy, axis1lo = self._logical_to_world(dummy1, axis1lo)
-            dummy, axis1hi = self._logical_to_world(dummy1, axis1hi)
-
-        return (axis0lo, axis1lo, axis0hi, axis1hi)

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -4497,8 +4497,7 @@ It is an integer or string.
     def get_y(self,
               filter: bool,
               yfunc: None,
-              response_id: IdType | None = None,
-              use_evaluation_space: bool = False
+              response_id: IdType | None = None
               ) -> np.ndarray:
         ...
 
@@ -4506,15 +4505,11 @@ It is an integer or string.
     def get_y(self,
               filter: bool,
               yfunc: ModelFunc,
-              response_id: IdType | None = None,
-              use_evaluation_space: bool = False
+              response_id: IdType | None = None
               ) -> tuple[np.ndarray, np.ndarray]:
         ...
 
-    # Note that use_evaluation_space is unused.
-    #
-    def get_y(self, filter=False, yfunc=None, response_id=None,
-              use_evaluation_space=False):
+    def get_y(self, filter=False, yfunc=None, response_id=None):
 
         vals = Data.get_y(self, yfunc=yfunc)
         vallist = (vals,) if yfunc is None else vals

--- a/sherpa/astro/io/tests/test_io_pha.py
+++ b/sherpa/astro/io/tests/test_io_pha.py
@@ -1288,7 +1288,7 @@ def test_csc_pha_roundtrip(make_data_path, tmp_path):
         raise RuntimeError(f"Unknown io backend: {io.backend}")
 
 
-@pytest.mark.parametrize("column", ["channel", "counts"])
+@pytest.mark.parametrize("column", ["counts"])
 @pytest.mark.parametrize("is_ascii", [True, False])
 @requires_fits
 def test_write_pha_missing_column(column, is_ascii, tmp_path):

--- a/sherpa/astro/tests/test_astro_data.py
+++ b/sherpa/astro/tests/test_astro_data.py
@@ -3166,7 +3166,7 @@ def test_data_is_empty(data_class, args):
     """There is no size attribute"""
 
     data = data_class("empty", *args)
-    assert data.size is None
+    assert data.size is 0
 
 
 def test_datapha_size():
@@ -3186,15 +3186,14 @@ def test_data2d_size(data_args):
 
 @pytest.mark.parametrize("data_class,args", EMPTY_DATA_OBJECTS)
 def test_data_can_not_set_dep_to_scalar_when_empty(data_class, args):
-    """Check out how we error out.
+    """Setting with a scalar sets all (in this case: 0) y values to that scalar.
 
     This is a regression test.
     """
 
     data = data_class("empty", *args)
-    with pytest.raises(DataErr,
-                       match="The size of 'empty' has not been set"):
-        data.set_dep(2)
+    data.set_dep(2)
+    assert data.get_dep() == pytest.approx(np.array([]))
 
 
 @pytest.mark.parametrize("data_class,args", EMPTY_DATA_OBJECTS_2D)
@@ -3819,15 +3818,10 @@ def test_pha_group_xxx_with_background(caplog):
 def test_eval_model_when_empty_datapha():
     """This is a regression test."""
 
-    def mdl(*args):
-        assert len(args) == 1
-        assert args[0] is None
-        return [-9]  # easy to check for
-
-    mdl.ndim = 1
     data = DataPHA("empty", None, None)
-    resp = data.eval_model(mdl)
-    assert resp == pytest.approx([-9])
+    with pytest.raises(DataErr,
+                       match="The size of 'empty' has not been set"):
+        _ = data.eval_model(Gauss1D())
 
 
 def test_eval_model_to_fit_when_empty_datapha():
@@ -3910,7 +3904,7 @@ def test_to_guess_when_empty_datapha():
 
     data = DataPHA("empty", None, None)
     with pytest.raises(DataErr,
-                       match="The size of 'empty' has not been set"):
+                       match="data set 'empty' has no channel information"):
         _ = data.to_guess()
 
 

--- a/sherpa/astro/tests/test_astro_data2.py
+++ b/sherpa/astro/tests/test_astro_data2.py
@@ -259,7 +259,7 @@ def test_pha_filter_when_empty(caplog):
 
     assert len(caplog.records) == 1
 
-    emsg = "Skipping dataset empty: The size of 'empty' has not been set"
+    emsg = "Skipping dataset empty: data set 'empty' has no channel information"
     r = caplog.record_tuples[0]
     assert r[0] == "sherpa.astro.data"
     assert r[1] == logging.INFO
@@ -3510,14 +3510,14 @@ def test_grouped_pha_set_related_invalid_size(related, make_grouped_pha):
                                     "backscal", "areascal",
                                     "grouping", "quality"])
 def test_pha_check_related_fields_correct_size(column, make_grouped_pha):
-    """Can we set the value to a 2-element array?"""
+    """Can we set the value if indep has not been set yet?"""
 
     d = DataPHA('example', None, None)
-    setattr(d, column, np.asarray([2, 10, 3]))
 
+    columnname = "y" if column == "counts" else column
     with pytest.raises(DataErr,
-                       match="independent axis can not change size: 3 to 4"):
-        d.indep = (np.asarray([2, 3, 4, 5]), )
+                       match=f"size mismatch between independent axis and {columnname}: 0 vs 3"):
+        setattr(d, column, np.asarray([2, 10, 3]))
 
 
 @pytest.mark.parametrize("label", ["filter", "grouping"])
@@ -4871,16 +4871,18 @@ def test_dataimgint_show(make_dataimgint):
     # output? For the moment just test what we do return.
     #
     assert out[0] == "name      = ival"
-    assert out[1] == "x0        = Float64[2]"
-    assert out[2] == "x1        = Float64[2]"
-    assert out[3] == "y         = Int64[2]"
-    assert out[4] == "shape     = (2, 1)"
-    assert out[5] == "staterror = None"
-    assert out[6] == "syserror  = None"
-    assert out[7] == "sky       = None"
-    assert out[8] == "eqpos     = None"
-    assert out[9] == "coord     = logical"
-    assert len(out) == 10
+    assert out[1] == "x0lo      = Int64[2]"
+    assert out[2] == "x1lo      = Int64[2]"
+    assert out[3] == "x0hi      = Int64[2]"
+    assert out[4] == "x1hi      = Int64[2]"
+    assert out[5] == "y         = Int64[2]"
+    assert out[6] == "shape     = (2, 1)"
+    assert out[7] == "staterror = None"
+    assert out[8] == "syserror  = None"
+    assert out[9] == "sky       = None"
+    assert out[10] == "eqpos     = None"
+    assert out[11] == "coord     = logical"
+    assert len(out) == 12
 
 
 def test_dataimgint_x0lo(make_dataimgint):

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -37,7 +37,7 @@ from typing import TYPE_CHECKING, Any, Mapping, TextIO, TypedDict
 
 import numpy
 
-from sherpa.astro.data import DataIMG, DataPHA, DataARF, DataRMF
+from sherpa.astro.data import DataIMG, DataPHA, DataARF, DataRMF, IMGMixIn
 from sherpa.astro import io
 from sherpa.astro.io.wcs import WCS
 
@@ -1541,7 +1541,7 @@ def _save_dataset(out: OutType,
     if isinstance(data, DataIMG):
         # This assumes that orig[0] == "logical"
         orig = data._orig_indep_axis
-        xs = (orig[1], orig[2])
+        xs = (orig[1][0][0], orig[1][0][1])
     else:
         xs = data.get_indep()
 

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -759,17 +759,19 @@ def test_show_data(session, flag):
         assert toks[idx] == "Filter: -300.0000--50.0000 x"
         idx += 1
 
-    assert toks[idx] == "name      = "
+    assert toks[idx] == "name       = "
     idx += 1
-    assert toks[idx] == "xlo       = Int64[2]"
+    assert toks[idx] == "xlo        = Int64[2]"
     idx += 1
-    assert toks[idx] == "xhi       = Int64[2]"
+    assert toks[idx] == "xhi        = Int64[2]"
     idx += 1
-    assert toks[idx] == "y         = Int64[2]"
+    assert toks[idx] == "y          = Int64[2]"
     idx += 1
-    assert toks[idx] == "staterror = None"
+    assert toks[idx] == "staterror  = None"
     idx += 1
-    assert toks[idx] == "syserror  = None"
+    assert toks[idx] == "syserror   = None"
+    idx += 1
+    assert toks[idx] == "integrated = True"
     idx += 1
     assert toks[idx] == ""
     idx += 1
@@ -780,15 +782,17 @@ def test_show_data(session, flag):
         assert toks[idx] == "Filter: 1.0000-20.0000 x"
         idx += 1
 
-    assert toks[idx] == "name      = "
+    assert toks[idx] == "name       = "
     idx += 1
-    assert toks[idx] == "x         = Int64[4]"
+    assert toks[idx] == "x          = Int64[4]"
     idx += 1
-    assert toks[idx] == "y         = Int64[4]"
+    assert toks[idx] == "y          = Int64[4]"
     idx += 1
-    assert toks[idx] == "staterror = None"
+    assert toks[idx] == "staterror  = None"
     idx += 1
-    assert toks[idx] == "syserror  = None"
+    assert toks[idx] == "syserror   = None"
+    idx += 1
+    assert toks[idx] == "integrated = False"
     idx += 1
     assert toks[idx] == ""
     idx += 1
@@ -796,7 +800,7 @@ def test_show_data(session, flag):
     idx += 1
     assert toks[idx] == ""
 
-    n = 19 if flag else 17
+    n = 21 if flag else 19
     assert len(toks) == n
 
 

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1208,27 +1208,24 @@ class Data(NoNewAttributesAfterInit, BaseData):
     @overload
     def get_y(self,
               filter: bool,
-              yfunc: None,
-              use_evaluation_space: bool = False
+              yfunc: None
               ) -> np.ndarray:
         ...
 
     @overload
     def get_y(self,
               filter: bool,
-              yfunc: ModelFunc,
-              use_evaluation_space: bool = False
+              yfunc: ModelFunc
               ) -> tuple[np.ndarray, ArrayType]:
         ...
 
-    def get_y(self, filter=False, yfunc=None, use_evaluation_space=False):
+    def get_y(self, filter=False, yfunc=None):
         """Return dependent axis in N-D view of dependent variable
 
         Parameters
         ----------
         filter
         yfunc
-        use_evaluation_space
 
         Returns
         -------
@@ -1696,8 +1693,7 @@ class Data1D(Data):
 
     def get_x(self,
               filter: bool = False,
-              model: ModelFunc | None = None,
-              use_evaluation_space: bool = False
+              model: ModelFunc | None = None
               ) -> np.ndarray | None:
 
         if model is not None:
@@ -1705,7 +1701,7 @@ class Data1D(Data):
             if mdim is not None and mdim != 1:
                 raise DataErr(f"Data and model dimensionality do not match: 1D and {mdim}D")
 
-        return self.get_evaluation_indep(filter, model, use_evaluation_space)[0]
+        return self.get_indep(filter)[0]
 
     def get_xerr(self,
                  filter: bool = False,
@@ -1768,28 +1764,24 @@ class Data1D(Data):
     @overload
     def get_y(self,
               filter: bool,
-              yfunc: None = None,
-              use_evaluation_space: bool = False
+              yfunc: None = None
               ) -> np.ndarray:
         ...
 
     @overload
     def get_y(self,
               filter: bool,
-              yfunc: ModelFunc,
-              use_evaluation_space: bool = False
+              yfunc: ModelFunc
               ) -> tuple[np.ndarray, ArrayType]:
         ...
 
-    def get_y(self, filter=False, yfunc=None,
-              use_evaluation_space=False):
+    def get_y(self, filter=False, yfunc=None):
         """Return the dependent axis.
 
         Parameters
         ----------
         filter
         yfunc
-        use_evaluation_space
 
         Returns
         -------
@@ -1807,7 +1799,7 @@ class Data1D(Data):
         if mdim is not None and mdim != 1:
             raise DataErr(f"Data and model dimensionality do not match: 1D and {mdim}D")
 
-        model_evaluation = yfunc(*self.get_evaluation_indep(filter, yfunc, use_evaluation_space))
+        model_evaluation = yfunc(*self.get_indep(filter))
         return (y, model_evaluation)
 
     @overload
@@ -1992,21 +1984,12 @@ class Data1D(Data):
                           staterrfunc: StatErrFunc | None = None):
         # As we introduced models defined on arbitrary grids, the x array can also depend on the
         # model function, at least in principle.
-        return (self.get_x(True, yfunc, use_evaluation_space=True),
-                self.get_y(True, yfunc, use_evaluation_space=True),
+        return (self.get_x(True, yfunc),
+                self.get_y(True, yfunc),
                 self.get_yerr(True, staterrfunc),
                 self.get_xerr(True, yfunc),
                 self.get_xlabel(),
                 self.get_ylabel())
-
-    def get_evaluation_indep(self,
-                             filter: bool = False,
-                             model: ModelFunc | None = None,
-                             use_evaluation_space: bool = False
-                             ) -> np.ndarray | None:
-        data_space = self._data_space.get(filter)
-
-        return data_space.grid
 
     def notice(self,
                xlo: float | None = None,
@@ -2173,10 +2156,9 @@ class Data1DInt(Data1D):
 
     def get_x(self,
               filter: bool = False,
-              model: ModelFunc | None = None,
-              use_evaluation_space: bool = False
+              model: ModelFunc | None = None
               ) -> np.ndarray:
-        indep = self.get_evaluation_indep(filter, model, use_evaluation_space)
+        indep = self.get_indep(filter)
         if len(indep) == 1:
             # assume all data has been filtered out
             return np.asarray([])
@@ -2209,7 +2191,7 @@ class Data1DInt(Data1D):
            can be None, it will always be an array, even if empty.
 
         """
-        indep = self.get_evaluation_indep(filter, model)
+        indep = self.get_indep(filter)
         if len(indep) == 1:
             # assume all data has been filtered out
             return np.asarray([])
@@ -2269,7 +2251,7 @@ class Data1DInt(Data1D):
         # would happen if we didn't over-ride Data1D.filter) but let's
         # use the start and end values for each selected bin.
         #
-        indep = self.get_evaluation_indep(filter=True)
+        indep = self.get_indep(filter=True)
         if len(indep) == 1:
             # assume all data has been filtered out
             return ''

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -702,7 +702,7 @@ class Filter:
         independent axis of a `Data` object - so ``(x, )`` for
         one-dimensional data, ``(xlo, xhi)`` for integrated
         one-dimensional data, ``(x0, x1)`` for two-dimensional data,
-        and ``(x0lo, x1lo, x0hi, x1hi)`` for integrated two-dimensinal
+        and ``(x0lo, x1lo, x0hi, x1hi)`` for integrated two-dimensional
         data. The ``mins`` and ``maxes`` must then be set to match
         this ordering.
 
@@ -861,7 +861,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
     field. Other fields are listed in _extra_fields.
     """
 
-    _extra_fields: FieldsType = ()
+    _extra_fields: FieldsType = ('integrated',)
     """Any extra fields that should be displayed by str(object)."""
 
     _related_fields: FieldsType = ("y", "staterror", "syserror")
@@ -875,25 +875,46 @@ class Data(NoNewAttributesAfterInit, BaseData):
     _size: int | None = None
     _staterror: np.ndarray | None = None
     _syserror: np.ndarray | None = None
+    _integrated: bool = False
 
     ndim: int | None = None
     "The dimensionality of the dataset, if defined, or None."
+
+    shape: tuple | None = None
 
     def __init__(self,
                  name: str,
                  indep: Sequence[ArrayType] | Sequence[None],
                  y: ArrayType | None,
                  staterror: ArrayType | None = None,
-                 syserror: ArrayType | None = None
+                 syserror: ArrayType | None = None,
+                 shape: tuple[int, int] | None = None,
+                 integrated: bool = False,
                  ) -> None:
         self.name = name
         self._data_space = self._init_data_space(Filter(), *indep)
         self.y, self.mask = _check_dep(y)
         self.staterror = staterror
         self.syserror = syserror
+        self._integrated = integrated
 
         self._ylabel = 'y'
+        if integrated and len(indep) % 2 != 0:
+            raise ValueError("In integrated mode, independent variables must be pairs of x0lo, x1lo, ... x0hi, x1hi... .")
+        self.ndim = len(indep) // {False: 1, True: 2}[integrated]
+        if shape is not None and len(shape) != self.ndim:
+            raise ValueError(f"Shape {shape} does not match data dimensionality {self.ndim}.")
+        else:
+            self.shape = shape
         NoNewAttributesAfterInit.__init__(self)
+
+    @property
+    def integrated(self) -> bool:
+        """Return whether the data is integrated.
+
+        This property cannot be changed after the class is created.
+        """
+        return self._integrated
 
     def _check_data_space(self, dataspace):
         """Check that the data space has the correct size.
@@ -1692,7 +1713,6 @@ class Data1D(Data):
         the systematic error associated with the data
     '''
     _fields: FieldsType = ("name", "x", "y", "staterror", "syserror")
-    ndim = 1
 
     def __init__(self,
                  name: str,
@@ -2180,7 +2200,8 @@ class Data1DInt(Data1D):
 
         # Note: we do not call the superclass here.
         self._xlabel = 'x'
-        Data.__init__(self, name, (xlo, xhi), y, staterror, syserror)
+        Data.__init__(self, name, (xlo, xhi), y, staterror, syserror,
+                      integrated=True)
 
     def _repr_html_(self) -> str:
         """Return a HTML (string) representation of the data
@@ -2379,124 +2400,56 @@ class Data1DInt(Data1D):
         """
         Property kept for compatibility
         """
-        return self._data_space.x_axis.lo
+        return self._data_space.axes[0].lo
 
     @property
     def xhi(self) -> np.ndarray | None:
         """
         Property kept for compatibility
         """
-        return self._data_space.x_axis.hi
+        return self._data_space.axes[0].hi
 
+class BaseData2D(Data):
+    """Base class for all data classes."""
+    def notice(self,
+               x0lo: float | None = None,
+               x0hi: float | None = None,
+               x1lo: float | None = None,
+               x1hi: float | None = None,
+               ignore: bool = False
+               ) -> None:
+        xlo = (x0lo, x1lo)
+        xhi = (x0hi, x1hi)
+        if self.integrated:
+            xlo = (None, None) + xlo
+            xhi = xhi + (None, None)
+        super().notice(xlo, xhi,
+                       ignore=ignore, integrated=self.integrated)
 
-class Data2D(Data):
-    '''2D data set
+    # Why have the "self.integrated" check in here instead of just defining
+    # in two separate classes?
+    # I want to be able to inherit in a common tree, e.g. DataIMG and DataIMGInt
+    # without having to worry if they inherit from an integrated or a
+    # non-integrated set.
 
-    This class represents a 2D data set. It is desigend to work with flattened
-    arrays for coordinates and independent variables, which makes it easy to
-    deal with filters and sparse or irregularly-placed grids.
-
-    Of course, the same structure can also be used for regularly-gridded data,
-    it just has to be passed in as a flattened array. However, in this case
-    the more specialized `~sherpa.astro.data.DataIMG` class might be more appropriate.
-
-    Parameters
-    ----------
-    name : string
-        name of this dataset
-    x0 : array-like
-        Independent coordinate values for the first dimension
-    x1 : array-like
-        Independent coordinate values for the second dimension
-    y : array-like
-        The values of the dependent observable. If this is a numpy masked
-        array, the mask will be used to initialize a mask.
-    shape : tuple
-        Shape of the data grid for regularly gridded data (optional). This is
-        used to return the data as an image e.g. for display,
-        but it not needed for fitting and modelling.
-        For irregularly gridded data, shape must be `None`.
-    staterror : array-like
-        the statistical error associated with the data
-    syserror : array-like
-        the systematic error associated with the data
-
-    Examples
-    --------
-    An irregularly-gridded 2D dataset, with points at (-200, -200),
-    (-200, 0), (0, 0), (200, -100), and (200, 150) can be created
-    with:
-
-        >>> irreg2d = Data2D("irregular2d",
-        ...                  [-200, -200, 0, 200, 200],
-        ...                  [-200, 0, 0, -100, 150],
-        ...                  [12, 15, 23, 45, -2])
-
-    A regularly-gridded 2D dataset can be created, but the
-    arguments must be flattened::
-
-        >>> import numpy as np
-        >>> x1, x0 = np.mgrid[20:30:2, 5:20:2]
-        >>> datashape = x0.shape
-        >>> y = np.sqrt((x0 - 10)**2 + (x1 - 31)**2)
-        >>> x0 = x0.flatten()
-        >>> x1 = x1.flatten()
-        >>> y = y.flatten()
-        >>> reg2d = Data2D("regular2d", x0, x1, y, shape=datashape)
-
-    .. note::
-        Sherpa provides the `~sherpa.astro.data.DataIMG` class to handle
-        regularly-gridded data more easily.
-    '''
-    _fields: FieldsType = ("name", "x0", "x1", "y", "shape", "staterror", "syserror")
-    ndim = 2
-
-    # Why should we add shape to extra-fields instead? See #1359 to
-    # fix #47.
-    #
-    # It would change the notebook output slightly so we don't change
-    # for now.
-    #
-    # _extra_fields = ("shape", )
-
-    def __init__(self,
-                 name: str,
-                 x0: ArrayType | None,
-                 x1: ArrayType | None,
-                 y: ArrayType | None,
-                 shape: tuple[int, int] | None = None,
-                 staterror: ArrayType | None = None,
-                 syserror: ArrayType | None = None
-                 ) -> None:
-        self.shape = shape
-
-        self._x0label = 'x0'
-        self._x1label = 'x1'
-
-        super().__init__(name, (x0, x1), y, staterror, syserror)
-
-    def _repr_html_(self) -> str:
-        """Return a HTML (string) representation of the data
-        """
-        return html_data2d(self)
-
-    def _init_data_space(self,
-                         filter: Filter,
-                         *data: ArrayType
-                         ) -> DataSpace2D:
-        ndata = len(data)
-        if ndata != 2:
-            raise DataErr("wrongaxiscount", self.name, 2, ndata)
-
-        ds = DataSpace2D(filter, *data)
-        self._check_data_space(ds)
-        return ds
-
+    # This somewhat duplicates midpoint_grid in the dataspace
+    # When the dataspace is set correctly, can call that instead.
+    # instad of implementing here again.
     def get_x0(self, filter: bool = False) -> np.ndarray | None:
-        return self._data_space.get(filter).x0
+        if self.size is None:
+            return None
+        indep = self._data_space.get(filter)
+        if self.integrated:
+            return (indep.x0lo + indep.x0hi) / 2.0
+        return indep.x0
 
-    def get_x1(self, filter: bool = False) -> np.ndarray | None:
-        return self._data_space.get(filter).x1
+    def get_x1(self, filter=False) -> np.ndarray | None:
+        if self.size is None:
+            return None
+        indep = self._data_space.get(filter)
+        if self.integrated:
+            return (indep.x1lo + indep.x1hi) / 2.0
+        return indep.x1
 
     def get_x0label(self) -> str:
         """Return label for first dimension in 2-D view of independent axis/axes.
@@ -2666,6 +2619,109 @@ class Data2D(Data):
         if self.shape is None:
             raise DataErr('shape', self.name)
 
+
+class Data2D(BaseData2D):
+    '''2D data set
+
+    This class represents a 2D data set. It is desigend to work with flattened
+    arrays for coordinates and independent variables, which makes it easy to
+    deal with filters and sparse or irregularly-placed grids.
+
+    Of course, the same structure can also be used for regularly-gridded data,
+    it just has to be passed in as a flattened array. However, in this case
+    the more specialized `~sherpa.astro.data.DataIMG` class might be more appropriate.
+
+    Parameters
+    ----------
+    name : string
+        name of this dataset
+    x0 : array-like
+        Independent coordinate values for the first dimension
+    x1 : array-like
+        Independent coordinate values for the second dimension
+    y : array-like
+        The values of the dependent observable. If this is a numpy masked
+        array, the mask will be used to initialize a mask.
+    shape : tuple
+        Shape of the data grid for regularly gridded data (optional). This is
+        used to return the data as an image e.g. for display,
+        but it not needed for fitting and modelling.
+        For irregularly gridded data, shape must be `None`.
+    staterror : array-like
+        the statistical error associated with the data
+    syserror : array-like
+        the systematic error associated with the data
+
+    Examples
+    --------
+    An irregularly-gridded 2D dataset, with points at (-200, -200),
+    (-200, 0), (0, 0), (200, -100), and (200, 150) can be created
+    with:
+
+        >>> irreg2d = Data2D("irregular2d",
+        ...                  [-200, -200, 0, 200, 200],
+        ...                  [-200, 0, 0, -100, 150],
+        ...                  [12, 15, 23, 45, -2])
+
+    A regularly-gridded 2D dataset can be created, but the
+    arguments must be flattened::
+
+        >>> import numpy as np
+        >>> x1, x0 = np.mgrid[20:30:2, 5:20:2]
+        >>> datashape = x0.shape
+        >>> y = np.sqrt((x0 - 10)**2 + (x1 - 31)**2)
+        >>> x0 = x0.flatten()
+        >>> x1 = x1.flatten()
+        >>> y = y.flatten()
+        >>> reg2d = Data2D("regular2d", x0, x1, y, shape=datashape)
+
+    .. note::
+        Sherpa provides the `~sherpa.astro.data.DataIMG` class to handle
+        regularly-gridded data more easily.
+    '''
+    _fields: FieldsType = ("name", "x0", "x1", "y", "shape", "staterror", "syserror")
+
+    # Why should we add shape to extra-fields instead? See #1359 to
+    # fix #47.
+    #
+    # It would change the notebook output slightly so we don't change
+    # for now.
+    #
+    # _extra_fields = ("shape", )
+
+    def __init__(self,
+                 name: str,
+                 x0: ArrayType | None,
+                 x1: ArrayType | None,
+                 y: ArrayType | None,
+                 shape: Sequence[int] | None = None,
+                 staterror: ArrayType | None = None,
+                 syserror: ArrayType | None = None
+                 ) -> None:
+
+        self._x0label = 'x0'
+        self._x1label = 'x1'
+
+        super().__init__(name, (x0, x1), y, staterror, syserror,
+                         integrated=False, shape=shape)
+
+    def _repr_html_(self) -> str:
+        """Return a HTML (string) representation of the data
+        """
+        return html_data2d(self)
+
+    def _init_data_space(self,
+                         filter: Filter,
+                         *data: ArrayType
+                         ) -> DataSpace2D:
+        ndata = len(data)
+        if ndata != 2:
+            raise DataErr("wrongaxiscount", self.name, 2, ndata)
+
+        ds = DataSpace2D(filter, *data)
+        self._check_data_space(ds)
+        return ds
+
     @property
     def x0(self) -> np.ndarray | None:
         """
@@ -2680,18 +2736,8 @@ class Data2D(Data):
         """
         return self.get_x1()
 
-    def notice(self,
-               x0lo: float | None = None,
-               x0hi: float | None = None,
-               x1lo: float | None = None,
-               x1hi: float | None = None,
-               ignore: bool = False
-               ) -> None:
-        Data.notice(self, (x0lo, x1lo), (x0hi, x1hi),
-                    ignore=ignore)
 
-
-class Data2DInt(Data2D):
+class Data2DInt(BaseData2D):
     '''2-D integrated data set
 
     This class represents a 2D data set. It is desigend to work with flattened
@@ -2780,7 +2826,8 @@ class Data2DInt(Data2D):
         self._x0label = 'x0'
         self._x1label = 'x1'
         self._ylabel = 'y'
-        Data.__init__(self, name, (x0lo, x1lo, x0hi, x1hi), y, staterror, syserror)
+        super().__init__(name, (x0lo, x1lo, x0hi, x1hi), y, staterror, syserror,
+                         integrated=True, shape=shape)
 
     def _init_data_space(self,
                          filter: Filter,
@@ -2794,27 +2841,7 @@ class Data2DInt(Data2D):
         self._check_data_space(ds)
         return ds
 
-    def get_x0(self, filter: bool = False) -> np.ndarray | None:
-        if self.size is None:
-            return None
-        indep = self._data_space.get(filter)
-        return (indep.x0lo + indep.x0hi) / 2.0
 
-    def get_x1(self, filter=False) -> np.ndarray | None:
-        if self.size is None:
-            return None
-        indep = self._data_space.get(filter)
-        return (indep.x1lo + indep.x1hi) / 2.0
-
-    def notice(self,
-               x0lo: float | None = None,
-               x0hi: float | None = None,
-               x1lo: float | None = None,
-               x1hi: float | None = None,
-               ignore: bool = False
-               ) -> None:
-        Data.notice(self, (None, None, x0lo, x1lo), (x0hi, x1hi, None, None),
-                    ignore=ignore, integrated=True)
 
     @property
     def x0lo(self) -> np.ndarray | None:
@@ -2843,6 +2870,26 @@ class Data2DInt(Data2D):
         Property kept for compatibility
         """
         return self._data_space.x1hi
+
+    @property
+    def x0(self) -> np.ndarray | None:
+        """
+        kept for compatibility:
+        Is this really needed?
+        Only used in a single test that says
+        "Result is presumably autogenerated"
+        """
+        return self.get_x0()
+
+    @property
+    def x1(self) -> np.ndarray | None:
+        """
+        kept for compatibility
+        Is this really needed?
+        Only used in a single test that says
+        "Result is presumably autogenerated"
+        """
+        return self.get_x1()
 
 
 # Notebook representations

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -66,10 +66,9 @@ The design for the `Data` class assumes
 - to support arbitrary dimensions, the data is treated as one-dimensional
   arrays.
 
-- `Data` objects can be created with no data, but are fixed once an
-  axis - expected to be the independent axis but it need not be - is
-  set (see the `~Data.size` attribute). In general the data is
-  assumed to be set when the object is created.
+- `Data` objects can be created with no data, but are fixed once the
+  independent axis is set (see the `~Data.size` attribute). In general the
+  data is assumed to be set when the object is created.
 
 - there are checks to ensure that the data has the correct size, shape,
   and potentially data type, but this is not intended to catch all
@@ -116,15 +115,15 @@ dependent axis (``y``) then filter to select only those values between
 
 """
 
-from abc import ABCMeta
+from abc import ABC
 from collections.abc import Sequence
 import logging
-from typing import Any, Literal, overload
+from typing import Any, Literal, overload, Self
 import warnings
 
 import numpy as np
 
-from sherpa.models.regrid import EvaluationSpace1D, IntegratedAxis, PointAxis
+from sherpa.models.regrid import EvaluationSpace1D, EvaluationSpace2D, EvaluationSpaceND, IntegratedAxis, PointAxis
 from sherpa.utils import NoNewAttributesAfterInit, formatting, \
     print_fields, create_expr, create_expr_integrated, \
     calc_total_error, bool_cast, filter_bins
@@ -215,318 +214,6 @@ def _check_dep(array):
     # We don't know what the mask convention is
     warnings.warn(f'Format of mask for array {array} not supported thus the mask is is ignored and values `behind the mask` are used. Set .mask attribute manually or use "set_filter" function.')
     return _check(array), True
-
-
-class DataSpace1D(EvaluationSpace1D):
-    """
-    Class for representing 1-D Data Space. Data Spaces are spaces that describe the data domain. As models can be
-    evaluated over data spaces, data spaces can be considered evaluation spaces themselves. However this "is-a"
-    relationship is in the code mostly for convenience and could be removed in future versions.
-    """
-    def __init__(self, filter, x):
-        """
-        Parameters
-        ----------
-        filter : Filter
-            a filter object that initialized this data space
-        x : array_like
-            the x axis of this data space
-        """
-        self.filter = filter
-        super().__init__(_check_nomask(x))
-
-    def get(self, filter=False):
-        """
-        Get a filtered representation of this data set. If `filter` is `False` this object is returned.
-
-        Parameters
-        ----------
-        filter : bool
-            whether the data set should be filtered before being returned
-
-        Returns
-        -------
-        DataSpace1D
-        """
-
-        if not bool_cast(filter):
-            return self
-
-        data = self.grid[0]
-
-        data = self.filter.apply(data)
-        return DataSpace1D(self.filter, data)
-
-
-
-class IntegratedDataSpace1D(EvaluationSpace1D):
-    """
-    Same as DataSpace1D, but for supporting integrated data sets.
-    """
-    def __init__(self, filter, xlo, xhi):
-        """
-        Parameters
-        ----------
-        filter : Filter
-            a filter object that initialized this data space
-        xlo : array_like
-            the lower bounds array of this data space
-        xhi : array_like
-            the higher bounds array of this data space
-        """
-        xlo = _check_nomask(xlo)
-        xhi = _check_nomask(xhi)
-
-        # We only have to check if xhi is None, as if it's set then the
-        # superclass will check the length. We do need to support both
-        # values being None though.
-        #
-        if xlo is not None and xhi is None:
-            raise DataErr("mismatchn", "lo", "hi", len(xlo), "None")
-
-        self.filter = filter
-        super().__init__(xlo, xhi)
-
-    def get(self, filter=False):
-        """
-        Get a filtered representation of this data set. If `filter` is `False` this object is returned.
-
-        Parameters
-        ----------
-        filter : bool
-            whether the data set should be filtered before being returned
-
-        Returns
-        -------
-        IntegratedDataSpace1D
-        """
-
-        if not bool_cast(filter):
-            return self
-
-        data = self.grid
-
-        data = tuple(self.filter.apply(axis) for axis in data)
-        return IntegratedDataSpace1D(self.filter, *data)
-
-
-
-# We do not inherit from EvaluationSpace2D because that would require
-# that the x0 and x1 arrays form a grid (e.g. nx by ny) and we need
-# to be able to support a non-grid set of points.
-#
-# The code is written to resemble sherpa.models.grid.EvaluationSpace2D
-# though, so that the checks added for that code are run here.
-#
-class DataSpace2D:
-    """Class for representing 2-D Data Spaces.
-
-    Data Spaces are spaces that describe the data domain.
-
-    Parameters
-    ----------
-    filter : Filter
-        A filter object that initialized this data space.
-    x0, x1 : array_like
-        The first and second axes of this data space. The arrays are
-        copied.
-
-    """
-
-    def __init__(self, filter, x0, x1):
-        x0 = _check_nomask(x0)
-        x1 = _check_nomask(x1)
-
-        self.filter = filter
-        self.x_axis = PointAxis(x0)
-        self.y_axis = PointAxis(x1)
-        if self.x_axis.size != self.y_axis.size:
-            raise DataErr("mismatchn", "x0", "x1", self.x_axis.size, self.y_axis.size)
-
-    def get(self, filter=False):
-        """
-        Get a filtered representation of this data set. If `filter` is `False` this object is returned.
-
-        Parameters
-        ----------
-        filter : bool
-            whether the data set should be filtered before being returned
-
-        Returns
-        -------
-        DataSpace2D
-        """
-
-        if not bool_cast(filter):
-            return self
-
-        data = self.grid
-
-        data = tuple(self.filter.apply(axis) for axis in data)
-        return DataSpace2D(self.filter, *data)
-
-    @property
-    def grid(self):
-        """The grid representation of this dataset.
-
-        The x0 and x1 arrays in the grid are one-dimensional representations of the meshgrid obtained
-        from the x and y axis arrays, as in `numpy.meshgrid(x, y)[0].ravel()`
-
-        Returns
-        -------
-        (x0, x1) : (ndarray, ndarray)
-            A tuple representing the x0 and x1 axes.
-        """
-        return self.x_axis.x, self.y_axis.x
-
-    # Should these be deprecated now that the code attempts to mimic EvaluationSpace2D?
-    #
-    @property
-    def x0(self):
-        """Return the first axis."""
-        return self.x_axis.x
-
-    @property
-    def x1(self):
-        """Return the second axis."""
-        return self.y_axis.x
-
-
-class IntegratedDataSpace2D:
-    """Same as DataSpace2D, but for supporting integrated data sets.
-
-    Parameters
-    ----------
-    filter : Filter
-        A filter object that initialized this data space.
-    x0lo, x1lo, x0hi, x1hi : array_like
-        The lower bounds array of the first and second axes, then the
-        upper bounds.
-
-    """
-
-    def __init__(self, filter, x0lo, x1lo, x0hi, x1hi):
-        x0lo = _check_nomask(x0lo)
-        x1lo = _check_nomask(x1lo)
-        x0hi = _check_nomask(x0hi)
-        x1hi = _check_nomask(x1hi)
-
-        self.filter = filter
-        self.x_axis = IntegratedAxis(x0lo, x0hi)
-        self.y_axis = IntegratedAxis(x1lo, x1hi)
-        if self.x_axis.size != self.y_axis.size:
-            raise DataErr("mismatchn", "x0", "x1", self.x_axis.size, self.y_axis.size)
-
-    def get(self, filter=False):
-        """
-        Get a filtered representation of this data set. If `filter` is `False` this object is returned.
-
-        Parameters
-        ----------
-        filter : bool
-            whether the data set should be filtered before being returned
-
-        Returns
-        -------
-        IntegratedDataSpace2D
-        """
-
-        if not bool_cast(filter):
-            return self
-
-        data = self.grid
-
-        data = tuple(self.filter.apply(axis) for axis in data)
-        return IntegratedDataSpace2D(self.filter, *data)
-
-    @property
-    def grid(self):
-        """The grid representation of this dataset.
-
-        The x0 and x1 arrays in the grid are one-dimensional representations of the meshgrid obtained
-        from the x and y axis arrays, as in `numpy.meshgrid(x, y)[0].ravel()`
-
-        Returns
-        -------
-        (x0lo, x1lo, x0hi, x1hi) : (ndarray, ndarray, ndarray, ndarray)
-            The axis data.
-
-        """
-        return self.x_axis.lo, self.y_axis.lo, self.x_axis.hi, self.y_axis.hi
-
-    # Should these be deprecated now that the code attempts to mimic EvaluationSpace2D?
-    #
-    @property
-    def x0lo(self):
-        """Return the first axis (low edge)"""
-        return self.x_axis.lo
-
-    @property
-    def x0hi(self):
-        """Return the first axis (high edge)."""
-        return self.x_axis.hi
-
-    @property
-    def x1lo(self):
-        """Return the second axis (low edge)."""
-        return self.y_axis.lo
-
-    @property
-    def x1hi(self):
-        """Return the second axis (high edge)."""
-        return self.y_axis.hi
-
-
-class DataSpaceND:
-    """Class for representing arbitrary N-Dimensional data domains
-
-    Parameters
-    ----------
-    filter : Filter
-        A filter object that initialized this data space.
-    indep : tuple of array_like
-        The tuple of independent axes. The arrays are copied rather
-        than storing a reference.
-
-    """
-
-    def __init__(self, filter, indep):
-        self.filter = filter
-        self.indep = tuple(_check_nomask(d) for d in indep)
-
-    def get(self, filter=False):
-        """
-        Get a filtered representation of this data set. If `filter` is `False` this object is returned.
-
-        Parameters
-        ----------
-        filter : bool
-            whether the data set should be filtered before being returned
-
-        Returns
-        -------
-        DataSpaceND
-        """
-
-        if not bool_cast(filter):
-            return self
-
-        data = tuple(self.filter.apply(axis) for axis in self.indep)
-        return DataSpaceND(self.filter, data)
-
-    @property
-    def grid(self):
-        """
-        Return the grid representation of this dataset.
-
-        The independent arrays are returned unchanged, i.e. unlike the DataSpace2D class they are not meshed
-
-        Returns
-        -------
-        tuple
-            A tuple representing the independent axes.
-        """
-        return self.indep
 
 
 # NOTE:
@@ -755,7 +442,251 @@ class Filter:
                 self.mask &= mask
 
 
-class BaseData(metaclass=ABCMeta):
+
+class DataSpaceMixInBase(ABC):
+    """Base class for  data spaces
+
+    Data spaces define the independent axes of datasets. They can contain
+    any number of dimensions and set an axis for each dimension. Those
+    axes can be integrated or not, and data spaces have a number of methods
+    to obtain properties such as the number or dimensions etc.
+    This functionality overlaps with the evaluation spaces used for model
+    evaluation, and thus data spaces inherit from evaluation spaces.
+
+    They add a filter property that allows to (temporarily) select only
+    a subregion of the data.
+
+    Since evaluation spaces are already organized in a hierarchy of classes
+    from `~sherpa.models.regrid.EvaluationSpaceND`, to its specializations
+    `~sherpa.models.regrid.EvaluationSpace1D` and
+    `~sherpa.models.regrid.EvaluationSpace2D`, this data class is written as
+    a mixin for multiple inheritance such that the properties defined here can
+    be added to any existing evaluation space class.
+
+    Parameters
+    ----------
+    filter : Filter
+        a filter object that is initialized this data space
+    args : tuple
+        positional arguments passed to the superclass initializer
+    kwargs : dict
+        keyword arguments passed to the superclass initializer
+
+    Notes
+    -----
+    ``*args`` and ``**kwargs`` are passed to the superclass initializer.
+    While on first sight, it might seem confusing that this class does not
+    derive from a superclass, we need to keep in mind that it's supposed to
+    be used as a mixin class in multiple inheritance. The calls to ``super()``
+    will then be resolved to the other superclasses (see Python's MRO).
+    """
+    def __init__(self, filter: Filter, *args, **kwargs) -> None:
+        self.filter = filter
+        # Static typecheckers do not know about the MRO order in the classes
+        # that we define to inherit from this mixin.
+        super().__init__(*args, **kwargs)  # type: ignore
+
+
+class DataSpaceMixIn(DataSpaceMixInBase):
+    """Mixin class for data spaces with packed axis arguments
+
+    The general `~sherpa.models.regrid.EvaluationSpaceND` expects a single
+    argument for the independent axes in the form of a tuple of arrays.
+    This mixin class supports that interface for data spaces.
+
+    Parameters
+    ----------
+    filter : Filter
+        a filter object that is initialized this data space
+    args : tuple
+        positional arguments passed to the superclass initializer
+    kwargs : dict
+        keyword arguments passed to the superclass initializer
+    """
+    def __init__(self, filter: Filter, *args, **kwargs) -> None:
+        """
+        Parameters
+        ----------
+        filter : Filter
+            a filter object that is initialized this data space
+        x : array_like
+            the x axis of this data space
+        """
+        for axis in args[0] + tuple((v for k, v in kwargs.items() if k[0] == 'x')):
+            _check_nomask(axis)
+        super().__init__(filter, *args, **kwargs)
+
+    def get(self, filter: bool = False) -> Self:
+        """
+        Get a filtered representation of this data set. If `filter` is
+        `False` this object is returned.
+
+        Parameters
+        ----------
+        filter : bool
+            whether the data set should be filtered before being returned
+
+        Returns
+        -------
+        data : Data
+            Return a (filtered) version of this data set. If no filter is used
+            this is a reference to this object, otherwise it's a filtered copy.
+        """
+
+        if not bool_cast(filter):
+            return self
+
+        data = tuple(self.filter.apply(axis) for axis in self.grid)
+        return type(self)(self.filter, data)
+
+
+class DataSpaceMixInUnpacked(DataSpaceMixInBase):
+    """Mixin class for data spaces with unpacked axis arguments
+
+    For convenience and to follow the historically established
+    interface, data classes for 1D and 2D expect the independent axes
+    to be sent as separate arguments rather than a single tuple of
+    arrays. This mixin class supports that interface for data spaces.
+
+    Parameters
+    ----------
+    filter : Filter
+        a filter object that is initialized this data space
+    args : tuple
+        positional arguments passed to the superclass initializer
+    kwargs : dict
+        keyword arguments passed to the superclass initializer
+    """
+    def __init__(self, filter: Filter, *args, **kwargs) -> None:
+        """
+        Parameters
+        ----------
+        filter : Filter
+            a filter object that is initialized this data space
+        x : array_like
+            the x axis of this data space
+        """
+        for axis in args + tuple((v for k, v in kwargs.items() if k[0] == 'x')):
+            _check_nomask(axis)
+        super().__init__(filter, *args, **kwargs)
+
+    def get(self, filter: bool = False) -> Self:
+        """
+        Get a filtered representation of this data set. If `filter` is
+        `False` this object is returned.
+
+        Parameters
+        ----------
+        filter : bool
+            whether the data set should be filtered before being returned
+
+        Returns
+        -------
+        data : Data
+            Return a (filtered) version of this data set. If no filter is used
+            this is a reference to this object, otherwise it's a filtered copy.
+        """
+
+        if not bool_cast(filter):
+            return self
+
+        data = tuple(self.filter.apply(axis) for axis in self.grid)
+        return type(self)(self.filter, *data, integrated=self.is_integrated,
+                          flat=self.flat, clean=False)
+
+
+class DataSpace1D(DataSpaceMixInUnpacked, EvaluationSpace1D):
+    """
+    Class for representing 1-D Data Space.
+    """
+    pass
+
+
+class IntegratedDataSpace1D(DataSpace1D):
+    """
+    Same as `DataSpace1D`, but for supporting integrated data sets.
+    """
+    def __init__(self, filter, xlo, xhi, **kwargs) -> None:
+        """
+        Parameters
+        ----------
+        filter : Filter
+            a filter object that initialized this data space
+        xlo : array_like
+            the lower bounds array of this data space
+        xhi : array_like
+            the higher bounds array of this data space
+        """
+        # We only have to check if xhi is None, as if it's set then the
+        # superclass will check the length. We do need to support both
+        # values being None though.
+        #
+        if xlo is not None and xhi is None:
+            raise DataErr("mismatchn", "lo", "hi", len(xlo), "None")
+
+        # This is an "integrated data space", but the super will not
+        # know if "xhi=None"
+        # On the other hand, we dont' know if "integrated" is already present
+        # in kwargs, so set here, not as argument in super() call.
+        kwargs['integrated'] = True
+        super().__init__(filter, xlo, xhi, **kwargs)
+
+
+class DataSpace2D(DataSpaceMixInUnpacked, EvaluationSpace2D):
+    """Class for representing 2-D Data Spaces.
+
+    Parameters
+    ----------
+    filter : Filter
+        A filter object that initialized this data space.
+    x0, x1 : array_like
+        The first and second axes.
+    kwargs : dict
+        Additional keyword arguments passed to `~sherpa.models.regrid.EvaluationSpace1D`
+
+    """
+    pass
+
+
+class IntegratedDataSpace2D(DataSpace2D):
+    """Same as `DataSpace2D`, but for supporting integrated data sets.
+
+    Parameters
+    ----------
+    filter : Filter
+        A filter object that initialized this data space.
+    x0lo, x1lo, x0hi, x1hi : array_like
+        The lower bounds array of the first and second axes, then the
+        upper bounds.
+    kwargs : dict
+        Additional keyword arguments passed to `~sherpa.models.regrid.EvaluationSpace2D`
+
+    """
+    def __init__(self, filter, x0lo, x1lo, x0hi, x1hi, **kwargs) -> None:
+        # This is an "integrated data space", but the super will not
+        # know if some of the axes are "None"
+        # On the other hand, we dont' know if "integrated" is already present
+        # in kwargs, so set here, not as argument in super() call.
+        kwargs['integrated'] = True
+        super().__init__(filter, x0lo, x1lo, x0hi, x1hi, **kwargs)
+
+
+class DataSpaceND(DataSpaceMixIn, EvaluationSpaceND):
+    """Class for representing arbitrary N-Dimensional data domains
+
+    Parameters
+    ----------
+    filter : Filter
+        A filter object that initialized this data space.
+    indep : tuple of array_like
+        The tuple of independent axes. The arrays are copied rather
+        than storing a reference.
+    kwargs : dict
+        Additional keyword arguments passed to `~sherpa.models.regrid.EvaluationSpaceND`
+    """
+    pass
+
+class BaseData(ABC, NoNewAttributesAfterInit):
     """
     Base class for all data classes. Left for compatibility with older versions.
     """
@@ -763,7 +694,7 @@ class BaseData(metaclass=ABCMeta):
 
 
 # DATA-NOTE: ND Data cannot be plotted
-class Data(NoNewAttributesAfterInit, BaseData):
+class Data(BaseData):
     """Generic, N-Dimensional data sets.
 
     A data class is the collection of a data space and a number of
@@ -825,10 +756,8 @@ class Data(NoNewAttributesAfterInit, BaseData):
     """
 
     _y: np.ndarray | None = None
-    _size: int | None = None
     _staterror: np.ndarray | None = None
     _syserror: np.ndarray | None = None
-    _integrated: bool = False
 
     ndim: int | None = None
     "The dimensionality of the dataset, if defined, or None."
@@ -841,15 +770,15 @@ class Data(NoNewAttributesAfterInit, BaseData):
                  y: ArrayType | None,
                  staterror: ArrayType | None = None,
                  syserror: ArrayType | None = None,
-                 shape: tuple[int, int] | None = None,
+                 shape: Sequence[int] | None = None,
                  integrated: bool = False,
                  ) -> None:
         self.name = name
-        self._data_space = self._init_data_space(Filter(), *indep)
+        self._data_space = self._init_data_space(Filter(), indep, integrated=integrated)
         self.y, self.mask = _check_dep(y)
         self.staterror = staterror
         self.syserror = syserror
-        self._integrated = integrated
+
 
         self._ylabel = 'y'
         if integrated and len(indep) % 2 != 0:
@@ -859,21 +788,21 @@ class Data(NoNewAttributesAfterInit, BaseData):
             raise ValueError(f"Shape {shape} does not match data dimensionality {self.ndim}.")
         else:
             self.shape = shape
-        NoNewAttributesAfterInit.__init__(self)
+        super().__init__()
 
     @property
-    def integrated(self) -> bool:
+    def integrated(self) -> bool | None:
         """Return whether the data is integrated.
 
         This property cannot be changed after the class is created.
         """
-        return self._integrated
+        if hasattr(self, "_data_space"):
+            return self._data_space.is_integrated
+        # If datasets has not been initialized in __init__ yet.
+        return None
 
     def _check_data_space(self, dataspace):
         """Check that the data space has the correct size.
-
-        Note that this also sets the size of the data object if it has
-        not been set.
 
         Parameters
         ----------
@@ -881,20 +810,13 @@ class Data(NoNewAttributesAfterInit, BaseData):
             The dataspace object for the data object.
 
         """
-
-        indep0 = dataspace.get().grid[0]
         nold = self.size
-
-        # If there is no data then we need to update the size, unless
-        # the new data is also empty.
+        # If the space is still empty on initialization then pass the test.
         #
-        if nold is None:
-            if indep0 is None:
-                return
-
-            self._size = len(indep0)
+        if nold is None or nold == 0:
             return
 
+        indep0 = dataspace.get().grid[0]
         # We could allow the independent axis to be reset to None.
         #
         if indep0 is None:
@@ -906,7 +828,8 @@ class Data(NoNewAttributesAfterInit, BaseData):
 
     def _init_data_space(self,
                          filter: Filter,
-                         *data: ArrayType
+                         data: Sequence[ArrayType | None],
+                         integrated: bool = False,
                          ) -> DataSpaceND:
         """
         Extending classes should implement this method to provide the proper data space construction.
@@ -925,7 +848,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
 
         """
 
-        ds = DataSpaceND(filter, data)
+        ds = DataSpaceND(filter, data, clean=False, flat=True, integrated=integrated)
         self._check_data_space(ds)
         return ds
 
@@ -942,6 +865,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
         contains a NumPy masked array which does not match the
         dependent axis.
 
+        kwargs is unused, but left for backwards compatibility.
         """
         if val is None:
             setattr(self, f"_{attr}", None)
@@ -963,11 +887,8 @@ class Data(NoNewAttributesAfterInit, BaseData):
                 warnings.warn(f"The mask of {attr} differs from the dependent array, only the mask of the dependent array is used in Sherpa.")
 
         nelem = self.size
-        if nelem is None:
-            # We set the object size here
-            self._size  = nval
-            setattr(self, f"_{attr}", vals)
-            return
+        #if nelem == 0:
+        #    raise DataErr('The independent axis has not been set yet.')
 
         if nval != nelem:
             raise DataErr('mismatchn', 'independent axis', attr, nelem, nval)
@@ -995,7 +916,10 @@ class Data(NoNewAttributesAfterInit, BaseData):
         size : int or None
             If the size has not been set then None is returned.
         """
-        return self._size
+        if hasattr(self, "_data_space"):
+            return self._data_space.size
+        # If datasets has not been initialized in __init__ yet.
+        return None
 
     # Allow users to len() a data object. The idea is that this
     # represents the "number of elements" (e.g. the size of the
@@ -1042,7 +966,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
         # filter.mask attribute.
         #
         if val is not None and np.ndim(val) != 0:
-            if self.size is None:
+            if self.size == 0:
                 raise DataErr("The independent axis has not been set yet")
 
             nval = len(val)
@@ -1116,7 +1040,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
         if not isinstance(val, tuple):
             raise TypeError(f"independent axis must be sent a tuple, not {type(val).__name__}")
 
-        ds = self._init_data_space(self._data_space.filter, *val)
+        ds = self._init_data_space(self._data_space.filter, val)
         self._data_space = ds
         self._clear_filter()
 
@@ -1142,7 +1066,14 @@ class Data(NoNewAttributesAfterInit, BaseData):
         get_dep : Return the dependent axis of a data set.
 
         """
-        return self._data_space.get(filter).grid
+        ds = self._data_space.get(filter)
+        # Note:
+        # An empty axes returns None for each axis, the same is true for
+        # integrated and non-integrated data.
+        # However, for integrated data, we want None for both the hi and lo.
+        #if ds.is_empty:
+        #    return (None, ) * ds.ndim * (2 if ds.is_integrated else 1)
+        return ds.grid
 
     def set_indep(self,
                   val: tuple[ArrayType, ...] | tuple[None, ...]
@@ -1255,7 +1186,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
         return self._staterror
 
     @staterror.setter
-    def staterror(self, val: ArrayType) -> None:
+    def staterror(self, val: ArrayType | None) -> None:
         self._set_related("staterror", val)
 
     @property
@@ -1267,7 +1198,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
         return self._syserror
 
     @syserror.setter
-    def syserror(self, val: ArrayType) -> None:
+    def syserror(self, val: ArrayType | None) -> None:
         self._set_related("syserror", val)
 
     def get_staterror(self,
@@ -1437,7 +1368,7 @@ class Data(NoNewAttributesAfterInit, BaseData):
             return None
 
         nelem = self.size
-        if nelem is None:
+        if nelem is None or nelem == 0:
             raise DataErr("sizenotset", self.name)
 
         data = _check(data)
@@ -1645,82 +1576,9 @@ class DataSimulFit(NoNewAttributesAfterInit):
         return self.datasets[0].to_plot(yfunc.parts[0], staterrfunc)
 
 
-class Data1D(Data):
-    '''Dateset for 1D data.
-
-    Parameters
-    ----------
-    name : string
-        name of this dataset
-    x : array-like
-        Coordinates of the independent variable
-    y : array-like
-        The values of the dependent observable. If this is a numpy masked
-        array, the mask will used to initialize a mask.
-    staterror : array-like
-        the statistical error associated with the data
-    syserror : array-like
-        the systematic error associated with the data
+class BaseData1D(Data):
+    '''Base class for 1-D data sets.
     '''
-    _fields: FieldsType = ("name", "x", "y", "staterror", "syserror")
-
-    def __init__(self,
-                 name: str,
-                 x: ArrayType | None,
-                 y: ArrayType | None,
-                 staterror: ArrayType | None = None,
-                 syserror: ArrayType | None = None
-                 ) -> None:
-        self._xlabel = 'x'
-        super().__init__(name, (x, ), y, staterror, syserror)
-
-    def _repr_html_(self) -> str:
-        """Return a HTML (string) representation of the data
-        """
-        return html_data1d(self)
-
-    def _init_data_space(self,
-                         filter: Filter,
-                         *data: ArrayType
-                         ) -> DataSpace1D:
-        ndata = len(data)
-        if ndata != 1:
-            raise DataErr("wrongaxiscount", self.name, 1, ndata)
-
-        ds = DataSpace1D(filter, *data)
-        self._check_data_space(ds)
-        return ds
-
-    def get_x(self,
-              filter: bool = False,
-              model: ModelFunc | None = None
-              ) -> np.ndarray | None:
-
-        if model is not None:
-            mdim = getattr(model, "ndim", None)
-            if mdim is not None and mdim != 1:
-                raise DataErr(f"Data and model dimensionality do not match: 1D and {mdim}D")
-
-        return self.get_indep(filter)[0]
-
-    def get_xerr(self,
-                 filter: bool = False,
-                 yfunc=None
-                 ) -> np.ndarray | None:
-        """Return linear view of bin size in independent axis/axes.
-
-        Parameters
-        ----------
-        filter
-        yfunc
-
-        Returns
-        -------
-        xerr : array or None
-
-        """
-        return None
-
     def get_xlabel(self) -> str:
         """Return label for linear view of independent axis/axes
 
@@ -1752,11 +1610,28 @@ class Data1D(Data):
         """
         self._xlabel = label
 
+    def get_x(self,
+              filter: bool = False,
+              model: ModelFunc | None = None
+              ) -> np.ndarray | None:
+
+        if model is not None:
+            mdim = getattr(model, "ndim", None)
+            if mdim is not None and mdim != 1:
+                raise DataErr(f"Data and model dimensionality do not match: 1D and {mdim}D")
+        return self.get_indep(filter)
+
+    def get_xerr(self,
+                 filter: bool = False,
+                 yfunc=None
+                 ) -> np.ndarray | None:
+        raise NotImplementedError
+
     # The superclass suggests returning both the independent and
     # dependent axis sizes.
     #
     def get_dims(self, filter: bool = False) -> tuple[int, ...]:
-        if self.size is None:
+        if self.size == 0:
             raise DataErr("sizenotset", self.name)
 
         return len(self.get_x(filter)),
@@ -1851,50 +1726,7 @@ class Data1D(Data):
                    format: str = '%.4f',
                    delim: str = ':'
                    ) -> str:
-        """Return the data filter as a string.
-
-        Parameters
-        ----------
-        format : str, optional
-            The formatting of the numeric values.
-        delim : str, optional
-            The string used to mark the low-to-high range.
-
-        Returns
-        -------
-        filter : str
-           The filter, represented as a collection of single values or
-           ranges, separated by commas.
-
-        See Also
-        --------
-        get_filter_expr, ignore, notice
-
-        Examples
-        --------
-
-        >>> import numpy as np
-        >>> x = np.asarray([1, 2, 3, 5, 6])
-        >>> y = np.ones(5)
-        >>> d = Data1D('example', x, y)
-        >>> d.get_filter()
-        '1.0000:6.0000'
-        >>> d.ignore(2.5, 4.5)
-        >>> d.get_filter()
-        '1.0000:2.0000,5.0000:6.0000'
-
-        >>> d.get_filter(format='%i', delim='-')
-        '1-2,5-6'
-
-        """
-
-        x = self.get_x(filter=True)
-        if np.iterable(self.mask):
-            mask = self.mask
-        else:
-            mask = np.ones(len(x), dtype=bool)
-
-        return create_expr(x, mask=mask, format=format, delim=delim)
+        raise NotImplementedError
 
     def get_filter_expr(self) -> str:
         """Return the data filter as a string along with the units.
@@ -2041,7 +1873,7 @@ class Data1D(Data):
 
         """
 
-        Data.notice(self, (xlo,), (xhi,), ignore)
+        super().notice((xlo,), (xhi,), ignore)
 
     @property
     def x(self) -> np.ndarray | None:
@@ -2049,6 +1881,133 @@ class Data1D(Data):
         Used for compatibility, in particular for __str__ and __repr__
         """
         return self.get_x()
+
+class Data1D(BaseData1D):
+    '''Dateset for 1D data.
+
+    Parameters
+    ----------
+    name : string
+        name of this dataset
+    x : array-like
+        Coordinates of the independent variable
+    y : array-like
+        The values of the dependent observable. If this is a numpy masked
+        array, the mask will used to initialize a mask.
+    staterror : array-like
+        the statistical error associated with the data
+    syserror : array-like
+        the systematic error associated with the data
+    '''
+    _fields: FieldsType = ("name", "x", "y", "staterror", "syserror")
+
+    def __init__(self,
+                 name: str,
+                 x: ArrayType | None,
+                 y: ArrayType | None,
+                 staterror: ArrayType | None = None,
+                 syserror: ArrayType | None = None
+                 ) -> None:
+        self._xlabel = 'x'
+        super().__init__(name, (x,), y, staterror, syserror)
+
+    def _repr_html_(self) -> str:
+        """Return a HTML (string) representation of the data
+        """
+        return html_data1d(self)
+
+    def _init_data_space(self,
+                         filter: Filter,
+                         data: Sequence[ArrayType | None],
+                         integrated: bool = False,
+                         ) -> DataSpace1D:
+        if integrated:
+            raise DataErr("internal", "Use Data1DInt for integrated data.")
+        ndata = len(data)
+        if ndata != 1:
+            raise DataErr("wrongaxiscount", self.name, 1, ndata)
+
+        ds = DataSpace1D(filter, *data, clean=False, flat=True)
+        self._check_data_space(ds)
+        return ds
+
+    def get_x(self,
+              filter: bool = False,
+              model: ModelFunc | None = None
+              ) -> np.ndarray | None:
+
+        return super().get_x(filter, model)[0]
+
+    def get_xerr(self,
+                 filter: bool = False,
+                 yfunc=None
+                 ) -> np.ndarray | None:
+        """Return linear view of bin size in independent axis/axes.
+
+        Parameters
+        ----------
+        filter
+        yfunc
+
+        Returns
+        -------
+        xerr : array or None
+
+        """
+        return None
+
+    def get_filter(self,
+                   format: str = '%.4f',
+                   delim: str = ':'
+                   ) -> str:
+        """Return the data filter as a string.
+
+        Parameters
+        ----------
+        format : str, optional
+            The formatting of the numeric values.
+        delim : str, optional
+            The string used to mark the low-to-high range.
+
+        Returns
+        -------
+        filter : str
+           The filter, represented as a collection of single values or
+           ranges, separated by commas.
+
+        See Also
+        --------
+        get_filter_expr, ignore, notice
+
+        Examples
+        --------
+
+        >>> import numpy as np
+        >>> x = np.asarray([1, 2, 3, 5, 6])
+        >>> y = np.ones(5)
+        >>> d = Data1D('example', x, y)
+        >>> d.get_filter()
+        '1.0000:6.0000'
+        >>> d.ignore(2.5, 4.5)
+        >>> d.get_filter()
+        '1.0000:2.0000,5.0000:6.0000'
+
+        >>> d.get_filter(format='%i', delim='-')
+        '1-2,5-6'
+
+        """
+        indep = self.get_indep(filter=True)
+        if indep[0] is None:
+            # assume all data has been filtered out
+            return ''
+
+        x = self.get_x(filter=True)
+        if np.iterable(self.mask):
+            mask = self.mask
+        else:
+            mask = np.ones(len(x), dtype=bool)
+
+        return create_expr(x, mask=mask, format=format, delim=delim)
 
 
 class Data1DAsymmetricErrs(Data1D):
@@ -2100,7 +2059,7 @@ class Data1DAsymmetricErrs(Data1D):
         return self.apply_filter(self.elo), self.apply_filter(self.ehi)
 
 
-class Data1DInt(Data1D):
+class Data1DInt(BaseData1D):
     """1-D integrated data set.
 
     This class is designed to handle non-consecutive bins.
@@ -2132,9 +2091,8 @@ class Data1DInt(Data1D):
                  syserror: ArrayType | None = None
                  ) -> None:
 
-        # Note: we do not call the superclass here.
         self._xlabel = 'x'
-        Data.__init__(self, name, (xlo, xhi), y, staterror, syserror,
+        super().__init__(name, (xlo, xhi), y, staterror, syserror,
                       integrated=True)
 
     def _repr_html_(self) -> str:
@@ -2144,13 +2102,16 @@ class Data1DInt(Data1D):
 
     def _init_data_space(self,
                          filter: Filter,
-                         *data: ArrayType
+                         data: ArrayType,
+                         integrated: bool = True,
                          ) -> IntegratedDataSpace1D:
+        if not integrated:
+            raise DataErr("internal", "Use Data1D for non-integrated data.")
         ndata = len(data)
         if ndata != 2:
             raise DataErr("wrongaxiscount", self.name, 2, ndata)
 
-        ds = IntegratedDataSpace1D(filter, *data)
+        ds = IntegratedDataSpace1D(filter, *data, clean=False, flat=True)
         self._check_data_space(ds)
         return ds
 
@@ -2158,11 +2119,10 @@ class Data1DInt(Data1D):
               filter: bool = False,
               model: ModelFunc | None = None
               ) -> np.ndarray:
-        indep = self.get_indep(filter)
-        if len(indep) == 1:
+        indep = super().get_x(filter, model)
+        if indep[0] is None:
             # assume all data has been filtered out
             return np.asarray([])
-
         return (indep[0] + indep[1]) / 2.0
 
     def get_xerr(self,
@@ -2192,7 +2152,7 @@ class Data1DInt(Data1D):
 
         """
         indep = self.get_indep(filter)
-        if len(indep) == 1:
+        if indep[0] is None:
             # assume all data has been filtered out
             return np.asarray([])
 
@@ -2252,7 +2212,9 @@ class Data1DInt(Data1D):
         # use the start and end values for each selected bin.
         #
         indep = self.get_indep(filter=True)
-        if len(indep) == 1:
+        # HMG: I'm not actually sure why len(indep) == 1 works here.
+        # if len(indep) == 1:
+        if indep[0] is None and indep[1] is None:
             # assume all data has been filtered out
             return ''
 
@@ -2343,7 +2305,7 @@ class Data1DInt(Data1D):
         return self._data_space.axes[0].hi
 
 class BaseData2D(Data):
-    """Base class for all data classes."""
+    """Base class for all 2D data classes."""
     def notice(self,
                x0lo: float | None = None,
                x0hi: float | None = None,
@@ -2368,21 +2330,17 @@ class BaseData2D(Data):
     # This somewhat duplicates midpoint_grid in the dataspace
     # When the dataspace is set correctly, can call that instead.
     # instad of implementing here again.
-    def get_x0(self, filter: bool = False) -> np.ndarray | None:
+    def _get_xi(self, i: int, filter: bool = False) -> np.ndarray | None:
         if self.size is None:
             return None
         indep = self._data_space.get(filter)
-        if self.integrated:
-            return (indep.x0lo + indep.x0hi) / 2.0
-        return indep.x0
+        return indep.midpoint_grid[i]
+
+    def get_x0(self, filter: bool = False) -> np.ndarray | None:
+        return self._get_xi(0, filter)
 
     def get_x1(self, filter=False) -> np.ndarray | None:
-        if self.size is None:
-            return None
-        indep = self._data_space.get(filter)
-        if self.integrated:
-            return (indep.x1lo + indep.x1hi) / 2.0
-        return indep.x1
+        return self._get_xi(1, filter)
 
     def get_x0label(self) -> str:
         """Return label for first dimension in 2-D view of independent axis/axes.
@@ -2450,7 +2408,7 @@ class BaseData2D(Data):
                 np.arange(self.shape[0]) + 1)
 
     def get_dims(self, filter: bool = False) -> tuple[int, ...]:
-        if self.size is None:
+        if self.size == 0:
             raise DataErr("sizenotset", self.name)
 
         # self._check_shape()
@@ -2614,14 +2572,6 @@ class Data2D(BaseData2D):
     '''
     _fields: FieldsType = ("name", "x0", "x1", "y", "shape", "staterror", "syserror")
 
-    # Why should we add shape to extra-fields instead? See #1359 to
-    # fix #47.
-    #
-    # It would change the notebook output slightly so we don't change
-    # for now.
-    #
-    # _extra_fields = ("shape", )
-
     def __init__(self,
                  name: str,
                  x0: ArrayType | None,
@@ -2645,13 +2595,16 @@ class Data2D(BaseData2D):
 
     def _init_data_space(self,
                          filter: Filter,
-                         *data: ArrayType
+                         data: ArrayType,
+                        integrated: bool = False
                          ) -> DataSpace2D:
+        if integrated:
+            raise DataErr("internal", "Use Data2DInt for integrated data.")
         ndata = len(data)
         if ndata != 2:
             raise DataErr("wrongaxiscount", self.name, 2, ndata)
 
-        ds = DataSpace2D(filter, *data)
+        ds = DataSpace2D(filter, *data, clean=False, flat=True)
         self._check_data_space(ds)
         return ds
 
@@ -2749,12 +2702,11 @@ class Data2DInt(BaseData2D):
                  x0hi: ArrayType | None,
                  x1hi: ArrayType | None,
                  y: ArrayType | None,
-                 shape: Sequence[int] | None = None,
+                 shape: tuple[int, int] | None = None,
                  staterror: ArrayType | None = None,
-                 syserror: ArrayType | None = None
+                 syserror: ArrayType | None = None,
                  ) -> None:
 
-        # Note: we do not call the superclass here.
         self.shape = shape
         self._x0label = 'x0'
         self._x1label = 'x1'
@@ -2764,13 +2716,16 @@ class Data2DInt(BaseData2D):
 
     def _init_data_space(self,
                          filter: Filter,
-                         *data: ArrayType
+                         data: ArrayType,
+                         integrated: bool = True
                          ) -> IntegratedDataSpace2D:
+        if not integrated:
+            raise DataErr("internal", "Use Data2D for non-integrated data.")
         ndata = len(data)
         if ndata != 4:
             raise DataErr("wrongaxiscount", self.name, 4, ndata)
 
-        ds = IntegratedDataSpace2D(filter, *data)
+        ds = IntegratedDataSpace2D(filter, *data, clean=False, flat=True)
         self._check_data_space(ds)
         return ds
 

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -257,29 +257,6 @@ class DataSpace1D(EvaluationSpace1D):
         data = self.filter.apply(data)
         return DataSpace1D(self.filter, data)
 
-    def for_model(self, model):
-        """
-        Models can be defined over arbitrary evaluation spaces. However,
-        at evaluation time during a fit, the model's evaluation space shall
-        be done at the user's request space only and set to 0 every where else.
-
-        Parameters
-        ----------
-        model : The model whose evaluation space needs to be joined with the dataset's data space.
-
-        Returns
-        -------
-        DataSpace1D
-            A data space that joins this data space with the model's evaluation space. if the model does not have an
-            evaluation space assigned to itself then `self` is returned.
-        """
-        evaluation_space = None
-
-        if model is not None and hasattr(model, "evaluation_space") \
-           and self not in model.evaluation_space:
-            evaluation_space = self
-
-        return self if evaluation_space is None else evaluation_space
 
 
 class IntegratedDataSpace1D(EvaluationSpace1D):
@@ -332,30 +309,6 @@ class IntegratedDataSpace1D(EvaluationSpace1D):
         data = tuple(self.filter.apply(axis) for axis in data)
         return IntegratedDataSpace1D(self.filter, *data)
 
-    def for_model(self, model):
-        """
-        Models can be defined over arbitrary evaluation spaces. However, at evaluation time during a fit, the model's
-        evaluation space and the data space will be joined together and the model will be evaluated over the joined
-        domain. This makes sure that when the models are rebinned back to the data space the evaluation does not have
-        to be extrapolated from the model's evaluation space alone.
-
-        Parameters
-        ----------
-        model : The model whose evaluation space needs to be joined with the dataset's data space.
-
-        Returns
-        -------
-        IntegratedDataSpace1D
-            A data space that joins this data space with the model's evaluation space. if the model does not have an
-            evaluation space assigned to itself then `self` is returned.
-        """
-        evaluation_space = None
-
-        if model is not None and hasattr(model, "evaluation_space") \
-           and self not in model.evaluation_space:
-            evaluation_space = self
-
-        return self if evaluation_space is None else evaluation_space
 
 
 # We do not inherit from EvaluationSpace2D because that would require
@@ -2052,8 +2005,6 @@ class Data1D(Data):
                              use_evaluation_space: bool = False
                              ) -> np.ndarray | None:
         data_space = self._data_space.get(filter)
-        if use_evaluation_space:
-            return data_space.for_model(model).grid
 
         return data_space.grid
 

--- a/sherpa/instrument.py
+++ b/sherpa/instrument.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2016, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2008, 2016, 2018-2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -999,9 +999,9 @@ they do not match.
         # Don't do anything special
         if pixel_size_comparison == self.SAME_RESOLUTION:
             if self.ndim == 1:
-                self.data_space = EvaluationSpace1D(*indep)
+                self.data_space = EvaluationSpace1D(*indep, clean=False, flat=True)
             elif self.ndim == 2:
-                self.data_space = EvaluationSpace2D(*indep)
+                self.data_space = EvaluationSpace2D(*indep, clean=False, flat=True)
             else:
                 # leave in in case we support higher dimensions or one
                 # of the rare dimensionless models is in use.

--- a/sherpa/models/regrid.py
+++ b/sherpa/models/regrid.py
@@ -274,7 +274,192 @@ class IntegratedAxis(Axis):
         return self.lo.size
 
 
-class EvaluationSpace1D():
+# TO-DO: Why does this not inherit from NoNewAttributesAfterInit?
+class EvaluationSpaceND():
+    """Class for N-D Evaluation Spaces.
+
+    Some methods return flat-True by default, others do not.
+    Currently, I trying to set the default behavior such that it's
+    backwards compatible, but some consistency would also be useful.
+
+    Also, if we did ways with the ability to initialize with None,
+    that would help a lot and simplify the code conceptually
+    (and also reduce length and make typing more useful).
+
+
+    """
+    def __init__(self, axes, integrated=False):
+        if integrated and not len(axes) % 2 == 0:
+            raise ValueError("In integrated mode, independent variables must be pairs of lo, hi.")
+
+        self.axes = [self._clean(arg) for arg in axes]
+        if not integrated:
+            self.axes = [PointAxis(arg) for arg in self.axes]
+        else:
+            self.axes = [IntegratedAxis(arg[0], arg[1]) for arg in zip(self.axes[:len(axes)//2],
+                                                                       self.axes[len(axes)//2:])]
+
+    @staticmethod
+    def _clean(array):
+        if array is None:
+            return None
+
+        # We need to take extra care not to change the order of the arrays, hence
+        # the additional complexity
+        array_unique, indexes = np.unique(array, return_index=True)
+        return array_unique[indexes.argsort()]
+
+    @property
+    def is_empty(self):
+        """Is the space empty (the x axis has no elements)?"""
+        return any([a.is_empty for a in self.axes])
+
+    @property
+    def is_integrated(self):
+        """Is the space integrated?"""
+        # We currently only support all axes to be integrated or none of them
+        # so it's sufficient to check the first one here.
+        return self.axes[0].is_integrated
+
+    @property
+    def grid(self, flat=True):
+        """The grid representation of the space.
+
+        Returns
+        -------
+        tuple
+            A tuple representing the x axis. The tuple will contain
+            two arrays if the dataset is integrated, one otherwise.
+        """
+        if self.is_integrated:
+            out = tuple(axis.lo for axis in self.axes)
+            out2 = tuple(axis.hi for axis in self.axes)
+        else:
+            out = tuple(axis.x for axis in self.axes)
+            out2 = ()
+
+        # Again: Special treatment for None. Would be so much easier
+        # if we did not allow initializing with empty axes.
+        if flat and not any(o is None for o in out):
+            meshgrid_axes = np.meshgrid(*out)
+            meshgrid_axes2 = np.meshgrid(*out2)
+            # meshgrid create a copy by default, so writing into
+            # the result would not propagate back to the original arrays.
+            # To avoid user confusion, make sure it's not writable.
+            for m in meshgrid_axes + meshgrid_axes2:
+                m.flags.writeable = False
+            return tuple(m.ravel() for m in meshgrid_axes) + tuple(m.ravel() for m in meshgrid_axes2)
+
+        return out + out2
+
+    @property
+    def is_ascending(self):
+        """Is the space ascending?
+
+        Returns
+        -------
+        (xflag, yflag) : (bool, bool)
+            True if the axis is ascending, False otherwise, for the
+            x and y axes respectively.
+        """
+        return tuple(a.is_ascending for a in self.axes)
+
+    @property
+    def start(self):
+        """The start (lowest value) of the space.
+
+        Returns
+        -------
+        (xstart, ystart) : (number, number)
+            The start of the x and y axis arrays, respectively.
+        """
+        return tuple(a.start for a in self.axes)
+
+    @property
+    def end(self):
+        """The end (highest value) of the space.
+
+        Returns
+        -------
+        (xend, yend) : (number, number)
+            The end of the x and y axis arrays, respectively.
+        """
+        return tuple(a.end for a in self.axes)
+
+    @property
+    def shape(self):
+        """The sizes of the x and y axes."""
+        return tuple(a.size for a in self.axes)
+
+    def zeros_like(self, flat=True):
+        """Returns zeroes for each element of the space.
+
+        Returns
+        -------
+        array
+            A one-dimensional array.
+        """
+        zeros = np.zeros(self.shape)
+        if flat:
+            return zeros.ravel()
+        return zeros
+
+    @property
+    def midpoint_grid(self):
+        """The mid-points of the space.
+
+        For non-integrated spaces this returns the X axis.
+
+        Returns
+        -------
+        array
+            Return the average point of the bins of integrated axes,
+            for each bin, or the non-integrated x axis array.
+
+        """
+        if self.is_integrated:
+            return tuple((axis.lo + axis.hi)/2 for axis in self.axes)
+
+        return tuple(axis.x for axis in self.axes)
+
+    def overlaps(self, other):
+        """Check if this evaluation space overlaps with another.
+
+        Parameters
+        ----------
+        other : EvaluationSpaceND
+            The space to compare to.
+
+        Returns
+        -------
+        bool
+            True if they overlap, False if not
+        """
+        if len(self.axes) != len(other.axes):
+            raise ValueError("Can only compare spaces with the same number of axes")
+        return any(a.overlaps(b) for a, b in zip(self.axes, other.axes))
+
+    def __contains__(self, other):
+        """Are all elements of other within the range (start, end) of this space?
+
+        Parameters
+        ----------
+        other : EvaluationSpace1D
+            The space to compare to.
+
+        Returns
+        -------
+        boolean
+        """
+        if len(self.axes) != len(other.axes):
+            raise ValueError("Can only compare spaces with the same number of axes")
+
+        # OL: I have mixed feelings about overriding this method. On one hand it makes the
+        # tests more expressive and natural, on the other this method is intended to check
+        # if an element is in a collection, so it's a bit of a stretch semantically.
+        return all(a.start <= b.start and a.end >= b.end for a, b in zip(self.axes, other.axes))
+
+class EvaluationSpace1D(EvaluationSpaceND):
     """Class for 1D Evaluation Spaces.
 
     An Evaluation Space is a set of data axes representing the data
@@ -291,35 +476,35 @@ class EvaluationSpace1D():
     def __init__(self, x=None, xhi=None):
         """The input arrays are used to instantiate a single axis."""
         if xhi is None:
-            self.x_axis = PointAxis(x)
+            super().__init__((x,), integrated=False)
         else:
-            self.x_axis = IntegratedAxis(x, xhi)
+            super().__init__((x, xhi), integrated=True)
 
-    @property
-    def is_empty(self):
-        """Is the space empty (the x axis has no elements)?"""
-        return self.x_axis.is_empty
 
-    @property
-    def is_integrated(self):
-        """Is the space integrated?"""
-        return self.x_axis.is_integrated
+    # Multi-D spaces try to reconstruct the original 1D input arrays by
+    # removing duplicates. Doe 1D we've never done that and allowed
+    # several points to have the same x-value.
+    # Do we want to unify that?
+    # For now, keep the old behavior.
+    @staticmethod
+    def _clean(array):
+        return array
 
     @property
     def is_ascending(self):
         """Is the space ascending?"""
-        return self.x_axis.is_ascending
+        return super().is_ascending[0]
 
-    @property
-    def grid(self):
-        """The grid representation of the space.
-
-        Returns
-        -------
-        tuple
-            A tuple representing the x axis. The tuple will contain
-            two arrays if the dataset is integrated, one otherwise.
-        """
+    #@property
+    #def grid(self):
+    #    """The grid representation of the space.
+    #
+    #    Returns
+    #    -------
+    #    tuple
+    #        A tuple representing the x axis. The tuple will contain
+    #        two arrays if the dataset is integrated, one otherwise.
+    #    """
         # We can not just rely on the is_integrated setting since
         # an integrated axis can have is_integrated set to False
         #
@@ -327,13 +512,13 @@ class EvaluationSpace1D():
         #       so maybe it's something we can address upstream? Or work out
         #       why we want is_integrated to be False when the axis size is 0?
         #
-        if self.x_axis.is_integrated:
-            return self.x_axis.lo, self.x_axis.hi
-
-        if isinstance(self.x_axis, IntegratedAxis):
-            return self.x_axis.lo,
-
-        return self.x_axis.x,
+    #    if self.x_axis.is_integrated:
+    #        return self.x_axis.lo, self.x_axis.hi
+    #
+    #    if isinstance(self.x_axis, IntegratedAxis):
+    #        return self.x_axis.lo,
+    #
+    #    return self.x_axis.x,
 
     @property
     def midpoint_grid(self):
@@ -348,66 +533,29 @@ class EvaluationSpace1D():
             for each bin, or the non-integrated x axis array.
 
         """
-        if self.x_axis.is_integrated:
-            return (self.x_axis.lo + self.x_axis.hi)/2
-
-        return self.x_axis.x
+        return super().midpoint_grid[0]
 
     @property
     def start(self):
         """The start (lowest value) of the space."""
-        return self.x_axis.start
+        return super().start[0]
 
     @property
     def end(self):
         """The end (highest value) of the space."""
-        return self.x_axis.end
+        return super().end[0]
 
-    def zeros_like(self):
-        """Returns zeroes for each element of the space.
+    @property
+    def x_axis(self):
+        """The x axis of the space.
 
-        Returns
-        -------
-        array
-            A one-dimensional array.
+        Or not deprecated? Used in RMFs internally.
+        Deprecated: For backwards compatibility
         """
-        return np.zeros(self.x_axis.size)
-
-    def overlaps(self, other):
-        """Check if this evaluation space overlaps with another.
-
-        Parameters
-        ----------
-        other : EvaluationSpace1D
-            The space to compare to.
-
-        Returns
-        -------
-        bool
-            True if they overlap, False if not
-        """
-        return self.x_axis.overlaps(other.x_axis)
-
-    def __contains__(self, other):
-        """Are all elements of other within the range (start, end) of this space?
-
-        Parameters
-        ----------
-        other : EvaluationSpace1D
-            The space to compare to.
-
-        Returns
-        -------
-        boolean
-        """
-
-        # OL: I have mixed feelings about overriding this method. On one hand it makes the
-        # tests more expressive and natural, on the other this method is intended to check
-        # if an element is in a collection, so it's a bit of a stretch semantically.
-        return self.start <= other.start and self.end >= other.end
+        return self.axes[0]
 
 
-class EvaluationSpace2D():
+class EvaluationSpace2D(EvaluationSpaceND):
     """Class for 2D Evaluation Spaces.
 
     An Evaluation Space is a set of data axes representing the data
@@ -432,79 +580,36 @@ class EvaluationSpace2D():
         # This means that this class does not check that x and y (if set) have
         # the same length.
         #
-        x_unique, y_unique, xhi_unique, yhi_unique = self._clean_arrays(x, y, xhi, yhi)
+        # The following cleaning is now done in the Evaluation space.
+        #x_unique, y_unique, xhi_unique, yhi_unique = self._clean_arrays(x, y, xhi, yhi)
 
-        if xhi_unique is None and yhi_unique is None:
-            self.x_axis = PointAxis(x_unique)
-            self.y_axis = PointAxis(y_unique)
+        if xhi is None and yhi is None:
+            super().__init__((x, y), integrated=False)
         else:
-            self.x_axis = IntegratedAxis(x_unique, xhi_unique)
-            self.y_axis = IntegratedAxis(y_unique, yhi_unique)
-
-    def _clean_arrays(self, x, y, xhi, yhi):
-        return self._clean(x), self._clean(y), self._clean(xhi), self._clean(yhi)
-
-    @staticmethod
-    def _clean(array):
-        if array is None:
-            return None
-
-        # We need to take extra care not to change the order of the arrays, hence
-        # the additional complexity
-        array_unique, indexes = np.unique(array, return_index=True)
-        return array_unique[indexes.argsort()]
+            super().__init__((x, y, xhi, yhi), integrated=True)
 
     @property
-    def is_empty(self):
-        """Is the space empty (the x axis has no elements)?"""
-        return self.x_axis.is_empty or self.y_axis.is_empty
+    def x_axis(self):
+        """The x axis of the space.
 
-    @property
-    def is_integrated(self):
-        """Is the space integrated?"""
-        return (not self.is_empty) \
-            and self.x_axis.is_integrated \
-            and self.y_axis.is_integrated
-
-    @property
-    def is_ascending(self):
-        """Is the space ascending?
-
-        Returns
-        -------
-        (xflag, yflag) : (bool, bool)
-            True if the axis is ascending, False otherwise, for the
-            x and y axes respectively.
+        Or not deprecated? Used in RMFs internally.
+        Deprecated: For backwards compatibility
         """
-        return self.x_axis.is_ascending, self.y_axis.is_ascending
+        return self.axes[0]
 
     @property
-    def start(self):
-        """The start (lowest value) of the space.
+    def y_axis(self):
+        """The y axis of the space.
 
-        Returns
-        -------
-        (xstart, ystart) : (number, number)
-            The start of the x and y axis arrays, respectively.
+        Or not deprecated? Used in RMFs internally.
+        Deprecated: For backwards compatibility
         """
-        return self.x_axis.start, self.y_axis.start
+        return self.axes[1]
 
-    @property
-    def end(self):
-        """The end (highest value) of the space.
-
-        Returns
-        -------
-        (xend, yend) : (number, number)
-            The end of the x and y axis arrays, respectively.
-        """
-        return self.x_axis.end, self.y_axis.end
-
-    @property
-    def shape(self):
-        """The sizes of the x and y axes."""
-        return self.x_axis.size, self.y_axis.size
-
+    # TO-DO: This would more accurately be called "same-endpoints"
+    # Why are we more stringent in 2D than in 1D?
+    # Do we want to change that? For now, but leave like this for backwards
+    # compatibility.
     def overlaps(self, other):
         """Check if this evaluation space overlaps with another.
 
@@ -525,39 +630,6 @@ class EvaluationSpace2D():
                     and self.y_axis.start == other.y_axis.start
                     and self.x_axis.end == other.x_axis.end
                     and self.y_axis.end == other.y_axis.end)
-
-    @property
-    def grid(self):
-        """The grid representation of the space.
-
-        The x and y arrays in the grid are one-dimensional
-        representations of the meshgrid obtained from the x and y axis
-        arrays, as in `numpy.meshgrid(x, y)[0].ravel()`
-
-        Returns
-        -------
-        tuple
-            A two element (x, y) or 4 element (x, y, xhi, yhi) tuple.
-
-        """
-        if self.x_axis.is_integrated:
-            x, y = reshape_2d_arrays(self.x_axis.lo, self.y_axis.lo)
-            xhi, yhi = reshape_2d_arrays(self.x_axis.hi, self.y_axis.hi)
-            return x, y, xhi, yhi
-
-        return reshape_2d_arrays(self.x_axis.x, self.y_axis.x)
-
-    def zeros_like(self):
-        """Returns zeroes for each element of the space.
-
-        Returns
-        -------
-        array
-            A one dimensional array.
-        """
-        size = self.x_axis.size * self.y_axis.size
-        return np.zeros(size)
-
 
 class ModelDomainRegridder1D():
     """Allow 1D models to be evaluated on a different grid.

--- a/sherpa/models/regrid.py
+++ b/sherpa/models/regrid.py
@@ -31,6 +31,8 @@ match the desired grid.
 from abc import ABCMeta, abstractmethod
 import itertools
 import logging
+import re
+from typing import Iterable, Self
 import warnings
 
 import numpy as np
@@ -45,8 +47,10 @@ warning = logging.getLogger(__name__).warning
 
 PIXEL_RATIO_THRESHOLD = 0.1
 
+# Match patterns like "x2lo" or "x1"
+X_ATTR_NAME = re.compile("x(?P<ndim>[0-9]?)(?P<hilo>(hi|lo)?)")
 
-def _to_readable_array(x):
+def _to_readable_array(x: Iterable | None) -> np.ndarray | None:
     """Convert x into a ndarray that can not be edited (or is None)."""
 
     if x is None:
@@ -67,10 +71,10 @@ class Axis(metaclass=ABCMeta):
     """Represent an axis of a N-D object."""
 
     # This is set when the data is set
-    _is_ascending = None
+    _is_ascending: bool | None = None
 
     @property
-    def is_empty(self):
+    def is_empty(self) -> bool:
         """Is the axis empty?
 
         An empty axis is either set to `None` or a zero-element
@@ -80,12 +84,12 @@ class Axis(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def is_integrated(self):
+    def is_integrated(self) -> bool | None:
         """Is the axis integrated?"""
         pass
 
     @property
-    def is_ascending(self):
+    def is_ascending(self) -> bool | None:
         """Is the axis ascending?
 
         The axis is ascending if the elements in `lo` are sorted in
@@ -98,13 +102,12 @@ class Axis(metaclass=ABCMeta):
         return self._is_ascending
 
     @property
-    @abstractmethod
     def start(self):
         """The starting point (lowest value) of the data axis."""
-        pass
+        if self.is_empty:
+            raise DataErr("Axis is empty or has a size of 0")
 
     @property
-    @abstractmethod
     def end(self):
         """The ending point of the data axis
 
@@ -115,15 +118,15 @@ class Axis(metaclass=ABCMeta):
         of the `hi` array or of the `lo` array, depending on whether
         the axis is integrated or not, respectively.
         """
-        pass
+        if self.is_empty:
+            raise DataErr("Axis is empty or has a size of 0")
 
     @property
-    @abstractmethod
-    def size(self):
+    def size(self) -> int:
         """The size of the axis."""
-        pass
+        return 0
 
-    def overlaps(self, other):
+    def overlaps(self, other: Self) -> bool:
         """Check if this axis overlaps with another.
 
         Parameters
@@ -141,12 +144,54 @@ class Axis(metaclass=ABCMeta):
         #
         # if not isinstance(other, Axis):
         #     raise TypeError("other argument must be an axis")
+        if self.is_empty or other.is_empty:
+            return False
 
         num = max(0, min(self.end, other.end) - max(self.start, other.start))
         return bool(num != 0)
 
+class UnorderedPointAxis(Axis):
+    """Represent a point (not integrated) axis of a N-D object.
 
-class PointAxis(Axis):
+    The length can not be changed once set.
+
+    Parameters
+    ----------
+    x : array_like
+        The starting point of the axis. If `None` or `[]` then the
+        data axis is said to be empty. The axis can be in ascending or
+        descending order but this is not checked.
+
+    """
+    def __init__(self, x : np.ndarray | None):
+        self._x = x
+
+    @property
+    def is_integrated(self):
+        return False
+
+    @property
+    def x(self):
+        # if self.is_empty:
+        #    raise DataErr("Axis is empty or has a size of 0")
+        return self._x
+
+    @property
+    def start(self):
+        return np.min(self.x)
+
+    @property
+    def end(self):
+        return np.max(self.x)
+
+    @property
+    def size(self):
+        if self._x is None:
+            return 0
+        return self._x.size
+
+
+class PointAxis(UnorderedPointAxis):
     """Represent a point (not integrated) axis of a N-D object.
 
     The length can not be changed once set.
@@ -160,46 +205,18 @@ class PointAxis(Axis):
 
     """
 
-    def __init__(self, x):
-        self._x = _to_readable_array(x)
-        if self._x is None:
+    def __init__(self, x: np.ndarray | None):
+        super().__init__(x)
+        if self._x is None or len(self._x) == 0:
             return
+        #if not self._x.size:
+        #    raise DataErr("Axis is empty or has a size of 0")
+        # Should check this is actually strictly ascending?
+        # This version worked for ordered, but not strictly ascending
+        # array, e.g. a flattened 2D index.
+        self._is_ascending = self._x[-1] > self._x[0]
 
-        nx = len(self._x)
-        if nx > 0:
-            self._is_ascending = self._x[-1] > self._x[0]
-
-    @property
-    def x(self):
-        return self._x
-
-    @property
-    def is_integrated(self):
-        return False
-
-    @property
-    def start(self):
-        if self.is_ascending:
-            return self.x[0]
-
-        return self.x[-1]
-
-    @property
-    def end(self):
-        if self.is_ascending:
-            return self.x[-1]
-
-        return self.x[0]
-
-    @property
-    def size(self):
-        if self.x is None:
-            return 0
-
-        return self.x.size
-
-
-class IntegratedAxis(Axis):
+class UnorderedIntegratedAxis(Axis):
     """Represent an integrated axis of a N-D object.
 
     Parameters
@@ -216,17 +233,15 @@ class IntegratedAxis(Axis):
 
     """
 
-    _lo = None
-    _hi = None
+    def __init__(self, lo: np.ndarray | None, hi: np.ndarray | None):
+        self._lo = lo
+        self._hi = hi
 
-    def __init__(self, lo, hi):
-        self._lo = _to_readable_array(lo)
-        self._hi = _to_readable_array(hi)
+        if lo is None and hi is None:
+            return
 
-        if self._lo is None:
-            if self._hi is None:
-                return
-
+        # and hi is not None (otherwise it would have returned earlier)
+        if lo is None:
             raise DataErr("mismatchn", "lo", "hi", "None", len(self._hi))
 
         nlo = len(self._lo)
@@ -237,41 +252,59 @@ class IntegratedAxis(Axis):
         if nlo != nhi:
             raise DataErr("mismatchn", "lo", "hi", nlo, nhi)
 
-        if nlo > 0:
-            self._is_ascending = lo[-1] > lo[0]
-
-    @property
-    def lo(self):
-        return self._lo
-
-    @property
-    def hi(self):
-        return self._hi
-
     @property
     def is_integrated(self):
         return True
 
     @property
-    def start(self):
-        if self.is_ascending:
-            return self.lo[0]
+    def lo(self) -> np.ndarray:
+        #if self.is_empty:
+        #    raise DataErr("Axis is empty or has a size of 0")
+        return self._lo
 
-        return self.lo[-1]
+    @property
+    def hi(self) -> np.ndarray:
+        #if self.is_empty:
+        #    raise DataErr("Axis is empty or has a size of 0")
+        return self._hi
+
+    @property
+    def start(self):
+        return np.min(self.lo)
 
     @property
     def end(self):
-        if self.is_ascending:
-            return self.hi[-1]
-
-        return self.hi[0]
+        return np.max(self.hi)
 
     @property
     def size(self):
-        if self.lo is None:
+        if self._lo is None:
             return 0
+        return self._lo.size
 
-        return self.lo.size
+class IntegratedAxis(UnorderedIntegratedAxis):
+    """Represent an integrated axis of a N-D object.
+
+    Parameters
+    ----------
+    lo : array_like or None
+        The starting point of the axis.  If `lo` is `None` or `[]`
+        then the data axis is said to be empty. The axis can be in
+        ascending or descending order.
+    hi : array_like or None
+        The ending point of the axis. The number of elements must match `lo` (either `None`
+        or a sequence of the same size). Each element is expected to
+        be larger than the corresponding element of the `lo` axis,
+        even if the `lo` array is in descending order.
+
+    """
+    def __init__(self, lo: np.ndarray | None, hi: np.ndarray | None):
+        super().__init__(lo, hi)
+
+        if (lo is None or len(lo) == 0) and (hi is None or len(hi) == 0):
+            return
+        # Should check that lo (and hi?) are actually strictly ascending?
+        self._is_ascending = lo[-1] > lo[0]
 
 
 # TO-DO: Why does this not inherit from NoNewAttributesAfterInit?
@@ -286,18 +319,67 @@ class EvaluationSpaceND():
     that would help a lot and simplify the code conceptually
     (and also reduce length and make typing more useful).
 
+    Parameters
+    ----------
+    axes : sequence of array_like or None
+        The data arrays for each axis, or the low and high ends of the
+        data bins if the dataset is "integrated". If `None` or `[]`
+        then the corresponding data axis is said to be empty.
+    integrated : bool, optional
+        If True, the dataset is treated as integrated (i.e., it has
+        low and high edges for each bin).
+    clean : bool, optional
+        Multi-D spaces try to reconstruct the original 1D input arrays by
+        removing duplicates if set to True.
 
     """
-    def __init__(self, axes, integrated=False):
+    def __init__(self, axes, integrated=False, clean=True, flat=False):
+        self.flat = flat
         if integrated and not len(axes) % 2 == 0:
             raise ValueError("In integrated mode, independent variables must be pairs of lo, hi.")
+        axes = [_to_readable_array(a) for a in axes]
+        if clean:
+            axes = [self._clean(arg) for arg in axes]
 
-        self.axes = [self._clean(arg) for arg in axes]
+        if flat and len(axes) > 1 and not all(a is None for a in axes):
+            for i, ax in enumerate(axes):
+                sizea = None if axes[0] is None else axes[0].size
+                sizeb = None if ax is None else ax.size
+                if sizea != sizeb:
+                    raise DataErr("mismatchn", "x0", f"x{i}", sizea, sizeb)
+
+
         if not integrated:
-            self.axes = [PointAxis(arg) for arg in self.axes]
+            self.axes = [PointAxis(arg) for arg in axes]
         else:
-            self.axes = [IntegratedAxis(arg[0], arg[1]) for arg in zip(self.axes[:len(axes)//2],
-                                                                       self.axes[len(axes)//2:])]
+            self.axes = [IntegratedAxis(arg[0], arg[1]) for arg in zip(axes[:len(axes)//2],
+                                                                       axes[len(axes)//2:])]
+
+    @property
+    def ndim(self):
+        """The number of dimensions of the space."""
+        return len(self.axes)
+
+    def __getattr__(self, name: str) -> np.ndarray:
+        attr_match = X_ATTR_NAME.fullmatch(name)
+
+        if attr_match:
+            if attr_match.group("ndim") == "" and self.ndim == 1:
+                ndim = 0
+            else:
+                ndim = int(attr_match.group("ndim"))
+
+            axes = self.axes
+            if ndim < self.ndim:
+                match attr_match.group("hilo"):
+                    case "":
+                        return axes[ndim].x
+                    case "lo":
+                        return axes[ndim].lo
+                    case "hi":
+                        return axes[ndim].hi
+
+        return super().__getattribute__(name)
 
     @staticmethod
     def _clean(array):
@@ -331,6 +413,8 @@ class EvaluationSpaceND():
             A tuple representing the x axis. The tuple will contain
             two arrays if the dataset is integrated, one otherwise.
         """
+        if self.flat and not flat:
+            raise ValueError("Cannot request non-flat grid when because axes are stored flattened already.")
         if self.is_integrated:
             out = tuple(axis.lo for axis in self.axes)
             out2 = tuple(axis.hi for axis in self.axes)
@@ -340,7 +424,7 @@ class EvaluationSpaceND():
 
         # Again: Special treatment for None. Would be so much easier
         # if we did not allow initializing with empty axes.
-        if flat and not any(o is None for o in out):
+        if flat and not self.flat and not any(o is None for o in out):
             meshgrid_axes = np.meshgrid(*out)
             meshgrid_axes2 = np.meshgrid(*out2)
             # meshgrid create a copy by default, so writing into
@@ -389,7 +473,17 @@ class EvaluationSpaceND():
     @property
     def shape(self):
         """The sizes of the x and y axes."""
+        if self.flat:
+            return self.axes[0].size
         return tuple(a.size for a in self.axes)
+
+    @property
+    def size(self):
+        """The total number of elements in the space."""
+        if self.flat:
+            return self.axes[0].size
+        sizes = [a.size for a in self.axes]
+        return int(np.prod(sizes))
 
     def zeros_like(self, flat=True):
         """Returns zeroes for each element of the space.
@@ -417,7 +511,10 @@ class EvaluationSpaceND():
             for each bin, or the non-integrated x axis array.
 
         """
+        axes = self.axes
         if self.is_integrated:
+            if any(axis.is_empty for axis in axes):
+                return tuple(None for axis in self.axes)
             return tuple((axis.lo + axis.hi)/2 for axis in self.axes)
 
         return tuple(axis.x for axis in self.axes)
@@ -457,6 +554,9 @@ class EvaluationSpaceND():
         # OL: I have mixed feelings about overriding this method. On one hand it makes the
         # tests more expressive and natural, on the other this method is intended to check
         # if an element is in a collection, so it's a bit of a stretch semantically.
+        for a, b in zip(self.axes, other.axes):
+            if a.is_empty or b.is_empty:
+                raise DataErr("Axis is empty or has a size of 0")
         return all(a.start <= b.start and a.end >= b.end for a, b in zip(self.axes, other.axes))
 
 class EvaluationSpace1D(EvaluationSpaceND):
@@ -473,52 +573,29 @@ class EvaluationSpace1D(EvaluationSpaceND):
     xhi : array_like or None, optional
         The high end of the data bins for integrated datasets.
     """
-    def __init__(self, x=None, xhi=None):
+    def __init__(self, x=None, xhi=None, **kwargs):
         """The input arrays are used to instantiate a single axis."""
-        if xhi is None:
-            super().__init__((x,), integrated=False)
+        # The second condition is for when we want to make an empty integrated space.
+        if xhi is None and not kwargs.get('integrated', False):
+            super().__init__((x,), **kwargs)
         else:
-            super().__init__((x, xhi), integrated=True)
+            kwargs['integrated'] = True
+            super().__init__((x, xhi), **kwargs)
 
 
     # Multi-D spaces try to reconstruct the original 1D input arrays by
-    # removing duplicates. Doe 1D we've never done that and allowed
+    # removing duplicates. In 1D we've never done that and allowed
     # several points to have the same x-value.
     # Do we want to unify that?
     # For now, keep the old behavior.
-    @staticmethod
-    def _clean(array):
-        return array
+    #@staticmethod
+    #def _clean(array):
+    #    return array
 
     @property
     def is_ascending(self):
         """Is the space ascending?"""
         return super().is_ascending[0]
-
-    #@property
-    #def grid(self):
-    #    """The grid representation of the space.
-    #
-    #    Returns
-    #    -------
-    #    tuple
-    #        A tuple representing the x axis. The tuple will contain
-    #        two arrays if the dataset is integrated, one otherwise.
-    #    """
-        # We can not just rely on the is_integrated setting since
-        # an integrated axis can have is_integrated set to False
-        #
-        # TODO: should we fix this? It only affects a few corner-case tests
-        #       so maybe it's something we can address upstream? Or work out
-        #       why we want is_integrated to be False when the axis size is 0?
-        #
-    #    if self.x_axis.is_integrated:
-    #        return self.x_axis.lo, self.x_axis.hi
-    #
-    #    if isinstance(self.x_axis, IntegratedAxis):
-    #        return self.x_axis.lo,
-    #
-    #    return self.x_axis.x,
 
     @property
     def midpoint_grid(self):
@@ -571,7 +648,7 @@ class EvaluationSpace2D(EvaluationSpaceND):
         The high end of the x and y data bins for integrated datasets.
     """
 
-    def __init__(self, x=None, y=None, xhi=None, yhi=None):
+    def __init__(self, x=None, y=None, xhi=None, yhi=None, **kwargs):
         # In the 2D case the arrays are redundant, as they are flattened from a meshgrid.
         # We need to clean them up first to have proper axes.
         # This may happen when an EvaluationSpace2D is instantiated using the arrays passed to
@@ -583,10 +660,13 @@ class EvaluationSpace2D(EvaluationSpaceND):
         # The following cleaning is now done in the Evaluation space.
         #x_unique, y_unique, xhi_unique, yhi_unique = self._clean_arrays(x, y, xhi, yhi)
 
-        if xhi is None and yhi is None:
-            super().__init__((x, y), integrated=False)
+        # The second condition is for when we want to make an empty integrated space.
+        if xhi is None and yhi is None and not kwargs.get('integrated', False):
+            kwargs['integrated'] = False
+            super().__init__((x, y), **kwargs)
         else:
-            super().__init__((x, y, xhi, yhi), integrated=True)
+            kwargs['integrated'] = True
+            super().__init__((x, y, xhi, yhi), **kwargs)
 
     @property
     def x_axis(self):
@@ -626,10 +706,12 @@ class EvaluationSpace2D(EvaluationSpaceND):
         bool
             True if they overlap, False if not
         """
-        return bool(self.x_axis.start == other.x_axis.start
+        overlaps = any(a.overlaps(b) for a, b in zip(self.axes, other.axes))
+        same_endpoint = bool(self.x_axis.start == other.x_axis.start
                     and self.y_axis.start == other.y_axis.start
                     and self.x_axis.end == other.x_axis.end
                     and self.y_axis.end == other.y_axis.end)
+        return overlaps and same_endpoint
 
 class ModelDomainRegridder1D():
     """Allow 1D models to be evaluated on a different grid.

--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017 - 2024
+#  Copyright (C) 2017-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1563,7 +1563,7 @@ def test_evaluationspace_empty_range(cls, meth):
 
 @pytest.mark.parametrize("cls,expected",
                          [(EvaluationSpace1D, (None, )),
-                          (EvaluationSpace2D, ([None], [None]))
+                          (EvaluationSpace2D, (None, None))
                           ])
 def test_evaluationspace_empty_grid(cls, expected):
     """Simple check.

--- a/sherpa/models/tests/test_regrid_unit.py
+++ b/sherpa/models/tests/test_regrid_unit.py
@@ -39,7 +39,7 @@ from sherpa.utils import linear_interp
 from sherpa.utils.err import DataErr, ModelErr
 from sherpa.utils.numeric_types import SherpaFloat
 
-from sherpa.models.regrid import ModelDomainRegridder1D, EvaluationSpace1D, \
+from sherpa.models.regrid import EvaluationSpaceND, ModelDomainRegridder1D, EvaluationSpace1D, \
     EvaluationSpace2D, PointAxis, IntegratedAxis
 
 
@@ -1129,56 +1129,58 @@ def test_axis_check_not_a_scalar():
 
     with pytest.raises(DataErr,
                        match="Array must be a sequence or None"):
-        PointAxis(23)
+        _ = EvaluationSpace1D(23)
 
 
 def test_axis_check_not_multidim():
     """Mainly to ensure this error condition is checked"""
-
+    arr = np.arange(12).reshape(3, 4)
     with pytest.raises(DataErr,
                        match="Array must be 1D"):
-        PointAxis(np.arange(12).reshape(3, 4))
+        _ = EvaluationSpace1D(arr)
 
 
-def test_pointaxis_not_integrated():
+def test_cannot_create_pointaxis_if_not_using_empty_subtype():
     """Check for the empty case"""
 
-    assert not PointAxis([]).is_integrated
+    es = EvaluationSpaceND(([],))
+    assert es.axes[0].is_empty
 
 
-def test_integratedaxis_is_integrated():
+def test_cannot_create_integratedaxis_if_not_using_empty_subtype():
     """Check for the empty case"""
 
-    assert IntegratedAxis([], []).is_integrated
+    es = EvaluationSpaceND(([], []), integrated=True)
+    assert es.axes[0].is_empty
 
 
 def test_pointaxis_size():
     """Pick a descending axis for fun"""
-    assert PointAxis([4, 3, 2]).size == 3
+    assert PointAxis(np.array([4, 3, 2])).size == 3
 
 
 def test_integratedaxis_size():
-    assert IntegratedAxis([4, 3, 2], [4.5, 3.5, 3]).size == 3
+    assert IntegratedAxis(np.array([4, 3, 2]), np.array([4.5, 3.5, 3])).size == 3
 
 
 def test_pointaxis_start():
     """Pick a descending axis for fun"""
-    assert PointAxis([4, 3, 2]).start == 2
+    assert PointAxis(np.array([4, 3, 2])).start == 2
 
 
 def test_pointaxis_end():
     """Pick a descending axis for fun"""
-    assert PointAxis([4, 3, 2]).end == 4
+    assert PointAxis(np.array([4, 3, 2])).end == 4
 
 
 def test_integratedaxis_start():
     """Pick a descending axis for fun"""
-    assert IntegratedAxis([4, 3, 2], [4.5, 3.5, 3]).start == 2
+    assert IntegratedAxis(np.array([4, 3, 2]), np.array([4.5, 3.5, 3])).start == 2
 
 
 def test_integratedaxis_end():
     """Pick a descending axis for fun"""
-    assert IntegratedAxis([4, 3, 2], [4.5, 3.5, 3]).end == pytest.approx(4.5)
+    assert IntegratedAxis(np.array([4, 3, 2]), np.array([4.5, 3.5, 3])).end == pytest.approx(4.5)
 
 
 def test_evaluationspace1d_zeros_like_empty():
@@ -1551,14 +1553,18 @@ def test_evaluationspace_empty_is_ascending(cls):
         _ = espace.is_ascending
 
 
-@pytest.mark.parametrize("cls", [EvaluationSpace1D, EvaluationSpace2D])
 @pytest.mark.parametrize("meth", ["start", "end"])
-def test_evaluationspace_empty_range(cls, meth):
+def test_evaluationspace_empty_range(meth):
     """Simple check"""
-    espace = cls()
-    with pytest.raises(DataErr, match="^Axis is empty or has a size of 0$"):
-        # These are properties, so accessing the field causes the error
-        _ = getattr(espace, meth)
+    espace = EvaluationSpace1D()
+    assert getattr(espace, meth) is None
+
+
+@pytest.mark.parametrize("meth", ["start", "end"])
+def test_evaluationspace_empty_range_2D(meth):
+    """Simple check"""
+    espace = EvaluationSpace2D()
+    assert getattr(espace, meth) == pytest.approx((None, None))
 
 
 @pytest.mark.parametrize("cls,expected",
@@ -1587,8 +1593,7 @@ def test_evaluationspace_empty_overlaps(cls):
     """Simple check"""
     espace1 = cls()
     espace2 = cls()
-    with pytest.raises(DataErr, match="^Axis is empty or has a size of 0$"):
-        espace1.overlaps(espace2)
+    assert espace1.overlaps(espace2) is False
 
 
 @pytest.mark.parametrize("cls", [EvaluationSpace1D])

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -933,7 +933,7 @@ class ModelHistogramPlot(HistogramPlot):
         (_, y, _, _, self.xlabel, self.ylabel) = plot
 
         # taken from get_x from Data1DInt
-        indep = data.get_evaluation_indep(filter=True, model=model)
+        indep = data.get_indep(filter=True)
 
         self.xlo = indep[0]
         self.xhi = indep[1]
@@ -1906,7 +1906,7 @@ class ComponentSourceHistogramPlot(SourceHistogramPlot):
         (_, y, _, _, self.xlabel, self.ylabel) = plot
 
         # taken from get_x from Data1DInt
-        indep = data.get_evaluation_indep(filter=True, model=model)
+        indep = data.get_indep(filter=True)
 
         self.xlo = indep[0]
         self.xhi = indep[1]
@@ -2306,7 +2306,7 @@ class BaseResidualHistogramPlot(ModelHistogramPlot):
         """Define the xlo and xhi fields"""
 
         # taken from get_x from Data1DInt
-        indep = data.get_evaluation_indep(filter=True, model=model)
+        indep = data.get_indep(filter=True)
         self.xlo = indep[0]
         self.xhi = indep[1]
 
@@ -2528,7 +2528,7 @@ class ChisqrHistogramPlot(ModelHistogramPlot):
         """Define the xlo and xhi fields"""
 
         # taken from get_x from Data1DInt
-        indep = data.get_evaluation_indep(filter=True, model=model)
+        indep = data.get_indep(filter=True)
         self.xlo = indep[0]
         self.xhi = indep[1]
 

--- a/sherpa/sim/sample.py
+++ b/sherpa/sim/sample.py
@@ -66,8 +66,8 @@ def multivariate_t(mean: ArrayType,
     ----------
     mean : 1-D array_like, length N
         Mean of the N-dimensional distribution
-    cov : 2-D array_like, shape (N, N)
-        Covariate matrix of the distribution.  Must be symmetric and
+    cov : 2-D array_like
+        Covariate matrix of the distribution of shape (N, N).  Must be symmetric and
         positive semi-definite for "physically meaningful" results.
     df : int
         Degrees of freedom of the distribution

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019 - 2022, 2024
+#  Copyright (C) 2019-2022, 2024-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -331,15 +331,15 @@ def test_data_len(Dataclass):
 @pytest.mark.parametrize("data", (Data, ), indirect=True)
 def test_data_str_repr(data):
     assert repr(data) == "<Data data set instance 'data_test'>"
-    assert str(data) == 'name      = data_test\nindep     = (array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),)\ndep       ' \
-                        '= Int64[10]\nstaterror = Float64[10]\nsyserror  = Float64[10]'
+    assert str(data) == 'name       = data_test\nindep      = (array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),)\ndep        ' \
+                        '= Int64[10]\nstaterror  = Float64[10]\nsyserror   = Float64[10]\nintegrated = False'
 
 
 @pytest.mark.parametrize("data", (Data1D, ), indirect=True)
 def test_data1d_str_repr(data):
     assert repr(data) == "<Data1D data set instance 'data_test'>"
-    assert str(data) == 'name      = data_test\nx         = Int64[10]\ny         = Int64[10]\nstaterror = ' \
-                        'Float64[10]\nsyserror  = Float64[10]'
+    assert str(data) == 'name       = data_test\nx          = Int64[10]\ny          = Int64[10]\nstaterror  = ' \
+                        'Float64[10]\nsyserror   = Float64[10]\nintegrated = False'
 
 
 @pytest.mark.parametrize("data", (Data, Data1D), indirect=True)

--- a/sherpa/tests/test_data.py
+++ b/sherpa/tests/test_data.py
@@ -1615,7 +1615,7 @@ def test_ispace2d_mismatch():
 
     with pytest.raises(DataErr,
                        match="size mismatch between x0 and x1: 9 vs 10"):
-        IntegratedDataSpace2D(Filter(), x0[:-1], x1[:-1], x0[1:], x1[1:])
+        IntegratedDataSpace2D(Filter(), x0[:-1], x1[:-1], x0[1:], x1[1:], flat=True)
 
 
 @pytest.fixture
@@ -2206,33 +2206,16 @@ def test_check_related_fields_correct_size(column):
     """
 
     d = Data1D('example', None, None)
-    setattr(d, column, numpy.asarray([2, 10, 3]))
+    with pytest.raises(DataErr,
+                       match=f"size mismatch between independent axis and {column}: 0 vs 3"):
+        setattr(d, column, numpy.asarray([2, 10, 3]))
+
+    d.indep = (numpy.asarray([2, 3, 4, 5]), )
 
     with pytest.raises(DataErr,
-                       match="independent axis can not change size: 3 to 4"):
-        d.indep = (numpy.asarray([2, 3, 4, 5]), )
+                       match=f"size mismatch between independent axis and {column}: 4 vs 3"):
+        setattr(d, column, numpy.asarray([2, 10, 3]))
 
-
-def test_data1d_mismatched_related_fields():
-    """Check setting the related fields to different sizes: Data1D
-
-    This is a regression test to check when the mismatch is detected,
-    if it is. It is important that we have not set the dependent axis
-    here, as there is likely to be better support for checking the
-    dependent and independent axes than the related axes.
-
-    The assumption here is that we don't need to test all the classes.
-    """
-
-    # Create an empty object, set the syserror and staterror fields to
-    # different lengths, then set the independent axis.
-    #
-    d = Data1D("x", None, None)
-
-    d.staterror = [1, 2, 3, 4]
-    with pytest.raises(DataErr,
-                       match="size mismatch between independent axis and syserror: 4 vs 6"):
-        d.syserror = [2, 3, 4, 5, 20, 12]
 
 
 @pytest.mark.parametrize("data", ALL_DATA_CLASSES, indirect=True)
@@ -2404,7 +2387,7 @@ def test_data_is_empty(data_class, args):
     """There is no size attribute"""
 
     data = data_class("empty", *args)
-    assert data.size is None
+    assert data.size is 0
 
 
 @pytest.mark.parametrize("data", (Data, ) + DATA_1D_CLASSES, indirect=True)
@@ -2431,15 +2414,14 @@ def test_data_size_2d(data):
 
 @pytest.mark.parametrize("data_class,args", EMPTY_DATA_OBJECTS)
 def test_data_can_not_set_dep_to_scalar_when_empty(data_class, args):
-    """Check out how we error out.
+    """Setting a scalar sets all (in this case 0, since empty) values.
 
     This is a regression test.
     """
 
     data = data_class("empty", *args)
-    with pytest.raises(DataErr,
-                       match="The size of 'empty' has not been set"):
-        data.set_dep(2)
+    data.set_dep(2)
+    assert data.dep == pytest.approx([])
 
 
 @pytest.mark.parametrize("data_class,args", EMPTY_DATA_OBJECTS_2D)
@@ -2698,19 +2680,15 @@ def test_eval_model_to_fit_when_all_ignored_2d(data_copy):
 def test_to_guess_when_empty(data_class, args):
     """This is a regression test."""
 
-    if data_class == Data1DInt:
-        # Error is
-        # TypeError: IntegratedDataSpace1D.__init__() missing 1 required positional argument: 'xhi'
-        #
-        pytest.xfail("test known to fail with Data1DInt")
-
     data = data_class("empty", *args)
     resp = data.to_guess()
 
+    # Get from input, don't use attributes of the objects that we want to test
+    ndim = int(data.__class__.__name__[4])
     # Ensure there are n None values, where n is the number of
     # independent + dependent axes - ie len(args)
     #
-    assert len(resp) == len(args)
+    assert len(resp) == ndim * {True: 2, False: 1}[data.integrated] + 1
     for r in resp:
         assert r is None
 
@@ -2753,15 +2731,15 @@ def test_get_filter_when_empty_1d(data_class, args):
     hard-codes the return value to be ''.
     """
 
-    if data_class == Data1DInt:
+    #if data_class == Data1DInt:
         # Error is
         # IntegratedDataSpace1D.__init__() missing 1 required positional argument: 'xhi'
-        pytest.xfail("test known to fail with Data1DInt")
+    #    pytest.xfail("test known to fail with Data1DInt")
 
     data = data_class("empty", *args)
     # This is not a nice error case, so catch it in case we decide to
     # change the code.
     #
-    with pytest.raises(TypeError,
-                       match=r"object of type 'NoneType' has no len\(\)"):
-        _ = data.get_filter()
+    assert '' == data.get_filter()
+
+

--- a/sherpa/ui/tests/test_session.py
+++ b/sherpa/ui/tests/test_session.py
@@ -1307,7 +1307,7 @@ def test_show_data_explicit_id():
     s.show_data("bob", outfile=out)
 
     # not a full check of the output
-    assert out.getvalue().startswith("Data Set: bob\nname      = \n")
+    assert out.getvalue().startswith("Data Set: bob\nname       = \n")
 
 
 def test_show_kernel_explicit_id(tmp_path):
@@ -1384,16 +1384,17 @@ def test_show_psf_explicit_id(tmp_path):
     #
     toks = out.getvalue().split("\n")
     assert toks[0] == "PSF Model: bob"
-    assert toks[1].startswith("name      = ")
-    assert toks[2] == "x         = Float64[4]"
-    assert toks[3] == "y         = Float64[4]"
-    assert toks[4] == "staterror = None"
-    assert toks[5] == "syserror  = None"
+    assert toks[1].startswith("name       = ")
+    assert toks[2] == "x          = Float64[4]"
+    assert toks[3] == "y          = Float64[4]"
+    assert toks[4] == "staterror  = None"
+    assert toks[5] == "syserror   = None"
+    assert toks[6] == "integrated = False"
 
-    assert toks[6] == ""
     assert toks[7] == ""
     assert toks[8] == ""
-    assert len(toks) == 9
+    assert toks[9] == ""
+    assert len(toks) == 10
 
 
 def test_show_kernel_multiple(tmp_path):


### PR DESCRIPTION
## Summary
Reorganize hirachy of evaluation spaces and data classes so that they all have a common ancestor.

## Details
`EvaluationSpaceND` will now be the base of all evaluation spaces and this has a simper property `integrated` so the same class can hold either integrated or non-integrated data.
`EvaluationSpace1D` and `EvaluationSpace2D` are merely specializations of that with a slightly different calling structure (The independend axes are passed individually to the constructor instead of as a tuple).
An evaluation space can be flat (i.e. all axes have the same length such as `x0=[1,1,1,2,2,2]` and `x1=[1,2,3,1,2,3]`)
or not (`x0=[1,2]` and `x1=[1,2,3]`). The former case allows evaluation on a non-rectangular grid.
    
Data spaces derive from Evaluation spaces by adding a filter as a mix-in class. This design allows us to reuse
the entire inheritance tree and basically build a parallel tree by just mixing in the mix-in class in every case.
It also means that we can reproduce our legacy DataXD and DataXDInt (with X=1,2) classes with very little code.

To allow this consistency some previously inconsistent features have been changed or removed:
- remove `for_model` method (which always returned `self` independent of the input parameters), `get_evaluation_indep` (which called `for_model`) and the  keyword `use_evaluation_sapce` in `get_x`, get_y` (which didn't do anything).


## Follow-up
The text in the commit messages has lines like "which we intend to change in a future commit". However, I see that this PR is already quite big and might be hard to review. While the user shouldn't see any change in normal Sherpa use and even advanced users who initialize data classes directly won't have to care what changed underneath, this is a significant change in our most fundamental data classes. 

## Benefits
The benefits of having a more consistent set of evaluation spaces and data classes are not fully exploited in this PR, because it's so big already; instead we'll to follow-up PRs. But broadly speaking, they are

- code clarity, consistency, fewer corner cases (the usual)
- Our plotting code works "per data class". With a more consistent data class layout, we need fewer plotting classes. Users who want to "just get the data out" to do their own plots (a common request) can do so with the same UI for all types of data.
- We didn't have IntegratedNDData at all. Integrated data is kind of Sherpa's specialty and I do have two scientific use cases that absolutely need that.
- Capabilities of DataClasses. This will make it easier to move some of the specialties of `DataPHA` that would be useful in other context to the parent classes. Grouping is useful not just for photons, but for any count data (number of galaxies per mass range, size of flares from young stars, ...). On-the-fly grouping and filtering is on of Sherpa's strong suits and can easily be generalized to any integrated 1D data. That may have been possible in the old paradigm, but it easier here.
- Some unused or useless (meaning that they are called but don't change behavior) functions or arguments are already removed in this PR. More can be removed in future PRs. That simplifies the code, makes it more readable and thus makes it easier to use it as a base for special, derived classes. In fact, that's why I started this PR...