### PR TITLE
BUILD: remove commented line from xspec_libraries. Fix #2253.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,8 @@ source-dir = docs
 # to $HEADAS/include and $HEADAS/lib respectively (expand out the
 # environment variable).
 #
+# Change 6.30 to the correct version in xspec_libraries for hdsp.
+#
 # If you are using a full XSPEC build, then it may be necessary to add
 # the correct version numbers to the cfitsio, CCfits, and wcs
 # libraries used in the build. For XSPEC 12.12.1 (HEAsoft 6.30.1)
@@ -90,7 +92,7 @@ source-dir = docs
 #xspec_version = 12.12.0
 #xspec_lib_dirs = None
 #xspec_include_dirs = None
-#xspec_libraries = XSFunctions XSUtil XS hdsp_6.30  # change 6.30 to the correct version
+#xspec_libraries = XSFunctions XSUtil XS hdsp_6.30
 #cfitsio_lib_dirs = None
 #cfitsio_libraries = cfitsio
 #ccfits_lib_dirs = None


### PR DESCRIPTION
# Summary

Internal tweak to the setup.cfg file to support building with clang. Fix #2253.

# Details

Move the comment from xspec_libraries to the main comments for the area. This will fix #2253.