### PR TITLE
Improve save_all for certain PHA situations

### DIFF
--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -603,12 +603,11 @@ def _save_dataset_settings_pha(out: OutType,
             if TYPE_CHECKING:
                 assert isinstance(bpha, DataPHA)
 
-            # If this is a PHA2 file then do not add the load call.
-            # This could check multi["bkg_ids"] but we can just check
-            # the filename.
+            # Has this been automatically loaded?
             #
             bname = bpha.name
-            if multi is None or multi["filename"] != bname:
+            if multi is None or bid not in multi["bkg_ids"] or \
+               multi["bkg_ids"][bid] != bname:
                 cmd = f'load_bkg({cmd_id}, "{bname}", bkg_id={cmd_bkg_id})'
                 _output(out, cmd)
 

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -1625,7 +1625,11 @@ def _save_id(out: OutType, state: SessionType) -> None:
     _output_nl(out)
 
 
-def save_all(state: SessionType, fh: TextIO | None = None) -> None:
+def save_all(state: SessionType,
+             fh: TextIO | None = None,
+             *,
+             always_load: bool = False
+             ) -> None:
     """Save the information about the current session to a file handle.
 
     This differs to the `save` command in that the output is human
@@ -1638,7 +1642,11 @@ def save_all(state: SessionType, fh: TextIO | None = None) -> None:
      3. some settings and values may not be recorded.
 
      .. versionchanged:: 4.18.0
-        Handling of PHA2 data sets has been improved.
+        Handling of PHA data has been improved, and the output now
+        defaults to not including automatically-loaded ancillary files
+        (such as background and responses). Set the ``always_load``
+        flag to True to add these commands back to the save file (and
+        match previous versions).
 
     Parameters
     ----------
@@ -1646,6 +1654,7 @@ def save_all(state: SessionType, fh: TextIO | None = None) -> None:
     fh : file_like, optional
        If not given the results are displayed to standard out,
        otherwise they are written to this file handle.
+    always_load : bool, optional
 
     See Also
     --------
@@ -1692,7 +1701,7 @@ def save_all(state: SessionType, fh: TextIO | None = None) -> None:
             "main": []
            }
 
-    _save_data(out, state)
+    _save_data(out, state, always_load=always_load)
     _output_nl(out)
     _save_statistic(out, state)
     _save_fit_method(out, state)

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -40,6 +40,11 @@ import numpy
 from sherpa.astro.data import DataIMG, DataPHA, DataARF, DataRMF
 from sherpa.astro import io
 from sherpa.astro.io.wcs import WCS
+
+from sherpa.data import Data, Data1D, Data1DInt, Data2D, Data2DInt
+from sherpa.models.basic import UserModel
+from sherpa.utils.types import IdType
+
 if TYPE_CHECKING:
     # Avoid an import cycle
     from sherpa.astro.ui.utils import Session
@@ -49,12 +54,6 @@ try:
     from sherpa.astro import xspec
 except ImportError:
     xspec = None
-
-from sherpa.data import Data, Data1D, Data1DInt, Data2D, Data2DInt
-from sherpa.models.basic import UserModel
-import sherpa.utils
-from sherpa.utils.err import ArgumentErr
-from sherpa.utils.types import IdType
 
 
 logger = logging.getLogger(__name__)
@@ -239,7 +238,7 @@ def _save_response(out: OutType,
 
 
 def _save_arf_response(out: OutType,
-                       state: SessionType,
+                       state: SessionType,  # currently unused
                        pha: DataPHA,
                        id: IdType,
                        rid: IdType,
@@ -275,7 +274,7 @@ def _save_arf_response(out: OutType,
 
 
 def _save_rmf_response(out: OutType,
-                       state: SessionType,
+                       state: SessionType,  # currently unused
                        pha: DataPHA,
                        id: IdType,
                        rid: IdType,
@@ -463,7 +462,7 @@ def _add_bkg_filter(out: OutType,
 
 
 def _handle_filter(out: OutType,
-                   state: SessionType,
+                   state: SessionType,  # currently unused
                    data: DataType,
                    id: IdType) -> None:
     """Set any filter expressions for source and background
@@ -713,7 +712,7 @@ def _save_dataset_settings_pha(out: OutType,
 
 
 def _save_dataset_settings_2d(out: OutType,
-                              state: SessionType,
+                              state: SessionType,  # currently unused
                               data: DataType,
                               id: IdType) -> None:
     """What settings need to be set for Data2D/IMG?"""
@@ -759,9 +758,6 @@ def _save_data(out: OutType,
     #
     _output_banner(out, "Load Data Sets")
 
-    cmd_id = ""
-    cmd_bkg_id = ""
-
     # Special case PHA2 files, as
     # - they create multiple ids in one go
     # - some of those ids may get deleted or over-written
@@ -793,12 +789,6 @@ def _save_data(out: OutType,
             _output(out, f"delete_data({_id_to_str(delid)})")
 
     for idval in ids:
-        # But if id is a string, then quote as a string
-        # But what about the rest of any possible load_data() options;
-        # how do we replicate the optional keywords that were possibly
-        # used?  Store them with data object?
-        cmd_id = _id_to_str(idval)
-
         data = state.get_data(idval)
         if TYPE_CHECKING:
             # Assert an actual type rather than the base type of Data
@@ -1478,9 +1468,7 @@ def _save_dataset(out: OutType,
         if "idvals" in store:
             return
 
-        else:
-            _save_dataset_pha(out, store)
-
+        _save_dataset_pha(out, store)
         return
 
     except KeyError:

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -2745,7 +2745,6 @@ def test_restore_pha_basic(make_data_path):
     assert ui.calc_stat() == pytest.approx(statval)
 
 
-@pytest.mark.xfail  # issue #2383
 @requires_data
 @requires_xspec
 @requires_fits
@@ -4118,7 +4117,6 @@ def test_store_default_id(defid):
     assert d.y == pytest.approx(y)
 
 
-@pytest.mark.xfail  # issue #2383
 @requires_data
 @requires_fits
 def test_copy_data_pha(make_data_path):

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -26,7 +26,7 @@ from io import StringIO
 import re
 import warnings
 
-import numpy
+import numpy as np
 from numpy.testing import assert_array_equal
 
 import pytest
@@ -656,6 +656,49 @@ set_xsxsect("vern")
 set_xsxset("APECROOT", "3.0.9")
 set_xsxset("NEIAPECROOT", "3.0.9")
 set_xsxset("NEIVERS", "3.0.4")
+"""
+
+_canonical_pha_load_bkg = """import numpy
+from sherpa.astro.ui import *
+
+######### Load Data Sets
+
+load_arrays("x",
+            [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0, 48.0, 49.0, 50.0, 51.0, 52.0, 53.0, 54.0, 55.0, 56.0, 57.0, 58.0, 59.0, 60.0, 61.0, 62.0, 63.0, 64.0, 65.0, 66.0, 67.0, 68.0, 69.0, 70.0, 71.0, 72.0, 73.0, 74.0, 75.0, 76.0, 77.0, 78.0, 79.0, 80.0, 81.0, 82.0, 83.0, 84.0, 85.0, 86.0, 87.0, 88.0, 89.0, 90.0, 91.0, 92.0, 93.0, 94.0, 95.0, 96.0, 97.0, 98.0, 99.0, 100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0, 109.0, 110.0, 111.0, 112.0, 113.0, 114.0, 115.0, 116.0, 117.0, 118.0, 119.0, 120.0, 121.0, 122.0, 123.0, 124.0, 125.0, 126.0, 127.0, 128.0, 129.0, 130.0, 131.0, 132.0, 133.0, 134.0, 135.0, 136.0, 137.0, 138.0, 139.0, 140.0, 141.0, 142.0, 143.0, 144.0, 145.0, 146.0, 147.0, 148.0, 149.0, 150.0, 151.0, 152.0, 153.0, 154.0, 155.0, 156.0, 157.0, 158.0, 159.0, 160.0, 161.0, 162.0, 163.0, 164.0, 165.0, 166.0, 167.0, 168.0, 169.0, 170.0, 171.0, 172.0, 173.0, 174.0, 175.0, 176.0, 177.0, 178.0, 179.0, 180.0, 181.0, 182.0, 183.0, 184.0, 185.0, 186.0, 187.0, 188.0, 189.0, 190.0, 191.0, 192.0, 193.0, 194.0, 195.0, 196.0, 197.0, 198.0, 199.0, 200.0, 201.0, 202.0, 203.0, 204.0, 205.0, 206.0, 207.0, 208.0, 209.0, 210.0, 211.0, 212.0, 213.0, 214.0, 215.0, 216.0, 217.0, 218.0, 219.0, 220.0, 221.0, 222.0, 223.0, 224.0, 225.0, 226.0, 227.0, 228.0, 229.0, 230.0, 231.0, 232.0, 233.0, 234.0, 235.0, 236.0, 237.0, 238.0, 239.0, 240.0, 241.0, 242.0, 243.0, 244.0, 245.0, 246.0, 247.0, 248.0, 249.0, 250.0, 251.0, 252.0, 253.0, 254.0, 255.0, 256.0, 257.0, 258.0, 259.0, 260.0, 261.0, 262.0, 263.0, 264.0, 265.0, 266.0, 267.0, 268.0, 269.0, 270.0, 271.0, 272.0, 273.0, 274.0, 275.0, 276.0, 277.0, 278.0, 279.0, 280.0, 281.0, 282.0, 283.0, 284.0, 285.0, 286.0, 287.0, 288.0, 289.0, 290.0, 291.0, 292.0, 293.0, 294.0, 295.0, 296.0, 297.0, 298.0, 299.0, 300.0, 301.0, 302.0, 303.0, 304.0, 305.0, 306.0, 307.0, 308.0, 309.0, 310.0, 311.0, 312.0, 313.0, 314.0, 315.0, 316.0, 317.0, 318.0, 319.0, 320.0, 321.0, 322.0, 323.0, 324.0, 325.0, 326.0, 327.0, 328.0, 329.0, 330.0, 331.0, 332.0, 333.0, 334.0, 335.0, 336.0, 337.0, 338.0, 339.0, 340.0, 341.0, 342.0, 343.0, 344.0, 345.0, 346.0, 347.0, 348.0, 349.0, 350.0, 351.0, 352.0, 353.0, 354.0, 355.0, 356.0, 357.0, 358.0, 359.0, 360.0, 361.0, 362.0, 363.0, 364.0, 365.0, 366.0, 367.0, 368.0, 369.0, 370.0, 371.0, 372.0, 373.0, 374.0, 375.0, 376.0, 377.0, 378.0, 379.0, 380.0, 381.0, 382.0, 383.0, 384.0, 385.0, 386.0, 387.0, 388.0, 389.0, 390.0, 391.0, 392.0, 393.0, 394.0, 395.0, 396.0, 397.0, 398.0, 399.0, 400.0, 401.0, 402.0, 403.0, 404.0, 405.0, 406.0, 407.0, 408.0, 409.0, 410.0, 411.0, 412.0, 413.0, 414.0, 415.0, 416.0, 417.0, 418.0, 419.0, 420.0, 421.0, 422.0, 423.0, 424.0, 425.0, 426.0, 427.0, 428.0, 429.0, 430.0, 431.0, 432.0, 433.0, 434.0, 435.0, 436.0, 437.0, 438.0, 439.0, 440.0, 441.0, 442.0, 443.0, 444.0, 445.0, 446.0, 447.0, 448.0, 449.0, 450.0, 451.0, 452.0, 453.0, 454.0, 455.0, 456.0, 457.0, 458.0, 459.0, 460.0, 461.0, 462.0, 463.0, 464.0, 465.0, 466.0, 467.0, 468.0, 469.0, 470.0, 471.0, 472.0, 473.0, 474.0, 475.0, 476.0, 477.0, 478.0, 479.0, 480.0, 481.0, 482.0, 483.0, 484.0, 485.0, 486.0, 487.0, 488.0, 489.0, 490.0, 491.0, 492.0, 493.0, 494.0, 495.0, 496.0, 497.0, 498.0, 499.0, 500.0, 501.0, 502.0, 503.0, 504.0, 505.0, 506.0, 507.0, 508.0, 509.0, 510.0, 511.0, 512.0, 513.0, 514.0, 515.0, 516.0, 517.0, 518.0, 519.0, 520.0, 521.0, 522.0, 523.0, 524.0, 525.0, 526.0, 527.0, 528.0, 529.0, 530.0, 531.0, 532.0, 533.0, 534.0, 535.0, 536.0, 537.0, 538.0, 539.0, 540.0, 541.0, 542.0, 543.0, 544.0, 545.0, 546.0, 547.0, 548.0, 549.0, 550.0, 551.0, 552.0, 553.0, 554.0, 555.0, 556.0, 557.0, 558.0, 559.0, 560.0, 561.0, 562.0, 563.0, 564.0, 565.0, 566.0, 567.0, 568.0, 569.0, 570.0, 571.0, 572.0, 573.0, 574.0, 575.0, 576.0, 577.0, 578.0, 579.0, 580.0, 581.0, 582.0, 583.0, 584.0, 585.0, 586.0, 587.0, 588.0, 589.0, 590.0, 591.0, 592.0, 593.0, 594.0, 595.0, 596.0, 597.0, 598.0, 599.0, 600.0, 601.0, 602.0, 603.0, 604.0, 605.0, 606.0, 607.0, 608.0, 609.0, 610.0, 611.0, 612.0, 613.0, 614.0, 615.0, 616.0, 617.0, 618.0, 619.0, 620.0, 621.0, 622.0, 623.0, 624.0, 625.0, 626.0, 627.0, 628.0, 629.0, 630.0, 631.0, 632.0, 633.0, 634.0, 635.0, 636.0, 637.0, 638.0, 639.0, 640.0, 641.0, 642.0, 643.0, 644.0, 645.0, 646.0, 647.0, 648.0, 649.0, 650.0, 651.0, 652.0, 653.0, 654.0, 655.0, 656.0, 657.0, 658.0, 659.0, 660.0, 661.0, 662.0, 663.0, 664.0, 665.0, 666.0, 667.0, 668.0, 669.0, 670.0, 671.0, 672.0, 673.0, 674.0, 675.0, 676.0, 677.0, 678.0, 679.0, 680.0, 681.0, 682.0, 683.0, 684.0, 685.0, 686.0, 687.0, 688.0, 689.0, 690.0, 691.0, 692.0, 693.0, 694.0, 695.0, 696.0, 697.0, 698.0, 699.0, 700.0, 701.0, 702.0, 703.0, 704.0, 705.0, 706.0, 707.0, 708.0, 709.0, 710.0, 711.0, 712.0, 713.0, 714.0, 715.0, 716.0, 717.0, 718.0, 719.0, 720.0, 721.0, 722.0, 723.0, 724.0, 725.0, 726.0, 727.0, 728.0, 729.0, 730.0, 731.0, 732.0, 733.0, 734.0, 735.0, 736.0, 737.0, 738.0, 739.0, 740.0, 741.0, 742.0, 743.0, 744.0, 745.0, 746.0, 747.0, 748.0, 749.0, 750.0, 751.0, 752.0, 753.0, 754.0, 755.0, 756.0, 757.0, 758.0, 759.0, 760.0, 761.0, 762.0, 763.0, 764.0, 765.0, 766.0, 767.0, 768.0, 769.0, 770.0, 771.0, 772.0, 773.0, 774.0, 775.0, 776.0, 777.0, 778.0, 779.0, 780.0, 781.0, 782.0, 783.0, 784.0, 785.0, 786.0, 787.0, 788.0, 789.0, 790.0, 791.0, 792.0, 793.0, 794.0, 795.0, 796.0, 797.0, 798.0, 799.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            DataPHA)
+
+######### Load Background Data Sets
+
+load_bkg("x", "@@/MNLup_2138_0670580101_EMOS1_S001_specbg.fits", bkg_id="foo")
+
+######### Background Spectral Responses
+
+load_arf("x", "@@/MNLup_2138_0670580101_EMOS1_S001_spec.arf", resp_id=1, bkg_id="foo")
+load_rmf("x", "@@/MNLup_2138_0670580101_EMOS1_S001_spec.rmf", resp_id=1, bkg_id="foo")
+
+######### Set Energy or Wave Units
+
+set_analysis("x", quantity="channel", type="rate", factor=0)
+
+
+######### Set Statistic
+
+set_stat("chi2gehrels")
+
+
+######### Set Fitting Method
+
+set_method("gridsearch")
+
+set_method_opt("ftol", 1.1920928955078125e-07)  # doctest: +FLOAT_CMP
+set_method_opt("maxfev", None)
+set_method_opt("method", None)
+set_method_opt("num", 16)
+set_method_opt("numcores", 1)
+set_method_opt("sequence", None)
+set_method_opt("verbose", 0)
+
 """
 
 _canonical_pha_no_response = """import numpy
@@ -2767,8 +2810,8 @@ def test_restore_pha_grouped(make_data_path):
 
     g = ui.get_grouping('grp')
     q = ui.get_quality('grp')
-    assert g.dtype == numpy.int16
-    assert q.dtype == numpy.int16
+    assert g.dtype == np.int16
+    assert q.dtype == np.int16
 
     assert_array_equal(grp, g, err_msg='grouping column')
     assert_array_equal(qual, q, err_msg='grouping column')
@@ -2819,18 +2862,18 @@ def test_restore_pha_back(make_data_path):
     # g = ui.get_grouping('bgrp')
     # q = ui.get_quality('bgrp')
     # The data types are '>i2' / int16
-    # assert g.dtype == numpy.int16
-    # assert q.dtype == numpy.int16
+    # assert g.dtype == np.int16
+    # assert q.dtype == np.int16
 
     # TODO set up correct grouping bins...
     # nchan = ui.get_data('bgrp').channel.size
-    # assert_array_equal(g, numpy.ones(nchan), err_msg='src grouping')
-    # assert_array_equal(q, numpy.zeros(nchan), err_msg='src quality')
+    # assert_array_equal(g, np.ones(nchan), err_msg='src grouping')
+    # assert_array_equal(q, np.zeros(nchan), err_msg='src quality')
 
     bg = ui.get_grouping('bgrp', bkg_id=1)
     bq = ui.get_quality('bgrp', bkg_id=1)
-    assert bg.dtype == numpy.int16
-    assert bq.dtype == numpy.int16
+    assert bg.dtype == np.int16
+    assert bq.dtype == np.int16
 
     assert_array_equal(bg, bgrp, err_msg='bgnd grouping')
     assert_array_equal(bq, bqual, err_msg='bgnd quality')
@@ -2857,6 +2900,81 @@ def test_restore_pha_back(make_data_path):
     assert cosmo[2] == pytest.approx(0.71)
 
     assert ui.calc_stat('bgrp') == pytest.approx(statval)
+
+
+@requires_data
+@requires_fits
+def test_canonical_pha_load_bkg(make_data_path, check_str):
+    """Check an explicit load_bkg call.
+
+    This is not a realistic situation, but does test the
+    load_bkg call.
+
+    """
+
+    ui.set_method("gridsearch")
+
+    ui.dataspace1d(0, 799, id="x", dstype=ui.DataPHA)
+
+    BASENAME = "MNLup_2138_0670580101_EMOS1_S001_specbg.fits"
+    bgfile = make_data_path(BASENAME)
+    ui.load_bkg("x", bgfile, bkg_id="foo")
+
+    # Load a response, but for the background only. These responses
+    # cause warning messages to get displayed, so hide them.
+    #
+    RMFNAME = "MNLup_2138_0670580101_EMOS1_S001_spec.rmf"
+    ARFNAME = "MNLup_2138_0670580101_EMOS1_S001_spec.arf"
+    rmffile = make_data_path(RMFNAME)
+    arffile = make_data_path(ARFNAME)
+    with warnings.catch_warnings(record=True):
+        ui.load_rmf("x", rmffile, bkg_id="foo")
+        ui.load_arf("x", arffile, bkg_id="foo")
+
+    # The name of the dataspace1d call is not saved, hence the
+    # version-specific check.
+    #
+    def check_data(name: str) -> None:
+        assert ui.list_data_ids() == ["x"]
+        data = ui.get_data("x")
+        assert data.name == name
+        assert data.channel == pytest.approx(np.arange(0, 800))
+        assert data.counts == pytest.approx([0] * 800)
+
+        assert ui.list_bkg_ids("x") == ["foo"]
+        bkg = ui.get_bkg("x", bkg_id="foo")
+        assert bkg.name.endswith(f"/{BASENAME}")
+        assert bkg.channel == pytest.approx(np.arange(0, 800))
+        # compare to the sum of the counds calculated with dmstat
+        # on the background file
+        assert bkg.counts.sum() == pytest.approx(2880)
+        assert bkg.counts.max() == pytest.approx(42)
+
+        rmf = ui.get_rmf("x", bkg_id="foo")
+        assert rmf.name.endswith(f"/{RMFNAME}")
+
+        arf = ui.get_arf("x", bkg_id="foo")
+        assert arf.name.endswith(f"/{ARFNAME}")
+
+        # The source has no response
+        #
+        with pytest.raises(IdentifierErr):
+            ui.get_rmf("x")
+
+        with pytest.raises(IdentifierErr):
+            ui.get_arf("x")
+
+    check_data(name="dataspace1d")
+
+    expected_output = add_datadir_path(_canonical_pha_load_bkg)
+    compare(check_str, expected_output)
+
+    # Need to avoid the warning messages from the ARF/RMF here too.
+    #
+    with warnings.catch_warnings(record=True):
+        restore()
+
+    check_data(name="")
 
 
 @requires_data
@@ -3197,7 +3315,7 @@ def test_restore_load_arrays_pha(check_str):
     dset.areascal = 0.001
 
     ui.set_data(dset)
-    ui.group_counts(3, tabStops=numpy.asarray([0, 0, 0, 1, 0]))
+    ui.group_counts(3, tabStops=np.asarray([0, 0, 0, 1, 0]))
 
     compare(check_str, _canonical_load_arrays_pha)
 
@@ -3329,12 +3447,12 @@ def test_restore_linker_parameter_with_function(clean_astro_ui):
     m1 = ui.create_model_component("gauss1d", "m1")
     m2 = ui.create_model_component("scale1d", "m2")
 
-    delta = numpy.sqrt((m2.c0 - 23)**2)
-    m1.fwhm = 2 * numpy.exp(delta / 14)
+    delta = np.sqrt((m2.c0 - 23)**2)
+    m1.fwhm = 2 * np.exp(delta / 14)
 
     m2.c0 = 30
 
-    expected = 2 * numpy.exp(0.5)
+    expected = 2 * np.exp(0.5)
 
     # safety check
     assert m1.fwhm.link is not None
@@ -3454,7 +3572,7 @@ def test_load_data(make_data_path, check_str):
     infile = make_data_path("data1.dat")
     ui.load_data(infile, ncols=3)
 
-    expected_x = numpy.arange(0.5, 11)
+    expected_x = np.arange(0.5, 11)
     expected_y = [1.6454, 1.7236, 1.9472, 2.2348, 2.6187, 2.8642,
                   3.1263, 3.2073, 3.2852, 3.3092, 3.4496]
     expected_dy = [0.04114] * 11
@@ -3520,7 +3638,7 @@ def test_load_data_basic(make_data_path, check_str):
     assert len(x[0]) == 1000
     assert x[0][0] == pytest.approx(0)
     assert x[0][-1] == pytest.approx(99.9)
-    assert numpy.ptp(ui.get_dep()) == pytest.approx(ptp)
+    assert np.ptp(ui.get_dep()) == pytest.approx(ptp)
 
     with pytest.raises(StatErr,
                        match="^If you select chi2 as the statistic, all datasets must provide a staterror column$"):
@@ -3543,7 +3661,7 @@ def test_load_data_basic(make_data_path, check_str):
     assert len(x[0]) == 1000
     assert x[0][0] == pytest.approx(0)
     assert x[0][-1] == pytest.approx(99.9)
-    assert numpy.ptp(ui.get_dep()) == pytest.approx(ptp)
+    assert np.ptp(ui.get_dep()) == pytest.approx(ptp)
 
     with pytest.raises(StatErr,
                        match="^If you select chi2 as the statistic, all datasets must provide a staterror column$"):
@@ -3914,10 +4032,10 @@ def test_fake_image_wcs():
 
     # nx=2, ny=3
     #
-    x1, x0 = numpy.mgrid[1:4, 1:3]
+    x1, x0 = np.mgrid[1:4, 1:3]
     x0 = x0.flatten()
     x1 = x1.flatten()
-    y = numpy.arange(6) * 10 + 10
+    y = np.arange(6) * 10 + 10
 
     sky = WCS("physical", "LINEAR", [100, 200], [1, 1], [10, 10])
     eqpos = WCS("world", "WCS", [30, 50], [100, 200], [-0.01, 0.01])
@@ -3959,10 +4077,10 @@ def test_fake_image_wcs_coord():
 
     # nx=3, ny=2
     #
-    x1, x0 = numpy.mgrid[1:3, 1:4]
+    x1, x0 = np.mgrid[1:3, 1:4]
     x0 = x0.flatten()
     x1 = x1.flatten()
-    y = numpy.arange(6) * 10 + 10
+    y = np.arange(6) * 10 + 10
 
     sky = WCS("physical", "LINEAR", [100, 200], [1, 1], [10, 10])
     eqpos = WCS("world", "WCS", [30, 50], [100, 200], [-0.1, 0.1])

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -2144,6 +2144,61 @@ set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
+_canonical_pha2_delete = """import numpy
+from sherpa.astro.ui import *
+
+######### Load Data Sets
+
+
+######### Load Background Data Sets
+
+
+######### Set Energy or Wave Units
+
+set_analysis(10, quantity="channel", type="rate", factor=0)
+
+######### Load Background Data Sets
+
+
+######### Set Energy or Wave Units
+
+set_analysis(3, quantity="channel", type="rate", factor=0)
+
+######### Load Background Data Sets
+
+
+######### Set Energy or Wave Units
+
+set_analysis(4, quantity="channel", type="rate", factor=0)
+
+######### Load Background Data Sets
+
+
+######### Set Energy or Wave Units
+
+set_analysis(9, quantity="channel", type="rate", factor=0)
+
+
+######### Set Statistic
+
+set_stat("chi2gehrels")
+
+
+######### Set Fitting Method
+
+set_method("levmar")
+
+set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
+set_method_opt("factor", 100.0)
+set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
+set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
+set_method_opt("maxfev", None)
+set_method_opt("numcores", 1)
+set_method_opt("verbose", 0)
+set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
+
+"""
+
 _canonical_pha_hetg = """import numpy
 from sherpa.astro.ui import *
 
@@ -3604,6 +3659,43 @@ def test_restore_pha2(make_data_path, check_str):
     restore()
 
     check_data()
+
+
+@requires_data
+@requires_fits
+def test_restore_pha2_delete(make_data_path, check_str):
+    """Can we restore a pha2 file after deleting files?
+
+    This is a regression test so we can see as soon as things have
+    changed, rather than marking it as xfail.
+
+    """
+
+    # Note: not including .gz for the file name
+    ui.load_pha(make_data_path("3c120_pha2"))
+
+    # Select just the first order (|TG_M| = 1) datasets.
+    #
+    for idval in [1, 2, 5, 6, 7, 8, 11, 12]:
+        ui.delete_data(idval)
+
+    def check_data():
+        assert ui.list_data_ids() == pytest.approx([10, 3, 4, 9])
+
+    check_data()
+
+    expected_output = add_datadir_path(_canonical_pha2_delete)
+    compare(check_str, expected_output)
+
+    # The current save_all output will fail when restored, so catch
+    # the expected error.
+    #
+    with pytest.raises(IdentifierErr,
+                       match="^data set 10 has not been set$"):
+        restore()
+
+    # check_data()
+    assert ui.list_data_ids() == []
 
 
 @requires_data

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -655,7 +655,7 @@ load_arrays("x",
 
 ######### Load Background Data Sets
 
-load_bkg("x", "@@/MNLup_2138_0670580101_EMOS1_S001_specbg.fits", bkg_id="foo")
+load_bkg("x", "@@/MNLup_2138_0670580101_EMOS1_S001_specbg.fits", bkg_id="foo", use_errors=True)
 
 ######### Background Spectral Responses
 

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -2168,6 +2168,16 @@ from sherpa.astro.ui import *
 
 ######### Load Data Sets
 
+# Load PHA2 into: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+load_pha(1, "@@/3c120_pha2")
+delete_data(1)
+delete_data(2)
+delete_data(5)
+delete_data(6)
+delete_data(7)
+delete_data(8)
+delete_data(11)
+delete_data(12)
 
 ######### Load Background Data Sets
 
@@ -3794,15 +3804,9 @@ def test_restore_pha2_delete(make_data_path, check_str):
     expected_output = add_datadir_path(_canonical_pha2_delete)
     compare(check_str, expected_output)
 
-    # The current save_all output will fail when restored, so catch
-    # the expected error.
-    #
-    with pytest.raises(IdentifierErr,
-                       match="^data set 10 has not been set$"):
-        restore()
+    restore()
 
-    # check_data()
-    assert ui.list_data_ids() == []
+    check_data()
 
 
 @requires_data

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -166,18 +166,13 @@ group(1)
 
 ######### Data Spectral Responses
 
-load_arf(1, "@@/3c273.arf", resp_id=1)
-load_rmf(1, "@@/3c273.rmf", resp_id=1)
 
 ######### Load Background Data Sets
 
-load_bkg(1, "@@/3c273_bg.pi", bkg_id=1)
 group(1, bkg_id=1)
 
 ######### Background Spectral Responses
 
-load_arf(1, "@@/3c273.arf", resp_id=1, bkg_id=1)
-load_rmf(1, "@@/3c273.rmf", resp_id=1, bkg_id=1)
 
 ######### Set Energy or Wave Units
 
@@ -317,12 +312,9 @@ group("grp")
 
 ######### Data Spectral Responses
 
-load_arf("grp", "@@/3c273.arf", resp_id=1)
-load_rmf("grp", "@@/3c273.rmf", resp_id=1)
 
 ######### Load Background Data Sets
 
-load_bkg("grp", "@@/3c273_bg.pi", bkg_id=1)
 
 ######### Background grouping flags
 
@@ -335,8 +327,6 @@ group("grp", bkg_id=1)
 
 ######### Background Spectral Responses
 
-load_arf("grp", "@@/3c273.arf", resp_id=1, bkg_id=1)
-load_rmf("grp", "@@/3c273.rmf", resp_id=1, bkg_id=1)
 
 ######### Set Energy or Wave Units
 
@@ -429,12 +419,9 @@ group("bgrp")
 
 ######### Data Spectral Responses
 
-load_arf("bgrp", "@@/3c273.arf", resp_id=1)
-load_rmf("bgrp", "@@/3c273.rmf", resp_id=1)
 
 ######### Load Background Data Sets
 
-load_bkg("bgrp", "@@/3c273_bg.pi", bkg_id=1)
 
 ######### Background grouping flags
 
@@ -447,8 +434,6 @@ group("bgrp", bkg_id=1)
 
 ######### Background Spectral Responses
 
-load_arf("bgrp", "@@/3c273.arf", resp_id=1, bkg_id=1)
-load_rmf("bgrp", "@@/3c273.rmf", resp_id=1, bkg_id=1)
 
 ######### Set Energy or Wave Units
 
@@ -752,7 +737,6 @@ load_rmf(1, "@@/3c273.rmf", resp_id=1)
 
 ######### Load Background Data Sets
 
-load_bkg(1, "@@/3c273_bg.pi", bkg_id=1)
 group(1, bkg_id=1)
 
 ######### Background Spectral Responses
@@ -1927,23 +1911,15 @@ load_pha(1, "@@/3c120_meg_1.pha")
 
 ######### Data Spectral Responses
 
-load_arf(1, "@@/3c120_meg_1.arf", resp_id=1)
-load_rmf(1, "@@/3c120_meg_1.rmf", resp_id=1)
 
 ######### Load Background Data Sets
 
-load_bkg(1, "@@/3c120_meg_1.pha", bkg_id=1)
 
 ######### Background Spectral Responses
 
-load_arf(1, "@@/3c120_meg_1.arf", resp_id=1, bkg_id=1)
-load_rmf(1, "@@/3c120_meg_1.rmf", resp_id=1, bkg_id=1)
-load_bkg(1, "@@/3c120_meg_1.pha", bkg_id=2)
 
 ######### Background Spectral Responses
 
-load_arf(1, "@@/3c120_meg_1.arf", resp_id=1, bkg_id=2)
-load_rmf(1, "@@/3c120_meg_1.rmf", resp_id=1, bkg_id=2)
 
 ######### Set Energy or Wave Units
 
@@ -2251,23 +2227,15 @@ load_pha(1, "@@/3c120_heg_-1.pha")
 
 ######### Data Spectral Responses
 
-load_arf(1, "@@/3c120_heg_-1.arf", resp_id=1)
-load_rmf(1, "@@/3c120_heg_-1.rmf", resp_id=1)
 
 ######### Load Background Data Sets
 
-load_bkg(1, "@@/3c120_heg_-1.pha", bkg_id=1)
 
 ######### Background Spectral Responses
 
-load_arf(1, "@@/3c120_heg_-1.arf", resp_id=1, bkg_id=1)
-load_rmf(1, "@@/3c120_heg_-1.rmf", resp_id=1, bkg_id=1)
-load_bkg(1, "@@/3c120_heg_-1.pha", bkg_id=2)
 
 ######### Background Spectral Responses
 
-load_arf(1, "@@/3c120_heg_-1.arf", resp_id=1, bkg_id=2)
-load_rmf(1, "@@/3c120_heg_-1.rmf", resp_id=1, bkg_id=2)
 
 ######### Set Energy or Wave Units
 
@@ -2320,12 +2288,9 @@ group("csc")
 
 ######### Data Spectral Responses
 
-load_arf("csc", "@@/acisf01575_001N001_r0085_arf3.fits", resp_id=1)
-load_rmf("csc", "@@/acisf01575_001N001_r0085_rmf3.fits", resp_id=1)
 
 ######### Load Background Data Sets
 
-load_bkg("csc", "@@/acisf01575_001N001_r0085_pha3.fits", bkg_id=1)
 
 ######### Background grouping flags
 
@@ -2338,8 +2303,6 @@ group("csc", bkg_id=1)
 
 ######### Background Spectral Responses
 
-load_arf("csc", "@@/acisf01575_001N001_r0085_arf3.fits", resp_id=1, bkg_id=1)
-load_rmf("csc", "@@/acisf01575_001N001_r0085_rmf3.fits", resp_id=1, bkg_id=1)
 
 ######### Set Energy or Wave Units
 
@@ -3675,14 +3638,7 @@ def test_load_data_basic(make_data_path, check_str):
 @requires_data
 @requires_fits
 def test_restore_pha_multiple_backgrounds(make_data_path, check_str):
-    """Can we restore a grating dataset with multiple backgrounds?
-
-    See issue #320
-
-    This is a regression test so we can see as soon as things have
-    changed, rather than marking it as xfail.
-
-    """
+    """Can we restore a grating dataset with multiple backgrounds?"""
 
     # Note: not including .gz for the file name
     ui.load_pha(make_data_path("3c120_meg_1.pha"))
@@ -3709,21 +3665,13 @@ def test_restore_pha_multiple_backgrounds(make_data_path, check_str):
 
     restore()
 
-    assert ui.get_dep(filter=True, bkg_id=1).sum() == 31911  # TODO fix this
-    # check_data()
+    check_data()
 
 
 @requires_data
 @requires_fits
 def test_restore_pha2(make_data_path, check_str):
-    """Can we restore a pha2 file?
-
-    See issue #1882.
-
-    This is a regression test so we can see as soon as things have
-    changed, rather than marking it as xfail.
-
-    """
+    """Can we restore a pha2 file?"""
 
     # Note: not including .gz for the file name
     ui.load_pha(make_data_path("3c120_pha2"))
@@ -3863,6 +3811,10 @@ def test_restore_pha_hetg(make_data_path, check_str):
             assert ui.get_arf(bkg_id=bkg_id).name.endswith("/3c120_heg_-1.arf")
             assert ui.get_rmf(bkg_id=bkg_id).name.endswith("/3c120_heg_-1.rmf")
 
+        assert ui.get_data().counts == pytest.approx(c)
+        assert ui.get_bkg(bkg_id=1).counts == pytest.approx(b1)
+        assert ui.get_bkg(bkg_id=2).counts == pytest.approx(b2)
+
     check_data()
 
     expected_output = add_datadir_path(_canonical_pha_hetg)
@@ -3871,14 +3823,6 @@ def test_restore_pha_hetg(make_data_path, check_str):
     restore()
 
     check_data()
-
-    # This should be in check_data but not until #320 is fixed.
-    #
-    assert ui.get_data().counts == pytest.approx(c)
-    assert ui.get_bkg(bkg_id=1).counts == pytest.approx(c)
-    assert ui.get_bkg(bkg_id=2).counts == pytest.approx(c)
-    # assert ui.get_bkg(bkg_id=1).counts == pytest.approx(b1)
-    # assert ui.get_bkg(bkg_id=2).counts == pytest.approx(b2)
 
 
 @requires_data

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -361,14 +361,23 @@ class Session(sherpa.ui.utils.Session):
         self._energyfluxplot = sherpa.astro.plot.EnergyFluxHistogram()
         self._photonfluxplot = sherpa.astro.plot.PhotonFluxHistogram()
 
-        # Used to identify PHA2 datasets.
+        # Used to identify PHA datasets.
         #
-        # The value field could be more-precisely typed, but leave as
-        # generic for the moment. It is also likely that this approach
-        # (of storing the actual file name and arguments) can be
-        # extended to all the load_xxx calls, so that
-        # .serialize.save_all can use it rather than the current
-        # approach.
+        # These dictionaries are always cleared by set_data/bkg for
+        # the IdType value, and a few other commands
+        # (e.g. delete_data, delete_bkg, copy_data). Data is stored by
+        # the relevant load_pha/data/bkg commands after they call
+        # set_data/bkg.  This information is used by
+        # .serialize.save_all to re-create the relevant load_xxx
+        # command. At present this is restricted to PHA data but could
+        # be extended for the other types (e.g. tables, images).  The
+        # value type of "dict[str, Any]" could have better typing, but
+        # leave as this generic form for now.
+        #
+        # Note that the automatically-loaded ancillary data for PHA
+        # files (background, ARF, RMF) are included in this store so
+        # that save_all knows that these files do not need to be
+        # explicitly loaded.
         #
         self._load_data_store: dict[IdType, dict[str, Any]] = {}
         self._load_bkg_store: dict[IdType, dict[IdType, dict[str, Any]]] = {}

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -17228,9 +17228,9 @@ class Session(sherpa.ui.utils.Session):
         -----
 
         This command will create a series of commands that restores
-        the current Sherpa set up. It does not save the set of commands
-        used. Not all Sherpa settings are saved. Items not fully restored
-        include:
+        the current Sherpa set up. It does not save the original set
+        of commands used, and not all Sherpa settings are saved. Items
+        not fully restored include:
 
         - data changed from the version on disk - e.g. by calls to
           `set_counts` - will not be restored correctly,
@@ -17246,6 +17246,19 @@ class Session(sherpa.ui.utils.Session):
         recommended if the session is likely to be restored with newer
         versions of Sherpa. It is suggested that the output of both
         should be checked when the output may be used long term.
+
+        Using the output of `save_all` depends on what interpreter is
+        being used. If it is IPython then the ``%run`` `command
+        <https://ipython.org/ipython-doc/3/interactive/magics.html#magic-run>`_
+        can be used. So, if ``save_all("save.out")`` was used then the
+        output file can be loaded with:
+
+            %run -i save.out
+
+        When using the Python interactive environment the following
+        can be used:
+
+            exec(open("save.out").read())
 
         Examples
         --------

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -332,9 +332,9 @@ class Session(sherpa.ui.utils.Session):
             data = self._get_pha_data(id)
             return data.default_background_id
 
-            # return self._default_id
-
-        # We rely on the validation made by _fix_id
+        # We rely on the validation made by _fix_id. This is not
+        # expected to change the value (as bkg_id is not None).
+        #
         return self._fix_id(bkg_id)
 
     def __setstate__(self, state):
@@ -1026,7 +1026,6 @@ class Session(sherpa.ui.utils.Session):
 
         output.append(statinfo)
         return output
-
 
     ###########################################################################
     # Data
@@ -2104,14 +2103,10 @@ class Session(sherpa.ui.utils.Session):
             return store
 
         if not np.iterable(datasets):
+            # set_data clears _load_data_store
             self.set_data(idval, datasets)
-
             if isinstance(datasets, DataPHA):
                 self._load_data_store[idval] = mk_pha_store(datasets)
-
-            else:
-                with suppress(KeyError):
-                    del self._load_data_store[idval]
 
             return
 
@@ -2401,10 +2396,10 @@ class Session(sherpa.ui.utils.Session):
 
         """
         use_errors = bool_cast(use_errors)
-        return sherpa.astro.io.read_pha(arg, use_errors)
+        return sherpa.astro.io.read_pha(arg, use_errors=use_errors)
 
     # DOC-TODO: what does this return when given a PHA2 file?
-    def unpack_bkg(self, arg, use_errors=False):
+    def unpack_bkg(self, arg, use_errors: bool = False):
         """Create a PHA data structure for a background data set.
 
         Any instrument information referenced in the header of the PHA
@@ -2453,7 +2448,8 @@ class Session(sherpa.ui.utils.Session):
 
         """
         use_errors = bool_cast(use_errors)
-        return sherpa.astro.io.read_pha(arg, use_errors, True)
+        return sherpa.astro.io.read_pha(arg, use_errors=use_errors,
+                                        use_background=True)
 
     # DOC-TODO: how best to include datastack support?
     def load_pha(self, id, arg=None,

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -17161,7 +17161,7 @@ class Session(sherpa.ui.utils.Session):
     def save_all(self,
                  outfile=None,
                  clobber: bool = False,
-                 always_load: bool = False
+                 auto_load: bool = True
                  ) -> None:
         """Save the information about the current session to a text file.
 
@@ -17179,7 +17179,7 @@ class Session(sherpa.ui.utils.Session):
            Handling of PHA data has been improved, and the output now
            defaults to not including automatically-loaded ancillary
            files (such as background and responses). Set the
-           ``always_load`` flag to True to add these commands back to
+           ``auto_load`` flag to False to add these commands back to
            the save file (and match previous versions).
 
         .. versionchanged:: 4.17.0
@@ -17208,9 +17208,11 @@ class Session(sherpa.ui.utils.Session):
            whether an existing file can be overwritten (``True``)
            orysif it raises an exception (``False``, the default
            setting).
-        always_load : bool, optional
-           Should automatically-loaded PHA files, such as backgrounds,
-           ARFS, and RMFs, be explicitly included in the file?
+        auto_load : bool, optional
+           If set to ``False`` then automatically-loaded PHA files,
+           such as backgrounds, ARFS, and RMFs, will be included in
+           the output with `load_arf`, `load_rmf`, and `load_bkg`
+           calls.
 
         Raises
         ------
@@ -17273,7 +17275,7 @@ class Session(sherpa.ui.utils.Session):
         ANCRFILE, BACKFILE, and RESPFILE keywords in the PHA file(s).
 
         >>> save_all("restore1.py")
-        >>> save_all("restore2.py", always_load=True)
+        >>> save_all("restore2.py", auto_load=False)
 
         """
 
@@ -17285,7 +17287,7 @@ class Session(sherpa.ui.utils.Session):
                     raise IOErr('filefound', outfile)
 
             with open(outfile, 'w', encoding="UTF-8") as fh:
-                serialize.save_all(self, fh, always_load=always_load)
+                serialize.save_all(self, fh, auto_load=auto_load)
 
         else:
             if outfile is not None:
@@ -17293,4 +17295,4 @@ class Session(sherpa.ui.utils.Session):
             else:
                 fh = sys.stdout
 
-            serialize.save_all(self, fh, always_load=always_load)
+            serialize.save_all(self, fh, auto_load=auto_load)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -2611,7 +2611,10 @@ class Session(sherpa.ui.utils.Session):
 
         """
         if arg is None:
-            id, arg = arg, id
+            idval = self.get_default_id()
+            arg = id
+        else:
+            idval = self._fix_id(id)
 
         phasets = self.unpack_pha(arg, use_errors)
 
@@ -2621,7 +2624,7 @@ class Session(sherpa.ui.utils.Session):
         if use_errors:
             kwargs["use_errors"] = True
 
-        self._load_data(id, phasets, filename=arg, kwargs=kwargs)
+        self._load_data(idval, phasets, filename=arg, kwargs=kwargs)
 
     def _get_pha_data(self,
                       id: IdType | None,

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -17158,7 +17158,11 @@ class Session(sherpa.ui.utils.Session):
     # Session Text Save Function
     ###########################################################################
 
-    def save_all(self, outfile=None, clobber=False) -> None:
+    def save_all(self,
+                 outfile=None,
+                 clobber: bool = False,
+                 always_load: bool = False
+                 ) -> None:
         """Save the information about the current session to a text file.
 
         This differs to the `save` command in that the output is human
@@ -17172,7 +17176,11 @@ class Session(sherpa.ui.utils.Session):
             header information).
 
         .. versionchanged:: 4.18.0
-           Handling of PHA2 data sets has been improved.
+           Handling of PHA data has been improved, and the output now
+           defaults to not including automatically-loaded ancillary
+           files (such as background and responses). Set the
+           ``always_load`` flag to True to add these commands back to
+           the save file (and match previous versions).
 
         .. versionchanged:: 4.17.0
            The file will now contain a `set_default_id` call if the
@@ -17198,8 +17206,11 @@ class Session(sherpa.ui.utils.Session):
         clobber : bool, optional
            If `outfile` is a filename, then this flag controls
            whether an existing file can be overwritten (``True``)
-           or if it raises an exception (``False``, the default
+           orysif it raises an exception (``False``, the default
            setting).
+        always_load : bool, optional
+           Should automatically-loaded PHA files, such as backgrounds,
+           ARFS, and RMFs, be explicitly included in the file?
 
         Raises
         ------
@@ -17222,8 +17233,7 @@ class Session(sherpa.ui.utils.Session):
         - data changed from the version on disk - e.g. by calls to
           `set_counts` - will not be restored correctly,
 
-        - any optional keywords to commands such as `load_data`
-          or `load_pha`,
+        - any optional keywords to commands such as `load_data`,
 
         - user models may not be restored correctly,
 
@@ -17257,6 +17267,14 @@ class Session(sherpa.ui.utils.Session):
         from sherpa.astro.ui import *
         ...
 
+        The two files should re-create the same session but
+        restore2.py will include lines such as load_arf and load_bkg
+        that are not necessary, as Sherpa will load them due to the
+        ANCRFILE, BACKFILE, and RESPFILE keywords in the PHA file(s).
+
+        >>> save_all("restore1.py")
+        >>> save_all("restore2.py", always_load=True)
+
         """
 
         if _is_str(outfile):
@@ -17267,7 +17285,7 @@ class Session(sherpa.ui.utils.Session):
                     raise IOErr('filefound', outfile)
 
             with open(outfile, 'w', encoding="UTF-8") as fh:
-                serialize.save_all(self, fh)
+                serialize.save_all(self, fh, always_load=always_load)
 
         else:
             if outfile is not None:
@@ -17275,4 +17293,4 @@ class Session(sherpa.ui.utils.Session):
             else:
                 fh = sys.stdout
 
-            serialize.save_all(self, fh)
+            serialize.save_all(self, fh, always_load=always_load)


### PR DESCRIPTION
# Summary

The save_all output for PHA data now avoids loading in files it does not need to do (e.g. a background file set in the BACKFILE keyword), which fixes handling of grating data with BACKGROUND_UP and BACKGROUND_DOWN columns. The use_errors flag is now correctly recorded for load_pha calls. The auto_load flag has been added to save_all to allow the output to include these files, to match the output from previous versions. Fix #320. Fix #2383.

# Details

Extend the work added in #2377 to fix #320: this is where a PHA file contains multiple backgrounds (e.g. Chandra HETG data with BACKGROUND_UP/DOWN columns). We take advantage of the "data store" added in #2377 and extend it to all PHA files (not just PHA2 files), and use it to determine when we can avoid loading in ancillary data (by tracking what ancillary data is automatically loaded for us). As part of this (tracking load_bkg calls) we can also fix #2383.

There are at least two use cases for the old behaviour - that is, explicitly including load_arf/rmf/bkg calls even when not needed:

1. to more-closely match previous output (e.g. if the save file is passed through some post-processing or you just want to check what has changed)
2. there is a use for being explicit about all the files that are needed to re-create the state

So, the `save_all` command has gained a new optional parameter, `auto_load` which, when set to `False` (it's default is `True`), will include these `load_arf/rmf/bkg` calls in the output that are technically un-needed.

The resulting serialization code is a bit messy, but it is hopefully not too complex, and covered by both existing and new tests. 