### PR TITLE
Update the Zenodo information

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -289,7 +289,8 @@ It can query the Zenodo API, but it also contains a list of known
 releases in the ``sherpa._get_citation_hardcoded`` routine. To add
 to this list (for when there's been a new release), run the
 ``scripts/make_zenodo_release.py`` script with the version number
-and add the screen output to the list in ``_get_citation_hardcoded``.
+and add the screen output to the list in ``_get_citation_hardcoded``,
+which is in the file ``sherpa/__init__.py``.
 
 For example, using release 4.12.2 would create (the author list has been
 simplified)::

--- a/scripts/make_zenodo_release.py
+++ b/scripts/make_zenodo_release.py
@@ -19,6 +19,7 @@ is expected.
 import datetime
 import json
 import ssl
+import sys
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
@@ -78,7 +79,7 @@ def make_zenodo_citation(jsdata):
     print(f"        idval='{idval}')")
 
 
-def dump_zenodo(version):
+def dump_zenodo(version: str | None) -> None:
     """Access Zenodo for the version information.
 
     Parameters
@@ -87,6 +88,27 @@ def dump_zenodo(version):
         The version string (e.g. '4.12.2'). If None then all versions
         are reported.
     """
+
+    # Does Sherpa already know about this version? Do not make this a
+    # required check (so Sherpa does not have to be installed).
+    #
+    # As well as an import error, this can also fail because it loads
+    # a sherpa module which is empty, and so raising an attribute
+    # error. In this case the user should ensure that PYTHONPATH is
+    # set correctly (as it is probably an editable install path
+    # issue).
+    #
+    if version is not None:
+        try:
+            import sherpa
+
+            res = sherpa._get_citation_hardcoded(version)
+            if res is not None:
+                sys.stderr.write("WARNING: already support "
+                                 f"version {version}\n")
+
+        except (AttributeError, ImportError):
+            pass
 
     params = {"q": "parent.id:593753",
               "all_versions": 1,

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2014-2016, 2019-2025
+#  Copyright (C) 2007, 2014-2016, 2019-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -208,6 +208,20 @@ def _get_citation_hardcoded(version: str) -> Optional[str]:
         assert version not in cite
         cite[version] = dict(**kwargs)
         cite[version]['version'] = version
+
+    add(version='4.18.0', title='sherpa/sherpa: Sherpa 4.18.0',
+        date=todate(2025, 10, 7),
+        authors=['Doug Burke', 'Omar Laurino', 'wmclaugh', 'Hans Moritz Günther', 'Marie-Terrell', 'dtnguyen2', 'Aneta Siemiginowska', 'Harlan Cheer', 'Jamie Budynkiewicz', 'Tom Aldcroft', 'luzpaz', 'Christoph Deil', 'Brigitta Sipőcz', 'nplee', 'Johannes Buchner', 'Axel Donath', 'Iva Laginja', 'Katrin Leinweber', 'Todd'],
+        idval='17288983')
+
+    add(version='4.17.1', title='sherpa/sherpa: Sherpa 4.17.1',
+        date=todate(2025, 5, 13),
+        authors=['Doug Burke', 'Omar Laurino', 'wmclaugh', 'Hans Moritz Günther', 'Marie-Terrell', 'dtnguyen2', 'Aneta Siemiginowska', 'Harlan Cheer', 'Jamie Budynkiewicz', 'Tom Aldcroft', 'luzpaz', 'Christoph Deil', 'Brigitta Sipőcz', 'nplee', 'Johannes Buchner', 'Axel Donath', 'Iva Laginja', 'Katrin Leinweber', 'Todd'],
+        idval='15397764')
+    add(version='4.17.0', title='sherpa/sherpa: Sherpa 4.17.0',
+        date=todate(2024, 10, 9),
+        authors=['Doug Burke', 'Omar Laurino', 'wmclaugh', 'Hans Moritz Günther', 'Marie-Terrell', 'dtnguyen2', 'Aneta Siemiginowska', 'Harlan Cheer', 'Jamie Budynkiewicz', 'Tom Aldcroft', 'luzpaz', 'Christoph Deil', 'Brigitta Sipőcz', 'Johannes Buchner', 'nplee', 'Axel Donath', 'Iva Laginja', 'Katrin Leinweber', 'Todd'],
+        idval='13909532')
 
     add(version='4.16.1', title='sherpa/sherpa: Sherpa 4.16.1',
         date=todate(2024, 5, 21),


### PR DESCRIPTION
# Summary

Update the stored Zenodo release data for 4.17.0, 4.17.1, and 4.18.0.

# Details

There are also a few minor changes to the documentation and script used to create this output (a warning if the data is already known about).

For users this should not change the results of getting a citation, other than

- making it faster (as no internet request is made)
- work even without internet (as no internet request is made)

at least for these three versions.