### PR TITLE
XSPEC: add support for XSPEC 12.15.1

### DIFF
--- a/.github/scripts/setup_xspec.sh
+++ b/.github/scripts/setup_xspec.sh
@@ -33,8 +33,8 @@ echo "* configuring XSPEC"
 
 # Change build configuration
 sed -i.orig "s|#with_xspec=True|with_xspec=True|" setup.cfg
-sed -i.orig "s|#xspec_lib_dirs = None|xspec_lib_dirs=${xspec_library_path}|" setup.cfg
-sed -i.orig "s|#xspec_include_dirs = None|xspec_include_dirs=${xspec_include_path}|" setup.cfg
+sed -i.orig "s|#xspec_lib_dirs = .*|xspec_lib_dirs = ${xspec_library_path}|" setup.cfg
+sed -i.orig "s|#xspec_include_dirs = .*|xspec_include_dirs = ${xspec_include_path}|" setup.cfg
 sed -i.orig "s|#xspec_version = .*|xspec_version = ${xspec_version_string}|" setup.cfg
 
 # Xspec ~12.10.1n now requires fftw. This disables the fftw build from extern

--- a/.github/scripts/setup_xspec.sh
+++ b/.github/scripts/setup_xspec.sh
@@ -13,7 +13,8 @@ then
 fi
 echo "HEADAS=${HEADAS}"
 
-#Set the xspec_root as the top of the Conda environment
+# Set the xspec_root as the top of the Conda environment.
+# These settings are valid for the CXC xspec-modelsonly build.
 xspec_root=${CONDA_PREFIX}
 xspec_library_path=${xspec_root}/lib/
 xspec_include_path=${xspec_root}/include/

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -346,7 +346,7 @@ Update the XSPEC bindings?
 --------------------------
 
 The :py:mod:`sherpa.astro.xspec` module currently supports
-:term:`XSPEC` versions 12.15.0, 12.14.1, 12.14.0, 12.13.1, and 12.13.0.
+:term:`XSPEC` versions 12.15.1, 12.15.0, 12.14.1, 12.14.0, 12.13.1, and 12.13.0.
 It may build against newer versions, but if it does it will not provide
 access to any new models in the release. The following sections of the
 `XSPEC manual

--- a/docs/indices.rst
+++ b/docs/indices.rst
@@ -157,5 +157,5 @@ Glossary
        `models from XSPEC
        <https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixExternal.html>`_.
 
-       Sherpa can be built to use XSPEC versions 12.15.0, 12.14.1,
-       12.14.0, 12.13.1, and 12.13.0.
+       Sherpa can be built to use XSPEC versions 12.15.1, 12.15.0,
+       12.14.1, 12.14.0, 12.13.1, and 12.13.0.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -248,7 +248,33 @@ by the actual path to the HEADAS installation, and the versions of
 the libraries - such as ``CCfits_2.7`` - may need to be changed to
 match the contents of the XSPEC installation.
 
-1. If the full XSPEC 12.15.0 system has been built then use::
+.. note::
+
+   If XSPEC has been installed via conda - such as with the
+   `HEASARC <https://heasarc.gsfc.nasa.gov/docs/software/conda.html>`_
+   or
+   `CIAO <https://cxc.cfa.harvard.edu/ciao/download/conda.html>`_
+   channels - then the only settings which are needed are::
+
+     with_xspec
+     xspec_version
+     xspec_lib_dirs
+     xspec_include_dirs
+
+* If the full XSPEC 12.15.1 system has been built then use::
+
+       with_xspec = True
+       xspec_version = 12.15.1
+       xspec_lib_dirs = $HEADAS/lib
+       xspec_include_dirs = $HEADAS/include
+       xspec_libraries = XSFunctions XSUtil XS hdsp_6.36
+       ccfits_libraries = CCfits_2.7
+       wcslib_libraries = wcs-8.3
+
+  where the version numbers were taken from version 6.36 of HEASOFT and
+  may need updating with a newer release.
+
+* If the full XSPEC 12.15.0 system has been built then use::
 
        with_xspec = True
        xspec_version = 12.15.0
@@ -258,10 +284,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.7
        wcslib_libraries = wcs-8.3
 
-   where the version numbers were taken from version 6.35 of HEASOFT and
-   may need updating with a newer release.
-
-2. If the full XSPEC 12.14.1 system has been built then use::
+* If the full XSPEC 12.14.1 system has been built then use::
 
        with_xspec = True
        xspec_version = 12.14.1
@@ -271,10 +294,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.6
        wcslib_libraries = wcs-8.3
 
-   where the version numbers were taken from version 6.34 of HEASOFT and
-   may need updating with a newer release.
-
-3. If the full XSPEC 12.14.0 system has been built then use::
+* If the full XSPEC 12.14.0 system has been built then use::
 
        with_xspec = True
        xspec_version = 12.14.0
@@ -284,10 +304,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.6
        wcslib_libraries = wcs-8.2.1
 
-   where the version numbers were taken from version 6.33.1 of HEASOFT and
-   may need updating with a newer release.
-
-4. If the full XSPEC 12.13.1 system has been built then use::
+* If the full XSPEC 12.13.1 system has been built then use::
 
        with_xspec = True
        xspec_version = 12.13.1
@@ -297,10 +314,7 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.6
        wcslib_libraries = wcs-7.7
 
-   where the version numbers were taken from version 6.32 of HEASOFT and
-   may need updating with a newer release.
-
-5. If the full XSPEC 12.13.0 system has been built then use::
+* If the full XSPEC 12.13.0 system has been built then use::
 
        with_xspec = True
        xspec_version = 12.13.0
@@ -310,11 +324,11 @@ match the contents of the XSPEC installation.
        ccfits_libraries = CCfits_2.6
        wcslib_libraries = wcs-7.7
 
-6. If the model-only build of XSPEC - created with the
-   ``--enable-xs-models-only`` flag when building HEASOFT - has been
-   installed, then the configuration is similar, but the library names
-   may not need version numbers and locations, depending on how the
-   ``cfitsio``, ``CCfits``, and ``wcs`` libraries were installed.
+* If the model-only build of XSPEC - created with the
+  ``--enable-xs-models-only`` flag when building HEASOFT - has been
+  installed, then the configuration is similar, but the library names
+  may not need version numbers and locations, depending on how the
+  ``cfitsio``, ``CCfits``, and ``wcs`` libraries were installed.
 
 A common problem is to set one or both of the ``xspec_lib_dirs``
 and ``xspec_lib_include`` options to the value of ``$HEADAS`` instead of

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -219,22 +219,7 @@ XSPEC
 
 Sherpa can be built to use the Astronomy models provided by
 :term:`XSPEC`. To enable XSPEC support, several changes must be
-made to the ``xspec_config`` section of the ``setup.cfg`` file. The
-available options (with default values) are::
-
-    with_xspec = False
-    xspec_version = 12.14.1
-    xspec_lib_dirs = None
-    xspec_include_dirs = None
-    xspec_libraries = XSFunctions XSUtil XS
-    cfitsio_lib_dirs = None
-    cfitsio_libraries =
-    ccfits_lib_dirs = None
-    ccfits_libraries =
-    wcslib_lib_dirs = None
-    wcslib_libraries =
-    gfortran_lib_dirs = None
-    gfortran_libraries =
+made to the ``xspec_config`` section of the ``setup.cfg`` file.
 
 To build the :py:mod:`sherpa.astro.xspec` module, the
 ``with_xspec`` option must be set to ``True`` **and** the

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -218,112 +218,64 @@ XSPEC
 ^^^^^
 
 Sherpa can be built to use the Astronomy models provided by
-:term:`XSPEC`. To enable XSPEC support, several changes must be
-made to the ``xspec_config`` section of the ``setup.cfg`` file.
-
-To build the :py:mod:`sherpa.astro.xspec` module, the
-``with_xspec`` option must be set to ``True`` **and** the
+:term:`XSPEC`. To enable XSPEC support, several changes must be made
+to the ``xspec_config`` section of the ``setup.cfg`` file: the
+``with_xspec`` option must be set to ``True`` and the
 ``xspec_version`` option set to the correct version string (the XSPEC
-patch level must not be included), and then the
-remaining options depend on the version of XSPEC and whether
-the XSPEC model library or the full XSPEC system has been installed.
+patch level must not be included). The remaining options depend on the
+version of XSPEC and how it was built and installed.
 
-In the examples below, the ``$HEADAS`` value **must be replaced**
-by the actual path to the HEADAS installation, and the versions of
-the libraries - such as ``CCfits_2.7`` - may need to be changed to
-match the contents of the XSPEC installation.
+HEASARC
+"""""""
+
+If XSPEC has been installed from the
+`HEASARC <https://heasarc.gsfc.nasa.gov/docs/software/conda.html>`_
+conda channel then only set the ``with_xspec`` and ``xspec_version``
+lines.
+
+Note that the ``xspec-data`` package should also be installed
+otherwise some of the models may return zeros or cause the program to
+crash.
+
+CIAO
+""""
+
+If XSPEC has been installed from the
+`CIAO <https://cxc.cfa.harvard.edu/ciao/download/conda.html>`_
+conda channel (using the ``xspec-modelsonly`` package name) then
+the ``with_xspec``, ``xspec_version``, ``xspec_lib_dirs``, and
+``xspec_include_dirs`` lines need to be set. The directory
+names should be set to::
+
+  xspec_lib_dirs = $CONDA_PREFIX/lib
+  xspec_include_dirs = $CONDA_PREFIX/include
+
+The CIAO XSPEC package includes the data files needed to evaluate the
+models.
+
+Other
+"""""
+
+Modern XSPEC builds use run-time search paths to reference most of the
+libraries it uses, so the only settings that should be necessary are
+``with_xspec`` and ``xspec_version``.
+
+If the build fails then various settings can be changed, such as
+adding the hdsp library to the ``xspec_libraries`` setting, setting
+the ``ccfits_libraries``, ``wcslib_libraries`` or
+``gfortran_libraries`` values, or adding paths. Note that a number of
+libraries - such as ``hdsp``, ``CCfits``, and ``wcs`` - include
+version numbers in the names.
 
 .. note::
 
-   If XSPEC has been installed via conda - such as with the
-   `HEASARC <https://heasarc.gsfc.nasa.gov/docs/software/conda.html>`_
-   or
-   `CIAO <https://cxc.cfa.harvard.edu/ciao/download/conda.html>`_
-   channels - then the only settings which are needed are::
+   The ``xspec_lib_dirs`` and ``xspec_include_dirs`` options default
+   to ``$HEADAS/lib`` and ``$HEADAS/include`` respectively, so should
+   only be set if these paths are not valid.
 
-     with_xspec
-     xspec_version
-     xspec_lib_dirs
-     xspec_include_dirs
-
-* If the full XSPEC 12.15.1 system has been built then use::
-
-       with_xspec = True
-       xspec_version = 12.15.1
-       xspec_lib_dirs = $HEADAS/lib
-       xspec_include_dirs = $HEADAS/include
-       xspec_libraries = XSFunctions XSUtil XS hdsp_6.36
-       ccfits_libraries = CCfits_2.7
-       wcslib_libraries = wcs-8.3
-
-  where the version numbers were taken from version 6.36 of HEASOFT and
-  may need updating with a newer release.
-
-* If the full XSPEC 12.15.0 system has been built then use::
-
-       with_xspec = True
-       xspec_version = 12.15.0
-       xspec_lib_dirs = $HEADAS/lib
-       xspec_include_dirs = $HEADAS/include
-       xspec_libraries = XSFunctions XSUtil XS hdsp_6.35
-       ccfits_libraries = CCfits_2.7
-       wcslib_libraries = wcs-8.3
-
-* If the full XSPEC 12.14.1 system has been built then use::
-
-       with_xspec = True
-       xspec_version = 12.14.1
-       xspec_lib_dirs = $HEADAS/lib
-       xspec_include_dirs = $HEADAS/include
-       xspec_libraries = XSFunctions XSUtil XS hdsp_6.34
-       ccfits_libraries = CCfits_2.6
-       wcslib_libraries = wcs-8.3
-
-* If the full XSPEC 12.14.0 system has been built then use::
-
-       with_xspec = True
-       xspec_version = 12.14.0
-       xspec_lib_dirs = $HEADAS/lib
-       xspec_include_dirs = $HEADAS/include
-       xspec_libraries = XSFunctions XSUtil XS hdsp_6.33
-       ccfits_libraries = CCfits_2.6
-       wcslib_libraries = wcs-8.2.1
-
-* If the full XSPEC 12.13.1 system has been built then use::
-
-       with_xspec = True
-       xspec_version = 12.13.1
-       xspec_lib_dirs = $HEADAS/lib
-       xspec_include_dirs = $HEADAS/include
-       xspec_libraries = XSFunctions XSUtil XS hdsp_6.32
-       ccfits_libraries = CCfits_2.6
-       wcslib_libraries = wcs-7.7
-
-* If the full XSPEC 12.13.0 system has been built then use::
-
-       with_xspec = True
-       xspec_version = 12.13.0
-       xspec_lib_dirs = $HEADAS/lib
-       xspec_include_dirs = $HEADAS/include
-       xspec_libraries = XSFunctions XSUtil XS hdsp_6.31
-       ccfits_libraries = CCfits_2.6
-       wcslib_libraries = wcs-7.7
-
-* If the model-only build of XSPEC - created with the
-  ``--enable-xs-models-only`` flag when building HEASOFT - has been
-  installed, then the configuration is similar, but the library names
-  may not need version numbers and locations, depending on how the
-  ``cfitsio``, ``CCfits``, and ``wcs`` libraries were installed.
-
-A common problem is to set one or both of the ``xspec_lib_dirs``
-and ``xspec_lib_include`` options to the value of ``$HEADAS`` instead of
-``$HEADAS/lib`` and ``$HEADAS/include`` (after expanding out the
-environment variable). Doing so will cause the build to fail with
-errors about being unable to find various XSPEC libraries such as
-``XSFunctions`` and ``XSModel``.
-
-The ``gfortran`` options should be adjusted if there are problems
-using the XSPEC module.
+   In 4.18.0 and earlier, environment variables in the the
+   ``xspec_lib_dirs`` and ``xspec_include_dirs`` settings were not
+   automatically expanded, and they were not set by default.
 
 In order for the XSPEC module to be used from Python, the
 ``HEADAS`` environment variable **must** be set before the
@@ -333,8 +285,8 @@ The Sherpa test suite includes an extensive set of tests of this
 module, but a quick check of an installed version can be made with
 the following command::
 
-    % python -c 'from sherpa.astro import xspec; print(xspec.get_xsversion())'
-    12.15.0
+  % python -c 'from sherpa.astro import xspec; print(xspec.get_xsversion())'
+  12.15.1
 
 Other options
 ^^^^^^^^^^^^^

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -257,7 +257,7 @@ Other
 """""
 
 Modern XSPEC builds use run-time search paths to reference most of the
-libraries it uses, so the only settings that should be necessary are
+libraries they use, so the only settings that should be necessary are
 ``with_xspec`` and ``xspec_version``.
 
 If the build fails then various settings can be changed, such as

--- a/docs/model_classes/astro_xspec.rst
+++ b/docs/model_classes/astro_xspec.rst
@@ -37,6 +37,8 @@ The sherpa.astro.xspec module
       XSbexpcheb6
       XSbexrav
       XSbexriv
+      XSbfekblor
+      XSbfeklor
       XSbgadem
       XSbgnei
       XSbkn2pow
@@ -130,6 +132,7 @@ The sherpa.astro.xspec module
       XSexpdec
       XSexpfac
       XSezdiskbb
+      XSfekblor
       XSfeklor
       XSgabs
       XSgadem
@@ -207,6 +210,13 @@ The sherpa.astro.xspec module
       XSrgsext
       XSrgsxsrc
       XSrnei
+      XSrsapec
+      XSrsgaussian
+      XSrsrnei
+      XSrsvapec
+      XSrsvrnei
+      XSrsvvapec
+      XSrsvvrnei
       XSsedov
       XSsimpl
       XSsirf
@@ -281,11 +291,14 @@ The sherpa.astro.xspec module
       XSzashift
       XSzbabs
       XSzbbody
+      XSzbfekblor
+      XSzbfeklor
       XSzbknpower
       XSzbremss
       XSzcutoffpl
       XSzdust
       XSzedge
+      XSzfekblor
       XSzfeklor
       XSzgabs
       XSzgauss
@@ -321,7 +334,7 @@ The sherpa.astro.xspec module
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: XSagauss XSagnsed XSagnslim XSapec XSbapec XSbbody XSbbodyrad XSbcempow XSbcheb6 XSbcie XSbcoolflow XSbcph XSbequil XSbexpcheb6 XSbexrav XSbexriv XSbgadem XSbgnei XSbkn2pow XSbknpower XSbmc XSbnei XSbnpshock XSbpshock XSbremss XSbrnei XSbsedov XSbsnapec XSbtapec XSbvapec XSbvcempow XSbvcheb6 XSbvcie XSbvcoolflow XSbvcph XSbvequil XSbvexpcheb6 XSbvgadem XSbvgnei XSbvnei XSbvnpshock XSbvpshock XSbvrnei XSbvsedov XSbvtapec XSbvvapec XSbvvcie XSbvvgadem XSbvvgnei XSbvvnei XSbvvnpshock XSbvvpshock XSbvvrnei XSbvvsedov XSbvvtapec XSbvvwdem XSbvwdem XSbwcycl XSbwdem XSc6mekl XSc6pmekl XSc6pvmkl XSc6vmekl XScarbatm XScemekl XScempow XScevmkl XScflow XScheb6 XScie XScompLS XScompPS XScompST XScompTT XScompbb XScompmag XScomptb XScompth XScoolflow XScph XScplinear XScutoffpl XSdisk XSdiskbb XSdiskir XSdiskline XSdiskm XSdisko XSdiskpbb XSdiskpn XSeebremss XSeplogpar XSeqpair XSeqtherm XSequil XSexpcheb6 XSexpdec XSezdiskbb XSfeklor XSgadem XSgaussian XSgnei XSgrad XSgrbcomp XSgrbjet XSgrbm XShatm XSjet XSkerrbb XSkerrd XSkerrdisk XSkyrline XSlaor XSlaor2 XSlogpar XSlorentz XSmeka XSmekal XSmkcflow XSnei XSnlapec XSnpshock XSnsa XSnsagrav XSnsatmos XSnsmax XSnsmaxg XSnsx XSnteea XSnthComp XSoptxagn XSoptxagnf XSpegpwrlw XSpexmon XSpexrav XSpexriv XSplcabs XSposm XSpowerlaw XSpshock XSqsosed XSraymond XSredge XSrefsch XSrnei XSsedov XSsirf XSslimbh XSsnapec XSsrcut XSsresc XSssa XSsssed XSstep XStapec XSvagauss XSvapec XSvbremss XSvcempow XSvcheb6 XSvcie XSvcoolflow XSvcph XSvequil XSvexpcheb6 XSvgadem XSvgaussian XSvgnei XSvlorentz XSvmcflow XSvmeka XSvmekal XSvnei XSvnpshock XSvoigt XSvpshock XSvraymond XSvrnei XSvsedov XSvtapec XSvvapec XSvvcie XSvvgadem XSvvgnei XSvvnei XSvvnpshock XSvvoigt XSvvpshock XSvvrnei XSvvsedov XSvvtapec XSvvwdem XSvwdem XSwdem XSzagauss XSzbbody XSzbknpower XSzbremss XSzcutoffpl XSzfeklor XSzgauss XSzkerrbb XSzlogpar XSzlorentz XSzpowerlw XSzvagauss XSzvgaussian XSzvlorentz XSzvoigt XSzvvoigt
+.. inheritance-diagram:: XSagauss XSagnsed XSagnslim XSapec XSbapec XSbbody XSbbodyrad XSbcempow XSbcheb6 XSbcie XSbcoolflow XSbcph XSbequil XSbexpcheb6 XSbexrav XSbexriv XSbfekblor XSbfeklor XSbgadem XSbgnei XSbkn2pow XSbknpower XSbmc XSbnei XSbnpshock XSbpshock XSbremss XSbrnei XSbsedov XSbsnapec XSbtapec XSbvapec XSbvcempow XSbvcheb6 XSbvcie XSbvcoolflow XSbvcph XSbvequil XSbvexpcheb6 XSbvgadem XSbvgnei XSbvnei XSbvnpshock XSbvpshock XSbvrnei XSbvsedov XSbvtapec XSbvvapec XSbvvcie XSbvvgadem XSbvvgnei XSbvvnei XSbvvnpshock XSbvvpshock XSbvvrnei XSbvvsedov XSbvvtapec XSbvvwdem XSbvwdem XSbwcycl XSbwdem XSc6mekl XSc6pmekl XSc6pvmkl XSc6vmekl XScarbatm XScemekl XScempow XScevmkl XScflow XScheb6 XScie XScompLS XScompPS XScompST XScompTT XScompbb XScompmag XScomptb XScompth XScoolflow XScph XScplinear XScutoffpl XSdisk XSdiskbb XSdiskir XSdiskline XSdiskm XSdisko XSdiskpbb XSdiskpn XSeebremss XSeplogpar XSeqpair XSeqtherm XSequil XSexpcheb6 XSexpdec XSezdiskbb XSfekblor XSfeklor XSgadem XSgaussian XSgnei XSgrad XSgrbcomp XSgrbjet XSgrbm XShatm XSjet XSkerrbb XSkerrd XSkerrdisk XSkyrline XSlaor XSlaor2 XSlogpar XSlorentz XSmeka XSmekal XSmkcflow XSnei XSnlapec XSnpshock XSnsa XSnsagrav XSnsatmos XSnsmax XSnsmaxg XSnsx XSnteea XSnthComp XSoptxagn XSoptxagnf XSpegpwrlw XSpexmon XSpexrav XSpexriv XSplcabs XSposm XSpowerlaw XSpshock XSqsosed XSraymond XSredge XSrefsch XSrnei XSrsapec XSrsgaussian XSrsrnei XSrsvapec XSrsvrnei XSrsvvapec XSrsvvrnei XSsedov XSsirf XSslimbh XSsnapec XSsrcut XSsresc XSssa XSsssed XSstep XStapec XSvagauss XSvapec XSvbremss XSvcempow XSvcheb6 XSvcie XSvcoolflow XSvcph XSvequil XSvexpcheb6 XSvgadem XSvgaussian XSvgnei XSvlorentz XSvmcflow XSvmeka XSvmekal XSvnei XSvnpshock XSvoigt XSvpshock XSvraymond XSvrnei XSvsedov XSvtapec XSvvapec XSvvcie XSvvgadem XSvvgnei XSvvnei XSvvnpshock XSvvoigt XSvvpshock XSvvrnei XSvvsedov XSvvtapec XSvvwdem XSvwdem XSwdem XSzagauss XSzbbody XSzbfekblor XSzbfeklor XSzbknpower XSzbremss XSzcutoffpl XSzfekblor XSzfeklor XSzgauss XSzkerrbb XSzlogpar XSzlorentz XSzpowerlw XSzvagauss XSzvgaussian XSzvlorentz XSzvoigt XSzvvoigt
    :parts: 1
 
 .. inheritance-diagram:: XSSSS_ice XSTBabs XSTBfeo XSTBgas XSTBgrain XSTBpcf XSTBrel XSTBvarabs XSabsori XSacisabs XScabs XSconstant XScyclabs XSdust XSedge XSexpabs XSexpfac XSgabs XSheilin XShighecut XShrefl XSismabs XSismdust XSlog10con XSlogconst XSlorabs XSlyman XSnotch XSolivineabs XSpcfabs XSphabs XSplabs XSpwab XSredden XSsmedge XSspexpcut XSspline XSswind1 XSuvred XSvarabs XSvgabs XSvlorabs XSvoigtabs XSvphabs XSvvoigtabs XSwabs XSwndabs XSxion XSxscat XSzTBabs XSzbabs XSzdust XSzedge XSzgabs XSzhighect XSzigm XSzlorabs XSzpcfabs XSzphabs XSzredden XSzsmdust XSzvarabs XSzvfeabs XSzvgabs XSzvlorabs XSzvoigtabs XSzvphabs XSzvvoigtabs XSzwabs XSzwndabs XSzxipab XSzxipcf

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -30,7 +30,7 @@ from .extensions import build_ext
 #
 SUPPORTED_VERSIONS = [(12, 13, 0), (12, 13, 1),
                       (12, 14, 0), (12, 14, 1),
-                      (12, 15, 0)]
+                      (12, 15, 0), (12, 15, 1)]
 
 
 # We could use packaging.versions.Version here, but for our needs we

--- a/helpers/xspec_config.py
+++ b/helpers/xspec_config.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014-2018, 2020-2025
+#  Copyright (C) 2014-2018, 2020-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -18,6 +18,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from os.path import expandvars
 from setuptools import Command
 import re
 
@@ -80,9 +81,9 @@ class xspec_config(Command):
     description = "Configure XSPEC Models external module (optional) "
     user_options = [
                     ('with_xspec', None, "Whether sherpa must build the XSPEC module (default False)"),
-                    ('xspec_version', None, "the XSPEC version (default 12.12.0)"),
-                    ('xspec_lib_dirs', None, "Where the xspec libraries are located, if with_xspec is True"),
-                    ('xspec_libraries', None, "Name of the libraries that should be linked for xspec"),
+                    ('xspec_version', None, "the XSPEC version (default 12.15.1)"),
+                    ('xspec_lib_dirs', None, "Where the xspec libraries are located, if with_xspec is True (default $HEADAS/lib)"),
+                    ('xspec_libraries', None, "Name of the libraries that should be linked for xspec (default $HEADAS/include)"),
                     ('cfitsio_lib_dirs', None, "Where the cfitsio libraries are located, if with_xspec is True"),
                     ('cfitsio_libraries', None, "Name of the libraries that should be linked for cfitsio"),
                     ('ccfits_lib_dirs', None, "Where the CCfits libraries are located, if with_xspec is True"),
@@ -95,10 +96,15 @@ class xspec_config(Command):
 
     def initialize_options(self):
         self.with_xspec = False
-        self.xspec_version = '12.14.1'
-        self.xspec_include_dirs = ''
-        self.xspec_lib_dirs = ''
-        # This is set up for how CIAO builds XSPEC; other users may require more libraries
+        # The defaults are to support XSPEC builds where the various
+        # modules already reference the necessary "internal"
+        # libraries, such as hdsp, CCFits. Users can set them if
+        # necessary (e.g. add to the xspec_libraries line, set
+        # ccfits_libries, or add in paths).
+        #
+        self.xspec_version = '12.15.1'
+        self.xspec_include_dirs = '$HEADAS/include'
+        self.xspec_lib_dirs = '$HEADAS/lib'
         self.xspec_libraries = 'XSFunctions XSUtil XS'
         self.cfitsio_include_dirs = ''
         self.cfitsio_lib_dirs = ''
@@ -114,7 +120,13 @@ class xspec_config(Command):
         self.gfortran_libraries = ''
 
     def finalize_options(self):
-        pass
+        # Expand environment variables in the directory paths
+        for name in ["xspec", "cfitsio", "ccfits", "wcslib",
+                      "gfortran"]:
+            for dname in ["include", "lib"]:
+                field = f"{name}_{dname}_dirs"
+                oldval = getattr(self, field)
+                setattr(self, field, expandvars(oldval))
 
     def run(self):
         if not self.with_xspec:

--- a/scripts/use_ciao_config
+++ b/scripts/use_ciao_config
@@ -94,8 +94,8 @@ sed -i="" "s|#fftw_lib_dirs=build/lib|fftw_lib_dirs=${CONDA_PREFIX}/lib|" $cfg
 sed -i="" "s|#fftw_libraries=fftw3|fftw_libraries=fftw3|" $cfg
 
 sed -i="" "s|#with_xspec=True|with_xspec=True|" $cfg
-sed -i="" "s|#xspec_include_dirs = None|xspec_include_dirs=${CONDA_PREFIX}/include|" $cfg
-sed -i="" "s|#xspec_lib_dirs = None|xspec_lib_dirs=${CONDA_PREFIX}/lib|" $cfg
+sed -i="" "s|#xspec_include_dirs = .*|xspec_include_dirs = ${CONDA_PREFIX}/include|" $cfg
+sed -i="" "s|#xspec_lib_dirs = .*|xspec_lib_dirs = ${CONDA_PREFIX}/lib|" $cfg
 sed -i="" "s|#xspec_version = .*|xspec_version = ${xspec_version}|" $cfg
 
 # Depending on the version of sed, there might be a temporary file. Remove it if it exists.

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,39 +67,36 @@ source-dir = docs
 
 # XSPEC Models
 [xspec_config]
-# Uncomment (set to True) to build XSPEC extension
-#with_xspec=True
-
-# If with_xspec is True, make sure to point Sherpa to right
-# XSPEC-related libraries and to indicate the XSPEC version.
+# The minimal settings needed are
 #
-# The xspec_include_dirs and xspec_lib_dirs items should be set
-# to $HEADAS/include and $HEADAS/lib respectively (expand out the
-# environment variable).
+#   with_xspec = True
+#   xspec_version = <XSPEC version, the patch level is not needed>
+#   xspec_lib_dirs = <path>
+#   xspec_include_dirs = <path>
 #
-# Change 6.30 to the correct version in xspec_libraries for hdsp.
+# The xspec_libraries line may be needed, depending on how XSPEC is
+# built. When given the version of the hdsp library should be updated
+# (e.g. change hdsp_6.36 to match the installation).
 #
-# If you are using a full XSPEC build, then it may be necessary to add
-# the correct version numbers to the cfitsio, CCfits, and wcs
-# libraries used in the build. For XSPEC 12.12.1 (HEAsoft 6.30.1)
-# this means using CCfits_2.6, wcs-7.7, and hdsp_6.30.
-#
-# If you are using the models-only XSPEC build, then the cfitsio_lib_dirs,
-# ccfits_lib_dirs, and wcslib_lib_dirs will need to be set if
-# these libraries are installed in a different location to the XSPEC
-# libraries.
+# The cfitsio_libraries, ccfits_libraries, and wcslib_libraries may
+# need to be set, depending on how XSPEC is built. It is likely that
+# the ccfits_libraries and wcslib_libraries names will need to include
+# the version (e.g. CCfits_2.7 and wcs.8.3). The corresponsing
+# lib_dirs settings will only need to be set if they are not in the
+# xspec_lib_dirs path.
 #
 # The gfortran_lib_dirs should be set if needed.
 #
-#xspec_version = 12.12.0
+#with_xspec=True
+#xspec_version = 12.15.1
 #xspec_lib_dirs = None
 #xspec_include_dirs = None
-#xspec_libraries = XSFunctions XSUtil XS hdsp_6.30
+#xspec_libraries = XSFunctions XSUtil XS hdsp_6.36
 #cfitsio_lib_dirs = None
 #cfitsio_libraries = cfitsio
 #ccfits_lib_dirs = None
-#ccfits_libraries = CCfits
+#ccfits_libraries = CCfits_2.7
 #wcslib_lib_dirs = None
-#wcslib_libraries = wcs
+#wcslib_libraries = wcs.8.3
 #gfortran_lib_dirs = None
 #gfortran_libraries = gfortran

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,8 +71,10 @@ source-dir = docs
 #
 #   with_xspec = True
 #   xspec_version = <XSPEC version, the patch level is not needed>
-#   xspec_lib_dirs = <path>
-#   xspec_include_dirs = <path>
+#
+# The xspec_lib_dirs and xspec_include_dirs settings only need to be
+# given if they do not match $HEADAS/lib or $HEADAS/include
+# respectively.
 #
 # The xspec_libraries line may be needed, depending on how XSPEC is
 # built. When given the version of the hdsp library should be updated
@@ -89,8 +91,8 @@ source-dir = docs
 #
 #with_xspec=True
 #xspec_version = 12.15.1
-#xspec_lib_dirs = None
-#xspec_include_dirs = None
+#xspec_lib_dirs = $HEADAS/lib
+#xspec_include_dirs = $HEADAS/include
 #xspec_libraries = XSFunctions XSUtil XS hdsp_6.36
 #cfitsio_lib_dirs = None
 #cfitsio_libraries = cfitsio

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -63,10 +63,12 @@ has_xspec = has_package_from_list("sherpa.astro.xspec")
 # that are available).
 
 # Note that the XSPEC defaults changed in XSPEC 12.10.1 (xsxsect is
-# now vern rather than bcmc, but it can depend on what files a
-# user has - e.g. ~/.xspec/Xspec.init will over-ride it), so there
-# are explicit statements to set the values before the tests so
-# that we have a "known" state.
+# now vern rather than bcmc, but it can depend on what files a user
+# has - e.g. ~/.xspec/Xspec.init will over-ride it), so there are
+# explicit statements to set the values before the tests so that we
+# have a "known" state. There are also changes in XSPEC 12.15.1, with
+# model strings now being set for 'APECROOT', 'NEIAPECROOT', and
+# 'SPEXROOT'.
 #
 
 # A representation of the default Sherpa state
@@ -2541,6 +2543,33 @@ set_xsabund("angr")
 set_xscosmo(70, 0, 0.73)
 set_xsxsect("bcmc")
 """
+
+    # Split the version into a tuple of major, minor, micro, patch
+    # where patch='' if there is none. This assumes that the patch
+    # level can only be a single-character.
+    #
+    verstr = xspec.get_xsversion()
+    if verstr[-1].isdecimal():
+        toks = verstr.split('.')
+        patch = ''
+    else:
+        toks = verstr[:-1].split('.')
+        patch = verstr[-1]
+
+    xsver = tuple([int(t) for t in toks] + [patch])
+
+    # Add in the XSET settings, but only for XSPEC 12.15.1 and
+    # later. Since the versions can be uptated, take advantage of the
+    # ellipsis support to avoid explicit checks.
+    #
+    if xsver >= (12, 15, 1, ''):
+        _extra = """set_xsxset("APECROOT", "...  # doctest: +ELLIPSIS
+set_xsxset("NEIAPECROOT", "...  # doctest: +ELLIPSIS
+set_xsxset("SPEXROOT", "...  # doctest: +ELLIPSIS
+"""
+        _canonical_extra += _extra
+        _canonical_pha_back += _extra
+        del _extra
 
     _canonical_pha_basic += _canonical_extra
     _canonical_pha_grouped += _canonical_extra

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -2559,7 +2559,7 @@ set_xsxsect("bcmc")
     xsver = tuple([int(t) for t in toks] + [patch])
 
     # Add in the XSET settings, but only for XSPEC 12.15.1 and
-    # later. Since the versions can be uptated, take advantage of the
+    # later. Since the versions can be updated, take advantage of the
     # ellipsis support to avoid explicit checks.
     #
     if xsver >= (12, 15, 1, ''):

--- a/sherpa/astro/utils/xspec.py
+++ b/sherpa/astro/utils/xspec.py
@@ -1174,7 +1174,7 @@ def models_to_compiled(mdls: list[ModelDefinition],
     SUPPORTED_VERSIONS = [(12, 12, 0), (12, 12, 1),
                           (12, 13, 0), (12, 13, 1),
                           (12, 14, 0), (12, 14, 1),
-                          (12, 15, 0)]
+                          (12, 15, 0), (12, 15, 1)]
 
     xspec_version = (int(match[1]), int(match[2]), int(match[3]))
     for version in SUPPORTED_VERSIONS:

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -1869,6 +1869,13 @@ def mkabund(name: str,
                        hard_min=minval, hard_max=maxval, frozen=True)
 
 
+def mkRScolumn(name) -> XSParameter:
+    """Make a RScolumn parameter."""
+
+    return XSParameter(name, 'RScolumn', 0.0, min=0.0, max=10000.0,
+                       hard_min=0.0, hard_max=10000.0, frozen=True, units='10^22')
+
+
 class XSAdditiveModel(XSModel):
     """The base class for XSPEC additive models.
 
@@ -2468,8 +2475,8 @@ class XSapec(XSAdditiveModel):
 
     See Also
     --------
-    XSbapec, XSbvapec, XSbvvapec, XSeebremss, XSnlapec, XSsnapec,
-    XSvapec, XSvvapec, XSwdem
+    XSbapec, XSbvapec, XSbvvapec, XSeebremss, XSnlapec, XSrsapec,
+    XSsnapec, XSvapec, XSvvapec, XSwdem
 
     References
     ----------
@@ -2941,6 +2948,78 @@ class XSbexpcheb6(XSAdditiveModel):
                 self.CPcoef4, self.CPcoef5, self.CPcoef6, self.nH,
                 self.abundanc, self.Redshift, self.Velocity,
                 self.switch)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
+@version_at_least("12.15.1")
+class XSbfekblor(XSAdditiveModel):
+    """The XSPEC bfekblor model: Fe Kbeta line at high resolution.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.18.1
+       This model requires XSPEC 12.15.1 or later.
+
+    Attributes
+    ----------
+    Velocity
+       The velocity broadening in km/s.
+    norm
+       The total emission (in photom/cm^2/s) in the line.
+
+    See Also
+    --------
+    XSbfeklor, XSfekblor, XSzbfekblor, XSzfekblor
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelFekblor.html
+
+    """
+
+    __function__ = "C_bFeKbetafromFourLorentzians"
+
+    def __init__(self, name='bfekblor'):
+        self.Velocity = mkVelocity(name)
+
+        pars = (self.Velocity,)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
+@version_at_least("12.15.1")
+class XSbfeklor(XSAdditiveModel):
+    """The XSPEC bfeklor model: Fe Kalpha line at high resolution.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.18.1
+       This model requires XSPEC 12.15.1 or later.
+
+    Attributes
+    ----------
+    Velocity
+       The velocity broadening in km/s.
+    norm
+       The total emission (in photom/cm^2/s) in the line.
+
+    See Also
+    --------
+    XSbfekblor, XSfeklor, XSzbfeklor, XSzfeklor
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelFeklor.html
+
+    """
+
+    __function__ = "C_bFeKfromSevenLorentzians"
+
+    def __init__(self, name='bfeklor'):
+        self.Velocity = mkVelocity(name)
+
+        pars = (self.Velocity,)
         XSAdditiveModel.__init__(self, name, pars)
 
 
@@ -8301,9 +8380,42 @@ class XSezdiskbb(XSAdditiveModel):
         self.cache = 0
 
 
+@version_at_least("12.15.1")
+class XSfekblor(XSAdditiveModel):
+    """The XSPEC fekblor model: Fe Kbeta line at high resolution.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.18.1
+       This model requires XSPEC 12.15.1 or later.
+
+    Attributes
+    ----------
+    norm
+       The total emission (in photom/cm^2/s) in the line.
+
+    See Also
+    --------
+    XSbfekblor, XSfeklor, XSzbfekblor, XSzfekblor
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelFekblor.html
+
+    """
+
+    __function__ = "C_FeKbetafromFourLorentzians"
+
+    def __init__(self, name='fekblor'):
+
+        pars = ()
+        XSAdditiveModel.__init__(self, name, pars)
+
+
 @version_at_least("12.15.0")
 class XSfeklor(XSAdditiveModel):
-    """The XSPEC feklor model: Fe K fluourescence line at high resolution
+    """The XSPEC feklor model: Fe Kalpha line at high resolution.
 
     The model is described at [1]_.
 
@@ -8317,7 +8429,7 @@ class XSfeklor(XSAdditiveModel):
 
     See Also
     --------
-    XSzfeklor
+    XSbfeklor, XSfekblor, XSzbfeklor, XSzfeklor
 
     References
     ----------
@@ -10881,6 +10993,99 @@ class XSrefsch(XSAdditiveModel):
         self.cache = 0
 
 
+@version_at_least("12.15.1")
+class XSrsapec(XSAdditiveModel):
+    """The XSPEC rsapec model: APEC emission spectrum with resonance scattering.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.18.1
+       This model requires XSPEC 12.15.1 or later.
+
+    Attributes
+    ----------
+    kT
+       The temperature of the plasma, in keV.
+    Abundanc
+       The metal abundance of the plasma, as defined by the
+       ``set_xsabund`` function and the "APEC_TRACE_ABUND" xset
+       keyword.
+    Redshift
+       The redshift of the plasma.
+    Velocity
+       The gaussian sigma for velocity broadening, in km/s.
+    RScolumn
+       The resonance scattering column (10^22 cm^-2).
+    norm
+       The normalization of the model: see [1]_ for an explanation
+       of the units.
+
+    See Also
+    --------
+    XSapec, XSrsvapec, XSrsvvapec
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRsapec.html
+
+    """
+
+    __function__ = "C_rsapec"
+
+    def __init__(self, name='rsapec'):
+        self.kT = XSParameter(name, 'kT', 1.0, min=0.008, max=64.0, hard_min=0.008, hard_max=64.0, units='keV')
+        self.Abundanc = mkAbundanc(name)
+        self.Redshift = mkRedshift(name)
+        self.Velocity = mkVelocity(name)
+        self.RScolumn = mkRScolumn(name)
+
+        pars = (self.kT, self.Abundanc, self.Redshift, self.Velocity, self.RScolumn)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
+# Is rsgauss the same as rsgaussian? This is not the first model with this
+# naming confusion.
+#
+@version_at_least("12.15.1")
+class XSrsgaussian(XSAdditiveModel):
+    """The XSPEC rsgaussian model: gaussian line profile with resonance scattering
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.18.1
+       This model requires XSPEC 12.15.1 or later.
+
+    Attributes
+    ----------
+    LineE
+       The line energy in keV.
+    Sigma
+       The line width in keV.
+    Tau0
+       The optical depth at the line peak.
+    norm
+       The flux in the line (in photon/cm^2/s) before scattering
+       correction.
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRsgauss.html
+
+    """
+
+    __function__ = "C_rsgaussianLine"
+
+    def __init__(self, name='rsgaussian'):
+        self.LineE = XSParameter(name, 'LineE', 6.5, min=0.0, max=1000000.0, hard_min=0.0, hard_max=1000000.0, units='keV')
+        self.Sigma = XSParameter(name, 'Sigma', 0.1, min=0.0, max=10.0, hard_min=0.0, hard_max=20.0, units='keV')
+        self.Tau0 = XSParameter(name, 'Tau0', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0)
+
+        pars = (self.LineE, self.Sigma, self.Tau0)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
 class XSrnei(XSAdditiveModel):
     """The XSPEC rnei model: non-equilibrium recombining collisional plasma.
 
@@ -10907,7 +11112,7 @@ class XSrnei(XSAdditiveModel):
 
     See Also
     --------
-    XSnei, XSgnei, XSvrnei, XSvvrnei
+    XSnei, XSrnei, XSgnei, XSvrnei, XSvvrnei
 
     References
     ----------
@@ -10927,6 +11132,360 @@ class XSrnei(XSAdditiveModel):
 
         pars = (self.kT, self.kT_init, self.Abundanc, self.Tau,
                 self.Redshift)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
+@version_at_least("12.15.1")
+class XSrsrnei(XSAdditiveModel):
+    """The XSPEC rsrnei model: Non-equilibrium recombining collisional plasma with resonance scattering.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.18.1
+       This model requires XSPEC 12.15.1 or later.
+
+    Attributes
+    ----------
+    kT
+       The temperature of the plasma, in keV.
+    kT_init
+       The initial temperature of the plasma, in keV.
+    Abundanc
+       The metal abundance of the plasma, as defined by the
+       ``set_xsabund`` function.
+    Tau
+       The ionization timescale in units of s/cm^3.
+    Redshift
+       The redshift of the plasma.
+    Velocity
+       The gaussian sigma for velocity broadening, in km/s.
+    RScolumn
+       The resonance scattering column (10^22 cm^-2).
+    norm
+       The normalization of the model: see [1]_ for an explanation
+       of the units.
+
+    See Also
+    --------
+    XSrnei, XSrsvrnei, XSrsvvrnei
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRsrnei.html
+
+    """
+
+    __function__ = "C_rsrnei"
+
+    def __init__(self, name='rsrnei'):
+        self.kT = XSParameter(name, 'kT', 0.5, min=0.0808, max=79.9, hard_min=0.0808, hard_max=79.9, units='keV')
+        self.kT_init = XSParameter(name, 'kT_init', 1.0, min=0.0808, max=79.9, hard_min=0.0808, hard_max=79.9, units='keV')
+        self.Abundanc = XSParameter(name, 'Abundanc', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=10000.0, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 100000000000.0, min=100000000.0, max=50000000000000.0, hard_min=100000000.0, hard_max=50000000000000.0, units='s/cm^3')
+        self.Redshift = mkRedshift(name)
+        self.Velocity = mkVelocity(name)
+        self.RScolumn = mkRScolumn(name)
+
+        pars = (self.kT, self.kT_init, self.Abundanc, self.Tau, self.Redshift, self.Velocity, self.RScolumn)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
+@version_at_least("12.15.1")
+class XSrsvapec(XSAdditiveModel):
+    """The XSPEC rsvapec model: APEC emission spectrum with resonance scattering.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.18.1
+       This model requires XSPEC 12.15.1 or later.
+
+    Attributes
+    ----------
+    kT
+       The temperature of the plasma, in keV.
+    He, C, N, O, Ne, Mg, Al, Si, S, Ar, Ca, Fe, Ni
+        The abundance of the element in solar units.
+    Redshift
+       The redshift of the plasma.
+    Velocity
+       The gaussian sigma for velocity broadening, in km/s.
+    RScolumn
+       The resonance scattering column (10^22 cm^-2).
+    norm
+       The normalization of the model: see [1]_ for an explanation
+       of the units.
+
+    See Also
+    --------
+    XSrsapec, XSrsvvapec, XSvapec
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRsapec.html
+
+    """
+
+    __function__ = "C_rsvapec"
+
+    def __init__(self, name='rsvapec'):
+        self.kT = XSParameter(name, 'kT', 6.5, min=0.0808, max=68.447, hard_min=0.0808, hard_max=68.447, units='keV')
+        self.He = XSParameter(name, 'He', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Redshift = mkRedshift(name)
+        self.Velocity = mkVelocity(name)
+        self.RScolumn = mkRScolumn(name)
+
+        pars = (self.kT, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Al, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Redshift, self.Velocity, self.RScolumn)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
+@version_at_least("12.15.1")
+class XSrsvrnei(XSAdditiveModel):
+    """The XSPEC rsvrnei model: Non-equilibrium recombining collisional plasma with resonance scattering.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.18.1
+       This model requires XSPEC 12.15.1 or later.
+
+    Attributes
+    ----------
+    kT
+       The temperature of the plasma, in keV.
+    kT_init
+       The initial temperature of the plasma, in keV.
+    H
+        The H abundance: it should be set to 0 to switch on and
+        1 to switch off the free-free continuum.
+    He, C, N, O, Ne, Mg, Si, S, Ar, Ca, Fe, Ni
+        The abundance of the element, with respect to Solar.
+    Tau
+       The ionization timescale in units of s/cm^3.
+    Redshift
+       The redshift of the plasma.
+    Velocity
+       The gaussian sigma for velocity broadening, in km/s.
+    RScolumn
+       The resonance scattering column (10^22 cm^-2).
+    norm
+       The normalization of the model: see [1]_ for an explanation
+       of the units.
+
+    See Also
+    --------
+    XSrsrnei, XSrsvvrnei, XSvrnei
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRsrnei.html
+
+    """
+
+    __function__ = "C_rsvrnei"
+
+    def __init__(self, name='rsvrnei'):
+        self.kT = XSParameter(name, 'kT', 0.5, min=0.0808, max=79.9, hard_min=0.0808, hard_max=79.9, units='keV')
+        self.kT_init = XSParameter(name, 'kT_init', 1.0, min=0.0808, max=79.9, hard_min=0.0808, hard_max=79.9, units='keV')
+        self.H = XSParameter(name, 'H', 1.0, min=0.0, max=1.0, hard_min=0.0, hard_max=1.0, frozen=True)
+        self.He = XSParameter(name, 'He', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=10000.0, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=10000.0, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=10000.0, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=10000.0, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=10000.0, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=10000.0, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=10000.0, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=10000.0, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=10000.0, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=10000.0, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=10000.0, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=10000.0, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 100000000000.0, min=100000000.0, max=50000000000000.0, hard_min=100000000.0, hard_max=50000000000000.0, units='s/cm^3')
+        self.Redshift = mkRedshift(name)
+        self.Velocity = mkVelocity(name)
+        self.RScolumn = mkRScolumn(name)
+
+        pars = (self.kT, self.kT_init, self.H, self.He, self.C, self.N, self.O, self.Ne, self.Mg, self.Si, self.S, self.Ar, self.Ca, self.Fe, self.Ni, self.Tau, self.Redshift, self.Velocity, self.RScolumn)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
+@version_at_least("12.15.1")
+class XSrsvvapec(XSAdditiveModel):
+    """The XSPEC rsvvapec model: APEC emission spectrum with resonance scattering.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.18.1
+       This model requires XSPEC 12.15.1 or later.
+
+    Attributes
+    ----------
+    kT
+       The temperature of the plasma, in keV.
+    H, He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar,
+    K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
+       The abundance of the element in solar units.
+    Redshift
+       The redshift of the plasma.
+    Velocity
+       The gaussian sigma for velocity broadening, in km/s.
+    RScolumn
+       The resonance scattering column (10^22 cm^-2).
+    norm
+       The normalization of the model: see [1]_ for an explanation
+       of the units.
+
+    See Also
+    --------
+    XSrsapec, XSrsvapec, XSvvapec
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRsapec.html
+
+    """
+
+    __function__ = "C_rsvvapec"
+
+    def __init__(self, name='rsvvapec'):
+        self.kT = XSParameter(name, 'kT', 6.5, min=0.0808, max=68.447, hard_min=0.0808, hard_max=68.447, units='keV')
+        self.H = XSParameter(name, 'H', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.He = XSParameter(name, 'He', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Li = XSParameter(name, 'Li', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Be = XSParameter(name, 'Be', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.B = XSParameter(name, 'B', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.F = XSParameter(name, 'F', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.P = XSParameter(name, 'P', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.K = XSParameter(name, 'K', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Sc = XSParameter(name, 'Sc', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ti = XSParameter(name, 'Ti', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.V = XSParameter(name, 'V', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Mn = XSParameter(name, 'Mn', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Cu = XSParameter(name, 'Cu', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Zn = XSParameter(name, 'Zn', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Redshift = mkRedshift(name)
+        self.Velocity = mkVelocity(name)
+        self.RScolumn = mkRScolumn(name)
+
+        pars = (self.kT, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Redshift, self.Velocity, self.RScolumn)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
+@version_at_least("12.15.1")
+class XSrsvvrnei(XSAdditiveModel):
+    """The XSPEC rsvvrnei model: Non-equilibrium recombining collisional plasma with resonance scattering.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.18.1
+       This model requires XSPEC 12.15.1 or later.
+
+    Attributes
+    ----------
+    kT
+       The temperature of the plasma, in keV.
+    kT_init
+       The initial temperature of the plasma, in keV.
+    H
+       The H abundance: it should be set to 0 to switch on and
+       1 to switch off the free-free continuum.
+    He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar,
+    K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
+       The abundance of the element, with respect to Solar.
+    Tau
+       The ionization timescale in units of s/cm^3.
+    Redshift
+       The redshift of the plasma.
+    Velocity
+       The gaussian sigma for velocity broadening, in km/s.
+    RScolumn
+       The resonance scattering column (10^22 cm^-2).
+    norm
+       The normalization of the model: see [1]_ for an explanation
+       of the units.
+
+    See Also
+    --------
+    XSrsrnei, XSrsvrnei, XSvvrnei
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelRsrnei.html
+
+    """
+
+    __function__ = "C_rsvvrnei"
+
+    def __init__(self, name='rsvvrnei'):
+        self.kT = XSParameter(name, 'kT', 0.5, min=0.0808, max=79.9, hard_min=0.0808, hard_max=79.9, units='keV')
+        self.kT_init = XSParameter(name, 'kT_init', 1.0, min=0.0808, max=79.9, hard_min=0.0808, hard_max=79.9, units='keV')
+        self.H = XSParameter(name, 'H', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.He = XSParameter(name, 'He', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Li = XSParameter(name, 'Li', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Be = XSParameter(name, 'Be', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.B = XSParameter(name, 'B', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.C = XSParameter(name, 'C', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.N = XSParameter(name, 'N', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.O = XSParameter(name, 'O', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.F = XSParameter(name, 'F', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ne = XSParameter(name, 'Ne', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Na = XSParameter(name, 'Na', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Mg = XSParameter(name, 'Mg', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Al = XSParameter(name, 'Al', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Si = XSParameter(name, 'Si', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.P = XSParameter(name, 'P', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.S = XSParameter(name, 'S', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Cl = XSParameter(name, 'Cl', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ar = XSParameter(name, 'Ar', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.K = XSParameter(name, 'K', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ca = XSParameter(name, 'Ca', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Sc = XSParameter(name, 'Sc', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ti = XSParameter(name, 'Ti', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.V = XSParameter(name, 'V', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Cr = XSParameter(name, 'Cr', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Mn = XSParameter(name, 'Mn', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Fe = XSParameter(name, 'Fe', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Co = XSParameter(name, 'Co', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Ni = XSParameter(name, 'Ni', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Cu = XSParameter(name, 'Cu', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Zn = XSParameter(name, 'Zn', 1.0, min=0.0, max=1000.0, hard_min=0.0, hard_max=1000.0, frozen=True)
+        self.Tau = XSParameter(name, 'Tau', 100000000000.0, min=100000000.0, max=50000000000000.0, hard_min=100000000.0, hard_max=50000000000000.0, units='s/cm^3')
+        self.Redshift = mkRedshift(name)
+        self.Velocity = mkVelocity(name)
+        self.RScolumn = mkRScolumn(name)
+
+        pars = (self.kT, self.kT_init, self.H, self.He, self.Li, self.Be, self.B, self.C, self.N, self.O, self.F, self.Ne, self.Na, self.Mg, self.Al, self.Si, self.P, self.S, self.Cl, self.Ar, self.K, self.Ca, self.Sc, self.Ti, self.V, self.Cr, self.Mn, self.Fe, self.Co, self.Ni, self.Cu, self.Zn, self.Tau, self.Redshift, self.Velocity, self.RScolumn)
         XSAdditiveModel.__init__(self, name, pars)
 
 
@@ -13024,15 +13583,15 @@ class XSvvapec(XSAdditiveModel):
     Attributes
     ----------
     kT
-        The temperature of the plasma, in keV.
+       The temperature of the plasma, in keV.
     H, He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar,
     K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
-        The abundance of the element in solar units.
+       The abundance of the element in solar units.
     Redshift
-        The redshift of the plasma.
+       The redshift of the plasma.
     norm
-        The normalization of the model: see [1]_ for an explanation
-        of the units.
+       The normalization of the model: see [1]_ for an explanation
+       of the units.
 
     See Also
     --------
@@ -14221,6 +14780,84 @@ class XSzbbody(XSAdditiveModel):
         self.cache = 0
 
 
+@version_at_least("12.15.1")
+class XSzbfekblor(XSAdditiveModel):
+    """The XSPEC zbfekblor model: Fe Kbeta line at high resolution.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.18.1
+       This model requires XSPEC 12.15.1 or later.
+
+    Attributes
+    ----------
+    Velocity
+       The velocity broadening in km/s.
+    Redshift
+       The redshift of the component.
+    norm
+       The total emission (in photom/cm^2/s) in the line.
+
+    See Also
+    --------
+    XSbfekblor, XSfekblor, XSzbfeklor, XSzfekblor
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelFekblor.html
+
+    """
+
+    __function__ = "C_zbFeKbetafromFourLorentzians"
+
+    def __init__(self, name='zbfekblor'):
+        self.Velocity = mkVelocity(name)
+        self.Redshift = mkRedshift(name)
+
+        pars = (self.Velocity, self.Redshift)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
+@version_at_least("12.15.1")
+class XSzbfeklor(XSAdditiveModel):
+    """The XSPEC zbfeklor model: Fe Kalpha line at high resolution.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.18.1
+       This model requires XSPEC 12.15.1 or later.
+
+    Attributes
+    ----------
+    Velocity
+       The velocity broadening in km/s.
+    Redshift
+       The redshift of the component.
+    norm
+       The total emission (in photom/cm^2/s) in the line.
+
+    See Also
+    --------
+    XSbfeklor, XSfekblor, XSzbfekblor, XSzfeklor
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelFeklor.html
+
+    """
+
+    __function__ = "C_zbFeKfromSevenLorentzians"
+
+    def __init__(self, name='zbfeklor'):
+        self.Velocity = mkVelocity(name)
+        self.Redshift = mkRedshift(name)
+
+        pars = (self.Velocity, self.Redshift)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
 class XSzbknpower(XSAdditiveModel):
     """The XSPEC zbknpower model: broken power law.
 
@@ -14344,9 +14981,45 @@ class XSzcutoffpl(XSAdditiveModel):
         XSAdditiveModel.__init__(self, name, pars)
 
 
+@version_at_least("12.15.1")
+class XSzfekblor(XSAdditiveModel):
+    """The XSPEC zfekblor model: Fe Kbeta line at high resolution.
+
+    The model is described at [1]_.
+
+    .. versionadded:: 4.18.1
+       This model requires XSPEC 12.15.1 or later.
+
+    Attributes
+    ----------
+    Redshift
+       The redshift of the component.
+    norm
+       The total emission (in photom/cm^2/s) in the line.
+
+    See Also
+    --------
+    XSbfekblor, XSfekblor, XSzbfekblor, XSzfeklor
+
+    References
+    ----------
+
+    .. [1] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSmodelFekblor.html
+
+    """
+
+    __function__ = "C_zFeKbetafromFourLorentzians"
+
+    def __init__(self, name='zfekblor'):
+        self.Redshift = mkRedshift(name)
+
+        pars = (self.Redshift,)
+        XSAdditiveModel.__init__(self, name, pars)
+
+
 @version_at_least("12.15.0")
 class XSzfeklor(XSAdditiveModel):
-    """The XSPEC zfeklor model: Fe K fluourescence line at high resolution
+    """The XSPEC zfeklor model: Fe Kalpha line at high resolution.
 
     The model is described at [1]_.
 
@@ -14356,12 +15029,13 @@ class XSzfeklor(XSAdditiveModel):
     Attributes
     ----------
     Redshift
+       The redshift of the component.
     norm
        The total emission (in photom/cm^2/s) in the line.
 
     See Also
     --------
-    XSfeklor
+    XSbfeklor, XSfeklor, XSzbfeklor, XSzfekblor
 
     References
     ----------

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -20,7 +20,7 @@
 
 """Support for XSPEC models.
 
-Sherpa supports versions 12.15.0, 12.14.1, 12.14.0, 12.13.1, and
+Sherpa supports versions 12.15.1, 12.15.0, 12.14.1, 12.14.0, 12.13.1, and
 12.13.0 of XSPEC [1]_, and can be built against the model library or
 the full application.  There is no guarantee of support for older or
 newer versions of XSPEC.
@@ -795,6 +795,10 @@ def get_xsxset(name: str) -> str:
 
 def get_xsxset(name: str | None = None) -> str | dict[str, str]:
     """Return the X-Spec model setting or settings.
+
+    .. versionchanged:: 4.18.1
+       The model settings now include the "APECROOT", "NEIAPECROOT",
+       and "SPEXROOT" keywords when XSPEC 12.15.1 is used.
 
     .. versionchanged:: 4.17.1
        This routine can now be called with no argument, which means
@@ -9041,7 +9045,7 @@ class XSkerrdisk(XSAdditiveModel):
 
     """
 
-    __function__ = "C_spin"
+    __function__ = "dospin" if equal_or_greater_than("12.15.1") else "C_spin"
 
     def __init__(self, name='kerrdisk'):
         self.lineE = XSParameter(name, 'lineE', 6.4, 0.1, 100., 0.1, 100, units='keV', frozen=True)
@@ -10087,7 +10091,7 @@ class XSnthComp(XSAdditiveModel):
 
     """
 
-    __function__ = "C_nthcomp"
+    __function__ = "donthcomp" if equal_or_greater_than("12.15.1") else "C_nthcomp"
 
     def __init__(self, name='nthcomp'):
         self.Gamma = XSParameter(name, 'Gamma', 1.7, 1.001, 5., 1.001, 10.)
@@ -15824,7 +15828,7 @@ class XSpwab(XSMultiplicativeModel):
 
     """
 
-    __function__ = "C_xspwab"
+    __function__ = "xspwab" if equal_or_greater_than("12.15.1") else "C_xspwab"
 
     def __init__(self, name='pwab'):
         self.nHmin = XSParameter(name, 'nHmin', 1., 1.e-7, 1.e5, 1e-7, 1e6, units='10^22 atoms / cm^2')

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -127,6 +127,12 @@ from sherpa.utils.numeric_types import SherpaFloat
 from .utils import ModelMeta, version_at_least, equal_or_greater_than
 from . import _xspec  # type: ignore
 
+# The documentation tests can leave the XSPEC library in an unexpected
+# state, causing problems for other test runs. There are also tests
+# such as "what is the version" or "what is the default abundance
+# table" which change over time. So just skip these tests.
+#
+__doctest_skip__ = ['*']
 
 info = logging.getLogger(__name__).info
 warning = logging.getLogger(__name__).warning
@@ -262,7 +268,7 @@ def get_xsabundances(table: str | None = None) -> dict[str, float]:
     >>> get_xsabundances()
     {'H': 1.0, 'He': ...}
 
-    >>> set_xsabud("angr")
+    >>> set_xsabund("angr")
     >>> get_xsabundances()["Cu"]
     1.619999956403717e-08
     >>> get_xsabundances("felc")["Cu"]
@@ -418,7 +424,7 @@ def get_xsabundances_path() -> Path:
     --------
 
     >>> get_xsabundances_path()
-    PosixPath('/path/to/spectral/manager/abundances.dat')
+    PosixPath('.../spectral/manager/abundances.dat')
 
     """
 
@@ -489,7 +495,7 @@ def get_xsversion() -> str:
     --------
 
     >>> get_xsversion()
-    '12.11.0m'
+    '12.14.0k'
     """
 
     return _xspec.get_xsversion()
@@ -512,7 +518,7 @@ def get_xsxsect() -> str:
     --------
 
     >>> get_xsxsect()
-    'bcmc'
+    'vern'
     """
 
     return _xspec.get_xsxsect()
@@ -554,9 +560,10 @@ def set_xsabund(abundance: str) -> None:
 
     The values for these tables are given at [1]_.
 
-    Data files should be in ASCII format, containing a single
-    numeric (floating-point) column of the abundance values,
-    relative to Hydrogen.
+    Data files should be in ASCII format, containing a single numeric
+    (floating-point) column of the abundance values, relative to
+    Hydrogen. The `set_xsabundances` is an alternative approach to
+    setting the abundances without having to create a text file.
 
     The screen output of this function is controlled by the
     X-Spec chatter setting (`set_xschatter`).
@@ -771,8 +778,8 @@ def clear_xsxset() -> None:
     --------
 
     >>> set_xsxset("POW_EMIN", "0.5")
-    >>> get_xsxset()
-    {'POW_EMIN': '0.5'}
+    >>> get_xsxset()["POW_EMIN"]
+    '0.5'
     >>> clear_xsxset()
     >>> get_xsxset()
     {}
@@ -929,7 +936,7 @@ def get_xspath_manager() -> str:
     --------
 
     >>> get_xspath_manager()
-    '/usr/local/heasoft-6.22/x86_64-unknown-linux-gnu-libc2.24/../spectral/manager'
+    '.../spectral/manager'
     """
 
     return _xspec.get_xspath_manager()
@@ -952,7 +959,7 @@ def get_xspath_model() -> str:
     --------
 
     >>> get_xspath_model()
-    '/usr/local/heasoft-6.22/x86_64-unknown-linux-gnu-libc2.24/../spectral/modelData'
+    '.../spectral/modelData/'
     """
 
     return _xspec.get_xspath_model()
@@ -1291,15 +1298,17 @@ class XSBaseParameter(Parameter):
     --------
 
     >>> p = XSBaseParameter('mod', 'p', 2, min=1, max=9, hard_min=0, hard_max=10)
-    >>> p.min
+    >>> print(p.min)
     0.0
-    >>> p.hard_min
+    >>> print(p.hard_min)
     0.0
-    >>> p.max
+    >>> print(p.max)
     10.0
-    >>> p.hard_max
+    >>> print(p.hard_max)
     10.0
     >>> p.val = 20
+    Traceback (most recent call last):
+        ...
     sherpa.utils.err.ParameterErr: parameter mod.p has a maximum of 10
 
     """
@@ -1352,22 +1361,26 @@ class XSParameter(XSBaseParameter):
     >>> p = XSParameter('mod', 'p', 2, min=1, max=9, hard_min=0, hard_max=10)
     >>> p.frozen
     False
-    >>> p.min
+    >>> print(p.min)
     0.0
-    >>> p.hard_min
+    >>> print(p.hard_min)
     0.0
-    >>> p.max
+    >>> print(p.max)
     10.0
-    >>> p.hard_max
+    >>> print(p.hard_max)
     10.0
     >>> p.val = 20
+    Traceback (most recent call last):
+        ...
     sherpa.utils.err.ParameterErr: parameter mod.p has a maximum of 10
     >>> p.max = 30
+    Traceback (most recent call last):
+        ...
     sherpa.utils.err.ParameterErr: parameter mod.p has a hard maximum of 10
     >>> p.hard_max = 30
-    >>> p.max
+    >>> print(p.max)
     30.0
-    >>> p.hard_max
+    >>> print(p.hard_max)
     30.0
     >>> p.val = 20
     >>> p.frozen
@@ -2003,8 +2016,8 @@ class XSConvolutionKernel(XSModel):
        Param        Type          Value          Min          Max      Units
        -----        ----          -----          ---          ---      -----
        xscflux.Emin frozen          0.5            0        1e+06        keV
-       xscflux.Emax frozen           10            0        1e+06        keV
-       xscflux.lg10Flux thawed          -12         -100          100        cgs
+       xscflux.Emax frozen            7            0        1e+06        keV
+       xscflux.lg10Flux thawed        -12.1         -100          100        cgs
 
     The convolution models are not evaluated directly. Instead they
     are applied to a model expression which you specify as the
@@ -2138,21 +2151,21 @@ class XSConvolutionModel(CompositeModel, XSModel):
        Param        Type          Value          Min          Max      Units
        -----        ----          -----          ---          ---      -----
        xscflux.Emin frozen          0.5            0        1e+06        keV
-       xscflux.Emax frozen           10            0        1e+06        keV
-       xscflux.lg10Flux thawed          -12         -100          100        cgs
-       phabs.nH     thawed            1            0       100000 10^22 atoms / cm^2
-       powerlaw.PhoIndex thawed            1           -2            9
+       xscflux.Emax frozen            7            0        1e+06        keV
+       xscflux.lg10Flux thawed        -12.1         -100          100        cgs
+       phabs.nH     thawed            1            0        1e+06 10^22 atoms / cm^2
+       powerlaw.PhoIndex thawed            1           -3           10
        powerlaw.norm frozen            1            0        1e+24
 
     >>> print(mdl2)
     phabs * xscflux(powerlaw)
        Param        Type          Value          Min          Max      Units
        -----        ----          -----          ---          ---      -----
-       phabs.nH     thawed            1            0       100000 10^22 atoms / cm^2
+       phabs.nH     thawed            1            0        1e+06 10^22 atoms / cm^2
        xscflux.Emin frozen          0.5            0        1e+06        keV
-       xscflux.Emax frozen           10            0        1e+06        keV
-       xscflux.lg10Flux thawed          -12         -100          100        cgs
-       powerlaw.PhoIndex thawed            1           -2            9
+       xscflux.Emax frozen            7            0        1e+06        keV
+       xscflux.lg10Flux thawed        -12.1         -100          100        cgs
+       powerlaw.PhoIndex thawed            1           -3           10
        powerlaw.norm frozen            1            0        1e+24
 
     """

--- a/sherpa/astro/xspec/src/_xspec.cc
+++ b/sherpa/astro/xspec/src/_xspec.cc
@@ -1,4 +1,4 @@
-//  Copyright (C) 2007, 2015 - 2025
+//  Copyright (C) 2007, 2015-2026
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -39,6 +39,150 @@
 //
 #include <XSFunctions/funcWrappers.h>
 #include <XSFunctions/functionMap.h>
+
+
+// C++20 support is not guaranteed.
+//
+inline bool ends_with(const std::string &value,
+		      const std::string &suffix)
+{
+  return value.size() >= suffix.size() &&
+    std::equal(suffix.rbegin(),
+	       suffix.rend(),
+	       value.rbegin());
+}
+
+// Case-insensitive search.
+//
+static bool is_latest(const std::string &value)
+{
+  std::string check = value;
+  std::transform(check.begin(), check.end(), check.begin(),
+		 [](unsigned char c) { return std::tolower(c); });
+  return (check == "latest");
+}
+
+
+template <const std::string &getfunc(),
+          void setfunc(const std::string&)>
+static void set_if_latest(const std::map<std::string, std::string> versionMap,
+                          const std::string &key,
+                          const std::string &def)
+{
+
+  if (!is_latest(getfunc())) {
+    return;
+  }
+
+  std::map<std::string, std::string>::const_iterator it =
+    versionMap.find(key);
+  if (it == versionMap.end()) {
+    setfunc(def);
+  } else {
+    setfunc(it->second);
+  }
+}
+
+
+// As of XSPEC 12.15.1 the APEC/ATOMDB, NEI, and SPEX versions can be
+// set to "latest" and then converted to a value by the XSPEC
+// initialization code.
+//
+// The "latest" string is converted to a version by
+//
+// - checking for $HEADAS/spectral/modelData/latest.txt file
+//
+// - if not present, use a hard-coded value (for XSPEC 12.15.1 these
+//   values are different depending on if the XSPEC program or
+//   model libraries are in use).
+//
+// The "latest.txt" file is a text key-value file (with no apparent
+// error checking) with lines like
+//
+//     ATOMDB_VERSION: 3.1.3
+//     SPEX_VERSION: 3.0.8
+//     NEI_VERSION: 3.1.3
+//
+// Note that the file may not be present because, for instance, the
+// "XSPEC data" conda package has not been installed from the HEASOFT
+// conda channel.
+//
+// Note that these "versions" map to
+//
+//      FunctionUtility::atomdbVersion()
+//      FunctionUtility::neiVersion()
+//      FunctionUtility::spexVersion()
+//
+// and to the following "string model" keywords
+//
+//      APECROOT
+//      NEIAPECROOT
+//      SPEXROOT
+//
+// It appears that setting one of these will set the other, at least
+// for XSPEC 12.15.1.
+//
+// There does not appear to be any methods in FunctionUtility that
+// provide easy access to handling this (and, even if there were, they
+// would not be available to XSPEC libraries prior to 12.15.1), which
+// is why there's a lot of "DIY" code here that hopefully matches
+// XSPEC.
+//
+static void validateVersions()
+{
+
+  // Are any keywords set to "latest"?
+  //
+  bool foundLatest = false;
+  foundLatest |= is_latest(FunctionUtility::atomdbVersion());
+  foundLatest |= is_latest(FunctionUtility::neiVersion());
+#ifdef XSPEC_12_15_0
+  foundLatest |= is_latest(FunctionUtility::spexVersion());
+#endif
+  if (!foundLatest) {
+    return;
+  }
+
+  // Read in the versions from the latest file.
+  // There appears to be no validity check, and
+  // the lines are expected to be
+  //    <key>_VERSION: <version_str>
+  //
+  const std::string versionPath(FunctionUtility::modelDataPath() +
+				"latest.txt");
+  std::map<std::string, std::string> versionMap;
+
+  std::ifstream versionFile(versionPath.c_str());
+  if (versionFile) {
+    const std::string suffix = "_VERSION:";
+    std::string lKey, lVersion;
+    while (versionFile >> lKey >> lVersion) {
+      if (ends_with(lKey, suffix)) {
+	const std::string lName = lKey.substr(0, lKey.size() - suffix.size());
+	versionMap[lName] = lVersion;
+      }
+    }
+  }
+
+  // It is not obvious what to use as the default value (if the above
+  // has no match) since this code supports multiple XSPEC versions.
+  // Use the defaults from XSPEC 12.15.1/HEADAS 6.36 which added
+  // support for the "latest.txt" file.
+  //
+  set_if_latest<FunctionUtility::atomdbVersion,
+                FunctionUtility::atomdbVersion>
+    (versionMap, "ATOMDB", "3.1.3");
+  set_if_latest<FunctionUtility::neiVersion,
+                FunctionUtility::neiVersion>
+    (versionMap, "NEI", "3.1.3");
+#ifdef XSPEC_12_15_0
+  set_if_latest<FunctionUtility::spexVersion,
+                FunctionUtility::spexVersion>
+    (versionMap, "SPEX", "3.08");
+#endif
+
+}
+
 
 // The XSPEC initialization used to be done lazily - that is, only
 // when the first routine from XSPEC was about to be called - but
@@ -105,6 +249,16 @@ static int _sherpa_init_xspec_library()
   FunctionUtility::setH0( 70.0 );
   FunctionUtility::setq0( 0.0 );
   FunctionUtility::setlambda0( 0.73 );
+
+  // Convert "latest" version numbers. Ideally this would only be done
+  // if XSPEC 12.15.1 or later were in use, but users can have a XSPEC
+  // 12.15.1 ~/.xspec/Xspec.init file - e.g. with lines like
+  //
+  //      ATOMDB_VERSION:  latest
+  //
+  // but still be building against XSPEC 12.15.0 (or earlier).
+  //
+  validateVersions();
 
   init = true;
   return EXIT_SUCCESS;
@@ -602,6 +756,12 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C(C_bcph, 5),                      // XSbcph
   XSPECMODELFCT_C(C_bequil, 4),                    // XSbequil
   XSPECMODELFCT_C(C_bexpcheb6, 11),                // XSbexpcheb6
+#endif
+#ifdef XSPEC_12_15_1
+  XSPECMODELFCT_C(C_bFeKbetafromFourLorentzians, 1), // XSbfekblor
+  XSPECMODELFCT_C(C_bFeKfromSevenLorentzians, 1),  // XSbfeklor
+#endif
+#ifdef XSPEC_12_14_0
   XSPECMODELFCT_C(C_bgaussDem, 7),                 // XSbgadem
   XSPECMODELFCT_C(C_bgnei, 6),                     // XSbgnei
   XSPECMODELFCT_C(C_bnei, 5),                      // XSbnei
@@ -716,6 +876,9 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C(C_expcheb6, 10),                 // XSexpcheb6
 #endif
   XSPECMODELFCT(ezdiskbb, 1),                      // XSezdiskbb
+#ifdef XSPEC_12_15_1
+  XSPECMODELFCT_C(C_FeKbetafromFourLorentzians, 0), // XSfekblor
+#endif
 #ifdef XSPEC_12_15_0
   XSPECMODELFCT_C(C_FeKfromSevenLorentzians, 0),   // XSfeklor
 #endif
@@ -730,7 +893,11 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT(jet, 15),                          // XSjet
   XSPECMODELFCT_C(C_kerrbb, 9),                    // XSkerrbb
   XSPECMODELFCT_C(C_kerrd, 7),                     // XSkerrd
+#ifdef XSPEC_12_15_1
+  XSPECMODELFCT(dospin, 9),                        // XSkerrdisk
+#else
   XSPECMODELFCT_C(C_spin, 9),                      // XSkerrdisk
+#endif
 
   XSPECMODELFCT_CON_F77(kyconv, 12),               // XSkyconv
 
@@ -752,7 +919,11 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C(C_nsmaxg, 5),                    // XSnsmaxg
   XSPECMODELFCT_C(C_nsx, 5),                       // XSnsx
   XSPECMODELFCT_C(C_xsnteea, 15),                  // XSnteea
+#ifdef XSPEC_12_15_1
+  XSPECMODELFCT(donthcomp, 5),                     // XSnthComp
+#else
   XSPECMODELFCT_C(C_nthcomp, 5),                   // XSnthComp
+#endif
   XSPECMODELFCT(optxagn, 13),                      // XSoptxagn
   XSPECMODELFCT(optxagnf, 11),                     // XSoptxagnf
   XSPECMODELFCT(xspegp, 3),                        // XSpegpwrlw
@@ -777,6 +948,15 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_CON_F77(rgsxsrc, 1),               // XSrgsxsrc
 #endif
 
+#ifdef XSPEC_12_15_1
+  XSPECMODELFCT_C(C_rsapec, 5),                    // XSrsapec
+  XSPECMODELFCT_C(C_rsgaussianLine, 3),            // XSrsgaussian
+  XSPECMODELFCT_C(C_rsrnei, 7),                    // XSrsrnei
+  XSPECMODELFCT_C(C_rsvapec, 17),                  // XSrsvapec
+  XSPECMODELFCT_C(C_rsvrnei, 19),                  // XSrsvrnei
+  XSPECMODELFCT_C(C_rsvvapec, 34),                 // XSrsvvapec
+  XSPECMODELFCT_C(C_rsvvrnei, 36),                 // XSrsvvrnei
+#endif
   XSPECMODELFCT_C(C_rnei, 5),                      // XSrnei
   XSPECMODELFCT_C(C_sedov, 5),                     // XSsedov
   XSPECMODELFCT_C(C_sirf, 9),                      // XSsirf
@@ -845,9 +1025,16 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT_C(C_wDem, 7),                      // XSwdem
   XSPECMODELFCT_C(C_zagauss, 3),                   // XSzagauss
   XSPECMODELFCT(xszbod, 2),                        // XSzbbody
+#ifdef XSPEC_12_15_1
+  XSPECMODELFCT_C(C_zbFeKbetafromFourLorentzians, 2), // XSzbfekblor
+  XSPECMODELFCT_C(C_zbFeKfromSevenLorentzians, 2), // XSzbfeklor
+#endif
   XSPECMODELFCT_C(C_zBrokenPowerLaw, 4),           // XSzbknpower
   XSPECMODELFCT(xszbrm, 2),                        // XSzbremss
   XSPECMODELFCT_C(C_zcutoffPowerLaw, 3),           // XSzcutoffpl
+#ifdef XSPEC_12_15_1
+  XSPECMODELFCT_C(C_zFeKbetafromFourLorentzians, 1), // XSzfekblor
+#endif
 #ifdef XSPEC_12_15_0
   XSPECMODELFCT_C(C_zFeKfromSevenLorentzians, 1),  // XSzfeklor
 #endif
@@ -890,7 +1077,11 @@ static PyMethodDef XSpecMethods[] = {
   XSPECMODELFCT(xsabsp, 2),                        // XSpcfabs
   XSPECMODELFCT(xsphab, 1),                        // XSphabs
   XSPECMODELFCT(xsplab, 2),                        // XSplabs
+#ifdef XSPEC_12_15_1
+  XSPECMODELFCT(xspwab, 3),                        // XSpwab
+#else
   XSPECMODELFCT_C(C_xspwab, 3),                    // XSpwab
+#endif
   XSPECMODELFCT(xscred, 1),                        // XSredden
   XSPECMODELFCT(xssmdg, 4),                        // XSsmedge
   XSPECMODELFCT_C(C_superExpCutoff, 2),            // XSspexpcut

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -37,7 +37,7 @@ from sherpa.utils.err import ParameterErr
 #    '(XSConvolutionKernel)'
 # in `xspec/__init__.py`
 #
-XSPEC_MODELS_COUNT = 210 + 72 + 24
+XSPEC_MODELS_COUNT = 223 + 72 + 24
 
 # Conversion between wavelength (Angstrom) and energy (keV)
 # The values used are from sherpa/include/constants.hh

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -775,6 +775,9 @@ def check_str_fixture(out, expecteds):
 
     to the end of each line that needs it.
 
+    Using "# doctest: +ELLIPSIS" will stop the comparison at the
+    ellipsis, which must exist in the line.
+
     Parameters
     ----------
     out : str
@@ -792,6 +795,7 @@ def check_str_fixture(out, expecteds):
         # expected is one of:
         #  - a pattern
         #  - a string ending in #doctest: +FLOAT_CMP
+        #  - a string ending in #doctest: +ELLIPSIS
         #  - a normal string
         #
         try:
@@ -801,6 +805,15 @@ def check_str_fixture(out, expecteds):
             if idx > -1:
                 pat = NumberChecker(expected[:idx].rstrip())
                 pat.check(tok)
+                continue
+
+            idx = expected.find("# doctest: +ELLIPSIS")
+            if idx > -1:
+                idx = expected.find("...")
+                # If there is no ellipsis then the test is in error
+                assert idx > -1, expected
+
+                assert tok[:idx] == expected[:idx]
                 continue
 
             assert tok == expected


### PR DESCRIPTION
# Summary

Allow Sherpa to build against XSPEC 12.15.1 and simplify the XSPEC installation steps. Add 13 new additive models: XSbfekblor, XSfekblor, XSzfekblor, XSzbfekblor, XSbfeklor, XSzbfeklor, XSrsapec, XSrsvapec, XSrsvvapec, XSrsgaussian, XSrsrnei, XSrsvrnei, XSrsvvrnei. Fix #2392.

# Details

The documentation for the XSPEC configuration has (hopefully) been improved, and now mentions the (relatively new) HEASARC xspec builds. It turns out that with recent XSPEC builds we do not need to be as explicit as we used to with the "ancillary" libraries as they are referenced via rpath/whatever the magic is. This means that we not need to include "hdsp_<version>" in the XSPEC libraries list, nor do we need to give CCFits and wcslib libraries (again with versions). So the documenation has had the "per-XSPEC-version" list of options removed. I have also changed the XSPEC build step to default to $HEADAS/include and $HEADAS/lib for the XSPEC paths [*] and then allowed environment variables to be used for any of the paths **but only for** the XSPEC options (i.e. not FFTW or region or ...).

[*] Of cource, the CXC-provided `xspec-modelsonly` packages actually have $HEADAS pointing to somewhere different, and you actually want either $HEADAS/../lib or $CONDA_PREFIX/lib instead. Which means that the `scripts/use_ciao_config` and `.github/scrpts/setup_xspec.sh` helper scripts need minor tweaks (because the default options in `setup.cfg` have changed so the scripts don't recognize the lines to change). Other downstream code, like #1544, will also likely need to be updated.

Allows Sherpa to be built with XSPEC 12.15.1 and provide access to the 13 new additive models:

    XSbfekblor     XSfekblor    XSzfekblor    XSzbfekblor
    XSbfeklor      XSzbfeklor
    XSrsapec       XSrsvapec     XSrsvvapec
    XSrsgaussian
    XSrsrnei        XSrsvrnei       XSrsvvrnei

XSPEC 12.15.1 has added support for `"latest"` settings for the apec/atomdb, nei, and spex database versions (the names of this are not clear, e.g. apec vs atomdb, nei vs neiapec). For example:

```
% grep VERSION ~/.xspec/Xspec.init
ATOMDB_VERSION:  latest
SPEX_VERSION:  latest
NEI_VERSION: latest
```

There is now a `latest.txt` file in the `modelData` directory that can be used to find out what "latest" means, but this is not guaranteed to exist, in which case it falls back to default values. It appeas that the default depends on whether you are running XSPEC (the program) or accessing just the model library.

For now we attempt to follow the program versions (as they are newer) as the defaults (when the `latest.txt` file does not exist), but **only** when the interface is built with XSPEC 12.15.1 (or later), as it's not clear what to do with older XSPEC libraries. One option would be to just error out if `latest` is set but there's no `latest.txt` file: I decided against this as it's possible to get a 12.15.1 `Xspec.init` file, which has `latest` values in it, and then switch to use Sherpa (e.g. via CIAO) and it would be annoying for it to then fall over (although there is a strong argument to be said it would make things more obvious about what is going on, but I don't think most users would agree with this choice). 

The `xset` database now gets three values automatically associated with it. This is not technically a breaking change but it can be surprising (e.g. the `save_all` output will now include these three settings if XSPEC is installed/used):

```
>>> from sherpa.astro import xspec
>>> xspec.get_xsversion()
'12.15.1'
>>> xspec.get_xsxset()
{'APECROOT': '3.1.3', 'NEIAPECROOT': '3.1.3', 'SPEXROOT': '3.0.8'}
```

# Notes

I believe there are some issues with the XSPEC 12.15.1 release but I have not reported them yet as HEASARC is closed down. Problems include

- XSPEC initalization defaults to atomdb/nei/spex versions of 3.13/3.13/3.08 but the FORTRAN `FNINIT` code we have to use uses 3.12/3.12/3.08 (at least that is what it seems like)
- however, the $HEADAS/spectral/modelData/latest.txt uses "3.0.8" for the SPEX version and this will win out if you have a "new" ~/.xspec/Xspec.init file with "SPEX_VERSION: latest" in it. I believe this is wrong and it should be "3.08".

**EDIT** These have now been reported to the XSPEC team (Jan 14 2026).

Originally this supported `get_xsversion("atomdb")` and `set_xsversion("atomdb", "4.0.1")` but I have removed this because

a) too many ways to set the same information (e.g. `set_xsxset("APECROOT", "4.0.1")`) makes it confusing
b) if you use a pre-XSPEC 12.15.1 library then the different ways to set this information can lead to different behavior (which means we probably don't want to do this until we default to 12.15.1, if ever)

# Examples

XSPEC 12.15.1 installed via HEASARC conda packages, including the data

```
% grep VERSION ~/.xspec/Xspec.init
ATOMDB_VERSION:  latest
SPEX_VERSION:  latest
NEI_VERSION: latest
% cat $HEADAS/spectral/modelData/latest.txt 
ATOMDB_VERSION: 3.1.3
SPEX_VERSION: 3.0.8
NEI_VERSION: 3.1.3
```

```
>>> from sherpa.astro import xspec
>>> xspec.get_xsversion()
'12.15.1'
>>> xspec.get_xsxset()
{'APECROOT': '3.1.3', 'NEIAPECROOT': '3.1.3', 'SPEXROOT': '3.0.8'}
```

We can see an apec model and some of the files it loads by bumping the `chatter` setting:

```
>>> xspec.set_xschatter(50)
>>> mdl = xspec.XSapec()
>>> mdl([0.1, 0.2, 0.3], [0.2, 0.3, 0.4])
calcMultiTempPlasma : plasmaType = 6

calcMultiTempPlasma : plasmaType = 6
calcMultiTempPlasma : TraceAbund = 1

Reading APEC data from 3.1.3

Reading continuum   data from /home/dburke/micromamba/envs/xspec/heasoft/spectral/modelData/apec_v3.1.3_coco.fits
Reading line        data from /home/dburke/micromamba/envs/xspec/heasoft/spectral/modelData/apec_v3.1.3_line.fits
Reading ion balance data from /home/dburke/micromamba/envs/xspec/heasoft/spectral/modelData/apec_v3.1.0_ionbal.fits

Reading continuum data from /home/dburke/micromamba/envs/xspec/heasoft/spectral/modelData/apec_v3.1.3_coco.fits
Reading line data from /home/dburke/micromamba/envs/xspec/heasoft/spectral/modelData/apec_v3.1.3_line.fits
Reading ion balance data from /home/dburke/micromamba/envs/xspec/heasoft/spectral/modelData/apec_v3.1.0_ionbal.fits
Not applying thermal broadening
Velocity broadening : 0
Linear interpolation on tabulated temperatures
Not multi-threading over temperatures
Including electron-electron bremsstrahlung
Not doing electron density correction on normalization
Column (rsColumn) for resonance scattering 0

For continuum interpolating between 0.966887 and 1.02418 for 1
with coefficients 0.422019 and 0.577981

For lines interpolating between 0.966887 and 1.02418 for 1
with coefficients 0.422019 and 0.577981

Reading data for temperature 122 0.966887 0.966882

Reading data for temperature 122 0.966887 0.966882
Read 30417 element lines and 30  continuum points for 30 unique elements.

Reading data for temperature 123 1.02418 1.02417

Reading data for temperature 123 1.02418 1.02417
Read 28818 element lines and 30  continuum points for 30 unique elements.

array([2.01612911, 0.30307714, 0.2181515 ])
```

