### PR TITLE
Remove duplication of the `load_table_model` method between `sherpa.ui` and `sherpa.astro.ui`.

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2021 - 2024
+#  Copyright (C) 2016, 2018, 2021-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -65,7 +65,7 @@ def test_load_table_model_fails_with_dir(tmp_path):
     assert ui.list_model_components() == []
 
     with pytest.raises(IOErr,
-                       match="^unable to open "):
+                       match="^No column data found in"):
         ui.load_table_model('tmpdir', str(tmpdir))
 
     assert ui.list_model_components() == []
@@ -110,7 +110,7 @@ def test_load_table_model_fails_with_empty_file(tmp_path):
     assert ui.list_model_components() == []
 
     with pytest.raises(IOErr,
-                       match="^No column data found in /dev/null$"):
+                       match="^No column data found in /dev/null"):
         ui.load_table_model('devnull', '/dev/null')
 
     assert ui.list_model_components() == []

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -23,10 +23,13 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
+from functools import partial
 import logging
 import os
 from typing import Any
 import sys
+from types import MethodType
+import warnings
 
 import numpy as np
 
@@ -1368,7 +1371,7 @@ class Session(sherpa.ui.utils.Session):
             return sherpa.astro.io.read_arrays(*args)
         except NotImplementedError:
             # if the astro backend is not set, fall back on io module version.
-            return sherpa.io.read_arrays(*args)
+            return super().unpack_arrays(*args)
 
     # DOC-NOTE: also in sherpa.utils
     # DOC-TODO: rework the Data type notes section (also needed for
@@ -11069,43 +11072,46 @@ class Session(sherpa.ui.utils.Session):
         self._background_sources.get(idval, {}).pop(bkg_id, None)
 
     def _read_user_model(self, filename, *args, **kwargs):
-        x = None
-        y = None
-        try:
-            data = self.unpack_ascii(filename, *args, **kwargs)
-            x = data.get_x()
-            y = data.get_y()
+        """Read in user model data from a file.
 
-        # we have to check for the case of a *single* column in an ascii file
-        # extract the single array from the read and bypass the dataset
-        except TypeError:
-            hdu, _ = sherpa.astro.io.backend.get_ascii_data(filename,
-                                                            *args,
-                                                            **kwargs)
-            y = hdu.columns[0].values
-        except Exception:
+        While some options can be set by keyword arguments,
+        fundamentally, this is trying out a list of possible formats
+        (ASCII with the backend, general table (e. g. fits), image)
+        until one works.
+        If no working backend is loaded, this falls back to the
+        sherpa.ui version, which can read ascii files.
+        """
+        def read_backend(func, filename, *args, **kwargs):
+            hdu, _ = func(filename, *args, **kwargs)
+            cols = hdu.columns
+            if len(cols) == 0:
+                raise IOErr(f"No column data found in {filename}")
+            if len(cols) == 1:
+                return (None, cols[0].values)
+            return (cols[0].values, cols[1].values)
+
+        read_backend_ascii = partial(read_backend,
+                                     sherpa.astro.io.backend.get_ascii_data)
+        read_backend_table = partial(read_backend,
+                                     sherpa.astro.io.backend.get_table_data)
+
+        def read_backend_image(self, filename, *args, **kwargs):
+            data = self.unpack_image(filename, *args, **kwargs)
+            return (None, data.get_y())
+
+        def read_with_super(self, filename, *args, **kwargs):
+            return super()._read_user_model(filename, *args, **kwargs)
+
+        for func in (read_backend_ascii,
+                     read_backend_table,
+                     # The following two need "self", so we make them a method
+                     MethodType(read_backend_image, self),
+                     MethodType(read_with_super, self)):
             try:
-                data = self.unpack_table(filename, *args, **kwargs)
-                x = data.get_x()
-                y = data.get_y()
-
-            # we have to check for the case of a *single* column in a
-            # fits table
-            # extract the single array from the read and bypass the dataset
-            except TypeError:
-                hdu, _ = sherpa.astro.io.backend.get_table_data(filename,
-                                                                *args,
-                                                                **kwargs)
-                y = hdu.columns[0].values
-
-            except Exception:
-                # unpack_data doesn't include a call to try
-                # getting data from image, so try that here.
-                data = self.unpack_image(filename, *args, **kwargs)
-                # x = data.get_x()
-                y = data.get_y()
-
-        return (x, y)
+                return func(filename, *args, **kwargs)
+            except:
+                pass
+        raise IOErr(f"No column data found in {filename} with supported file formats")
 
     def load_xstable_model(self, modelname, filename,
                            etable=False) -> None:
@@ -11200,11 +11206,15 @@ class Session(sherpa.ui.utils.Session):
         self._tbl_models.append(tablemodel)
         self._add_model_component(tablemodel)
 
-    # also in sherpa.utils
+    # implementation just calls super, but that calls `self._read_user_model`
+    # which is overwritten in this class.
+    # As a consequence, this method accepts a wider range of inputs
+    # (such as fits files) than the super method (only ascii files) and
+    # thus we do define a method here just so we can write a new docstring.
     # DOC-NOTE: can filename be a crate/hdulist?
     # DOC-TODO: how to describe the supported args/kwargs (not just for this function)?
     def load_table_model(self, modelname, filename,
-                         method=sherpa.utils.linear_interp, *args,
+                         *args,
                          **kwargs) -> None:
         # pylint: disable=W1113
         """Load tabular or image data and use it as a model component.
@@ -11224,11 +11234,6 @@ class Session(sherpa.ui.utils.Session):
            The name of the file containing the data, which should
            contain two columns, which are the x and y values for
            the data, or be an image.
-        method : func
-           The interpolation method to use to map the input data onto
-           the coordinate grid of the data set. Linear,
-           nearest-neighbor, and polynomial schemes are provided in
-           the sherpa.utils module.
         args
            Arguments for reading in the data.
         kwargs
@@ -11268,22 +11273,7 @@ class Session(sherpa.ui.utils.Session):
         >>> set_source('img', emap * gauss2d)
 
         """
-
-        x = None
-        y = None
-        try:
-            x, y = self._read_user_model(filename, *args, **kwargs)
-        except Exception:
-            data = sherpa.io.read_data(filename, ncols=2)
-            x = data.x
-            y = data.y
-
-        tablemodel = TableModel(modelname)
-        tablemodel.method = method
-        tablemodel.filename = filename
-        tablemodel.load(x, y)
-        self._tbl_models.append(tablemodel)
-        self._add_model_component(tablemodel)
+        super().load_table_model(modelname, filename, *args, **kwargs)
 
     # ## also in sherpa.utils
     # DOC-TODO: how to describe *args/**kwargs

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -7595,23 +7595,16 @@ class Session(NoNewAttributesAfterInit):
     #
 
     def _read_user_model(self, filename, ncols=2, colkeys=None,
-                         dstype=sherpa.data.Data1D, sep=' ', comment='#'):
-        x = None
-        y = None
-        try:
-            data = self.unpack_data(filename, ncols, colkeys,
-                                    dstype, sep, comment)
-            x = data.get_x()
-            y = data.get_y()
+                         sep=' ', comment='#'):
+        cols = sherpa.io.get_ascii_data(filename, ncols=ncols, colkeys=colkeys,
+                                         sep=sep, comment=comment)[1]
 
-        except TypeError:
-            # we have to check for the case of a *single* column in the file
-            # extract the single array from the read and bypass the dataset
-            y = sherpa.io.get_ascii_data(filename, ncols=1, colkeys=colkeys,
-                                         sep=sep, dstype=dstype,
-                                         comment=comment)[1].pop()
+        if len(cols) == 0:
+               raise IOErr(f"No column data found in {filename}")
+        elif len(cols) == 1:
+                return (None, cols[0])
+        return (cols[0], cols[1])
 
-        return (x, y)
 
     # DOC-TODO: I am not sure I have the data format correct.
     # DOC-TODO: description of template interpolation needs a lot of work.
@@ -7754,9 +7747,9 @@ class Session(NoNewAttributesAfterInit):
         """
         add_interpolator(name, interpolator_class, **kwargs)
 
-    def load_table_model(self, modelname, filename, ncols=2, colkeys=None,
-                         dstype=sherpa.data.Data1D, sep=' ', comment='#',
-                         method=sherpa.utils.linear_interp):
+    def load_table_model(self, modelname, filename,
+                         method=sherpa.utils.linear_interp,
+                         *args, **kwargs):
         """Load ASCII tabular data and use it as a model component.
 
         A table model is defined on a grid of points which is
@@ -7778,9 +7771,6 @@ class Session(NoNewAttributesAfterInit):
            ``None``, which uses the first ``ncols`` columns in the file.
            The default column names are col followed by the column number,
            so ``col1`` for the first column.
-        dstype : data class to use, optional
-           What type of data is to be used. Supported values include
-           `Data1D` (the default) and `Data1DInt`.
         sep : str, optional
            The separator character for columns. The default is ``' '``.
         comment : str, optional
@@ -7837,9 +7827,14 @@ class Session(NoNewAttributesAfterInit):
         >>> set_par(filt.ampl, 1e3, min=1, max=1e6)
 
         """
+        # Implementation note: the *args and **kwargs are
+        # passed to _read_user_model where the default values are set.
+        # The reason to not define all parameters here is that
+        # sherpa.astro.ui.load_user_model can't work with these defaults
+        # (because they are applicable to ASCII, but not to fits files) and we
+        # want to call this method here from the astro.Session child class.
 
-        x, y = self._read_user_model(filename, ncols, colkeys,
-                                     dstype, sep, comment)
+        x, y = self._read_user_model(filename, *args, **kwargs)
 
         tablemodel = TableModel(modelname)
         tablemodel.method = method
@@ -7852,8 +7847,7 @@ class Session(NoNewAttributesAfterInit):
     # DOC-TODO: how is the _y value used if set
     # @loggable()
     def load_user_model(self, func, modelname, filename=None, ncols=2,
-                        colkeys=None, dstype=sherpa.data.Data1D,
-                        sep=' ', comment='#'):
+                        colkeys=None, sep=' ', comment='#'):
         """Create a user-defined model.
 
         Assign a name to a function; this name can then be used as any
@@ -7879,10 +7873,6 @@ class Session(NoNewAttributesAfterInit):
         colkeys : array of str, optional
            An array of the column name to read in. The default is
            ``None``.
-        dstype : data class to use, optional
-           What type of data is to be used. Supported values include
-           `Data1D` (the default), `Data1DInt`, `Data2D`, and
-           `Data2DInt`.
         sep : str, optional
            The separator character. The default is ``' '``.
         comment : str, optional
@@ -7950,7 +7940,7 @@ class Session(NoNewAttributesAfterInit):
         usermodel._file = filename
         if filename is not None:
             _, usermodel._y = self._read_user_model(filename, ncols, colkeys,
-                                                    dstype, sep, comment)
+                                                    sep, comment)
         self._add_model_component(usermodel)
 
     # @loggable()


### PR DESCRIPTION
## Summary
Improve robustness of `load_table_model` by simplifying implementation and aligning method signature between Sherpa's different Session classes.

## Details

To implement this I align the signature of the `load_table_model` in `sherpa.ui` and `sherpa.astro.ui`.
This is technically an API breaking change in case someone relied on the ordering of arguments and passed in the interpolation method as third argument instead of a keyword argument.

I think that's unlikely to happen in practice (most people won't pass that in at all and just use the default), but it's separated into it's own commit in case we want to discuss or reverse that change.

Matching the API does not only make the linters happy, it also simplifies documentation as we could now point to (or generate from in some way) the docs of this method from the docs of the superclass  method.

In fact, I'm removing keywords that are no longer used, because they are confusing. Again, I don't think any of them are used in practice, but to keep backwards compatibility, we could just keep those unused keywords in the signature and raise a DeprecationWarning if they are set.

Also, this changes some error messages. It raises the same type of exceptions as before (`IoErr`)  but with a different string message. Again, that's technically breaking the API, but I don't think it changes any workflow in practice.

## Questions
- Do we want to keep te API backwards compatible as much as possible (a reordering of keywords is required to make this PR work, but we could keep the old keywords around (in a different order) to blunt the impact)? Personally, I prefer the way it's in the PR right now, with breaking changes, because it's a llittle used routine and there is a real cost in developer time to preprecate for one cycle and then having to go back and remove them later.

closes #1648