### PR TITLE
Include background components in plot_model_components. Fix #2400.

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -5171,7 +5171,6 @@ def test_plot_model_components_pha_no_bgnd(idval, clean_astro_ui):
     assert p2.y == pytest.approx(y2)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("idval", [None, 2])
 def test_plot_model_components_pha_with_bgnd_scalar(idval, clean_astro_ui):
     """See issue #2400
@@ -5233,7 +5232,6 @@ def test_plot_model_components_pha_with_bgnd_scalar(idval, clean_astro_ui):
     assert p3.y == pytest.approx(y3)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("idval", [None, 2])
 def test_plot_model_components_pha_with_bgnd_vector(idval, clean_astro_ui):
     """See issue #2400
@@ -5267,19 +5265,21 @@ def test_plot_model_components_pha_with_bgnd_vector(idval, clean_astro_ui):
 
     mp = ui.get_model_components_plot(idval)
     assert mp.title == "Component plot"
-    assert len(mp.plots) == 2
+    assert len(mp.plots) == 3
 
     # Basic check the plots contain the expected data
     p1 = mp.plots[0]
     p2 = mp.plots[1]
+    p3 = mp.plots[2]
 
     if idval is None:
         cpt = "scale1"
     else:
         cpt = f"scale{idval}"
 
-    assert p1.title == "Model component: apply_rmf(apply_arf(1201.0 * (box1d.m1 + box1d.m2)))"
-    assert p2.title == f"Model component: {cpt} * apply_rmf(apply_arf(1201.0 * box1d.bm))"
+    assert p1.title == "Model component: apply_rmf(apply_arf(1201.0 * box1d.m1))"
+    assert p2.title == "Model component: apply_rmf(apply_arf(1201.0 * box1d.m2))"
+    assert p3.title == f"Model component: {cpt} * apply_rmf(apply_arf(1201.0 * box1d.bm))"
 
     for p in mp.plots:
         assert p.xlabel == "Channel"
@@ -5300,5 +5300,6 @@ def test_plot_model_components_pha_with_bgnd_vector(idval, clean_astro_ui):
     y2 = m2(elo, ehi) * norm
     y3 = bm(elo, ehi) * norm * src_backscal / bkg_backscal
 
-    assert p1.y == pytest.approx(y1 + y2)
-    assert p2.y == pytest.approx(y3)
+    assert p1.y == pytest.approx(y1)
+    assert p2.y == pytest.approx(y2)
+    assert p3.y == pytest.approx(y3)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -56,7 +56,7 @@ from sherpa.data import Data, Data1D, Data1DAsymmetricErrs, Data2D, \
 from sherpa.fit import Fit
 import sherpa.io
 from sherpa.models.basic import TableModel, UserModel
-from sherpa.models.model import Model
+from sherpa.models.model import Model, model_deconstruct
 import sherpa.plot
 from sherpa.sim import NormalParameterSampleFromScaleMatrix, \
     ReSampleData
@@ -12151,6 +12151,91 @@ class Session(sherpa.ui.utils.Session):
             return plotobj
 
         return super().get_model_component_plot(id, model=model, recalc=recalc)
+
+    # We can not just copy over the docstring from sherpa.ui.utils
+    #
+    def get_model_components_plot(self,
+                                  id: IdType | None = None
+                                  ) -> sherpa.plot.MultiPlot:
+        """Return the data used by plot_model_components.
+
+        .. versionchanged:: 4.18.1
+           Background model components will now be included.
+
+        .. versionadded:: 4.16.1
+
+        Parameters
+        ----------
+        id : int, str, or None, optional
+           The data set that provides the data. If not given then the
+           default identifier is used, as returned by `get_default_id`.
+
+        Returns
+        -------
+        plot : MultiPlot
+           A plot object containing the individual plot objects.
+
+        See Also
+        --------
+        get_model_plot, plot_model, plot_model_component,
+        plot_model_components
+
+        Notes
+        -----
+
+        Unlike get_model_component this routine does not accept
+        either model or recalc arguments.
+
+        Examples
+        --------
+
+        Return the plot data for the individual components used in the
+        default data set. In this case it will report plots for
+        ``gal * pl`` and ``gal * gline``:
+
+        >>> set_source(xsphabs.gal * (powlaw1d.pl + gauss1d.gline))
+        >>> cplots = get_model_components_plot()
+
+        """
+
+        idval = self._fix_id(id)
+        model = self.get_source(idval)
+        data = self.get_data(idval)
+        if isinstance(data, DataPHA):
+            # Replicate much of get_response_for_pha
+            resp = self.get_response(idval)  # TODO: bkg_id?
+            if not data.subtracted:
+
+                bkg_srcs = sherpa.astro.background.get_bkg_srcs(self, idval)
+                if len(bkg_srcs) > 0:
+
+                    out = sherpa.astro.background.get_full_expr(idval,
+                                                                data,
+                                                                resp,
+                                                                model,
+                                                                bkg_srcs)
+                    base_model, bmodels = out
+
+                    # Do we need to worry about separate background models?
+                    if len(bmodels) == 0:
+                        model = base_model
+
+                    else:
+                        # Manually expand base_models.
+                        cpts = model_deconstruct(base_model)
+
+                        # Create a single model (that will then get
+                        # decomposed in get_components_helper, but
+                        # this lets any individual components in
+                        # base_model get separated).
+                        #
+                        rcpts = [resp(cpt) for cpt in cpts] + \
+                            [scale * resp(bmdl)
+                             for scale, bmdl in bmodels]
+                        model = sum(rcpts[1:], start=rcpts[0])
+
+        return sherpa.ui.utils.get_components_helper(self.get_model_component_plot,
+                                                     model=model, idval=idval)
 
     # copy doc string from sherpa.utils
     def get_source_component_plot(self, id, model=None, recalc: bool = True):


### PR DESCRIPTION
# Summary

Include background components in plot_model_components. Fix #2400.

# Details

So, `plot_model_components` takes the model expression, splits it up using `sherpa.models.model.model_deconstruct`. However, it uses `get_source` to get the model expression, which means that it does not know anything about background models.

The "obvious" solution is to use `get_model` rather than `get_source`, but this returns the model expression wrapped within an instrument response, and `model_deconstruct` can not deconstruct this.

So, one solution would be to switch to using `get_source` and then teach `model_deconstruct` how to split up responses. However, we can not guarantee that the response is linear - i.e. we can not say that `resp(mdl1+ mdl2) == resp(mdl1) + resp(mdl2)` - because if the response is a pileup model it definitely is not valid to say this.

We can rewrite the code so that we can ask what the "model" expression for a DataPHA-related model [this is the only case where we have implicit background components] in a form that we can then split up manually for the background case. Technically this is actually what I just talked about, apart from it is a manual deconstruction of a response term, and it is only done in one place rather than in `model_deconstruct`, and we add a warning if we end up trying this with a pileup model. It is not obvious that this is the better option, since we end up having to add an astro-specific version of `get_model_components` (although we have plenty of other examples of this in `sherpa.astro.ui.utils`, so it's not the first time).