### PR TITLE
Increase tolerance for a test that occasionally fails in CI

### DIFF
--- a/sherpa/optmethods/tests/test_scipy_interface.py
+++ b/sherpa/optmethods/tests/test_scipy_interface.py
@@ -184,7 +184,7 @@ def test_scipy_unconstrainted(optimizer, works_unconstrained):
     [(optmethods.Scipy_Minimize, 1e-5),
      (optmethods.Scipy_Basinhopping, 1e-5),
      (optmethods.Scipy_DifferentialEvolution, 1e-4),
-     (optmethods.Scipy_DualAnnealing, 1e-5),
+     (optmethods.Scipy_DualAnnealing, 1e-4),
      (optmethods.Scipy_Shgo, 1e-5),
      (optmethods.Scipy_Direct, 0.001),
      ],


### PR DESCRIPTION
## Summary

## Details
One o the scipy tests occasionally fails in CI, which is obviously due to numerics, so this PR simply increasese the numerical tolerance by a bit.
For an example, see
https://github.com/sherpa/sherpa/actions/runs/18729863538/job/53423975996?pr=2404
(though logs are not retained forever, so this link will become unavailable at some point).