### PR TITLE
Split `TableModel` into separate classes

### DIFF
--- a/docs/model_classes/basic.rst
+++ b/docs/model_classes/basic.rst
@@ -19,8 +19,10 @@ The sherpa.models.basic module
       Erfc
       Exp
       Exp10
+      FixedTableModel
       Gauss1D
       Integrate1D
+      InterpolatedTableModel1D
       Log
       Log10
       LogParabola
@@ -34,6 +36,7 @@ The sherpa.models.basic module
       StepHi1D
       StepLo1D
       TableModel
+      TableModelBase
       Tan
       UserModel
 
@@ -49,5 +52,5 @@ The sherpa.models.basic module
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram:: Box1D Const1D Scale1D Cos Delta1D Erf Erfc Exp Exp10 Gauss1D Integrate1D Log Log10 LogParabola NormGauss1D Poisson Polynom1D PowLaw1D Sin Sqrt StepHi1D StepLo1D TableModel Tan UserModel Box2D Const2D Scale2D Delta2D Gauss2D SigmaGauss2D NormGauss2D Polynom2D
+.. inheritance-diagram:: Box1D Const1D Scale1D Cos Delta1D Erf Erfc Exp Exp10 FixedTableModel Gauss1D Integrate1D InterpolatedTableModel1D Log Log10 LogParabola NormGauss1D Poisson Polynom1D PowLaw1D Sin Sqrt StepHi1D StepLo1D TableModelBase TableModel Tan UserModel Box2D Const2D Scale2D Delta2D Gauss2D SigmaGauss2D NormGauss2D Polynom2D
    :parts: 1

--- a/sherpa/astro/io/dummy_backend.py
+++ b/sherpa/astro/io/dummy_backend.py
@@ -81,7 +81,7 @@ def get_table_data(arg,
         otherwise the backend selects. The default is `None`.
         Names are compared using a case insensitive match.
     make_copy: bool, optional
-        If set then the returned NumPy arrays are explictly copied,
+        If set then the returned NumPy arrays are explicitly copied,
         rather than using a reference from the data structure
         created by the backend. Backends are not required to
         honor this setting. The default is `True`.

--- a/sherpa/astro/tests/test_astro_instrument.py
+++ b/sherpa/astro/tests/test_astro_instrument.py
@@ -42,7 +42,7 @@ from sherpa.astro.instrument import ARF1D, ARFModelNoPHA, ARFModelPHA, \
 from sherpa.data import Data1D
 from sherpa.fit import Fit
 from sherpa.models.basic import Box1D, Const1D, Gauss1D, Polynom1D, \
-    PowLaw1D, TableModel
+    PowLaw1D, FixedTableModel
 from sherpa.models.model import ArithmeticModel, \
     ArithmeticConstantModel, BinaryOpModel, Model
 from sherpa.utils.err import DataErr, PSFErr
@@ -2294,7 +2294,7 @@ def test_psfmodel_kernel_has_no_dimension():
     y = np.ones_like(x)
     data = Data1D("data-data", x, y)
 
-    m = PSFModel(kernel=TableModel())
+    m = PSFModel(kernel=FixedTableModel())
     with pytest.raises(PSFErr,
                        match="PSF model dimension must be <= 2"):
         m.get_kernel(data)

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -1048,7 +1048,7 @@ def _save_model_components(out: OutType, state: SessionType) -> bool:
             cmd = f'load_psf("{mod._name}", "{mod.kernel.name}")'
             _output(out, cmd)
 
-        elif typename == "tablemodel":
+        elif typename in ["fixedtablemodel", "interpolatedtablemodel1d"]:
             cmd = f'load_table_model("{modelname}", "{mod.filename}")'
             _output(out, cmd)
 

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -1824,7 +1824,11 @@ def test_get_xxx_component_plot_with_templates_data1dint_no_interp(session, labe
         assert len(mplot.y) == 19
         assert len(cplot.y) == 100
 
-        assert mplot.y[0] == pytest.approx(cplot.y[0] * ynorm)
+        bin_width = np.diff(edges)
+        expected_bin_0 = cplot.y[0] * ynorm
+        # The model is integrated over several bins, but the result is close
+        # to the value of the first bin.
+        assert mplot.y[0] / bin_width[0] == pytest.approx(expected_bin_0, rel=2e-2)
         assert np.all(mplot.y > 0)
         assert np.all(cplot.y > 0)
 
@@ -1988,19 +1992,10 @@ def test_compare_get_model_component_plot_with_templates(interp, make_data_path)
 
     assert cplot_int.xlo == pytest.approx(cplot_pha.xlo)
     assert cplot_1d.x == pytest.approx(cplot_pha.xlo)
-
-    # It looks like the model is not integrated across the bin for
-    # the 1DInt case.
-    #
-    assert cplot_1d.y == pytest.approx(cplot_int.y)
-
-    # The DataPHA result, when compared to Data1D is:
-    #
-    # a) multiplied by SPECRESP
-    # b) divided by BIN_WIDTH
-    #
-    r = cplot_int.y / cplot_pha.y
-    assert r == pytest.approx(ones * BIN_WIDTH / SPECRESP)
+    assert cplot_1d.y == pytest.approx(cplot_int.y / BIN_WIDTH)
+    # DataPHA is a not-integrated dataset (although maybe it should be)
+    # So it differs from Data1D only by the response.
+    assert cplot_pha.y == pytest.approx(cplot_1d.y * SPECRESP)
 
 
 @requires_data

--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -3011,7 +3011,7 @@ def test_add_model_types_simple(session):
     s._add_model_types(sherpa.models.basic)
 
     # This will need updating if models are added to basic
-    assert len(s.list_models()) == 31
+    assert len(s.list_models()) == 33
 
 
 @pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])
@@ -3023,7 +3023,7 @@ def test_add_model_types_scalar(session):
                        baselist=ArithmeticModel)
 
     # This will need updating if models are added to basic
-    assert len(s.list_models()) == 31
+    assert len(s.list_models()) == 33
 
 
 @pytest.mark.parametrize("session", [pytest.param(Session, marks=pytest.mark.session), AstroSession])

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -360,8 +360,8 @@ def test_ui_table_model_1d_testfile(clean_astro_ui, comment, ncols):
         f.write(f'{comment}\n1\n2\n3\n')
         f.seek(0)
         ui.load_table_model('tbl', f.name, comment=comment, ncols=ncols)
-        assert tbl.get_x() is None
         assert tbl.get_y() == pytest.approx([1, 2, 3])
+        assert not hasattr(tbl, 'get_x')
 
 
 def test_ui_table_model_1d_testfile_fails(clean_astro_ui):

--- a/sherpa/astro/ui/tests/test_astro_ui.py
+++ b/sherpa/astro/ui/tests/test_astro_ui.py
@@ -352,7 +352,7 @@ def test_ui_table_model_1d_testfile(clean_astro_ui, comment, ncols):
     """Test table model with simple 1D ASCII files
 
     This should work for any IO backend, because it falls through
-    to the sherpa.io ASCII reader is necessary.
+    to the sherpa.io ASCII reader if necessary.
 
     Regression test for https://github.com/sherpa/sherpa/issues/1648
     """

--- a/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_utils_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2021 - 2024
+#  Copyright (C) 2016, 2018, 2021-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -65,7 +65,7 @@ def test_load_table_model_fails_with_dir(tmp_path):
     assert ui.list_model_components() == []
 
     with pytest.raises(IOErr,
-                       match="^unable to open "):
+                       match="^No column data found in"):
         ui.load_table_model('tmpdir', str(tmpdir))
 
     assert ui.list_model_components() == []
@@ -110,7 +110,7 @@ def test_load_table_model_fails_with_empty_file(tmp_path):
     assert ui.list_model_components() == []
 
     with pytest.raises(IOErr,
-                       match="^No column data found in /dev/null$"):
+                       match="^No column data found in /dev/null"):
         ui.load_table_model('devnull', '/dev/null')
 
     assert ui.list_model_components() == []

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -35,7 +35,7 @@ from sherpa.astro.models import JDPileup
 from sherpa.astro import ui
 from sherpa.astro.io.wcs import WCS
 
-from sherpa.models.basic import TableModel
+from sherpa.models.basic import FixedTableModel
 
 from sherpa.utils.err import ArgumentErr, DataErr, \
     IdentifierErr, IOErr, StatErr
@@ -3311,8 +3311,8 @@ def test_restore_table_model(make_data_path, check_str):
 
     restore()
 
-    assert isinstance(tbl, TableModel)
-    assert tbl.name == "tablemodel.tbl"
+    assert isinstance(tbl, FixedTableModel)
+    assert tbl.name == "fixedtablemodel.tbl"
     assert tbl.ampl.val == 10
     assert tbl.ampl.min == 0
     assert tbl.ampl.max == 20

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -59,7 +59,7 @@ from sherpa.data import Data, Data1D, Data1DAsymmetricErrs, Data2D, \
     Data2DInt
 from sherpa.fit import Fit
 import sherpa.io
-from sherpa.models.basic import TableModel, UserModel
+from sherpa.models.basic import UserModel
 from sherpa.models.model import Model
 import sherpa.plot
 from sherpa.sim import NormalParameterSampleFromScaleMatrix, \

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -29,7 +29,6 @@ import os
 from typing import Any
 import sys
 from types import MethodType
-import warnings
 
 import numpy as np
 
@@ -11212,7 +11211,6 @@ class Session(sherpa.ui.utils.Session):
     # (such as fits files) than the super method (only ascii files) and
     # thus we do define a method here just so we can write a new docstring.
     # DOC-NOTE: can filename be a crate/hdulist?
-    # DOC-TODO: how to describe the supported args/kwargs (not just for this function)?
     def load_table_model(self, modelname, filename,
                          *args,
                          **kwargs) -> None:
@@ -11226,6 +11224,13 @@ class Session(sherpa.ui.utils.Session):
         The ``load_xstable_model`` routine must be used with XSPEC table
         models.
 
+        Tables can take many forms. The most common are 1D data (with 2 columns),
+        1D data with integrated bins (wiht colunns xlow, xhigh, y), and 2D data such
+        as an image. This function will try to infer the format of the data from
+        the structure of the file given.
+        Details also depend on the file tome (fits or ascii) and the backend in use
+        (crates, astropy, or just the build in ascii reader).
+
         Parameters
         ----------
         modelname : str
@@ -11234,10 +11239,17 @@ class Session(sherpa.ui.utils.Session):
            The name of the file containing the data, which should
            contain two columns, which are the x and y values for
            the data, or be an image.
-        args
-           Arguments for reading in the data.
+        method : func, optional
+           The interpolation method to use to map the input data onto the
+           coordinate grid of the data set.
+           Sherpa provides `~sherpa.utils.linear_interp`,
+           `~sherpa.utils.nearest_interp`, `~sherpa.utils.neville`, and
+           `~sherpa.utils.neville2d` in `sherpa.utils` but other functions
+           with the same signature can be used.
         kwargs
-           Keyword arguments for reading in the data.
+           The accepted keyword arguments depend on the file type and
+           backend used to read in the data. They are listed in the "notes" section below.
+
 
         See Also
         --------
@@ -11250,14 +11262,63 @@ class Session(sherpa.ui.utils.Session):
 
         Notes
         -----
-        Examples of interpolation schemes provided by `sherpa.utils`
-        are: `linear_interp`, `nearest_interp`, `neville`, and
-        `neville2d`.
+
+        * Keywords for ASCII tables*
+
+            ncols : int, optional
+                The number of columns to read in (the first ``ncols`` columns
+                in the file). This is ignored if ``colkeys`` is given.
+            colkeys : array of str, optional
+                An array of the column name to read in. The default is `None`.
+            sep : str, optional
+                The separator character. The default is ``' '``.
+            dstype : data class to use, optional
+                Used to check that the data file contains enough columns.
+            comment : str, optional
+                The comment character. The default is ``'#'``.
+            require_floats : bool, optional
+                If `True` (the default), non-numeric data values will
+                raise a `ValueError`.
+
+        * Keywords for FITS tables
+
+            ncols: int, optional
+                The number of columns to read in when colkeys is not
+                set (the first ncols columns are chosen).
+            colkeys: sequence of str or None, optional
+                If given, what columns from the table should be selected,
+                otherwise the backend selects. The default is `None`.
+                Names are compared using a case insensitive match.
+            make_copy: bool, optional
+                If set then the returned NumPy arrays are explicitly copied,
+                rather than using a reference from the data structure
+                created by the backend. Backends are not required to
+                honor this setting. The default is `True`.
+            fix_type: bool, optional
+                Should the returned arrays be converted to the
+                `sherpa.utils.numeric_types.SherpaFloat` type. The default
+                is `True`.
+            blockname: str or None, optional
+                The name of the "block" (HDU) to read the column data (useful
+                for data structures containing multiple blocks/HDUs) or None.
+                Names are compared using a case insensitive match.
+            hdrkeys: sequence of str or None, optional
+                If set, the table structure must contain these keys, and the
+                values are returned.  Names are compared using a case
+                insensitive match.
+
+        * Keywords for FITS images
+
+            coord : { 'logical', 'image', 'physical', 'world', 'wcs' }, optional
+                Ensure that the image contains the given coordinate system.
+            dstype : optional
+                The image class to use. The default is `~sherpa.astro.data.DataIMG`.
+
 
         Examples
         --------
 
-        Load in the data from filt.fits and use it to multiply
+        Load in the data from "filt.fits" and use it to multiply
         the source model (a power law and a gaussian). Allow
         the amplitude for the table model to vary between 1
         and 1e6, starting at 1e3.

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -23,10 +23,13 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
+from functools import partial
 import logging
 import os
 from typing import Any
 import sys
+from types import MethodType
+import warnings
 
 import numpy as np
 
@@ -1368,7 +1371,7 @@ class Session(sherpa.ui.utils.Session):
             return sherpa.astro.io.read_arrays(*args)
         except NotImplementedError:
             # if the astro backend is not set, fall back on io module version.
-            return sherpa.io.read_arrays(*args)
+            return super().unpack_arrays(*args)
 
     # DOC-NOTE: also in sherpa.utils
     # DOC-TODO: rework the Data type notes section (also needed for
@@ -11069,43 +11072,46 @@ class Session(sherpa.ui.utils.Session):
         self._background_sources.get(idval, {}).pop(bkg_id, None)
 
     def _read_user_model(self, filename, *args, **kwargs):
-        x = None
-        y = None
-        try:
-            data = self.unpack_ascii(filename, *args, **kwargs)
-            x = data.get_x()
-            y = data.get_y()
+        """Read in user model data from a file.
 
-        # we have to check for the case of a *single* column in an ascii file
-        # extract the single array from the read and bypass the dataset
-        except TypeError:
-            hdu, _ = sherpa.astro.io.backend.get_ascii_data(filename,
-                                                            *args,
-                                                            **kwargs)
-            y = hdu.columns[0].values
-        except Exception:
+        While some options can be set by keyword arguments,
+        fundamentally, this is trying out a list of possible formats
+        (ASCII with the backend, general table (e. g. fits), image)
+        until one works.
+        If no working backend is loaded, this falls back to the
+        sherpa.ui version, which can read ascii files.
+        """
+        def read_backend(func, filename, *args, **kwargs):
+            hdu, _ = func(filename, *args, **kwargs)
+            cols = hdu.columns
+            if len(cols) == 0:
+                raise IOErr(f"No column data found in {filename}")
+            if len(cols) == 1:
+                return (None, cols[0].values)
+            return (cols[0].values, cols[1].values)
+
+        read_backend_ascii = partial(read_backend,
+                                     sherpa.astro.io.backend.get_ascii_data)
+        read_backend_table = partial(read_backend,
+                                     sherpa.astro.io.backend.get_table_data)
+
+        def read_backend_image(self, filename, *args, **kwargs):
+            data = self.unpack_image(filename, *args, **kwargs)
+            return (None, data.get_y())
+
+        def read_with_super(self, filename, *args, **kwargs):
+            return super()._read_user_model(filename, *args, **kwargs)
+
+        for func in (read_backend_ascii,
+                     read_backend_table,
+                     # The following two need "self", so we make them a method
+                     MethodType(read_backend_image, self),
+                     MethodType(read_with_super, self)):
             try:
-                data = self.unpack_table(filename, *args, **kwargs)
-                x = data.get_x()
-                y = data.get_y()
-
-            # we have to check for the case of a *single* column in a
-            # fits table
-            # extract the single array from the read and bypass the dataset
-            except TypeError:
-                hdu, _ = sherpa.astro.io.backend.get_table_data(filename,
-                                                                *args,
-                                                                **kwargs)
-                y = hdu.columns[0].values
-
-            except Exception:
-                # unpack_data doesn't include a call to try
-                # getting data from image, so try that here.
-                data = self.unpack_image(filename, *args, **kwargs)
-                # x = data.get_x()
-                y = data.get_y()
-
-        return (x, y)
+                return func(filename, *args, **kwargs)
+            except:
+                pass
+        raise IOErr(f"No column data found in {filename} with supported file formats")
 
     def load_xstable_model(self, modelname, filename,
                            etable=False) -> None:
@@ -11200,11 +11206,15 @@ class Session(sherpa.ui.utils.Session):
         self._tbl_models.append(tablemodel)
         self._add_model_component(tablemodel)
 
-    # also in sherpa.utils
+    # implementation just calls super, but that calls `self._read_user_model`
+    # which is overwritten in this class.
+    # As a consequence, this method accepts a wider range of inputs
+    # (such as fits files) than the super method (only ascii files) and
+    # thus we do define a method here just so we can write a new docstring.
     # DOC-NOTE: can filename be a crate/hdulist?
     # DOC-TODO: how to describe the supported args/kwargs (not just for this function)?
     def load_table_model(self, modelname, filename,
-                         method=sherpa.utils.linear_interp, *args,
+                         *args,
                          **kwargs) -> None:
         # pylint: disable=W1113
         """Load tabular or image data and use it as a model component.
@@ -11224,11 +11234,6 @@ class Session(sherpa.ui.utils.Session):
            The name of the file containing the data, which should
            contain two columns, which are the x and y values for
            the data, or be an image.
-        method : func
-           The interpolation method to use to map the input data onto
-           the coordinate grid of the data set. Linear,
-           nearest-neighbor, and polynomial schemes are provided in
-           the sherpa.utils module.
         args
            Arguments for reading in the data.
         kwargs
@@ -11268,22 +11273,7 @@ class Session(sherpa.ui.utils.Session):
         >>> set_source('img', emap * gauss2d)
 
         """
-
-        x = None
-        y = None
-        try:
-            x, y = self._read_user_model(filename, *args, **kwargs)
-        except Exception:
-            data = sherpa.io.read_data(filename, ncols=2)
-            x = data.x
-            y = data.y
-
-        tablemodel = TableModel(modelname)
-        tablemodel.method = method
-        tablemodel.filename = filename
-        tablemodel.load(x, y)
-        self._tbl_models.append(tablemodel)
-        self._add_model_component(tablemodel)
+        super().load_table_model(modelname, filename, *args, **kwargs)
 
     # ## also in sherpa.utils
     # DOC-TODO: how to describe *args/**kwargs

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -11225,11 +11225,11 @@ class Session(sherpa.ui.utils.Session):
         models.
 
         Tables can take many forms. The most common are 1D data (with 2 columns),
-        1D data with integrated bins (wiht colunns xlow, xhigh, y), and 2D data such
+        1D data with integrated bins (with columns xlow, xhigh, y), and 2D data such
         as an image. This function will try to infer the format of the data from
         the structure of the file given.
-        Details also depend on the file tome (fits or ascii) and the backend in use
-        (crates, astropy, or just the build in ascii reader).
+        Details also depend on the file type (fits or ascii) and the backend in use
+        (crates, astropy, or just the build-in ascii reader).
 
         Parameters
         ----------
@@ -11263,7 +11263,7 @@ class Session(sherpa.ui.utils.Session):
         Notes
         -----
 
-        * Keywords for ASCII tables*
+        * Keywords for ASCII tables
 
             ncols : int, optional
                 The number of columns to read in (the first ``ncols`` columns

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1369,7 +1369,6 @@ class Session(sherpa.ui.utils.Session):
         try:
             return sherpa.astro.io.read_arrays(*args)
         except NotImplementedError:
-            # if the astro backend is not set, fall back on io module version.
             return super().unpack_arrays(*args)
 
     # DOC-NOTE: also in sherpa.utils

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -155,6 +155,7 @@ known_warnings = {
             r"unorderable dtypes.*",
             r"Non-string object detected for the array ordering.*",
             r"Use load_xstable_model to load XSPEC table models",
+            r"TableModel is deprecated and will be removed in a future version. Use FixedTableModel \(if only setting y values\) or InterpolatedTableModel1D \(if setting both x and y values\).",
 
             # NumPy 1.25 warnings that are raised by (mid-2023) crates code.
             # Hopefully this can be removed by December 2023.
@@ -173,7 +174,8 @@ known_warnings = {
             #
             # For now we hide them.
             #
-            r".* is multi-threaded, use of fork\(\) may lead to deadlocks in the child\."
+            r".* is multi-threaded, use of fork\(\) may lead to deadlocks in the child\.",
+
 
         ],
     UserWarning:

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -21,6 +21,7 @@
 from abc import ABCMeta
 from collections.abc import Callable, Sequence
 import logging
+from warnings import warn
 
 import numpy
 
@@ -2020,6 +2021,10 @@ class TableModel(ArithmeticModel):
         self._method = linear_interp
         self.ampl = Parameter(name, 'ampl', 1)
         ArithmeticModel.__init__(self, name, (self.ampl,))
+        warn("TableModel is deprecated and will be removed in a future version. "
+             "Use FixedTableModel (if only setting y values) "
+             "or InterpolatedTableModel1D (if setting both x and y values).",
+             category=DeprecationWarning)
 
     def load(self, x, y):
         """Set the model values.

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -18,12 +18,14 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from abc import ABCMeta
+from collections.abc import Callable, Sequence
 import logging
 
 import numpy
 
-from sherpa.utils import bool_cast, interpolate, linear_interp, \
-    sao_fcmp
+from sherpa.utils import bool_cast, integrate_tabulated_function, interpolate, linear_interp, \
+    integrate, sao_fcmp
 from sherpa.utils.err import ModelErr
 from sherpa.utils.guess import get_position, guess_amplitude, \
     guess_amplitude_at_ref, guess_amplitude2d, guess_bounds, \
@@ -46,6 +48,7 @@ __all__ = ('Box1D', 'Const1D', 'Cos', 'Delta1D', 'Erf', 'Erfc', 'Exp', 'Exp10',
            'StepLo1D', 'Tan',
            'Box2D', 'Const2D', 'Delta2D', 'Gauss2D', 'SigmaGauss2D',
            'NormGauss2D', 'Polynom2D', 'Scale2D', 'UserModel', 'TableModel',
+           'FixedTableModel', 'InterpolatedTableModel1D',
            'Integrate1D')
 
 DBL_EPSILON = numpy.finfo(float).eps
@@ -2182,6 +2185,397 @@ class TableModel(ArithmeticModel):
 
         raise ModelErr("filtermismatch", 'table model',
                        f"data, ({len(self.__y)} vs {len(x0)})")
+
+
+
+class TableModelBase(ArithmeticModel, metaclass=ABCMeta):
+    """Tabulated values are linearly scaled and may be interpolated.
+
+    This is an abstract base class.
+    """
+
+    def __init__(self, name='tablemodelbase'):
+        self._y = None
+        self.filename = None
+        self.ampl = Parameter(name, 'ampl', 1)
+        super().__init__( name, (self.ampl,))
+
+    def get_y(self):
+        """Return the dependent axis or None.
+
+        See Also
+        --------
+        get_x, load
+
+        """
+        return self._y
+
+    # A simplified version of sherpa.data._check, which is not
+    # used here to avoid circular dependencies. Rather than raise
+    # DataErr, we raise ModelErr with a similar message.
+    #
+    def _check_array(self, val):
+        if val is None:
+            return None
+
+        val = numpy.asarray(val)
+        if val.ndim != 1:
+            raise ModelErr("Array must be 1D or None")
+
+        # Check we can add 0 to the values. This is to try and
+        # catch cases when a string column is passed to load. It
+        # will not catch all possible problem cases. An
+        # alternative would be to check
+        #    isinstance(val[0], numbers.Number)
+        # but it's not clear which is best.
+        #
+        # We could also check whether values are np.isfinite() but
+        # users may want to read in bad values that we then always
+        # mask out.
+        #
+        try:
+            val + 0
+        except Exception:
+            raise ModelErr(f"Unable to treat array as numeric: {val}") from None
+
+        return val
+
+
+class FixedTableModel(TableModelBase):
+    """Tabulated values are linearly scaled and may be interpolated.
+
+    The `load` method is used to read in the tabular data.
+    The model must have the same size as the y values of the data, and
+    the `fold` method must be sent the data object to be fit
+    before a fit is made if the data is filtered in any way,
+    **because the model will otherwise not know which values to use**.
+
+    The model values - the y argument to `load` - are multiplied by
+    the `ampl` parameter of the model.
+
+    Attributes
+    ----------
+    ampl
+        The linear scaling factor for the table values
+
+    Notes
+    -----
+    The model has `ndim` set to `None` as it can be used for any
+    dimension of data.
+
+    The model ignores the integrate setting.
+
+    See Also
+    --------
+    Const1D, Scale1D, InterpolatedTableModel1D
+
+    Examples
+    --------
+
+    If the x array is given to the `load` call then the model can
+    interpolate from the requested grid onto the load data (the
+    default is linear interpolation):
+
+    The model can be used for data when the independent axis is either
+    not useful - such as for an image mask - or the data does not have
+    a meaningful independent axis, as in the the independent variable
+    being an index for a star and the dependent axis is a property of
+    each star. In this case the `fold`
+    method must be used if the data has been filtered in any way, but
+    it's safest to always use it:
+
+    >>> from sherpa.models.basic import FixedTableModel
+    >>> from sherpa.data import Data1D
+    >>> from sherpa.fit import Fit
+    >>> d = Data1D('data', [1, 2, 3, 4, 5], [1.2, .4, 2.2, .3, 1.])
+    >>> d.staterror = [.2, .2, .2, .2, .2]
+    >>> tm1 = FixedTableModel('tabmodel')
+    >>> tm1.load([.6, .2, 1.1, .2, .5])
+    >>> print(tm1.ampl.val)
+    1.0
+    >>> tm1.fold(d)
+    >>> fit1 = Fit(d, tm1)
+    >>> res1 = fit1.fit()
+    >>> print(tm1.ampl.val)
+    1.9894736842102083
+
+    In this case the `fold` method is necessary, to ensure that the
+    fit only uses the valid data bins:
+
+    >>> import numpy as np
+    >>> y = np.ma.masked_invalid([np.nan, np.nan, 2.2, .3, 1.])
+    >>> d = Data1D('data', [1, 2, 3, 4, 5], y)
+    >>> d.staterror = [.2, .2, .2, .2, .2]
+    >>> tm2 = FixedTableModel('tabmodel')
+    >>> tm2.load([.6, .2, 1.1, .2, .5])
+    >>> tm2.fold(d)
+    >>> print(tm2.ampl.val)
+    1.0
+    >>> fit2 = Fit(d, tm2)
+    >>> res2 = fit2.fit()
+    >>> print(tm2.ampl.val)
+    1.9866666666663104
+
+    The masking also holds if the notice or ignore method has been
+    used on the dataset:
+
+    >>> d = Data1D('data', [1, 2, 3, 4, 5], [1.2, .4, 2.2, .3, 1])
+    >>> d.staterror = [.2, .2, .2, .2, .2]
+    >>> d.ignore(xhi=2)
+    >>> tm3 = FixedTableModel('tabmodel')
+    >>> tm3.load([.6, .2, 1.1, .2, .5])
+    >>> tm3.fold(d)
+    >>> print(tm3.ampl.val)
+    1.0
+    >>> fit3 = Fit(d, tm3)
+    >>> res = fit3.fit()
+    >>> print(tm3.ampl.val)
+    1.9866666666663104
+
+    """
+    def __init__(self, name='fixedtablemodel', y=None):
+        self._filtered_y = None
+        super().__init__(name)
+        self.load(y)
+
+    def load(self, y: Sequence | None):
+        """Set the model values.
+
+        Parameters
+        ----------
+        y : Sequence
+           The model values.
+
+        See Also
+        --------
+        get_x, get_y
+
+        """
+        self._y = self._check_array(y)
+
+        # clear the filtered array
+        self._filtered_y = None
+
+    def fold(self, data):
+        """Ensure the model matches the data filter.
+
+        This should be called after load, to ensure that any existing
+        filter is applied correctly during a fit.
+
+        Parameters
+        ----------
+        data : sherpa.data.Data instance
+           An object with a mask attribute.
+
+        """
+
+        if self._y is None:
+            raise ModelErr("The tablemodel's load method must be called first")
+
+        # Clear out the setting. If needed it will get reset.
+        #
+        self._filtered_y = None
+
+        # What should we do with data.mask = {True, False}?
+        #
+        mask = data.mask
+        if not numpy.iterable(mask):
+            return
+
+        # At this point we know mask is an iterable, so it should
+        # match the y data of the model.
+        #
+        if len(mask) != len(self._y):
+            raise ModelErr("filtermismatch", 'table model',
+                           f"data, ({len(self._y)} vs {len(mask)})")
+
+        self._filtered_y = self._y[mask]
+
+    def calc(self, p, x0, x1=None, *args, **kwargs):
+        """Evaluate the model.
+
+        The load method must have been called first.
+        """
+        if self._y is None:
+            raise ModelErr("The tablemodel's load method must be called first")
+
+        if (self._filtered_y is not None and
+              len(x0) == len(self._filtered_y)):
+            return p[0] * self._filtered_y
+
+        if len(x0) == len(self._y):
+            return p[0] * self._y
+
+        raise ModelErr("filtermismatch", 'table model',
+                       f"data, ({len(self._y)} vs {len(x0)})")
+
+class InterpolatedTableModel1D(TableModelBase, RegriddableModel1D):
+    """Tabulated values are linearly scaled and may be interpolated.
+
+    The `load` method is used to read in the tabular data and model
+    evaluation will interpolate the requested grid onto the data, with the
+    interpolation scheme controlled by the `method` attribute.
+
+    The model values - the y argument to `load` - are multiplied by
+    the `ampl` parameter of the model.
+
+    Attributes
+    ----------
+    ampl
+        The linear scaling factor for the table values
+    method : callable
+        The interpolation method.
+    integrate_kwargs
+        Used to pass extra parameters to the integrator (currently
+        `epsabs`, `epsrel`, `maxeval`, `errflag`, and `logger`).
+        Only used if the `integrate` attribute is set to True.
+
+    See Also
+    --------
+    Const1D, Scale1D, FixedTableModel
+
+    Examples
+    --------
+
+    The model can interpolate from the requested grid onto the load data
+    (the default is linear interpolation):
+
+    >>> tm = InterpolatedTableModel1D()
+    >>> tm.load([10, 20, 25, 30], [14, 12, 17, 18])
+    >>> tm.ampl = 10
+    >>> tm([15, 20, 27])
+    array([130., 120., 174.])
+
+    The `method` attribute can be changed to select a different
+    interpolation scheme: it requires a function that accepts (xout,
+    xin, yin) and returns yout which are the interpolated values of
+    xin,yin onto the grid xout:
+
+    >>> from sherpa.utils import neville
+    >>> tm.method = neville
+    >>> tm([15, 20, 27])
+    array([ 90.   , 120.   , 182.16])
+    """
+    ndim = 1
+
+    @property
+    def method(self):
+        """The interpolation method.
+
+        The method argument is a function that accepts arguments (xout,
+        xin, yin) and returns the yout values from interpolating xout onto
+        (xin, yin). The default is linear interpolation
+        (sherpa.utils.linear_interp).
+        """
+        return self._method
+
+    @method.setter
+    def method(self, val):
+        self._method = val
+
+        # as the method affects the cache, clear it (we could skip
+        # this if the method has not changed but is it worth it?)
+        #
+        self.cache_clear()
+
+    def __init__(self, name: str='interpolatedtablemodel1d',
+                 x: Sequence | None=None, y: Sequence | None=None,
+                 method: Callable=linear_interp,
+                 integrate_method: Callable=integrate_tabulated_function,
+                 integrate_kwargs: dict ={}):
+        self._x = None
+        self._method = method
+        self.integrate_kwargs = integrate_kwargs
+        self.integrate_method = integrate_method
+        super().__init__(name)
+        self.load(x, y)
+
+    def load(self, x, y):
+        """Set the model values.
+
+        Parameters
+        ----------
+        x, y : sequence
+           The model values. It is expected that either both are
+           given, and have the same number of elements, or that only y
+           is set, although the model can be cleared by setting both
+           to None. If x is given then the data is saved after being
+           sorted into increasing order of x.
+
+        See Also
+        --------
+        get_x, get_y
+
+        """
+
+        # Is there a reason to still accept None here?
+        # Presumably you have data to set if you call "load".
+        if (x is not None and y is None):
+            raise ModelErr("y must be set if x is set")
+        if (x is None and y is not None):
+            raise ModelErr("x and y must be set together or both be None")
+        # Clear the cache. We could avoid doing this if the
+        # data has not changed but this is not worth the
+        # complexity.
+        #
+        self.cache_clear()
+
+        self._y = self._check_array(y)
+        self._x = self._check_array(x)
+
+        # The latter two conditions are just there to make type-checkers happy.
+        # If x is None, then _x  is None as well, since it's set from x just above,
+        # and the checks on the top of this method ensure that either both x and y
+        # are None or neither of them is.
+        if x is None or (self._x is None) or (self._y is None):
+            return
+
+        nx = len(self._x)
+        ny = len(self._y)
+        if nx != ny:
+            raise ModelErr(f"size mismatch between x and y: {nx} vs {ny}")
+
+        # Ensure the data is sorted.
+        #
+        idx = self._x.argsort()
+        self._y = self._y[idx]
+        self._x = self._x[idx]
+
+    def get_x(self):
+        """Return the independent axis or None.
+
+        See Also
+        --------
+        get_y, load
+
+        """
+        return self._x
+
+
+    @modelCacher1d
+    def _calc_interpolate(self, x0):
+        return interpolate(x0, self._x, self._y, function=self.method)
+
+    @modelCacher1d
+    def _calc_integrate(self, x0, x1):
+        return integrate(x0, x1, self._x, self._y,
+                         interpolate_func=self.method,
+                         integrate_func=self.integrate_method,
+                         **self.integrate_kwargs)
+
+    def calc(self, p, x0, x1=None, *args, **kwargs):
+        """Evaluate the model.
+
+        The load method must have been called first to set the values that
+        should be interpolated.
+        """
+        if self._y is None:
+            raise ModelErr("The tablemodel's load method must be called first")
+
+        if self.integrate and x1 is not None:
+            return p[0] * self._calc_integrate(x0, x1)
+
+        return p[0] * self._calc_interpolate(x0)
 
 
 class UserModel(ArithmeticModel):

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1930,7 +1930,7 @@ class TableModel(ArithmeticModel):
 
     The model can be used for data when the independent axis is either
     not useful - such as for an image mask - or the data does not have
-    a meaningful independent axis, as in the the independent variable
+    a meaningful independent axis, as in the independent variable
     being an index for a star and the dependent axis is a property of
     each star. In this case the x argument to `load` is set to `None`,
     which means that no interpolation is used and that the `fold`

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1885,6 +1885,9 @@ class TableModel(ArithmeticModel):
     The model values - the y argument to `load` - are multiplied by
     the `ampl` parameter of the model.
 
+    ... deprecated:: 4.19.0
+        Use the FixedTableModel or InterpolatedTableModel1D classes instead.
+
     Attributes
     ----------
     ampl
@@ -2283,7 +2286,7 @@ class FixedTableModel(TableModelBase):
 
     The model can be used for data when the independent axis is either
     not useful - such as for an image mask - or the data does not have
-    a meaningful independent axis, as in the the independent variable
+    a meaningful independent axis, e.g. the independent variable
     being an index for a star and the dependent axis is a property of
     each star. In this case the `fold`
     method must be used if the data has been filtered in any way, but
@@ -2428,12 +2431,17 @@ class InterpolatedTableModel1D(TableModelBase):
     ----------
     ampl
         The linear scaling factor for the table values
-    method : callable
-        The interpolation method.
+    interpolate_method : callable
+        The interpolation method. The method argument is a function that accepts arguments (xout,
+        xin, yin) and returns the yout values from interpolating xout onto
+        (xin, yin). The default is linear interpolation
+        (`sherpa.utils.linear_interp`).
+    integrate_method : callable
+        The integration method.
     integrate_kwargs
-        Used to pass extra parameters to the integrator (currently
-        `epsabs`, `epsrel`, `maxeval`, `errflag`, and `logger`).
-        Only used if the `integrate` attribute is set to True.
+            Used to pass extra parameters to the integrator (currently
+            `epsabs`, `epsrel`, `maxeval`, `errflag`, and `logger`).
+            Only used if the `integrate` attribute is set to True.
 
     See Also
     --------
@@ -2442,7 +2450,7 @@ class InterpolatedTableModel1D(TableModelBase):
     Examples
     --------
 
-    The model can interpolate from the requested grid onto the load data
+    The model can interpolate the loaded data onto the requested grid
     (the default is linear interpolation):
 
     >>> tm = InterpolatedTableModel1D()
@@ -2463,6 +2471,15 @@ class InterpolatedTableModel1D(TableModelBase):
     """
     ndim = 1
 
+    def __init__(self, name: str='interpolatedtablemodel1d',
+                 x: Sequence | None=None, y: Sequence | None=None):
+        self._x = None
+        self._method = linear_interp
+        self._integrate_kwargs = {}
+        self._integrate_method = integrate_tabulated_function
+        super().__init__(name)
+        self.load(x, y)
+
     @property
     def method(self):
         """The interpolation method.
@@ -2470,7 +2487,7 @@ class InterpolatedTableModel1D(TableModelBase):
         The method argument is a function that accepts arguments (xout,
         xin, yin) and returns the yout values from interpolating xout onto
         (xin, yin). The default is linear interpolation
-        (sherpa.utils.linear_interp).
+        (`sherpa.utils.linear_interp`).
         """
         return self._method
 
@@ -2483,17 +2500,50 @@ class InterpolatedTableModel1D(TableModelBase):
         #
         self.cache_clear()
 
-    def __init__(self, name: str='interpolatedtablemodel1d',
-                 x: Sequence | None=None, y: Sequence | None=None,
-                 method: Callable=linear_interp,
-                 integrate_method: Callable=integrate_tabulated_function,
-                 integrate_kwargs: dict ={}):
-        self._x = None
-        self._method = method
-        self.integrate_kwargs = integrate_kwargs
-        self.integrate_method = integrate_method
-        super().__init__(name)
-        self.load(x, y)
+    @property
+    def integrate_method(self):
+        """The integration method.
+
+        The method argument is a function that accepts arguments (xout,
+        xin, yin) and returns the yout values from interpolating xout onto
+        (xin, yin). The default is linear interpolation
+        (`sherpa.utils.linear_interp`).
+        """
+        return self._integrate_method
+
+    @integrate_method.setter
+    def integrate_method(self, val):
+        self._integrate_method = val
+
+        # as the method affects the cache, clear it (we could skip
+        # this if the method has not changed but is it worth it?)
+        #
+        self.cache_clear()
+
+    @property
+    def integrate_kwargs(self):
+        '''Used to pass extra parameters to the integrator
+
+        Only used if the `integrate` attribute is set to True.
+        This is a dictionary with key corresponding to the keyword arguments
+        of the integrator.
+        If the entire dictionary is replaced, the model cache is reset since the
+        output will change. However, since dictionary are mutable in Python, this
+        will not detect if a single value in the dictionary is changed.
+        If relevant, the cache can be cleared manually by calling the `cache_clear` method.
+        '''
+        return self._integrate_kwargs
+
+    @integrate_kwargs.setter
+    def integrate_kwargs(self, val):
+
+        self._integrate_kwargs = val
+
+        # as the method affects the cache, clear it (we could skip
+        # this if the method has not changed but is it worth it?)
+        #
+        self.cache_clear()
+
 
     def load(self, x, y):
         """Set the model values.

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -2414,7 +2414,7 @@ class FixedTableModel(TableModelBase):
         raise ModelErr("filtermismatch", 'table model',
                        f"data, ({len(self._y)} vs {len(x0)})")
 
-class InterpolatedTableModel1D(TableModelBase, RegriddableModel1D):
+class InterpolatedTableModel1D(TableModelBase):
     """Tabulated values are linearly scaled and may be interpolated.
 
     The `load` method is used to read in the tabular data and model

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -2427,21 +2427,26 @@ class InterpolatedTableModel1D(TableModelBase):
     The model values - the y argument to `load` - are multiplied by
     the `ampl` parameter of the model.
 
+    Parameters
+    ----------
+    name : str, optional
+        The name of the model, by default 'interpolatedtablemodel1d'
+    x : sequence, optional
+        The independent axis values, by default None
+    y : sequence, optional
+        The dependent axis values, by default None
+    method : callable, optional
+        The interpolation method, by default `sherpa.utils.linear_interp`.
+    integrate_method : callable, optional
+        The integration method, by default
+        `sherpa.utils.integrate_tabulated_function`.
+    integrate_kwargs : dict, optional
+        Used to pass extra parameters to the integrator, by default an empty dict.
+
     Attributes
     ----------
     ampl
         The linear scaling factor for the table values
-    interpolate_method : callable
-        The interpolation method. The method argument is a function that accepts arguments (xout,
-        xin, yin) and returns the yout values from interpolating xout onto
-        (xin, yin). The default is linear interpolation
-        (`sherpa.utils.linear_interp`).
-    integrate_method : callable
-        The integration method.
-    integrate_kwargs
-            Used to pass extra parameters to the integrator (currently
-            `epsabs`, `epsrel`, `maxeval`, `errflag`, and `logger`).
-            Only used if the `integrate` attribute is set to True.
 
     See Also
     --------
@@ -2472,11 +2477,14 @@ class InterpolatedTableModel1D(TableModelBase):
     ndim = 1
 
     def __init__(self, name: str='interpolatedtablemodel1d',
-                 x: Sequence | None=None, y: Sequence | None=None):
+                 x: Sequence | None=None, y: Sequence | None=None,
+                 method: Callable = linear_interp,
+                 integrate_method: Callable = integrate_tabulated_function,
+                 integrate_kwargs: dict = {}):
         self._x = None
-        self._method = linear_interp
-        self._integrate_kwargs = {}
-        self._integrate_method = integrate_tabulated_function
+        self._method = method
+        self._integrate_kwargs: dict = integrate_kwargs
+        self._integrate_method = integrate_method
         super().__init__(name)
         self.load(x, y)
 
@@ -2484,9 +2492,9 @@ class InterpolatedTableModel1D(TableModelBase):
     def method(self):
         """The interpolation method.
 
-        The method argument is a function that accepts arguments (xout,
-        xin, yin) and returns the yout values from interpolating xout onto
-        (xin, yin). The default is linear interpolation
+        The method argument is a function that accepts arguments (x_out,
+        x_in, y_in) and returns the y_out values from interpolating x_out onto
+        (x_in, y_in). The default is linear interpolation
         (`sherpa.utils.linear_interp`).
         """
         return self._method
@@ -2504,10 +2512,7 @@ class InterpolatedTableModel1D(TableModelBase):
     def integrate_method(self):
         """The integration method.
 
-        The method argument is a function that accepts arguments (xout,
-        xin, yin) and returns the yout values from interpolating xout onto
-        (xin, yin). The default is linear interpolation
-        (`sherpa.utils.linear_interp`).
+        Only used if the `integrate` attribute is set to True.
         """
         return self._integrate_method
 

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -2441,9 +2441,8 @@ class InterpolatedTableModel1D(TableModelBase):
         The integration method, by default
         `sherpa.utils.integrate_tabulated_function`.
     integrate_kwargs : dict, optional
-        Used to pass extra parameters to the integrator, by default an empty dict.
-
-    Attributes
+        Used to pass extra parameters to the integrator.
+        If not specified or `None`, no extra arguments are passed to the integrator.
     ----------
     ampl
         The linear scaling factor for the table values
@@ -2480,10 +2479,10 @@ class InterpolatedTableModel1D(TableModelBase):
                  x: Sequence | None=None, y: Sequence | None=None,
                  method: Callable = linear_interp,
                  integrate_method: Callable = integrate_tabulated_function,
-                 integrate_kwargs: dict = {}):
+                 integrate_kwargs: dict| None = None):
         self._x = None
         self._method = method
-        self._integrate_kwargs: dict = integrate_kwargs
+        self._integrate_kwargs: dict = integrate_kwargs if integrate_kwargs is not None else {}
         self._integrate_method = integrate_method
         super().__init__(name)
         self.load(x, y)

--- a/sherpa/models/tests/test_model_op.py
+++ b/sherpa/models/tests/test_model_op.py
@@ -438,7 +438,7 @@ def test_load_table_model(make_data_path):
     s = Session()
     s.load_table_model('tbl', make_data_path('double.dat'))
     tbl = s.get_model_component('tbl')
-    assert tbl.ndim is None
+    assert tbl.ndim == 1
 
 
 @pytest.mark.parametrize("flag", [True, False])

--- a/sherpa/models/tests/test_tablemodel.py
+++ b/sherpa/models/tests/test_tablemodel.py
@@ -770,3 +770,14 @@ def test_pickle_interpolation(cls, tmp_path):
     assert nmdl.method is nearest_interp
 
     assert nmdl(xtest) == pytest.approx(ytest)
+
+
+def test_TableModel_deprecation_warning():
+    """Check that TableModel raises a deprecation warning upon instantiation."""
+
+    with pytest.warns(DeprecationWarning,
+                      match="TableModel is deprecated and will be removed in a future version. "
+                      "Use FixedTableModel "
+                      r"\(if only setting y values\) or InterpolatedTableModel1D "
+                      r"\(if setting both x and y values\)\."):
+        _ = TableModel()

--- a/sherpa/models/tests/test_tablemodel.py
+++ b/sherpa/models/tests/test_tablemodel.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2022
+#  Copyright (C) 2022, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -31,68 +31,82 @@ import numpy as np
 import pytest
 
 from sherpa.data import Data1D
-from sherpa.models.basic import TableModel
+from sherpa.models.basic import TableModel, FixedTableModel, InterpolatedTableModel1D
 from sherpa.models.model import ArithmeticModel
 from sherpa.utils import linear_interp, nearest_interp
 from sherpa.utils.err import ModelErr
 
 
-def test_create():
+TABLE_MODELS = (TableModel, FixedTableModel, InterpolatedTableModel1D)
+
+
+@pytest.mark.parametrize("cls", TABLE_MODELS)
+def test_create(cls):
     """Basic creation test"""
 
-    mdl = TableModel()
+    mdl = cls()
     assert isinstance(mdl, ArithmeticModel)
 
 
-def test_name():
+@pytest.mark.parametrize("cls, name", [(TableModel, "tablemodel"),
+                                       (FixedTableModel, "fixedtablemodel"),
+                                       (InterpolatedTableModel1D, "interpolatedtablemodel1d")])
+def test_name(cls, name):
     """Basic creation test: name"""
 
-    mdl = TableModel()
-    assert mdl.name == "tablemodel"
+    mdl = cls()
+    assert mdl.name == name
 
 
-def test_named():
+@pytest.mark.parametrize("cls", TABLE_MODELS)
+def test_named(cls):
     """Basic creation test: name"""
 
-    mdl = TableModel("bobby")
+    mdl = cls("bobby")
     assert mdl.name == "bobby"
 
 
-def test_filename():
+@pytest.mark.parametrize("cls", TABLE_MODELS)
+def test_filename(cls):
     """Basic creation test: filename
 
     How is the filename attribute meant to be used?
     """
 
-    mdl = TableModel()
+    mdl = cls()
     assert mdl.filename is None
 
 
-def test_ndim():
+@pytest.mark.parametrize("cls, ndim", [(TableModel, None),
+                                         (FixedTableModel, None),
+                                         (InterpolatedTableModel1D, 1)])
+def test_ndim(cls, ndim):
     """What is the ndim?
 
     At the moment we can use this with nD data but only really if we do
     not set the "x" argument.
     """
 
-    mdl = TableModel()
-    assert mdl.ndim is None
+    mdl = cls()
+    assert mdl.ndim == ndim
 
 
-def test_pars():
+@pytest.mark.parametrize("cls", TABLE_MODELS)
+def test_pars(cls):
     """We have a single parameter."""
 
-    mdl = TableModel()
+    mdl = cls()
     assert len(mdl.pars) == 1
     assert mdl.pars[0].name == "ampl"
     assert mdl.pars[0].val == pytest.approx(1)
     assert not mdl.pars[0].frozen
 
 
-def test_show():
+@pytest.mark.parametrize("cls", TABLE_MODELS)
+def test_show(cls):
     """Basic show test"""
 
-    mdl = TableModel("test")
+    mdl = cls("test")
     out = str(mdl).split("\n")
     assert out[0] == "test"
     assert out[1].startswith("   Param        Type ")
@@ -101,33 +115,38 @@ def test_show():
     assert len(out) == 4
 
 
-def test_empty():
+@pytest.mark.parametrize("cls", TABLE_MODELS)
+def test_empty(cls):
     """Basic creation test: no data"""
 
-    mdl = TableModel()
-    assert mdl.get_x() is None
+    mdl = cls()
+    if cls in (TableModel, InterpolatedTableModel1D):
+        assert mdl.get_x() is None
     assert mdl.get_y() is None
 
 
-def test_method_change():
+@pytest.mark.parametrize("cls", (TableModel, InterpolatedTableModel1D))
+def test_method_change(cls):
     """We can change the method"""
 
-    mdl = TableModel()
+    mdl = cls()
     assert mdl.method == linear_interp
 
     mdl.method = nearest_interp
     assert mdl.method == nearest_interp
 
 
-def test_method_must_be_callable():
+@pytest.mark.parametrize("cls, name", ([TableModel, 'TableModel'],
+                                       [InterpolatedTableModel1D, 'InterpolatedTableModel1D']))
+def test_method_must_be_callable(cls, name):
     """method must be callable"""
 
-    mdl = TableModel()
+    mdl = cls()
 
     # This comes from NoNewAttributesAfterInit via AttrithmeticModel
     #
     with pytest.raises(AttributeError,
-                       match="^'TableModel' object attribute 'method' cannot be replaced with a non-callable attribute$"):
+                       match=f"^'{name}' object attribute 'method' cannot be replaced with a non-callable attribute$"):
         mdl.method = 23
 
 
@@ -140,25 +159,35 @@ def test_load_no_x():
     assert mdl.get_y() == pytest.approx([3, 2, 7])
 
 
-def test_load_x_y_sorted():
+def test_load_no_y_InterpolatedTableModel1D():
+    mdl = InterpolatedTableModel1D()
+    with pytest.raises(ModelErr,
+                       match="^x and y must be set together or both be None$"):
+        mdl.load(None, [3, 2, 7])
+
+
+@pytest.mark.parametrize("cls", (TableModel, InterpolatedTableModel1D))
+def test_load_x_y_sorted(cls):
     """load: x and y (sorted)"""
 
-    mdl = TableModel()
+    mdl = cls()
     mdl.load([12, 14, 17], [3, 2, 7])
     assert mdl.get_x() == pytest.approx([12, 14, 17])
     assert mdl.get_y() == pytest.approx([3, 2, 7])
 
 
-def test_load_x_y_unsorted():
+@pytest.mark.parametrize("cls", (TableModel, InterpolatedTableModel1D))
+def test_load_x_y_unsorted(cls):
     """load: x and y (unsorted)"""
 
-    mdl = TableModel()
+    mdl = cls()
     mdl.load([17, 12, 14], [7, 3, 2])
     assert mdl.get_x() == pytest.approx([12, 14, 17])
     assert mdl.get_y() == pytest.approx([3, 2, 7])
 
 
-def test_load_no_x_check_storage():
+@pytest.mark.parametrize("cls", (TableModel, FixedTableModel))
+def test_load_no_x_check_storage(cls):
     """How are the x/y values stored?
 
     This is a regression test (that is, the behavior could be
@@ -166,19 +195,23 @@ def test_load_no_x_check_storage():
 
     """
 
-    mdl = TableModel()
-    mdl.load(None, [1, 3, 7])
+    mdl = cls()
+    if cls is FixedTableModel:
+        mdl.load([1, 3, 7])
+    else:
+        mdl.load(None, [1, 3, 7])
     y = mdl.get_y()
     assert isinstance(y, np.ndarray)
 
 
-def test_load_x_y_sorted_check_storage():
+@pytest.mark.parametrize("cls", (TableModel, InterpolatedTableModel1D))
+def test_load_x_y_sorted_check_storage(cls):
     """How are the x/y values stored?
 
     This is a regression test.
     """
 
-    mdl = TableModel()
+    mdl = cls()
     mdl.load([1, 2, 3], [1, 3, 7])
     x = mdl.get_x()
     y = mdl.get_y()
@@ -186,13 +219,14 @@ def test_load_x_y_sorted_check_storage():
     assert isinstance(y, np.ndarray)
 
 
-def test_load_x_y_unsorted_check_storage():
+@pytest.mark.parametrize("cls", (TableModel, InterpolatedTableModel1D))
+def test_load_x_y_unsorted_check_storage(cls):
     """How are the x/y values stored?
 
     This is a regression test.
     """
 
-    mdl = TableModel()
+    mdl = cls()
     mdl.load([3, 2, 1], [1, 3, 7])
     x = mdl.get_x()
     y = mdl.get_y()
@@ -200,43 +234,47 @@ def test_load_x_y_unsorted_check_storage():
     assert isinstance(y, np.ndarray)
 
 
-def test_load_no_y():
+@pytest.mark.parametrize("cls", (TableModel, InterpolatedTableModel1D))
+def test_load_no_y(cls):
     """do we error out or not?
 
     This is a regression test.
     """
 
-    mdl = TableModel()
+    mdl = cls()
     with pytest.raises(ModelErr,
                        match="^y must be set if x is set$"):
         mdl.load([12, 14, 17], None)
 
 
-def test_load_x_longer_than_y():
+@pytest.mark.parametrize("cls", (TableModel, InterpolatedTableModel1D))
+def test_load_x_longer_than_y(cls):
     """do we error out or not?
 
     This is a regression test.
     """
 
-    mdl = TableModel()
+    mdl = cls()
     with pytest.raises(ModelErr,
                        match="^size mismatch between x and y: 3 vs 2$"):
         mdl.load([12, 14, 17], [3, 2])
 
 
-def test_load_x_shorter_than_y():
+@pytest.mark.parametrize("cls", (TableModel, InterpolatedTableModel1D))
+def test_load_x_shorter_than_y(cls):
     """do we error out or not?
 
     This is a regression test.
     """
 
-    mdl = TableModel()
+    mdl = cls()
     with pytest.raises(ModelErr,
                        match="^size mismatch between x and y: 3 vs 4$"):
         mdl.load([12, 17, 14], [3, 2, 4, 5])
 
 
-def test_load_y_not_1d():
+@pytest.mark.parametrize("cls", (TableModel, InterpolatedTableModel1D))
+def test_load_y_not_1d(cls):
     """do we error out or not?
 
     This is a regression test.
@@ -244,12 +282,13 @@ def test_load_y_not_1d():
 
     x = np.arange(6) + 1
     y = np.arange(6).reshape(2, 3)
-    mdl = TableModel()
+    mdl = cls()
     with pytest.raises(ModelErr,
                        match="Array must be 1D or None"):
         mdl.load(x, y)
 
 
+@pytest.mark.parametrize("cls", (TableModel, InterpolatedTableModel1D))
 # sherpa.utils.interpolate assumes inputs are ndarray, so work around
 # this by forcing the input to be one.
 #
@@ -257,28 +296,36 @@ def test_load_y_not_1d():
                          [(None, False),
                           ([14, 16, 20, 25], False),
                           ([14, 16, 20, 25], True)])
-def test_eval_x_y(x2, iflag):
+def test_eval_x_y(cls, x2, iflag):
     """Check we can interpolate onto a grid after load(x,y)
 
-    The application ignores the integrate setting/upper-edge of the bin.
+    The TableModel ignores the integrate setting/upper-edge of the
+    bin, but the InterpolatedTableModel1D uses it if integrate is set.
     """
 
-    tm = TableModel()
+    tm = cls()
     tm.load([10, 15, 20], [4, 6, 2])
     tm.ampl = 10
     tm.integrate = iflag
 
     yout = tm(np.asarray([12, 14, 16, 20]), x2)
-    exp = 10 * np.asarray([4.8, 5.6, 5.2, 2])
+
+    if cls is InterpolatedTableModel1D and iflag:
+        # integrate from 12-14, 14-16, 16-20, 20-25
+        exp = 10 * np.array([2., 2., 4. , 5]) * \
+            np.asarray([5.2, 0.5 * 5.8 + 0.5 * 5.6, 3.6, 0])
+    else:
+        exp = 10 * np.asarray([4.8, 5.6, 5.2, 2])
     assert yout == pytest.approx(exp)
 
 
+@pytest.mark.parametrize("cls", (TableModel, FixedTableModel))
 @pytest.mark.parametrize("y", [[4, 6, 2], np.asarray([4, 6, 2])])
 @pytest.mark.parametrize("x2,iflag",
                          [(None, False),
                           ([14, 16, 20], False),
                           ([14, 16, 20], True)])
-def test_eval_no_x(y, x2, iflag):
+def test_eval_no_x(cls, y, x2, iflag):
     """Check we can return something after load(None,y)
 
     The application ignores the integrate setting/upper-edge of the
@@ -288,8 +335,11 @@ def test_eval_no_x(y, x2, iflag):
 
     """
 
-    tm = TableModel()
-    tm.load(None, y)
+    tm = cls()
+    if cls is FixedTableModel:
+        tm.load(y)
+    else:
+        tm.load(None, y)
     tm.ampl = 10
     tm.integrate = iflag
 
@@ -298,14 +348,18 @@ def test_eval_no_x(y, x2, iflag):
     assert yout == pytest.approx([40, 60, 20])
 
 
+@pytest.mark.parametrize("cls", (TableModel, FixedTableModel))
 @pytest.mark.parametrize("y", [[4, 6, 2, 8, 7], np.asarray([4, 6, 2, 8, 7])])
 @pytest.mark.parametrize("iflag", [False, True])
-def test_eval_filtered(y, iflag):
+def test_eval_filtered(cls, y, iflag):
     """Check we can return something after load(None, y) and filtering the dataset.
     """
 
-    tm = TableModel()
-    tm.load(None, y)
+    tm = cls()
+    if cls is FixedTableModel:
+        tm.load(y)
+    else:
+        tm.load(None, y)
     tm.ampl = 10
     tm.integrate = iflag
 
@@ -319,7 +373,8 @@ def test_eval_filtered(y, iflag):
     assert yout == pytest.approx([60, 20, 70])
 
 
-def test_eval_pick_up_changed_load():
+@pytest.mark.parametrize("cls", (TableModel, FixedTableModel))
+def test_eval_pick_up_changed_load(cls):
     """Corner case: does __filtered_y get cleaned up?
 
     There's no "nice" way to check if __filtered_y gets cleared after
@@ -327,8 +382,11 @@ def test_eval_pick_up_changed_load():
 
     """
 
-    tm = TableModel()
-    tm.load(None, [5, 7, 2, 8, 4])
+    tm = cls()
+    if cls is FixedTableModel:
+        tm.load([5, 7, 2, 8, 4])
+    else:
+        tm.load(None, [5, 7, 2, 8, 4])
     tm.ampl = 10
 
     d = Data1D('simple', [20, 30, 40, 50, 70], [1, 2, 3, 4, 5])
@@ -342,7 +400,10 @@ def test_eval_pick_up_changed_load():
 
     # Call load with a different y array
     #
-    tm.load(None, [2, 3, 1, 4, 2])
+    if cls is FixedTableModel:
+        tm.load([2, 3, 1, 4, 2])
+    else:
+        tm.load(None, [2, 3, 1, 4, 2])
 
     # The filter has been removed, so we can not call it with a
     # filtered array.
@@ -354,15 +415,19 @@ def test_eval_pick_up_changed_load():
         tm([1, 2, 3, 4])
 
 
+@pytest.mark.parametrize("cls", (TableModel, FixedTableModel))
 @pytest.mark.parametrize("flag", [True, False])
-def test_eval_filter_all_or_none(flag):
+def test_eval_filter_all_or_none(cls, flag):
     """Check that .fold does nothing when the mask is True or False
 
     This is a regression test.
     """
 
-    mdl = TableModel()
-    mdl.load(None, np.asarray([5, 3, 4]))
+    mdl = cls()
+    if cls is FixedTableModel:
+        mdl.load([5, 3, 4])
+    else:
+        mdl.load(None, np.asarray([5, 3, 4]))
 
     d = Data1D("ex", [1, 2, 3], [1, 1, 2])
 
@@ -378,21 +443,26 @@ def test_eval_filter_all_or_none(flag):
     assert y == pytest.approx([5, 3, 4])
 
 
-def test_eval_pass_kwargs():
+@pytest.mark.parametrize("cls", (TableModel, FixedTableModel))
+def test_eval_pass_kwargs(cls):
     """Check we can pass kwargs, even though we ignore them.
 
     This is a regression test.
     """
 
-    mdl = TableModel()
-    mdl.load(None, [10, 12 , 2])
+    mdl = cls()
+    if cls is FixedTableModel:
+        mdl.load([10, 12 , 2])
+    else:
+        mdl.load(None, [10, 12 , 2])
     mdl.ampl = 5
 
     y = mdl([1, 2, 3], arg1=True, not_a_kwarg={"answer": 23})
     assert y == pytest.approx([50, 60, 10])
 
 
-def test_eval_checks_length():
+@pytest.mark.parametrize("cls", TABLE_MODELS)
+def test_eval_checks_length(cls):
     """Check we error out when the lengths are wrong: calc via model evaluation
 
     This requires
@@ -400,14 +470,15 @@ def test_eval_checks_length():
 
     """
 
-    tm = TableModel('tbl')
+    tm = cls('tbl')
 
     with pytest.raises(ModelErr,
                        match="^The tablemodel's load method must be called first$"):
         tm([1, 2, 3])
 
 
-def test_fold_no_load_checks_length():
+@pytest.mark.parametrize("cls", (TableModel, FixedTableModel))
+def test_fold_no_load_checks_length(cls):
     """Check we error out when the lengths are wrong: fold.
 
     This requires
@@ -415,9 +486,7 @@ def test_fold_no_load_checks_length():
       - the data being partially filtered
 
     """
-
-    ytbl = [5, 7, 3, 2]
-    tm = TableModel('tbl')
+    tm = cls('tbl')
 
     xdata = np.asarray([0, 10, 20, 25, 30, 40])
     ydata = np.ones_like(xdata)
@@ -429,18 +498,23 @@ def test_fold_no_load_checks_length():
         tm.fold(d)
 
 
-def test_fold_load_checks_length():
+@pytest.mark.parametrize("cls", (TableModel, FixedTableModel))
+def test_fold_load_checks_length(cls):
     """Check we error out when the lengths are wrong: fold.
 
     This requires
       - the table data having no X array
+      - But we do have Y data
       - the data being partially filtered
 
     """
 
     ytbl = [5, 7, 3, 2]
-    tm = TableModel('tbl')
-    tm.load(None, ytbl)
+    tm = cls('tbl')
+    if cls is FixedTableModel:
+        tm.load(ytbl)
+    else:
+        tm.load(None, ytbl)
 
     xdata = np.asarray([0, 10, 20, 25, 30, 40])
     ydata = np.ones_like(xdata)
@@ -452,14 +526,15 @@ def test_fold_load_checks_length():
         tm.fold(d)
 
 
-def test_cached_basic():
+@pytest.mark.parametrize("cls", (TableModel, InterpolatedTableModel1D))
+def test_cached_basic(cls):
     """Basic check the cache works.
 
     This is mainly here so we can have confidence in
     test_cache_is_revoked.
     """
 
-    mdl = TableModel()
+    mdl = cls()
     mdl.load([1, 2, 3], [5, 2, 12])
 
     # We could check the _cache_ctr all in one go but we do want false
@@ -489,11 +564,12 @@ def test_cached_basic():
     assert mdl._cache_ctr["misses"] == 2
 
 
-def test_cache_is_revoked():
+@pytest.mark.parametrize("cls", (TableModel, InterpolatedTableModel1D))
+def test_cache_is_revoked(cls):
     """Loading new data should clear the cache. Does it?
     """
 
-    mdl = TableModel()
+    mdl = cls()
     mdl.load([1, 2, 3], [5, 2, 12])
 
     y = mdl([1, 2, 3])
@@ -517,14 +593,15 @@ def test_cache_is_revoked():
     assert mdl._cache_ctr["misses"] == 1
 
 
-def test_cache_method():
+@pytest.mark.parametrize("cls", (TableModel, InterpolatedTableModel1D))
+def test_cache_method(cls):
     """Does changing the method cause the cache to change?
 
     In this case we just test the model evaluation,
     and not the actual cache values.
     """
 
-    mdl = TableModel()
+    mdl = cls()
     mdl.load([1, 2, 3], [5, 2, 12])
     assert mdl.method == linear_interp
 
@@ -536,7 +613,8 @@ def test_cache_method():
     assert y == pytest.approx([5, 12])
 
 
-def test_pickle_none(tmp_path):
+@pytest.mark.parametrize("cls", TABLE_MODELS)
+def test_pickle_none(cls, tmp_path):
     """Can we save/restore a TableModel with no data?"""
 
     x = [1, 2, 3]
@@ -544,7 +622,7 @@ def test_pickle_none(tmp_path):
     xtest = [1.5, 2, 2.5, 3]
     ytest = [1, -2, 5.5, 13]
 
-    mdl = TableModel("fred")
+    mdl = cls("fred")
 
     out = tmp_path / "model.state"
     out = str(out)
@@ -554,23 +632,24 @@ def test_pickle_none(tmp_path):
     with open(out, "rb") as ifh:
         nmdl = pickle.load(ifh)
 
-    assert isinstance(nmdl, TableModel)
+    assert isinstance(nmdl, cls)
     assert nmdl.name == "fred"
     assert nmdl.filename is None
-    assert nmdl.get_x() is None
     assert nmdl.get_y() is None
     assert nmdl.ampl.val == pytest.approx(1)
     assert not nmdl.ampl.frozen
 
-    assert nmdl.method is linear_interp
+    if cls in (TableModel, InterpolatedTableModel1D):
+        assert nmdl.method is linear_interp
+        assert nmdl.get_x() is None
+        # Check we can use the restored object
+        #
+        nmdl.load(x, y)
+        assert nmdl(xtest) == pytest.approx(ytest)
 
-    # Check we can use the restored object
-    #
-    nmdl.load(x, y)
-    assert nmdl(xtest) == pytest.approx(ytest)
 
-
-def test_pickle_x_y(tmp_path):
+@pytest.mark.parametrize("cls", (TableModel, InterpolatedTableModel1D))
+def test_pickle_x_y(cls, tmp_path):
     """Can we save/restore a TableModel with x/y?"""
 
     x = [1, 2, 3]
@@ -578,7 +657,7 @@ def test_pickle_x_y(tmp_path):
     xtest = [1.5, 2, 2.5, 3]
     ytest = [-5 * 1, -5 * -2, -5 * 5.5, -5 * 13]
 
-    mdl = TableModel()
+    mdl = cls()
     mdl.load(x, y)
     mdl.ampl = -5
     mdl.ampl.freeze()
@@ -592,8 +671,8 @@ def test_pickle_x_y(tmp_path):
     with open(out, "rb") as ifh:
         nmdl = pickle.load(ifh)
 
-    assert isinstance(nmdl, TableModel)
-    assert nmdl.name == "tablemodel"
+    assert isinstance(nmdl, cls)
+    assert "tablemodel" in nmdl.name  # Fully qualified name is tested elsewhere
     assert nmdl.filename is None
     assert nmdl.get_x() == pytest.approx(x)
     assert nmdl.get_y() == pytest.approx(y)
@@ -603,7 +682,8 @@ def test_pickle_x_y(tmp_path):
     assert nmdl(xtest) == pytest.approx(ytest)
 
 
-def test_pickle_y(tmp_path):
+@pytest.mark.parametrize("cls", (TableModel, FixedTableModel))
+def test_pickle_y(cls, tmp_path):
     """Can we save/restore a TableModel with just y and filtered?"""
 
     x = [0, 1, 2, 3, 5]
@@ -611,8 +691,11 @@ def test_pickle_y(tmp_path):
     xtest = [1, 2, 3]
     ytest = [-5 * 4, -5 * -2, -5 * 13]
 
-    mdl = TableModel("test")
-    mdl.load(None, y)
+    mdl = cls("test")
+    if cls is FixedTableModel:
+        mdl.load(y)
+    else:
+        mdl.load(None, y)
     mdl.ampl = -5
     mdl.ampl.freeze()
 
@@ -635,10 +718,11 @@ def test_pickle_y(tmp_path):
     with open(out, "rb") as ifh:
         nmdl = pickle.load(ifh)
 
-    assert isinstance(nmdl, TableModel)
+    assert isinstance(nmdl, cls)
     assert nmdl.name == "test"
     assert nmdl.filename == filename
-    assert nmdl.get_x() is None
+    if cls is TableModel:
+        assert nmdl.get_x() is None
     assert nmdl.get_y() == pytest.approx(y)
     assert nmdl.ampl.val == pytest.approx(-5)
     assert nmdl.ampl.frozen
@@ -646,7 +730,8 @@ def test_pickle_y(tmp_path):
     assert nmdl(xtest) == pytest.approx(ytest)
 
 
-def test_pickle_interpolation(tmp_path):
+@pytest.mark.parametrize("cls", (TableModel, InterpolatedTableModel1D))
+def test_pickle_interpolation(cls, tmp_path):
     """Can we save/restore a TableModel with different interpolation
 
     This is only relevant for load(x, y) cases.
@@ -657,7 +742,7 @@ def test_pickle_interpolation(tmp_path):
     xtest = [0.6, 3.9]
     ytest = [-5 * 4, -5 * 13]
 
-    mdl = TableModel("test")
+    mdl = cls("test")
     mdl.load(x, y)
     mdl.ampl = -5
     mdl.ampl.freeze()
@@ -674,7 +759,7 @@ def test_pickle_interpolation(tmp_path):
     with open(out, "rb") as ifh:
         nmdl = pickle.load(ifh)
 
-    assert isinstance(nmdl, TableModel)
+    assert isinstance(nmdl, cls)
     assert nmdl.name == "test"
     assert nmdl.filename is None
     assert nmdl.get_x() == pytest.approx(x)

--- a/sherpa/models/tests/test_tablemodel.py
+++ b/sherpa/models/tests/test_tablemodel.py
@@ -82,9 +82,6 @@ def test_filename(cls):
                                          (InterpolatedTableModel1D, 1)])
 def test_ndim(cls, ndim):
     """What is the ndim?
-
-    At the moment we can use this with nD data but only really if we do
-    not set the "x" argument.
     """
 
     mdl = cls()

--- a/sherpa/models/tests/test_template.py
+++ b/sherpa/models/tests/test_template.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2018, 2021, 2022, 2023
+#  Copyright (C) 2011, 2015-2016, 2018, 2021-2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -22,7 +22,7 @@ import numpy
 
 import pytest
 
-from sherpa.models import TableModel, Gauss1D
+from sherpa.models import InterpolatedTableModel1D, Gauss1D
 from sherpa.models.template import create_template_model
 from sherpa.utils.testing import requires_data
 from sherpa.utils.err import ModelErr
@@ -124,7 +124,7 @@ def setUp():
 
     templates = []
     for ii in range(ntemplates):
-        t = TableModel()
+        t = InterpolatedTableModel1D()
         g1.fwhm = rng.uniform(0.5, 2.0)
         g1.pos = rng.uniform(1.0, 4.5)
         g1.ampl = rng.uniform(1.0, 50.)

--- a/sherpa/stats/tests/test_stats_unit.py
+++ b/sherpa/stats/tests/test_stats_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2017, 2021, 2022, 2023
+#  Copyright (C) 2016-2017, 2021-2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -50,7 +50,7 @@ from sherpa.astro.data import DataPHA
 from sherpa.astro.instrument import create_delta_rmf
 from sherpa.data import Data1D, Data1DInt, Data2D, DataSimulFit
 from sherpa.models.model import SimulFitModel
-from sherpa.models.basic import Const1D, Polynom1D, TableModel
+from sherpa.models.basic import Const1D, Polynom1D, FixedTableModel
 from sherpa.astro.models import Lorentz2D
 from sherpa.utils.err import DataErr, FitErr, StatErr
 
@@ -1351,8 +1351,8 @@ def test_cstat_negative_model(stat, expected):
     # value. Match the data except for the discrepant point.
     #
     data = Data1D("x", [1, 2, 3], [1, 0.1, 3])
-    model = TableModel()
-    model.load(None, [1, -ZERODELT, 3])
+    model = FixedTableModel()
+    model.load([1, -ZERODELT, 3])
 
     statobj = stat()
     answer, _ = statobj.calc_stat(data, model)

--- a/sherpa/tests/test_instrument.py
+++ b/sherpa/tests/test_instrument.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020, 2021, 2022, 2023
+#  Copyright (C) 2020-2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -32,7 +32,7 @@ from sherpa.data import Data1D, Data2D
 from sherpa.instrument import Kernel, PSFModel, RadialProfileKernel, \
     ConvolutionKernel, PSFKernel
 from sherpa.models.basic import Box1D, Box2D, Const1D, Const2D, Gauss1D, \
-    StepLo1D, TableModel
+    StepLo1D, FixedTableModel
 from sherpa.utils.err import PSFErr
 
 
@@ -288,7 +288,7 @@ def test_psfmodel_kernel_has_no_dimension():
     y = np.ones_like(x)
     data = Data1D("data-data", x, y)
 
-    m = PSFModel(kernel=TableModel())
+    m = PSFModel(kernel=FixedTableModel())
     with pytest.raises(PSFErr,
                        match="PSF model dimension must be <= 2"):
         m.get_kernel(data)

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -7595,23 +7595,16 @@ class Session(NoNewAttributesAfterInit):
     #
 
     def _read_user_model(self, filename, ncols=2, colkeys=None,
-                         dstype=sherpa.data.Data1D, sep=' ', comment='#'):
-        x = None
-        y = None
-        try:
-            data = self.unpack_data(filename, ncols, colkeys,
-                                    dstype, sep, comment)
-            x = data.get_x()
-            y = data.get_y()
+                         sep=' ', comment='#'):
+        cols = sherpa.io.get_ascii_data(filename, ncols=ncols, colkeys=colkeys,
+                                         sep=sep, comment=comment)[1]
 
-        except TypeError:
-            # we have to check for the case of a *single* column in the file
-            # extract the single array from the read and bypass the dataset
-            y = sherpa.io.get_ascii_data(filename, ncols=1, colkeys=colkeys,
-                                         sep=sep, dstype=dstype,
-                                         comment=comment)[1].pop()
+        if len(cols) == 0:
+               raise IOErr(f"No column data found in {filename}")
+        elif len(cols) == 1:
+                return (None, cols[0])
+        return (cols[0], cols[1])
 
-        return (x, y)
 
     # DOC-TODO: I am not sure I have the data format correct.
     # DOC-TODO: description of template interpolation needs a lot of work.
@@ -7754,9 +7747,9 @@ class Session(NoNewAttributesAfterInit):
         """
         add_interpolator(name, interpolator_class, **kwargs)
 
-    def load_table_model(self, modelname, filename, ncols=2, colkeys=None,
-                         dstype=sherpa.data.Data1D, sep=' ', comment='#',
-                         method=sherpa.utils.linear_interp):
+    def load_table_model(self, modelname, filename,
+                         method=sherpa.utils.linear_interp,
+                         *args, **kwargs):
         """Load ASCII tabular data and use it as a model component.
 
         A table model is defined on a grid of points which is
@@ -7778,9 +7771,6 @@ class Session(NoNewAttributesAfterInit):
            ``None``, which uses the first ``ncols`` columns in the file.
            The default column names are col followed by the column number,
            so ``col1`` for the first column.
-        dstype : data class to use, optional
-           What type of data is to be used. Supported values include
-           `Data1D` (the default) and `Data1DInt`.
         sep : str, optional
            The separator character for columns. The default is ``' '``.
         comment : str, optional
@@ -7837,9 +7827,14 @@ class Session(NoNewAttributesAfterInit):
         >>> set_par(filt.ampl, 1e3, min=1, max=1e6)
 
         """
+        # Implementation note: the *args and **kwargs are
+        # passed to _read_user_model where the default values are set.
+        # The reason to not define all parameters here is that
+        # sherpa.astro.ui.load_user_model can't work with these defaults
+        # (because they are applicable to ASCII, but not to fits files) and we
+        # want to call this method here from the astro.Session child class.
 
-        x, y = self._read_user_model(filename, ncols, colkeys,
-                                     dstype, sep, comment)
+        x, y = self._read_user_model(filename, *args, **kwargs)
 
         tablemodel = TableModel(modelname)
         tablemodel.method = method
@@ -7852,8 +7847,7 @@ class Session(NoNewAttributesAfterInit):
     # DOC-TODO: how is the _y value used if set
     # @loggable()
     def load_user_model(self, func, modelname, filename=None, ncols=2,
-                        colkeys=None, dstype=sherpa.data.Data1D,
-                        sep=' ', comment='#'):
+                        colkeys=None, sep=' ', comment='#'):
         """Create a user-defined model.
 
         Assign a name to a function; this name can then be used as any
@@ -7879,10 +7873,6 @@ class Session(NoNewAttributesAfterInit):
         colkeys : array of str, optional
            An array of the column name to read in. The default is
            ``None``.
-        dstype : data class to use, optional
-           What type of data is to be used. Supported values include
-           `Data1D` (the default), `Data1DInt`, `Data2D`, and
-           `Data2DInt`.
         sep : str, optional
            The separator character. The default is ``' '``.
         comment : str, optional
@@ -7950,7 +7940,7 @@ class Session(NoNewAttributesAfterInit):
         usermodel._file = filename
         if filename is not None:
             _, usermodel._y = self._read_user_model(filename, ncols, colkeys,
-                                                    dstype, sep, comment)
+                                                    sep, comment)
         self._add_model_component(usermodel)
 
     # @loggable()

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -52,7 +52,7 @@ import sherpa.instrument
 import sherpa.io
 import sherpa.image
 import sherpa.models
-from sherpa.models.basic import TableModel
+from sherpa.models.basic import FixedTableModel, InterpolatedTableModel1D
 import sherpa.models.model
 from sherpa.models.model import Model, SimulFitModel
 from sherpa.models.parameter import Parameter
@@ -523,7 +523,7 @@ def read_template_model(modelname, templatefile,
         if ntcols != 2:
             raise IOErr("wrongnumcols", 2, ntcols)
 
-        tm = TableModel(filename)
+        tm = InterpolatedTableModel1D(filename)
         tm.method = method  # interpolation method
         tm.load(*tcols)
         tm.ampl.freeze()
@@ -7836,10 +7836,13 @@ class Session(NoNewAttributesAfterInit):
 
         x, y = self._read_user_model(filename, *args, **kwargs)
 
-        tablemodel = TableModel(modelname)
-        tablemodel.method = method
+        if x is None:
+            tablemodel = FixedTableModel(name=modelname, y=y)
+        else:
+            tablemodel = InterpolatedTableModel1D(name=modelname,
+            x=x, y=y)
+            tablemodel.method = method
         tablemodel.filename = filename
-        tablemodel.load(x, y)
         self._tbl_models.append(tablemodel)
         self._add_model_component(tablemodel)
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -34,7 +34,7 @@ import pydoc
 import string
 import sys
 from types import FunctionType, MethodType
-from typing import Any, Generic, TypeVar, overload
+from typing import Any, Dict, Generic, TypeVar, overload
 import warnings
 
 import numpy as np
@@ -2294,7 +2294,8 @@ def nearest_interp(xout, xin, yin):
     return np.where((np.abs(xout - x0) < np.abs(xout - x1)), y0, y1)
 
 
-def interpolate(xout, xin, yin, function=linear_interp):
+def interpolate(xout: np.ndarray, xin: np.ndarray, yin: np.ndarray,
+                function: Callable[[np.ndarray, np.ndarray, np.ndarray], np.ndarray] = linear_interp):
     """One-dimensional interpolation.
 
     Parameters
@@ -2342,6 +2343,121 @@ def interpolate(xout, xin, yin, function=linear_interp):
         raise TypeError(f"input function '{repr(function)}' is not callable")
 
     return function(xout, xin, yin)
+
+
+def integrate_tabulated_function(x0: np.ndarray, x1: np.ndarray,
+                                 x_points: np.ndarray, y_points: np.ndarray,
+                                 *args, **kwargs):
+    '''Integrate y_points between x0 and x1
+
+    This function is meant to be used for models that linarly interpolate
+    between given points (x_points, y_points) and need to be integrated
+    between arbitrary limits (x0, x1) which my or may not coincide with the
+    given points. Numerical methods of integration do no always perform well
+    with non-differentiable functions such as linear interpolation which could
+    have a non-differentiable point at every x_point.
+
+    Parameters
+    ----------
+    x0, x1: array-like
+        The lower and upper bounds of the integration. Must have the same length.
+    x_points, y_points: array-like
+        The points defining the function to integrate.
+    args, kwargs
+        Unused, but needed to conform to the interface of other integrate functions.
+
+    Returns
+    -------
+    result: ndarray
+        The integral of y_points between x0 and x1.
+    '''
+    if np.any(x1 < x0):
+        raise ValueError("x1 must be greater than or equal to x0")
+
+    # Add the integration limits to the points, if they are not already present
+    x = np.concatenate([x_points, x0, x1])
+    y = np.concatenate([y_points,
+                        linear_interp(x0, x_points, y_points),
+                        linear_interp(x1, x_points, y_points)])
+    # some x values might be repeated because they appear in both x0 and x1
+    # or they are also one of the original x_points.
+    # Simplify the implementation by sorting and removing duplicate points
+    sortidx = np.argsort(x)
+    x = x[sortidx]
+    y = y[sortidx]
+    x, ind = np.unique(x, return_index=True)
+    y = y[ind]
+
+    area = np.diff(x) * (y[:-1] + y[1:]) / 2
+
+    result = np.zeros(x0.shape, dtype=np.float64)
+
+    for i in range(len(x0)):
+        ind0 = np.nonzero(x == x0[i])[0][0]
+        ind1 = np.nonzero(x == x1[i])[0][0]
+        result[i] = area[ind0:ind1].sum()
+
+    return result
+
+
+def integrate(x0: np.ndarray, x1: np.ndarray, xin: np.ndarray, yin: np.ndarray,
+              interpolate_func: Callable[[np.ndarray, np.ndarray, np.ndarray], np.ndarray] = linear_interp,
+              integrate_func: Callable[[np.ndarray, np.ndarray, np.ndarray, np.ndarray, Callable, Dict], np.ndarray] = integrate_tabulated_function,
+              **kwargs):
+    """One-dimensional integration.
+
+    This function performs one-dimensional integration of the
+    given data points (xin, yin) over the specified range
+    [x0, x1].
+
+    Parameters
+    ----------
+    x0, x1 : array_like
+       Bin boundaries where to integrate the interpolated function.
+    xin : array_like
+       The x values of the data to interpolate. This must be
+       sorted so that it is monotonically increasing.
+    yin : array_like
+       The y values of the data to interpolate (must be the same
+       size as ``xin``).
+    interpolate_func : func, optional
+       The function to perform the interpolation. It accepts
+       the arguments (xout, xin, yin) and returns the interpolated
+       values. The default is to use linear interpolation.
+    integrate_func : func, optional
+         The function to perform the integration. It accepts
+         the arguments (x0, x1, xin, yin, interpolate_func, **kwargs) and
+         returns the integrated values.
+
+    Returns
+    -------
+    yout : array_like
+       The integrated values.
+
+    See Also
+    --------
+    linear_interp, nearest_interp, integrate_tabulated_function, neville
+
+    Examples
+    --------
+
+    Define a function by giving a few tabulated points and then integrate
+    bins defined by x0 and x1:
+
+    >>> import numpy as np
+    >>> x = np.asarray([1.2, 3.4, 4.5, 5.2])
+    >>> y = np.asarray([12.2, 14.4, 16.8, 15.5])
+    >>> x0= np.array([2.0, 4.0])
+    >>> x1= np.array([3.0, 5.0])
+    >>> yout = integrate(x0, x1, x, y)
+    """
+
+    if not callable(integrate_func):
+        raise TypeError(f"input function '{repr(integrate_func)}' is not callable")
+
+    return integrate_func(x0, x1, xin, yin,
+                          interpolate_func=interpolate_func,
+                          **kwargs)
 
 
 def is_binary_file(filename: str) -> bool:

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -2350,7 +2350,7 @@ def integrate_tabulated_function(x0: np.ndarray, x1: np.ndarray,
                                  *args, **kwargs):
     '''Integrate y_points between x0 and x1
 
-    This function is meant to be used for models that linarly interpolate
+    This function is meant to be used for models that linearly interpolate
     between given points (x_points, y_points) and need to be integrated
     between arbitrary limits (x0, x1) which my or may not coincide with the
     given points. Numerical methods of integration do no always perform well

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -34,7 +34,7 @@ import pydoc
 import string
 import sys
 from types import FunctionType, MethodType
-from typing import Any, Dict, Generic, TypeVar, overload
+from typing import Any, Generic, TypeVar, overload
 import warnings
 
 import numpy as np
@@ -2402,7 +2402,7 @@ def integrate_tabulated_function(x0: np.ndarray, x1: np.ndarray,
 
 def integrate(x0: np.ndarray, x1: np.ndarray, xin: np.ndarray, yin: np.ndarray,
               interpolate_func: Callable[[np.ndarray, np.ndarray, np.ndarray], np.ndarray] = linear_interp,
-              integrate_func: Callable[[np.ndarray, np.ndarray, np.ndarray, np.ndarray, Callable, Dict], np.ndarray] = integrate_tabulated_function,
+              integrate_func: Callable[[np.ndarray, np.ndarray, np.ndarray, np.ndarray, Callable, dict | None], np.ndarray] = integrate_tabulated_function,
               **kwargs):
     """One-dimensional integration.
 

--- a/sherpa/utils/tests/test_utils_unit.py
+++ b/sherpa/utils/tests/test_utils_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018-2024, 2026
+#  Copyright (C) 2016, 2018-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -18,17 +18,16 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import warnings
-
-import numpy
+import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal, \
     assert_array_almost_equal
 
 import pytest
 
-from sherpa.utils import _utils, is_binary_file, pad_bounding_box, \
+from sherpa.utils import _utils, integrate, is_binary_file, pad_bounding_box, \
     histogram1d, histogram2d, dataspace1d, dataspace2d, \
-    interpolate, bool_cast, multinormal_pdf, multit_pdf
+    interpolate, bool_cast, multinormal_pdf, multit_pdf, \
+    integrate_tabulated_function
 from sherpa.utils.guess import get_fwhm
 from sherpa.utils.testing import requires_data
 
@@ -120,7 +119,7 @@ def test_calc_hist1d():
     """
     this test was created using sherpa 4.8.1 (2507414) as an oracle for the python 3 migration
     """
-    x, xlo, xhi = numpy.arange(0, 21)/2, range(0, 20, 1), range(1, 21, 1)
+    x, xlo, xhi = np.arange(0, 21)/2, range(0, 20, 1), range(1, 21, 1)
     expected = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     assert_array_equal(expected, _utils.hist1d(x, xlo, xhi))
 
@@ -129,8 +128,8 @@ def test_calc_hist2d():
     """
     this test was created using sherpa 4.8.1 (2507414) as an oracle for the python 3 migration
     """
-    x = numpy.arange(10)//2
-    xx, yy = numpy.meshgrid(x, x)
+    x = np.arange(10)//2
+    xx, yy = np.meshgrid(x, x)
     xin = xx.ravel()
     yin = yy.ravel()
 
@@ -206,7 +205,7 @@ def test_neville():
     """
     x = [1.2, 3.4, 4.5, 5.2]
     y = [12.2, 14.4, 16.8, 15.5]
-    xgrid = numpy.linspace(2, 5, 5)
+    xgrid = np.linspace(2, 5, 5)
     expected = [10.7775023, 12.24227718, 14.7319838, 16.60004786, 16.19989505]
     assert_almost_equal(expected, _utils.neville(xgrid, x, y))
 
@@ -243,19 +242,19 @@ def test_rebin_partial_overlap():
     # and then rebinned onto the requested grid. So, the edge bins
     # are partially filled.
     #
-    xdataspace = numpy.arange(1, 7, 0.5)
+    xdataspace = np.arange(1, 7, 0.5)
     xdlo, xdhi = xdataspace[:-1], xdataspace[1:]
 
-    xgrid = numpy.arange(2.1, 6, 0.5)
+    xgrid = np.arange(2.1, 6, 0.5)
     xglo, xghi = xgrid[:-1], xgrid[1:]
 
     # Manually calculated
-    ygrid = numpy.asarray([0, 0.4, 2, 2, 2, 1.6, 0])
+    ygrid = np.asarray([0, 0.4, 2, 2, 2, 1.6, 0])
 
     yans = _utils.rebin(ygrid, xglo, xghi, xdlo, xdhi)
 
     # Manually calculated
-    yexp = numpy.asarray([0, 0, 0, 0.32, 1.68, 2, 2, 1.68, 0.32, 0, 0])
+    yexp = np.asarray([0, 0, 0, 0.32, 1.68, 2, 2, 1.68, 0.32, 0, 0])
     assert yans == pytest.approx(yexp)
 
 
@@ -283,8 +282,8 @@ def test_is_binary_file(make_data_path):
 def test_pad_bounding_box_fail():
     """The mask size must be >= kernel."""
 
-    kernel = numpy.arange(12)
-    mask = numpy.ones(10)
+    kernel = np.arange(12)
+    mask = np.ones(10)
     with pytest.raises(TypeError) as excinfo:
 
         pad_bounding_box(kernel, mask)
@@ -308,13 +307,13 @@ def test_pad_bounding_box_fail():
 def test_pad_bounding_box(mask, expected):
     """Basic tests"""
 
-    kernel = numpy.asarray([1, 2, 3, 4, 5])
+    kernel = np.asarray([1, 2, 3, 4, 5])
 
     # The tests use equality rather than approximate equality
     # since the values are just being copied around by the
     # code, not manipulated.
     #
-    exp = numpy.asarray(expected).astype(numpy.float64)
+    exp = np.asarray(expected).astype(np.float64)
 
     ans = pad_bounding_box(kernel, mask)
     assert_array_equal(ans, exp)
@@ -331,14 +330,14 @@ def test_pad_bounding_box_mask_too_large():
     instead?
     """
 
-    kernel = numpy.arange(5)
-    mask = numpy.ones(10)
+    kernel = np.arange(5)
+    mask = np.ones(10)
 
     ans = pad_bounding_box(kernel, mask)
 
     # Assume that the "extra" mask elements get mapped to 0 (or
     # ignored).
-    exp = numpy.asarray([0, 1, 2, 3, 4, 0, 0, 0, 0, 0]).astype(numpy.float64)
+    exp = np.asarray([0, 1, 2, 3, 4, 0, 0, 0, 0, 0]).astype(np.float64)
     assert_array_equal(ans, exp)
 
 
@@ -362,11 +361,11 @@ def test_pad_bounding_box_mask_too_large():
 # If the values are <= 0 then we just use the fall-through value
 # of half the x range.
 #
-fwhm_x = numpy.asarray([10, 22, 30, 45, 50, 61, 70, 90, 100, 120])
-fwhm_y_both = numpy.asarray([9, 28, 25, 52, 53, 49, 33, 10, 10, 6])
-fwhm_y_left = numpy.asarray([10, 5, 3, 5, 7, 13, 8, 42, 57, 43])
-fwhm_y_right = numpy.asarray([46, 45, 40, 16, 20, 7, 6, 5, 3, 7])
-fwhm_y_flat = numpy.ones(fwhm_x.size)
+fwhm_x = np.asarray([10, 22, 30, 45, 50, 61, 70, 90, 100, 120])
+fwhm_y_both = np.asarray([9, 28, 25, 52, 53, 49, 33, 10, 10, 6])
+fwhm_y_left = np.asarray([10, 5, 3, 5, 7, 13, 8, 42, 57, 43])
+fwhm_y_right = np.asarray([46, 45, 40, 16, 20, 7, 6, 5, 3, 7])
+fwhm_y_flat = np.ones(fwhm_x.size)
 
 @pytest.mark.parametrize("x,y,expected",
                          [(fwhm_x, fwhm_y_both, 60),
@@ -393,8 +392,8 @@ def test_histogram1d_sort_axis():
 
     """
 
-    glo = numpy.asarray([1, 3, 6, 7, 9])
-    ghi = numpy.asarray([6, 3, 12, 7, 9])
+    glo = np.asarray([1, 3, 6, 7, 9])
+    ghi = np.asarray([6, 3, 12, 7, 9])
 
     ga = glo.copy()
     gb = ghi.copy()
@@ -423,7 +422,7 @@ def test_histogram1d_with_fixed_bins():
     """
 
     # Ensure we can't overwrite the grid
-    grid = numpy.asarray([1, 3, 6, 7, 9, 12])
+    grid = np.asarray([1, 3, 6, 7, 9, 12])
     grid.setflags(write=False)
 
     n = histogram1d([2, 3, 4, 5, 6, -1, 7, 20, 8, 9], grid[:-1], grid[1:])
@@ -437,16 +436,16 @@ def test_histogram2d_with_fixed_bins():
 
     """
 
-    x0 = numpy.asarray([1, 2, 3])
-    x1 = numpy.asarray([1, 2, 3, 4])
+    x0 = np.asarray([1, 2, 3])
+    x1 = np.asarray([1, 2, 3, 4])
     x0.setflags(write=False)
     x1.setflags(write=False)
 
-    x = numpy.asarray([2, 3, 0])
-    y = numpy.asarray([3, 4, 0])
+    x = np.asarray([2, 3, 0])
+    y = np.asarray([3, 4, 0])
 
     n = histogram2d(x, y, x0, x1)
-    expected = numpy.zeros((3, 4))
+    expected = np.zeros((3, 4))
     expected[1, 2] = 1
     expected[2, 3] = 1
     assert n == pytest.approx(expected)
@@ -644,3 +643,32 @@ def test_multit_pdf(x, mu, sigma, dof, expected):
 
     out = multit_pdf(x, mu, sigma, dof)
     assert out == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("func", [integrate_tabulated_function, integrate])
+def test_integrate_tabulated_function(func):
+    """Test that we can calculate the area under a linearly interpolated function.
+
+    Expected results are manually calculated.
+    The test is run twice - directly with the integrate_tabulated_function
+    and via the integrate() wrapper with default settings (which default to
+    integrate_tabulated_function).
+    """
+    x0 = np.array([2,3,5,6.5])
+    x1 = np.array([3,5,6.5,7.5])
+    x_points = np.array([0, 15])
+    y_points = np.array([2, 2])
+    out = func(x0, x1, x_points, y_points)
+    assert out == pytest.approx([2., 4., 3., 2.])
+
+    x0 = np.array([-1, 4, 10, 15])
+    x1 = np.array([1, 6, 15, 20])
+    x_points = np.array([0, 5, 10])
+    y_points = np.array([1, 5, 2])
+    out = func(x0, x1, x_points, y_points)
+    assert out == pytest.approx([  2. ,   9.3,   2.5, -12.5])
+
+    x0 = np.array([1])
+    x1 = np.array([1])
+    out = func(x0, x1, x_points, y_points)
+    assert out == pytest.approx([0.])


### PR DESCRIPTION
## Summary
Split the `TableModel` into two separate models: `FixedTableModel` for a model where the number of bins is fixed to be the same number as the data values and `InterpolatedTableModel1D` where a tabulated x/y table is interpolated (and integrated if needed) to match the data values/bins.

## Details

The old `TableModel` has two separate applications: It can be an x/y table that is interpolated in x as needed, or it can just be a table of y values assuming that the number of values exactly matches the number of data values.
    
This is conceptually different and can be confusing to users (and also in the code). This commit introduces two new classes to split the two different functionalities into separate classes (with a common base class).

Adding those two new classes is followed by:

- deprecating `TableModel`
- Adjusting the models generated by UI functions that load a table

in doing so, this includes the changes in #2376, which change the loading functions in a way that is technically breaking API, but in practice I judge that to be a minimal impact which allows for significantly more consistency in the API (I would just treat the change as a "bug fix"):  align the signature of the `load_table_model` in `sherpa.ui` and `sherpa.astro.ui`. This is technically an API breaking change in case someone relied on the ordering of arguments and passed in the interpolation method as third argument instead of a keyword argument.

I think that's unlikely to happen in practice (most people won't pass that in at all and just use the default), but it's separated into it's own commit in case we want to discuss or reverse that change.

Matching the API does not only make the linters happy, it also simplifies documentation as we could now point to (or generate from in some way) the docs of this method from the docs of the superclass method.

In fact, I'm removing keywords that are no longer used, because they are confusing. Again, I don't think any of them are used in practice, but to keep backwards compatibility, we could just keep those unused keywords in the signature and raise a DeprecationWarning if they are set.

Also, this changes some error messages. It raises the same type of exceptions as before (IoErr) but with a different string message. Again, that's technically breaking the API, but I don't think it changes any workflow in practice.

## Questions

We could keep more of API backwards compatible (a re-ordering of keywords is required, but we can keep the old keywords around (in a differenet order) to blunt the impact).

closes #1648
closes #1620
fixes #1056
closes #2376