### PR TITLE
TESTS: support no region/group/wcs builds - fix #2387

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -82,5 +82,5 @@ doctest_subpackage_requires =
     docs/evaluation/examples.rst = group sherpa.astro.xspec._xspec
     # pycrates OR astropy would do, but the syntax does not allow to specify alternatives, so just pick one
     docs/evaluation/examples.rst = astropy
+    docs/fit/poisson.rst = group
     sherpa/astro/data.py = astropy
-

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -159,6 +159,7 @@ from sherpa.astro.utils import arf_fold, rmf_fold, filter_resp, \
 
 __doctest_requires__ = {
     '.': ['sherpatest'],  # requirements for module-level doctest
+    'DataPHA.group_counts': ['group']
     }
 
 if TYPE_CHECKING:

--- a/sherpa/astro/ui/tests/test_astro_ui_data.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_data.py
@@ -24,9 +24,10 @@ from tempfile import NamedTemporaryFile
 
 from sherpa.astro.io.wcs import WCS
 from sherpa.astro import ui
-from sherpa.utils.testing import requires_fits
+from sherpa.utils.testing import requires_fits, requires_wcs
 
 
+@requires_wcs
 @requires_fits
 def test_DataIMG_filter(caplog, clean_astro_ui):
     """Test filtering of DataIMG

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -4285,6 +4285,7 @@ def test_store_default_id(defid):
 
 @requires_data
 @requires_fits
+@requires_group
 def test_copy_data_pha(make_data_path):
     """Can we copy a PHA dataset and track it?"""
 


### PR DESCRIPTION
# Summary

Update the tests to support builds where support for the region and wcs libraries are disabled. Fix #2387.

# Details

Update the tests and documentation to support builds where the region, group, or WCS features are not built (although it looks like the no-region-library cases is already supported). I think it would be a good idea to change one of our minimal pip builds on CI to turn off all the options to try and catch these issues, but I do not want to do that here as there's a few changes needed for the CI builds to upgrade python and numpy versions.

There is no functional change to Sherpa here.