### PR TITLE
Pass backend-specific options through to pylab and bokeh

### DIFF
--- a/sherpa/plot/bokeh_backend.py
+++ b/sherpa/plot/bokeh_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2023, 2024
+#  Copyright (C) 2023-2025
 #  MIT
 #
 #
@@ -286,6 +286,7 @@ class BokehBackend(BasicBackend):
               label=None,
               linewidth=None,
               linecolor=None,
+              **kwargs
               ):
         """Draw histogram data.
 
@@ -326,7 +327,8 @@ class BokehBackend(BasicBackend):
                 linewidth=linewidth,
                 drawstyle=drawstyle,
                 color=color, marker=None, alpha=alpha,
-                xaxis=False, ratioline=False)
+                xaxis=False, ratioline=False,
+                **kwargs)
 
         # Draw points and error bars at the mid-point of the bins.
         # Use the color used for the data plot: should it
@@ -358,31 +360,9 @@ class BokehBackend(BasicBackend):
                           markerfacecolor=markerfacecolor,
                           ecolor=ecolor,
                           capsize=capsize,
+                          **kwargs
                          )
 
-    # Note that this is an internal method that is not wrapped in
-    # @ translate_args
-    # This is called from methods like plot, histo, etc.
-    # so the arguments passed to this method are already translated and we do
-    # not want to apply the translation a second time.
-    def _set_line(self, line, linecolor=None, linestyle=None, linewidth=None):
-        """Apply the line attributes, if set.
-
-        Parameters
-        ----------
-        line :
-            The line to change
-        linecolor, linestyle, linewidth : optional
-            The attribute value or None.
-        """
-        if linecolor is not None:
-            line.glyph.line_color = linecolor
-
-        if linestyle is not None:
-            line.glyph.line_dash = linestyle
-
-        if linewidth is not None:
-            line.glyph.line_width = linewidth
 
     # There is no support for alpha in the Plot.vline class
     @add_kwargs_to_doc(kwargs_doc)
@@ -392,7 +372,9 @@ class BokehBackend(BasicBackend):
               linecolor=None,
               linestyle=None,
               linewidth=None,
-              overplot=False, clearwindow=True):
+              overplot=False, clearwindow=True,
+              **kwargs
+              ):
         """Draw a vertical line
 
         Parameters
@@ -406,7 +388,9 @@ class BokehBackend(BasicBackend):
         line = Span(location=x, dimension='height',
                     line_width=linewidth,
                     line_color=linecolor,
-                    line_dash=linestyle)
+                    line_dash=linestyle,
+                    **kwargs
+                    )
         axes.add_layout(line)
 
     # There is no support for alpha in the Plot.hline class
@@ -418,7 +402,9 @@ class BokehBackend(BasicBackend):
               linecolor=None,
               linestyle=None,
               linewidth=None,
-              overplot=False, clearwindow=True):
+              overplot=False, clearwindow=True,
+              **kwargs
+              ):
         """Draw a horizontal line
 
         Parameters
@@ -432,7 +418,9 @@ class BokehBackend(BasicBackend):
         line = Span(location=y, dimension='width',
                     line_width=linewidth,
                     line_color=linecolor,
-                    line_dash=linestyle)
+                    line_dash=linestyle,
+                    **kwargs
+                    )
         axes.add_layout(line)
 
     @add_kwargs_to_doc(kwargs_doc)
@@ -458,6 +446,7 @@ class BokehBackend(BasicBackend):
              linewidth=1,
              linecolor=None,
              xaxis=None, ratioline=None,
+             **kwargs
              ):
         """Draw x, y data.
 
@@ -503,7 +492,6 @@ class BokehBackend(BasicBackend):
 
         objs = []
 
-        kwargs = {}
         if label is not None:
             kwargs['legend_label'] = label
         if linestyle != 'noline':
@@ -529,12 +517,10 @@ class BokehBackend(BasicBackend):
             glyph = Scatter(marker=marker,
                             line_alpha=alpha,
                             fill_alpha=alpha,
-                            hatch_alpha=alpha,
                             line_color=markerfacecolor,
                             fill_color=markerfacecolor,
-                            hatch_color=markerfacecolor,
                             size=markersize,
-                            *kwargs
+                            **kwargs
                             )
             axes.add_glyph(source, glyph)
             objs.append(glyph)
@@ -607,6 +593,7 @@ class BokehBackend(BasicBackend):
                 linestyles='solid',
                 colors=None,
                 label=None,
+                **kwargs
                 ):
         """Draw 2D contour data.
 
@@ -646,7 +633,8 @@ class BokehBackend(BasicBackend):
 
 
         axes.contour(x0, x1, y, levels, line_alpha=alpha,
-                     line_color=colors, line_width=linewidths)
+                     line_color=colors, line_width=linewidths,
+                     **kwargs)
 
     @add_kwargs_to_doc(kwargs_doc)
     @translate_args
@@ -673,7 +661,6 @@ class BokehBackend(BasicBackend):
             with shape (len(x0), len(x1))
         {kwargs}
         """
-        print(x0, x1, y, aspect, kwargs)
         axes = self.setup_axes(overplot, clearwindow)
 
         # Set up the axes
@@ -681,7 +668,7 @@ class BokehBackend(BasicBackend):
             self.setup_plot(axes, title, xlabel, ylabel)
 
         axes.image(image=[y], x=x0[0], y=x1[0], dw=x0[-1] - x0[0], dh=x1[-1] - x1[0],
-                   level='image', palette="Sunset11")
+                   level='image', palette="Sunset11", **kwargs)
         axes.aspect_ratio = aspect
 
 

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2017, 2019 - 2024
+#  Copyright (C) 2010, 2015, 2017, 2019-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -253,6 +253,7 @@ class PylabBackend(BasicBackend):
               label=None,
               linewidth=None,
               linecolor=None,
+              **kargs
               ):
         """Draw histogram data.
 
@@ -294,6 +295,7 @@ class PylabBackend(BasicBackend):
                          linestyle=linestyle, linewidth=linewidth,
                          drawstyle=drawstyle,
                          color=color, marker=None, alpha=alpha,
+                         **kargs
                          )
 
         # Draw points and error bars at the mid-point of the bins.
@@ -344,7 +346,7 @@ class PylabBackend(BasicBackend):
     # This is called from methods like plot, histo, etc.
     # so the arguments passed to this method are already translated and we do
     # not want to apply the translation a second time.
-    def _set_line(self, line, linecolor=None, linestyle=None, linewidth=None):
+    def _set_line(self, line, linecolor=None, linestyle=None, linewidth=None, **kwargs):
         """Apply the line attributes, if set.
 
         Parameters
@@ -364,6 +366,8 @@ class PylabBackend(BasicBackend):
         setf('color', linecolor)
         setf('linestyle', linestyle)
         setf('linewidth', linewidth)
+        for k, v in kwargs.items():
+            setf(k, v)
 
     # There is no support for alpha in the Plot.vline class
     @add_kwargs_to_doc(kwargs_doc)
@@ -373,7 +377,8 @@ class PylabBackend(BasicBackend):
               linecolor=None,
               linestyle=None,
               linewidth=None,
-              overplot=False, clearwindow=True):
+              overplot=False, clearwindow=True,
+              **kwargs):
         """Draw a vertical line
 
         Parameters
@@ -386,7 +391,7 @@ class PylabBackend(BasicBackend):
 
         line = axes.axvline(x, ymin, ymax)
         self._set_line(line, linecolor=linecolor, linestyle=linestyle,
-                       linewidth=linewidth)
+                       linewidth=linewidth, **kwargs)
 
     # There is no support for alpha in the Plot.hline class
 
@@ -397,7 +402,7 @@ class PylabBackend(BasicBackend):
               linecolor=None,
               linestyle=None,
               linewidth=None,
-              overplot=False, clearwindow=True):
+              overplot=False, clearwindow=True, **kwargs):
         """Draw a horizontal line
 
         Parameters
@@ -410,7 +415,7 @@ class PylabBackend(BasicBackend):
 
         line = axes.axhline(y, xmin, xmax)
         self._set_line(line, linecolor=linecolor, linestyle=linestyle,
-                       linewidth=linewidth)
+                       linewidth=linewidth, **kwargs)
 
     @add_kwargs_to_doc(kwargs_doc)
     @translate_args
@@ -436,6 +441,7 @@ class PylabBackend(BasicBackend):
              linewidth=None,
              linecolor=None,
              xaxis=None, ratioline=None,
+             **kwargs
              ):
         """Draw x, y data.
 
@@ -507,7 +513,9 @@ class PylabBackend(BasicBackend):
                                  ecolor=ecolor,
                                  capsize=capsize,
                                  barsabove=barsabove,
-                                 zorder=zorder)
+                                 zorder=zorder,
+                                 **kwargs
+                                 )
 
         else:
             obj = axes.plot(x, y,
@@ -520,7 +528,9 @@ class PylabBackend(BasicBackend):
                             marker=marker,
                             markersize=markersize,
                             markerfacecolor=markerfacecolor,
-                            zorder=zorder)
+                            zorder=zorder,
+                            **kwargs
+                            )
         handles, _ = axes.get_legend_handles_labels()
         if len(handles) > 0:
             axes.legend()
@@ -539,7 +549,11 @@ class PylabBackend(BasicBackend):
                 linewidths=None,
                 linestyles='solid',
                 colors=None,
-                label=None,
+                label=None,  # label is not used by axes.contour
+                             # so we want to make sure it's not part of the kwargs
+                             # because it's set by default to '_nolegend_' in the chain that
+                             # calls this method from sherpa.plot.Contour
+                **kwargs
                 ):
         """Draw 2D contour data.
 
@@ -572,12 +586,16 @@ class PylabBackend(BasicBackend):
             axes.contour(x0, x1, y, alpha=alpha,
                          colors=colors,
                          linewidths=linewidths,
-                         linestyles=linestyles)
+                         linestyles=linestyles,
+                         **kwargs
+                         )
         else:
             axes.contour(x0, x1, y, levels, alpha=alpha,
                          colors=colors,
                          linewidths=linewidths,
-                         linestyles=linestyles)
+                         linestyles=linestyles,
+                         **kwargs
+                         )
         handles, _ = axes.get_legend_handles_labels()
         if len(handles) > 0:
             axes.legend()
@@ -615,7 +633,7 @@ class PylabBackend(BasicBackend):
             self.setup_plot(axes, title, xlabel, ylabel)
 
         extent = (x0[0], x0[-1], x1[0], x1[-1])
-        im = axes.imshow(y, origin='lower', extent=extent, aspect=aspect)
+        im = axes.imshow(y, origin='lower', extent=extent, aspect=aspect, **kwargs)
 
         # TODO: This should be optional and have parameters.
         # but, for now, it's only used in _repr_html_ for DataIMG,

--- a/sherpa/plot/tests/test_bokeh.py
+++ b/sherpa/plot/tests/test_bokeh.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2024
+#  Copyright (C) 2024-2025
 #  MIT
 #
 #
@@ -21,9 +21,16 @@
 
 import os
 import pytest
+
+import numpy as np
+
 from sherpa import plot
 from sherpa.astro import ui
+from sherpa.models.basic import Const1D
+from sherpa.stats import Chi2DataVar
 from sherpa.utils.testing import requires_data, requires_fits
+from sherpa.plot import DataPlot, DataHistogramPlot, DelchiPlot, RatioPlot, ResidPlot
+from sherpa.data import Data1D, Data1DInt
 
 
 @requires_fits
@@ -53,3 +60,97 @@ def test_bokeh_delchi(caplog, clean_ui):
     newback = bokehbackend.BokehBackend()
     with plot.TemporaryPlottingBackend(newback):
         ui.plot_fit_delchi()
+
+
+def test_bokeh_specific_option_does_not_error():
+    """Test that a bokeh-specific option does not error out.
+
+    """
+    bokehbackend = pytest.importorskip("sherpa.plot.bokeh_backend")
+    # previous line guarantees that bokeh is installed
+    from bokeh.embed import file_html
+    from bokeh.resources import CDN
+
+    data = Data1DInt('tst', np.asarray([1, 2, 3]), np.asarray([1, 2, 3]) + 1,
+                      np.asarray([10, 12, 10.5]))
+    pl = DataPlot()
+    pl.prepare(data, stat=None)
+    newback = bokehbackend.BokehBackend()
+    with plot.TemporaryPlottingBackend(newback):
+        pl.plot(marker='o',tags=['foo', 10], line_dash_offset=3, linestyle="dashed")
+        html = file_html(plot.backend.current_fig, CDN, "my plot")
+
+    assert '"tags":["foo",10]' in html
+    assert '"line_dash_offset":3' in html
+
+
+def test_bokeh_specific_option_scatter():
+    """Test a bokeh-specific option (hatch_pattern) when doing a scatter plot"""
+    bokehbackend = pytest.importorskip("sherpa.plot.bokeh_backend")
+    # previous line guarantees that bokeh is installed
+    from bokeh.embed import file_html
+    from bokeh.resources import CDN
+
+    rng = np.random.default_rng(1273)
+    z1 = rng.wald(100, 20, size=1000)
+    z2 = rng.wald(100, 2000, size=1000)
+
+    splot = plot.ScatterPlot()
+    splot.prepare(z1, z2, xlabel='$$z_1$$', ylabel='$$z_2$$')
+    newback = bokehbackend.BokehBackend()
+    with plot.TemporaryPlottingBackend(newback):
+        splot.plot(xlog=True, hatch_pattern='/', markersize=20, alpha=0.5)
+        html = file_html(plot.backend.current_fig, CDN, "my plot")
+
+    assert '"hatch_pattern":{"type":"value","value":"/"}' in html
+
+
+@pytest.mark.parametrize("plotclass", [DataPlot, DataHistogramPlot])
+def test_warning_plot_unknown_keyword(plotclass):
+    """We get an error when we attempt to set a plotting parameter
+    that neither Sherpa nor the underlying plotting library understand.
+    """
+    bokehbackend = pytest.importorskip("sherpa.plot.bokeh_backend")
+
+    data = Data1DInt('tst', np.asarray([1, 2, 3]), np.asarray([1, 2, 3]) + 1,
+                     np.asarray([10, 12, 10.5]))
+    pl = plotclass()
+    pl.prepare(data, stat=None)
+    newback = bokehbackend.BokehBackend()
+    with plot.TemporaryPlottingBackend(newback):
+        with pytest.raises(AttributeError,
+                           match="unexpected attribute 'keyword_makes_no_sense' to Scatter"):
+            pl.plot(keyword_makes_no_sense='mousey')
+
+
+@pytest.mark.parametrize("plottype", [DelchiPlot, RatioPlot, ResidPlot])
+def test_ignore_ylog_prefs(plottype):
+    """Do the "residual" style plots ignore the ylog preference setting?
+
+    And while we are at it: Do the plots pass through Bokeh specific options?
+    (here: tags, line_dash_offset)
+    """
+
+    bokehbackend = pytest.importorskip("sherpa.plot.bokeh_backend")
+    # previous line guarantees that bokeh is installed
+    from bokeh.embed import file_html
+    from bokeh.resources import CDN
+
+    data = Data1D('tst', np.asarray([1, 2, 3]), np.asarray([10, 12, 10.5]))
+    mdl = Const1D('tst-model')
+    mdl.c0 = 11.1
+
+    pl = plottype()
+    pl.plot_prefs['xlog'] = True
+    pl.plot_prefs['ylog'] = True
+    pl.prepare(data, mdl, stat=Chi2DataVar())
+
+    newback = bokehbackend.BokehBackend()
+    with plot.TemporaryPlottingBackend(newback):
+        pl.plot(tags=['foo', 10], line_dash_offset=3, linestyle="dashed")
+        html = file_html(plot.backend.current_fig, CDN, "my plot")
+
+    assert '"tags":["foo",10]' in html
+    assert '"line_dash_offset":3' in html
+    assert '"x_scale":{"type":"object","name":"LogScale"' in html
+    assert '"y_scale":{"type":"object","name":"LinearScale"' in html


### PR DESCRIPTION
## Summary
Pass backend-specific options through to pylab and bokeh

## Details
Sherpa plotting commands should be passing through keywords that are not part of the sherpa-specific interface to the plotting library that is used as backend underneath.
This was one of the main design goals of the plotting work done for 4.17, and there is even a test for it, but as it turns out that test happens to use the wrong keyword (one that is part of the sherpa-specific set) so we never caught that it was, inf fact, NOT passing through stuff.

Two related small changes are included here:
- remove a print statement that was left over from some debugging
- There is an ambiguity on how to match general (sherpa API) keywords to backend keywords when it's not a 1:1 ratio. For example, if alpha is set, should it apply to the markers, the lines, the hatches or all of them? Hatches are invisible when they are always exactly identical in color, alpha etc to the filling color of a symbol, so we are no longer setting the hatch properties based on the general input and leave it to the user to pass through hatch specific keywords.

fixes #2084

This should have been part if 4.17, so it would be great to get it into 4.18 at least.