### PR TITLE
Update out-dated comments in utils.py

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -16786,9 +16786,7 @@ class Session(sherpa.ui.utils.Session):
             warning("XSPEC support is not available")
             return
 
-        # Very similar to the XSPEC "show abund" format, except that
-        # we do not have the "documentation" for the abundance table.
-        # This can be added but needs changes to the _xspec module.
+        # Very similar to the XSPEC "show abund" format.
         #
         lines = ["Solar Abundance Table:",
                  f"{xspec.get_xsabund():4s}  {xspec.get_xsabund_doc()}",


### PR DESCRIPTION
# Summary

Remove an outdated comment. There is no functional change.

# Details

The comments are from #2107 and should have been removed when #2138 was applied.