### PR TITLE
DOCS: update docstring for list_stats

### DIFF
--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -2951,7 +2951,9 @@ class Session(NoNewAttributesAfterInit):
          'chi2modvar',
          'chi2xspecvar',
          'cstat',
+         'cstatnegativepenalty',
          'leastsq',
+         'userstat',
          'wstat']
 
         """


### PR DESCRIPTION
# Summary

Add both 'cstatnegativepenalty' and 'userstat' to the output of the list_stats() call to match the current behavior.

# Details

This is left over from #2294