### PR TITLE
Allow "dummy" as an alias for BasicBackend in plotting

### DIFF
--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -138,6 +138,10 @@ plot_opt_str = config.get('options', 'plot_pkg', fallback='BasicBackend')
 plot_opt = [o.strip() for o in plot_opt_str.split()]
 
 for plottry in plot_opt:
+    # For backwards compatibility we alias "dummy" to BasicBackend
+    if plottry == "dummy":
+        plottry = "BasicBackend"
+
     if plottry in PLOT_BACKENDS:
         backend = PLOT_BACKENDS[plottry]()
         break


### PR DESCRIPTION
## Summary
Allow "dummy" as an alias for BasicBackend in plotting

## Details
I tested this locally and I don't think it needs and automated test.
However, the question is if we want to make this change at all. 

## Question
It's motivated by #2167, but we've now had a full release cycle without "dummy" as a valid plot backend value, so it is still worth it to add the alias back in now?

If we don't take this, we should just close #2167 as "won't fix".