### PR TITLE
sim: add type statements

### DIFF
--- a/sherpa/sim/__init__.py
+++ b/sherpa/sim/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015-2016, 2018-2021, 2023-2025
+#  Copyright (C) 2011, 2015-2016, 2018-2021, 2023-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -193,7 +193,6 @@ parameter::
 """
 from datetime import datetime
 import logging
-from typing import Optional
 
 import numpy as np
 
@@ -842,8 +841,8 @@ class ReSampleData(NoNewAttributesAfterInit):
 
     def __call__(self, niter=1000, seed=None, rng=None,
                  *,
-                 stat: Optional[Stat] = None,
-                 method: Optional[OptMethod] = None
+                 stat: Stat | None = None,
+                 method: OptMethod | None = None
                  ) -> dict[str, np.ndarray]:
         return self.call(niter, seed=seed, rng=rng, stat=stat,
                          method=method)
@@ -854,8 +853,8 @@ class ReSampleData(NoNewAttributesAfterInit):
              # interface and the interface is complicated enough it
              # is worth marking them keyword only.
              #
-             stat: Optional[Stat] = None,
-             method: Optional[OptMethod] = None
+             stat: Stat | None = None,
+             method: OptMethod | None = None
              ) -> dict[str, np.ndarray]:
         """Resample the data and fit the model to each iteration.
 

--- a/sherpa/sim/__init__.py
+++ b/sherpa/sim/__init__.py
@@ -191,14 +191,19 @@ parameter::
     >>> pval, plo, phi = get_error_estimates(par1[nburn:])
 
 """
+
+from collections.abc import Callable
 from datetime import datetime
 import logging
+from typing import Any
 
 import numpy as np
 
 import sherpa
 from sherpa.data import Data1D, Data1DAsymmetricErrs
 from sherpa.fit import Fit
+from sherpa.models.model import Model
+from sherpa.models.parameter import Parameter
 from sherpa.optmethods import LevMar, OptMethod
 
 from sherpa.stats import Cash, CStat, WStat, LeastSq, Stat
@@ -246,8 +251,8 @@ def inverse2(x):
     return 1.0 / (x * x)
 
 
-_samplers = {"metropolismh": MetropolisMH, "mh": MH}
-_walkers = {"metropolismh": Walk, "mh": Walk}
+_samplers: dict[str, type[Sampler]] = {"metropolismh": MetropolisMH, "mh": MH}
+_walkers: dict[str, type[Walk]] = {"metropolismh": Walk, "mh": Walk}
 
 
 class MCMC(NoNewAttributesAfterInit):
@@ -263,31 +268,33 @@ class MCMC(NoNewAttributesAfterInit):
 
     __walkers = _walkers.copy()
 
-    def _get_sampler(self):
+    def _get_sampler(self) -> type[Sampler]:
         return self._sampler
 
-    def _set_sampler(self, sampler):
+    def _set_sampler(self, sampler: type[Sampler]) -> None:
         self._sampler = sampler
         self._sampler_opt = get_keyword_defaults(sampler.init)
 
     sampler = property(_get_sampler, _set_sampler)
 
-    def _get_walker(self):
+    def _get_walker(self) -> type[Walk]:
         return self._walker
 
-    def _set_walker(self, walker):
+    def _set_walker(self, walker: type[Walk]) -> None:
         self._walker = walker
 
     walker = property(_get_walker, _set_walker)
 
-    def _get_sampler_opt(self, opt):
+    def _get_sampler_opt(self, opt: str) -> Any:
         return self._sampler_opt[opt]
 
-    def _set_sampler_opt(self, opt, val):
+    def _set_sampler_opt(self, opt: str, val: Any) -> None:
         self._sampler_opt[opt] = val
 
-    def __init__(self):
-        self.priors = {}
+    def __init__(self) -> None:
+        # A prior can be a function or a model instance, but models
+        # are callable so there is no need to say Callable | Model
+        self.priors: dict[str, Callable] = {}
         self._walker = Walk
         self._sampler = MetropolisMH
         self._sampler_opt = get_keyword_defaults(MetropolisMH.init)
@@ -307,7 +314,7 @@ class MCMC(NoNewAttributesAfterInit):
         self.__dict__.update(state)
 
     # ## DOC-TODO: include examples
-    def list_priors(self):
+    def list_priors(self) -> dict[str, Callable]:
         """Return the priors set for model parameters, if any.
 
         Returns
@@ -324,7 +331,7 @@ class MCMC(NoNewAttributesAfterInit):
         """
         return self.priors
 
-    def get_prior(self, par):
+    def get_prior(self, par: Parameter) -> Callable:
         """Return the prior function for a parameter.
 
         Parameters
@@ -361,7 +368,10 @@ class MCMC(NoNewAttributesAfterInit):
         return prior
 
     # ## DOC-TODO: should set_sampler_opt be mentioned here?
-    def set_prior(self, par, prior):
+    def set_prior(self,
+                  par: Parameter,
+                  prior: Callable
+                  ) -> None:
         """Set the prior function to use with a parameter.
 
         The default prior used by ``get_draws`` for each parameter
@@ -422,7 +432,7 @@ class MCMC(NoNewAttributesAfterInit):
 
         self.priors[par.fullname] = prior
 
-    def list_samplers(self):
+    def list_samplers(self) -> list[str]:
         """List the samplers available for MCMC analysis with ``get_draws``.
 
         Returns
@@ -451,7 +461,7 @@ class MCMC(NoNewAttributesAfterInit):
         """
         return list(self.__samplers.keys())
 
-    def set_sampler(self, sampler):
+    def set_sampler(self, sampler: str | type[Sampler]) -> None:
         """Set the MCMC sampler.
 
         The sampler determines the type of jumping rule to
@@ -525,7 +535,7 @@ class MCMC(NoNewAttributesAfterInit):
         else:
             raise TypeError(f"Unknown sampler '{sampler}'")
 
-    def get_sampler(self):
+    def get_sampler(self) -> dict[str, Any]:
         """Return the current MCMC sampler options.
 
         Returns
@@ -545,7 +555,7 @@ class MCMC(NoNewAttributesAfterInit):
         """
         return self._sampler_opt.copy()
 
-    def get_sampler_name(self):
+    def get_sampler_name(self) -> str:
         """Return the name of the current MCMC sampler.
 
         Returns
@@ -566,7 +576,7 @@ class MCMC(NoNewAttributesAfterInit):
         """
         return self.sampler.__name__
 
-    def get_sampler_opt(self, opt):
+    def get_sampler_opt(self, opt: str) -> Any:
         """Return an option of the current MCMC sampler.
 
         Returns
@@ -589,7 +599,7 @@ class MCMC(NoNewAttributesAfterInit):
         """
         return self._get_sampler_opt(opt)
 
-    def set_sampler_opt(self, opt, value):
+    def set_sampler_opt(self, opt: str, value: Any) -> None:
         """Set an option for the current MCMC sampler.
 
         Parameters
@@ -649,7 +659,13 @@ class MCMC(NoNewAttributesAfterInit):
         """
         self._set_sampler_opt(opt, value)
 
-    def get_draws(self, fit, sigma, niter=1000, cache=True, rng=None):
+    def get_draws(self,
+                  fit: Fit,
+                  sigma,
+                  niter: int = 1000,
+                  cache: bool = True,
+                  rng: random.RandomType | None = None
+                  ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Run the pyBLoCXS MCMC algorithm.
 
         The function runs a Markov Chain Monte Carlo (MCMC) algorithm
@@ -834,7 +850,7 @@ class ReSampleData(NoNewAttributesAfterInit):
     (10, 61)
 
     """
-    def __init__(self, data, model):
+    def __init__(self, data: Data1D, model: Model) -> None:
 
         # Should this error out if data is an instance of Data1DInt?
         if data.ndim != 1:
@@ -845,7 +861,10 @@ class ReSampleData(NoNewAttributesAfterInit):
         self.model = model
         super().__init__()
 
-    def __call__(self, niter=1000, seed=None, rng=None,
+    def __call__(self,
+                 niter: int = 1000,
+                 seed: int | None = None,
+                 rng: random.RandomType | None = None,
                  *,
                  stat: Stat | None = None,
                  method: OptMethod | None = None
@@ -853,7 +872,10 @@ class ReSampleData(NoNewAttributesAfterInit):
         return self.call(niter, seed=seed, rng=rng, stat=stat,
                          method=method)
 
-    def call(self, niter, seed=None, rng=None,
+    def call(self,
+             niter: int,
+             seed: int | None = None,
+             rng: random.RandomType | None = None,
              *,
              # Mark these as keyword-only as they are additions to the
              # interface and the interface is complicated enough it

--- a/sherpa/sim/__init__.py
+++ b/sherpa/sim/__init__.py
@@ -522,18 +522,27 @@ class MCMC(NoNewAttributesAfterInit):
             # case insensitive
             sampler = str(sampler).lower()
 
-            if sampler not in self.__samplers:
-                raise TypeError(f"Unknown sampler '{sampler}'")
+            try:
+                self.sampler = self.__samplers[sampler]
+            except KeyError as exc:
+                raise TypeError(f"Unknown sampler '{sampler}'") from exc
 
-            self.sampler = self.__samplers.get(sampler)
             self.walker = self.__walkers.get(sampler, Walk)
+            return
 
-        elif issubclass(sampler, Sampler):
-            self.sampler = sampler
-            self.walker = self.__walkers.get(sampler, Walk)
+        try:
+            check = issubclass(sampler, Sampler)
+        except TypeError:
+            # sampler is assumed not to be a class
+            check = False
 
-        else:
+        if not check:
             raise TypeError(f"Unknown sampler '{sampler}'")
+
+        self.sampler = sampler
+        # Use the class name as the index.
+        sampler_name = sampler.__class__.__name__.lower()
+        self.walker = self.__walkers.get(sampler_name, Walk)
 
     def get_sampler(self) -> dict[str, Any]:
         """Return the current MCMC sampler options.

--- a/sherpa/sim/__init__.py
+++ b/sherpa/sim/__init__.py
@@ -201,19 +201,27 @@ from sherpa.data import Data1D, Data1DAsymmetricErrs
 from sherpa.fit import Fit
 from sherpa.optmethods import LevMar, OptMethod
 
-# Although all this module needs is the following import
-#   from sherpa.sim.mh import LimitError, MetropolisMH, MH, Sampler, Walk
-# it looks like the following modules are being re-exported by this
-# one, so the 'from blah import *' lines can not easily be removed.
-#
-from sherpa.sim.simulate import *
-from sherpa.sim.sample import *
-from sherpa.sim.mh import *
-
 from sherpa.stats import Cash, CStat, WStat, LeastSq, Stat
 from sherpa.utils import NoNewAttributesAfterInit, get_keyword_defaults
 from sherpa.utils.logging import SherpaVerbosity
 from sherpa.utils import random
+
+# To support old code, be explicit about the symbols loaded into this
+# module. It is possible that not all exports are needed, but leave as
+# is.
+#
+from .simulate import LikelihoodRatioTest, LikelihoodRatioResults
+from .sample import multivariate_t, multivariate_cauchy, \
+    normal_sample, uniform_sample, t_sample, \
+    ParameterScaleVector, ParameterScaleMatrix, \
+    UniformParameterSampleFromScaleVector, \
+    NormalParameterSampleFromScaleVector, \
+    NormalParameterSampleFromScaleMatrix, \
+    StudentTParameterSampleFromScaleMatrix, \
+    NormalSampleFromScaleMatrix, NormalSampleFromScaleVector, \
+    UniformSampleFromScaleVector, StudentTSampleFromScaleMatrix
+from .mh import LimitError, MetropolisMH, MH, Sampler, Walk, \
+    dmvt as dmvt, dmvnorm as dmvnorm
 
 info = logging.getLogger("sherpa").info
 
@@ -229,15 +237,13 @@ def flat(x):
 def inverse(x):
     """Returns the inverse of x."""
 
-    prior = 1.0 / x
-    return prior
+    return 1.0 / x
 
 
 def inverse2(x):
     """Returns the inverse of x^2."""
 
-    prior = 1.0 / (x * x)
-    return prior
+    return 1.0 / (x * x)
 
 
 _samplers = {"metropolismh": MetropolisMH, "mh": MH}

--- a/sherpa/sim/mh.py
+++ b/sherpa/sim/mh.py
@@ -258,8 +258,8 @@ class Walk():
                 try:
                     proposed_params = self._sampler.draw(current_params)
                 except CovarError:
-                    error("Covariance matrix failed! %s", str(proposed_params))
                     # automatically reject if the covar is malformed
+                    error("Covariance matrix failed! %s", str(current_params))
                     self._sampler.reject()
                     continue
 

--- a/sherpa/sim/mh.py
+++ b/sherpa/sim/mh.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2016, 2019-2021, 2023, 2025
+#  Copyright (C) 2011, 2016, 2019-2021, 2023, 2025-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -55,8 +55,10 @@ al. (2001) and in more detail in Chapter 11 of Gelman, Carlin, Stern, and Rubin
 https://hea-www.harvard.edu/AstroStat/pyBLoCXS/
 """
 
-# The pyBLoCXS code base is cleanly separable from Sherpa!
+from __future__ import annotations
 
+from abc import ABC, abstractmethod
+from collections.abc import Callable
 import inspect
 import logging
 import math
@@ -64,6 +66,7 @@ import math
 import numpy as np
 
 from sherpa.utils import random
+from sherpa.utils.types import ArrayType
 
 
 logger = logging.getLogger("sherpa")
@@ -83,7 +86,11 @@ class CovarError(Exception):
     pass
 
 
-def rmvt(mu, sigma, dof, rng=None):
+def rmvt(mu: np.ndarray,
+         sigma: np.ndarray,
+         dof: int,
+         rng: random.RandomType | None = None
+         ) -> np.ndarray:
     """Sampling the non-central multivariate Student's t distribution
     using deviates from multivariate normal and chi-squared distributions
     Source: Kshirsagar method taken from function `rmvt` in R package `mvtnorm`.
@@ -122,9 +129,13 @@ def rmvt(mu, sigma, dof, rng=None):
     return proposal
 
 
-def dmvt(x, mu, sigma, dof, log=True, norm=False):
+def dmvt(x: np.ndarray,
+         mu: np.ndarray,
+         sigma: np.ndarray,
+         dof: int,
+         log: bool = True,
+         norm: bool = False) -> float:
     """Probability Density of a multi-variate Student's t distribution
-
     """
 
     # if np.min( np.linalg.eigvalsh(sigma))<=0 :
@@ -152,10 +163,11 @@ def dmvt(x, mu, sigma, dof, log=True, norm=False):
     return val
 
 
-def dmvnorm(x, mu, sigma, log=True):
-    """
-
-    Probability Density of a multi-variate Normal distribution
+def dmvnorm(x: np.ndarray,
+            mu: np.ndarray,
+            sigma: np.ndarray,
+            log: bool = True) -> float:
+    """Probability Density of a multi-variate Normal distribution
     """
 
     # if np.min( np.linalg.eigvalsh(sigma))<=0 :
@@ -197,16 +209,18 @@ def dmvnorm(x, mu, sigma, log=True):
 #     sys.stdout.flush()
 
 
-class Walk():
+class Walk:
 
-    def __init__(self, sampler=None, niter=1000):
+    def __init__(self,
+                 sampler: Sampler | None = None,
+                 niter: int = 1000) -> None:
         self._sampler = sampler
         self.niter = int(niter)
 
-    def set_sampler(self, sampler):
+    def set_sampler(self, sampler: Sampler) -> None:
         self._sampler = sampler
 
-    def __call__(self, **kwargs):
+    def __call__(self, **kwargs) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
 
         if self._sampler is None:
             raise AttributeError("sampler object has not been set, " +
@@ -288,9 +302,9 @@ class Walk():
         return (stats, acceptflag, params)
 
 
-class Sampler():
+class Sampler(ABC):
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs) -> None:
 
         sig = inspect.signature(self.init)
         opts = [(p.name, p.default)
@@ -301,23 +315,33 @@ class Sampler():
         self._opts = dict(opts)
         self.walk = None
 
-    def init(self):
+    @abstractmethod
+    def init(self, *args, **kwargs) -> tuple[np.ndarray, float]:
+        ...
+
+    @abstractmethod
+    def draw(self, current: np.ndarray) -> np.ndarray:
+        ...
+
+    @abstractmethod
+    def accept(self,
+               current: np.ndarray,
+               current_stat: float,
+               proposal: np.ndarray,
+               proposal_stat: float,
+               **kwargs) -> bool:
+        ...
+
+    @abstractmethod
+    def reject(self) -> None:
+        ...
+
+    @abstractmethod
+    def calc_stat(self, proposed_params: np.ndarray) -> float:
         raise NotImplementedError
 
-    def draw(self, current, **kwargs):
-        raise NotImplementedError
-
-    def accept(self, current, current_stat, proposal, proposal_stat, **kwargs):
-        raise NotImplementedError
-
-    def reject(self):
-        raise NotImplementedError
-
-    def calc_stat(self, proposed_params):
-        raise NotImplementedError
-
-    def tear_down(self):
-        raise NotImplementedError
+    def tear_down(self) -> None:
+        pass
 
 
 class MH(Sampler):
@@ -335,7 +359,14 @@ class MH(Sampler):
 
     """
 
-    def __init__(self, fcn, sigma, mu, dof, *args, rng=None):
+    def __init__(self,
+                 fcn: Callable[[np.ndarray], float],
+                 sigma: ArrayType,
+                 mu: ArrayType,
+                 dof: int,
+                 *args,
+                 rng: random.RandomType | None = None
+                 ) -> None:
         self.fcn = fcn
         self._dof = dof
         self._mu = np.array(mu)
@@ -351,20 +382,28 @@ class MH(Sampler):
         self.defaultprior = True
         self.priorshape = False
         self.originalscale = True
-        self.scale = 1
+        self.scale: float = 1
         self.prior_funcs = ()
         self.sigma_m = False
 
         # How are RNGs generated?
         self.rng = rng
 
-        Sampler.__init__(self)
+        super().__init__()
 
-    def calc_fit_stat(self, proposed_params):
+    def calc_fit_stat(self, proposed_params: np.ndarray) -> float:
         return self.fcn(proposed_params)
 
-    def init(self, log=False, inv=False, defaultprior=True, priorshape=False,
-             priors=(), originalscale=True, scale=1, sigma_m=False):
+    def init(self,
+             log: bool = False,
+             inv: bool = False,
+             defaultprior: bool = True,
+             priorshape: bool = False,
+             priors=(),
+             originalscale = True,  # shouldn't this be a sequence?
+             scale: float = 1,
+             sigma_m: bool = False
+             ) -> tuple[np.ndarray, float]:
 
         if self._sigma is None or self._mu is None:
             raise AttributeError('sigma or mu is None, initialization failed')
@@ -454,7 +493,11 @@ class MH(Sampler):
 
         return (current, stat)
 
-    def update(self, stat, mu, init=True):
+    def update(self,
+               stat: float,
+               mu: np.ndarray,
+               init: bool = True
+               ) -> float:
         """ include prior """
         if not self.defaultprior:
             x = mu.copy()
@@ -483,7 +526,7 @@ class MH(Sampler):
                 stat -= stat_temp
         return stat
 
-    def draw(self, current):
+    def draw(self, current: np.ndarray) -> np.ndarray:
         """Create a new set of parameter values using the t distribution.
 
         Given the best-guess (mu) and current (current) set of
@@ -494,22 +537,36 @@ class MH(Sampler):
         self.accept_func = self.accept_mh
         return proposal
 
-    def mh(self, current):
+    def mh(self, current: np.ndarray) -> np.ndarray:
         """ MH jumping rule """
 
         # The current proposal is ignored here.
         # MH jumps from the best-fit parameter values at each iteration
         return rmvt(self._mu, self._sigma, self._dof, rng=self.rng)
 
-    def dmvt(self, x, log=True, norm=False):
+    def dmvt(self,
+             x: np.ndarray,
+             log: bool = True,
+             norm: bool = False
+             ) -> float:
         return dmvt(x, self._mu, self._sigma, self._dof, log, norm)
 
-    def accept_mh(self, current, current_stat, proposal, proposal_stat):
+    def accept_mh(self,
+                  current: np.ndarray,
+                  current_stat: float,
+                  proposal: np.ndarray,
+                  proposal_stat: float
+                  ) -> float:
         alpha = np.exp(proposal_stat + self.dmvt(current) -
                        current_stat - self.dmvt(proposal))
         return alpha
 
-    def accept(self, current, current_stat, proposal, proposal_stat, **kwargs):
+    def accept(self,
+               current: np.ndarray,
+               current_stat: float,
+               proposal: np.ndarray,
+               proposal_stat: float,
+               **kwargs) -> bool:
         """
         Should the proposal be accepted (using the Cash statistic and the
         t distribution)?
@@ -518,11 +575,11 @@ class MH(Sampler):
         u = random.uniform(self.rng, 0, 1)
         return u <= alpha
 
-    def reject(self):
+    def reject(self) -> None:
         # added for test
         self.rejections += 1
 
-    def calc_stat(self, proposed_params):
+    def calc_stat(self, proposed_params: np.ndarray) -> float:
 
         if np.sum(self.log) > 0:
             proposed_params[self.log] = np.exp(proposed_params[self.log])
@@ -543,22 +600,35 @@ class MH(Sampler):
 
         return proposed_stat
 
-    def tear_down(self):
-        pass
-
 
 class MetropolisMH(MH):
     """ The Metropolis Metropolis-Hastings Sampler """
 
-    def __init__(self, fcn, sigma, mu, dof, *args, rng=None):
-        MH.__init__(self, fcn, sigma, mu, dof, *args, rng=rng)
+    def __init__(self,
+                 fcn: Callable[[np.ndarray], float],
+                 sigma: ArrayType,
+                 mu: ArrayType,
+                 dof: int,
+                 *args,
+                 rng: random.RandomType | None = None
+                 ) -> None:
+        super().__init__(fcn, sigma, mu, dof, *args, rng=rng)
 
         # count the p_M
         self.num_mh = 0
         self.num_metropolis = 0
 
-    def init(self, log=False, inv=False, defaultprior=True, priorshape=False,
-             priors=(), originalscale=True, scale=1, sigma_m=False, p_M=.5):
+    def init(self,
+             log: bool = False,
+             inv: bool = False,
+             defaultprior: bool = True,
+             priorshape: bool = False,
+             priors=(),
+             originalscale = True,  # shouldn't this be a sequence?
+             scale: float = 1,
+             sigma_m: bool = False,
+             p_M: float = 0.5
+             ) -> tuple[np.ndarray, float]:
 
         debug("Running Metropolis with Metropolis-Hastings")
 
@@ -567,10 +637,10 @@ class MetropolisMH(MH):
         debug("X ~ uniform(0,1) <= %.2f --> Metropolis", float(p_M))
         debug("X ~ uniform(0,1) >  %.2f --> Metropolis-Hastings", float(p_M))
 
-        return MH.init(self, log, inv, defaultprior, priorshape, priors,
-                       originalscale, scale, sigma_m)
+        return super().init(log, inv, defaultprior, priorshape, priors,
+                            originalscale, scale, sigma_m)
 
-    def draw(self, current):
+    def draw(self, current: np.ndarray) -> np.ndarray:
         """Create a new set of parameter values using the t distribution.
 
         Given the best-guess (mu) and current (current) set of
@@ -590,7 +660,7 @@ class MetropolisMH(MH):
 
         return proposal
 
-    def metropolis(self, current):
+    def metropolis(self, current: np.ndarray) -> np.ndarray:
         """ Metropolis Jumping Rule """
 
         # Metropolis with MH jumps from the current accepted parameter
@@ -598,11 +668,18 @@ class MetropolisMH(MH):
         return rmvt(current, self.sigma_m * self.scale, self._dof,
                     rng=self.rng)
 
-    def accept_metropolis(self, current, current_stat, proposal, proposal_stat):
+    def accept_metropolis(self,
+                          current: np.ndarray,
+                          current_stat: float,
+                          proposal: np.ndarray,
+                          proposal_stat: float
+                          ) -> float:
         return np.exp(proposal_stat - current_stat)
 
-    def tear_down(self):
+    def tear_down(self) -> None:
         num = float(self.num_metropolis + self.num_mh)
         if num > 0:
-            debug("p_M: %g, Metropolis: %g%%", self.p_M, 100 * self.num_metropolis / num)
-            debug("p_M: %g, Metropolis-Hastings: %g%%", self.p_M, 100 * self.num_mh / num)
+            debug("p_M: %g, Metropolis: %g%%", self.p_M,
+                  100 * self.num_metropolis / num)
+            debug("p_M: %g, Metropolis-Hastings: %g%%", self.p_M,
+                  100 * self.num_mh / num)

--- a/sherpa/sim/mh.py
+++ b/sherpa/sim/mh.py
@@ -292,21 +292,11 @@ class Sampler():
 
     def __init__(self):
 
-        # get the initial keyword argument defaults;
-        # it looks like inspect.getargspec is not being removed
-        # in Python 3.6, but use the signature function if it is
-        # available to avoid possible warnings.
-        try:
-            sig = inspect.signature(self.init)
-            opts = [(p.name, p.default)
-                    for p in sig.parameters.values()
-                    if p.kind == p.POSITIONAL_OR_KEYWORD and
-                    p.default != p.empty]
-
-        except AttributeError:
-            argspec = inspect.getargspec(self.init)
-            first = len(argspec[0]) - len(argspec[3])
-            opts = zip(argspec[0][first:], argspec[3][0:])
+        sig = inspect.signature(self.init)
+        opts = [(p.name, p.default)
+                for p in sig.parameters.values()
+                if p.kind == p.POSITIONAL_OR_KEYWORD and
+                p.default != p.empty]
 
         self._opts = dict(opts)
         self.walk = None

--- a/sherpa/sim/tests/test_sim.py
+++ b/sherpa/sim/tests/test_sim.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2016, 2018, 2020-2021, 2023-2025
+#  Copyright (C) 2011, 2016, 2018, 2020-2021, 2023-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -20,6 +20,7 @@
 
 from collections import namedtuple
 from io import StringIO
+import re
 
 import numpy as np
 
@@ -575,6 +576,49 @@ def test_mh(setup, caplog):
     assert params.mean(axis=1) == pytest.approx(means)
 
 
+def test_mh_debug(setup, caplog):
+    """This is with DEBUG output engaged.
+
+    The main behaviour is checked in test_mh. This is
+    a regression test to know when the output has changed.
+    """
+
+    setup.fit.method = NelderMead()
+    setup.fit.stat = Cash()
+
+    setup.fit.fit()
+
+    results = setup.fit.est_errors()
+    cov = results.extra_output
+    mcmc = sim.MCMC()
+    for par in setup.fit.model.pars:
+        mcmc.set_prior(par, sim.flat)
+
+    mcmc.set_sampler('MH')
+
+    opt = mcmc.get_sampler_opt('defaultprior')
+    mcmc.set_sampler_opt('defaultprior', opt)
+    # mcmc.set_sampler_opt('verbose', True)
+
+    with SherpaVerbosity("DEBUG"):
+        _ = mcmc.get_draws(setup.fit, cov, niter=1e2, rng=setup.rng)
+
+    assert len(caplog.records) == 8
+    for rec, (lvl, msg) in zip(caplog.records,
+                               [("INFO", "^Using Priors:$"),
+                                ("INFO", "^p1.gamma: <function flat at .*>$"),
+                                ("INFO", "^p1.ampl: <function flat at .*>$"),
+                                ("INFO", "^g1.fwhm: <function flat at .*>$"),
+                                ("INFO", "^g1.pos: <function flat at .*>$"),
+                                ("INFO", "^g1.ampl: <function flat at .*>$"),
+                                ("DEBUG",
+                                 r"^\[<function flat at .*>, <function flat at .*>, <function flat at .*>, <function flat at .*>, <function flat at .*>\]$"),
+                                ("DEBUG", "^Running Metropolis-Hastings$"),
+                                ]):
+        assert rec.levelname == lvl, rec
+        assert re.match(msg, rec.getMessage()) != None, (msg, rec)
+
+
 def test_metropolisMH(setup, caplog):
 
     setup.fit.method = NelderMead()
@@ -631,6 +675,46 @@ def test_metropolisMH(setup, caplog):
 
     means = np.asarray([1.06278784, 9.2152448, 2.573655956, 2.5853907, 47.27058904])
     assert params.mean(axis=1) == pytest.approx(means)
+
+
+def test_metropolisMH_debug(setup, caplog):
+    """This is with DEBUG output engaged.
+
+    The main behaviour is checked in test_metropolisMH. This is
+    a regression test to know when the output has changed.
+    """
+
+    setup.fit.method = NelderMead()
+    setup.fit.stat = CStat()
+
+    setup.fit.fit()
+    results = setup.fit.est_errors()
+    cov = results.extra_output
+
+    mcmc = sim.MCMC()
+    mcmc.set_sampler('MetropolisMH')
+    with SherpaVerbosity("DEBUG"):
+        _ = mcmc.get_draws(setup.fit, cov, niter=1e2, rng=setup.rng)
+
+    assert len(caplog.records) == 13
+    for rec, (lvl, msg) in zip(caplog.records,
+                               [("INFO", "^Using Priors:$"),
+                                ("INFO", "^p1.gamma: <function flat at .*>$"),
+                                ("INFO", "^p1.ampl: <function flat at .*>$"),
+                                ("INFO", "^g1.fwhm: <function flat at .*>$"),
+                                ("INFO", "^g1.pos: <function flat at .*>$"),
+                                ("INFO", "^g1.ampl: <function flat at .*>$"),
+                                ("DEBUG", "^Running Metropolis with Metropolis-Hastings$"),
+                                ("DEBUG", r"^X ~ uniform\(0,1\) <= 0.50 --> Metropolis$"),
+                                ("DEBUG", r"^X ~ uniform\(0,1\) >  0.50 --> Metropolis-Hastings$"),
+                                ("DEBUG",
+                                 r"^\[<function flat at .*>, <function flat at .*>, <function flat at .*>, <function flat at .*>, <function flat at .*>\]$"),
+                                ("DEBUG", "^Running Metropolis-Hastings$"),
+                                ("DEBUG", "^p_M: 0.5, Metropolis: 48%$"),
+                                ("DEBUG", "^p_M: 0.5, Metropolis-Hastings: 52%$")
+                                ]):
+        assert rec.levelname == lvl, rec
+        assert re.match(msg, rec.getMessage()) != None, (msg, rec)
 
 
 def setup_no_fit():

--- a/sherpa/sim/tests/test_sim_unit.py
+++ b/sherpa/sim/tests/test_sim_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2021, 2023-2025
+#  Copyright (C) 2017, 2021, 2023-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -31,7 +31,8 @@ from sherpa.data import Data1D
 from sherpa.fit import Fit
 from sherpa.models.basic import Polynom1D
 from sherpa import sim
-from sherpa.sim.mh import dmvnorm, dmvt, rmvt
+from sherpa.sim.mh import MetropolisMH, MH, Sampler, Walk, \
+    dmvnorm, dmvt, rmvt
 from sherpa.stats import Chi2DataVar, LeastSq
 from sherpa.utils.err import EstErr
 
@@ -194,3 +195,60 @@ def test_parameterscale_checks_samples_size_matrix(myscales):
                        match="^scales must be a numpy array "
                        r"of size \(2,2\)$"):
         _ = p.get_scales(f, myscales=myscales)
+
+
+@pytest.mark.parametrize("name", ["MH", "mH",
+                                  "MetropolisMH", "metropolismh"])
+def test_mcmc_set_sampler_string_valid(name):
+    """Just check we can call this."""
+
+    mcmc = sim.MCMC()
+    mcmc.set_sampler(name)
+    sampler = mcmc.sampler
+    assert issubclass(sampler, Sampler)
+    assert sampler.__name__.endswith("MH")
+
+    # This is not the most-useful check
+    assert mcmc.walker == Walk
+
+
+@pytest.mark.parametrize("cls", [MH, MetropolisMH])
+def test_mcmc_set_sampler_class_valid(cls):
+    """Just check we can call this."""
+
+    mcmc = sim.MCMC()
+    mcmc.set_sampler(cls)
+    sampler = mcmc.sampler
+    assert sampler == cls
+
+    # This is not the most-useful check
+    assert mcmc.walker == Walk
+
+
+def test_mcmc_set_sampler_string_invalid():
+    """Check the error."""
+
+    mcmc = sim.MCMC()
+    with pytest.raises(TypeError,
+                       match="^Unknown sampler 'not-a-mh'$"):
+        mcmc.set_sampler("not-a-mh")
+
+
+def test_mcmc_set_sample_invalid_class():
+    """Check the error."""
+
+    mcmc = sim.MCMC()
+    with pytest.raises(TypeError,
+                       match="^Unknown sampler '<class 'sherpa.sim.mh.Walk'>'$"):
+        mcmc.set_sampler(Walk)
+
+
+def test_mcmc_set_sample_invalid_not_a_class():
+    """Check the error."""
+
+    # The error handling of set_sampler is not great. Hopefully
+    # the issubclass error does not change with Python version.
+    mcmc = sim.MCMC()
+    with pytest.raises(TypeError,
+                       match=r"^issubclass\(\) arg 1 must be a class$"):
+        mcmc.set_sampler(Walk())

--- a/sherpa/sim/tests/test_sim_unit.py
+++ b/sherpa/sim/tests/test_sim_unit.py
@@ -246,9 +246,7 @@ def test_mcmc_set_sample_invalid_class():
 def test_mcmc_set_sample_invalid_not_a_class():
     """Check the error."""
 
-    # The error handling of set_sampler is not great. Hopefully
-    # the issubclass error does not change with Python version.
     mcmc = sim.MCMC()
     with pytest.raises(TypeError,
-                       match=r"^issubclass\(\) arg 1 must be a class$"):
+                       match=r"^Unknown sampler '<sherpa.sim.mh.Walk object at .*>'$"):
         mcmc.set_sampler(Walk())


### PR DESCRIPTION
TODO

Check how much this is covered by

- #2507

# Summary

Add typing statements to the sherpa.sim code and improve an error check in the set_sampler routine.

# Details

Reviewing the sherpa.sim code it was hard to identify when an object or a class was meant to be sent around, so add type statements to address. There are also some code improvements - e.g. remove reference to a routine from `inspect` that was removed in Python 3.11 and take advantage of the ABC module - as well as a fix to the set_sampler routine when sent an invalid argument (so that you get the expected error message rather than because `issubclass` threw its own error).

There is likely more that could be done, such as avoiding quite so many `for` loops, but that is low priority work for later.