### PR TITLE
Bump conda workflow from macos-13 to macos-15-intel

### DIFF
--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -115,7 +115,7 @@ jobs:
         if-no-files-found: error
         retention-days: 3
 
-#Note macos-14+ is macos arm
+#Note macos-15-intel is the last version for Intel on macOS
   build-macos:
     name: ${{ matrix.name }}
     if: github.repository == 'sherpa/sherpa' && ${{ needs.check-skip.outputs.skip_pipeline }} == "false"
@@ -125,15 +125,15 @@ jobs:
       matrix:
         include:
           - name: MacOS (Intel) Python 3.10
-            os-type: "macos-13"
+            os-type: "macos-15-intel"
             os-dir: "osx-64"
             python-version: "3.10"
           - name: MacOS (Intel) Python 3.11
-            os-type: "macos-13"
+            os-type: "macos-15-intel"
             os-dir: "osx-64"
             python-version: "3.11"
           - name: MacOS (Intel) Python 3.12
-            os-type: "macos-13"
+            os-type: "macos-15-intel"
             os-dir: "osx-64"
             python-version: "3.12"
           - name: MacOS (ARM) Python 3.10

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         include:
           - name: MacOS Intel Full Build (Python 3.11)
-            os: macos-13
+            os: macos-15-intel
             python-version: "3.11"
             install-type: develop
             fits: astropy


### PR DESCRIPTION
# Summary

Update the GitHub macOS workflows to reflect changes in the available macOS options. There is no functional change.

# Details

The macOS 13 runner image will be retired by December 4th, 2025. We can replace it with `macos-14` or `macos-15-intel`. In this case we want the Intel build (so `macos-15-intel`).

To raise awareness of the upcoming removal, jobs using macOS 13 will temporarily fail during the scheduled brownout time periods defined below:

    November 4, 14:00 UTC - November 5, 00:00 UTC
    November 11, 14:00 UTC - November 12, 00:00 UTC
    November 18, 14:00 UTC - November 19, 00:00 UTC
    November 25, 14:00 UTC - November 26, 00:00 UTC