### PR TITLE
Add typing and cleanup of the image code

### DIFF
--- a/docs/plots/image.rst
+++ b/docs/plots/image.rst
@@ -12,6 +12,7 @@ The sherpa.image module
       :toctree: api
 
       Image
+      BaseImage
       DataImage
       ModelImage
       ComponentModelImage
@@ -25,5 +26,5 @@ The sherpa.image module
 Class Inheritance Diagram
 =========================
 
-.. inheritance-diagram::   Image DataImage ModelImage ComponentModelImage SourceImage ComponentSourceImage RatioImage ResidImage PSFImage PSFKernelImage
+.. inheritance-diagram::   Image BaseImage DataImage ModelImage ComponentModelImage SourceImage ComponentSourceImage RatioImage ResidImage PSFImage PSFKernelImage
    :parts: 1

--- a/sherpa/astro/ui/tests/test_astro_session_image.py
+++ b/sherpa/astro/ui/tests/test_astro_session_image.py
@@ -44,7 +44,7 @@ from sherpa.astro.ui.utils import Session as AstroSession
 from sherpa.astro.data import DataIMG
 
 from sherpa.utils.err import ArgumentTypeErr
-from sherpa.utils.testing import requires_ds9, requires_region
+from sherpa.utils.testing import requires_ds9, requires_region, requires_wcs
 
 
 def example_data():
@@ -197,3 +197,125 @@ def test_ignore2d_image():
     # 47 is from test_notice2d_image
     assert len(d.mask) == FILTER_NTOT
     assert d.mask.sum() == (FILTER_NTOT - FILTER_NSET)
+
+
+@requires_ds9
+def test_get_data_image_dataimg():
+    """Check that the OBJECT keyword is used"""
+
+    from sherpa.image import DataImage
+
+    s = AstroSession()
+    d = example_data()
+    d.header = {"OBJECT": "A big blob", "NOT_OBJ": "foo"}
+    s.set_data(d)
+
+    obj = s.get_data_image()
+    assert isinstance(obj, DataImage)
+    assert obj.name == 'A_big_blob'
+    assert obj.eqpos is None
+    assert obj.sky is None
+
+    assert d.y.ndim == 1
+    y = d.y.reshape((9, 9))
+    assert obj.y == pytest.approx(y)
+
+    # sanity check
+    assert y[2, 5] == pytest.approx(100.0)
+
+
+@requires_ds9
+def test_get_data_image_dataimg_repeated():
+    """If OBJECT is set and then not set, what happens?"""
+
+    s = AstroSession()
+    d = example_data()
+    d.header = {"OBJECT": "A big blob", "NOT_OBJ": "foo"}
+    s.set_data(d)
+
+    # This changes the name field (see test_get_data_image_dataimg)
+    _ = s.get_data_image()
+
+    d = example_data()
+    d.header = None
+    s.set_data(d)
+
+    # What is the name field now?
+    obj = s.get_data_image()
+    assert obj.name == 'A_big_blob'  # ideally this would be "Data"
+
+
+@requires_ds9
+@requires_wcs
+def test_send_wcs(tmp_path, check_str):
+    """Check we can send WCS information to DS9.
+
+    Validating this is awkward and it has revealed some subtle issues
+    with how DS9 interacts with its preference settings (e.g. ICRS vs
+    FK5) that can result in subtle changes. Hence the need to be
+    explicit.
+
+    """
+
+    from sherpa.astro.io.wcs import WCS
+
+    s = AstroSession()
+    s.dataspace2d([4, 3])
+
+    # Set the WCS to something that is easy to check when returned
+    # from DS9.
+    #
+    d = s.get_data()
+    d.sky = WCS(type="LINEAR", name="physical", crval=[2000.0, 3000.0],
+                crpix=[0.5, 0.5], cdelt=[2.0, 2.0])
+
+    d.eqpos = WCS(type="WCS", name="world", crval=[50.5, -23.4],
+                  crpix=[2000.0, 3000.0], cdelt=[-0.036, 0.036],
+                  crota=0.0, epoch=2000.0, equinox=2000.0)
+
+    # This needs to call the image methd, not just prepare_image
+    s.image_data()
+
+    resp = s.image_xpaget("wcs")
+    assert resp == "wcs\n"
+
+    # Is this the best way to check the WCS info that DS9 has?
+    # Ensure we use ICRS, since the results are slightly different
+    # if the FK5 system is in use.
+    #
+    s.image_xpaset("wcs sky icrs")
+    wcsfile = tmp_path / "test.wcs"
+    s.image_xpaset(f"wcs save {wcsfile}")
+
+    # How much does the output here depend on system info (e.g
+    # numerical precision) and is the order fixed across versions of
+    # DS9?
+    #
+    cts = wcsfile.read_text()
+
+    lines = ["WCSAXES =                    2 / Number of WCS axes",
+             "CRPIX1  =                  0.5 / Reference pixel on axis 1",
+             "CRPIX2  =                  0.5 / Reference pixel on axis 2",
+             "CRVAL1  =                 50.5 / Value at ref. pixel on axis 1",
+             "CRVAL2  =                -23.4 / Value at ref. pixel on axis 2",
+             "CTYPE1  = 'RA---TAN'           / Type of co-ordinate on axis 1",
+             "CTYPE2  = 'DEC--TAN'           / Type of co-ordinate on axis 2",
+             "CDELT1  =               -0.072 / Pixel size on axis 1",
+             "CDELT2  =                0.072 / Pixel size on axis 2",
+             "RADESYS = 'ICRS    '           / Reference frame for RA/DEC values",
+             # "EQUINOX =               2000.0 / [yr] Epoch of reference equinox",
+             "WCSAXESP=                    2 / Number of WCS axes",
+             "WCSNAMEP= 'PHYSICAL'           / Reference name for the coord. frame",
+             "CRPIX1P =                  1.0 / Reference pixel on axis 1",
+             "CRPIX2P =                  1.0 / Reference pixel on axis 2",
+             "CRVAL1P =               2001.0 / Value at ref. pixel on axis 1",
+             "CRVAL2P =               3001.0 / Value at ref. pixel on axis 2",
+             "CTYPE1P = 'x       '           / Type of co-ordinate on axis 1",
+             "CTYPE2P = 'y       '           / Type of co-ordinate on axis 2",
+             "CDELT1P =                  2.0 / Pixel size on axis 1",
+             "CDELT2P =                  2.0 / Pixel size on axis 2"
+             ]
+
+    # No idea why the two blank/empty lines
+    expected = [f"{l:80s}" for l in lines] + ["", ""]
+    check_str(cts, expected)

--- a/sherpa/astro/ui/tests/test_astro_session_image.py
+++ b/sherpa/astro/ui/tests/test_astro_session_image.py
@@ -237,12 +237,12 @@ def test_get_data_image_dataimg_repeated():
     _ = s.get_data_image()
 
     d = example_data()
-    d.header = None
+    d.header = {"NOT_OBJ": "foo"}
     s.set_data(d)
 
     # What is the name field now?
     obj = s.get_data_image()
-    assert obj.name == 'A_big_blob'  # ideally this would be "Data"
+    assert obj.name == 'Data'
 
 
 @requires_ds9

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -18,116 +18,12 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-r"""
-Interface for viewing images with the ds9 image viewer.
-Loosely based on XPA, by Andrew Williams.
+"""Interface for viewing images with the ds9 image viewer.
 
-For more information, see the XPA Access Points section
-of the ds9 reference manual (under Help in ds9).
+Loosely based on XPA, by Andrew Williams, with the original code by
+ROwen 2004-2005 and then from the Sherpa team from 2006. This code has
+been simplified to only support the features that Sherpa needs.
 
-Requirements:
-
-*** Unix Requirements
-- ds9 and xpa must be installed somewhere on your $PATH
-
-*** MacOS X Requirements
-- The MacOS X ds9.app must be in one of the two *standard* locations
-  applications (e.g. ~/Applications or /Applications on English systems).
-  and/or, if you prefer:
-- xpa for darwin installed somewhere on your $PATH
-- ds9 for darwin installed somewhere on your $PATH
-
-  Note: as I write this, ds9 4.0b7 is out and the MacOS X application
-  does not include xpa. They plan to fix this, but if your ds9.app
-  does not include xpa then you MUST install darwin xpa.
-
-*** Windows Requirements
-- Mark Hammond's pywin32 package: <https://sourceforge.net/projects/pywin32/>
-- ds9 installed in the default directory (C:\Program Files\ds9\
-  on English systems)
-- xpa executables installed in the default directory (C:\Program Files\\xpa\)
-  or in the same directory as ds9.exe. Why might you choose the latter?
-  Because (at least for ds9 3.0.3) to use ds9 with xpa from the command line,
-  the xpa executables should be in with ds9.exe. Otherwise ds9 can't find
-  xpans when it starts up and so fails to register itself.
-
-Extra Keyword Arguments:
-Many commands take additional keywords as arguments. These are sent
-as separate commands after the main command is executed.
-Useful keywords for viewing images include: scale, orient and zoom.
-See the XPA Access Points section of the ds9 reference manual
-for more information. Note that the value of each keyword
-is sent as an unquoted string. If you want quotes, provide them
-as part of the value string.
-
-Template Argument:
-The template argument allows you to specify which copy of ds9
-or which other software you wish to command via xpa.
-One common use is to have multiple copies of ds9 on your own machine
-(often necessary because ds9 only has one window, grr).
-If you launch ds9 with the -title command-line option then you can
-send commands to that ds9 by using that title as the template.
-See the XPA documentation for other uses for template, such as talking
-to ds9 on a remote host.
-
-For a list of local servers try % xpaget xpans
-
-History:
-2004-04-15 ROwen        First release.
-2004-04-20 ROwen        showarry improvements:
-                                        - Accepts any array whose values can be represented as signed ints.
-                                        - Bug fix: x and y dimensions were swapped (#@$@# numarray)
-2004-04-29 ROwen        Added xpaset function.
-2004-05-05 ROwen        Added DS9Win class and moved the showXXX functions to it.
-                                        Added function xpaget.
-                                        Added template argument to xpaset.
-2004-10-15 ROwen        Bug fix: could only communicate with one ds9;
-                                        fixed by specifying port=0 when opening ds9.
-2004-11-02 ROwen        Improved Mac compatibility (now looks in [~]/Applications).
-                                        Made compatible with Windows, except showArray is broken;
-                                        this appears to be a bug in ds9 3.0.3.
-                                        loadFITSFile no longer tests the file name's extension.
-                                        showArray now handles most array types without converting the data.
-                                        Eliminated showBinFile because I could not get it to work;
-                                        this seems to be an bug or documentation bug in ds9.
-                                        Changed order of indices for 3-d images from (y,x,z) to (z,y,x).
-2004-11-17 ROwen        Corrected a bug in the subprocess version of xpaget.
-                                        Updated header comments for big-fixed version of subprocess.
-2004-12-01 ROwen        Bug fix in xpaset: terminate data with \n if not already done.
-                                        Modified to use subprocess module (imported from RO.Future
-                                        if Python is old enough not to include it).
-                                        Added __all__.
-2004-12-13 ROwen        Bug fix in DS9Win; the previous version was missing
-                                        the code that waited for DS9 to launch.
-2005-05-16 ROwen        Added doRaise argument to xpaget, xpaset and DS9Win;
-                                        the default is False so the default behavior has changed.
-2005-09-23 ROwen        Bug fix: used the warnings module without importing it.
-2005-09-27 ROwen        Added function setup.
-                                        Checks for xpa and ds9. If not found at import
-                                        then raise a warning make DS9Win. xpaset and xpaget
-                                        retry the check and raise RuntimeError on failure
-                                        (so you can install xpa and ds9 and run without reloading).
-                                        MacOS X: modified to launch X11 if not already running.
-2005-09-30 ROwen        Windwows: only look for xpa in ds9's directory
-                                        (since ds9 can't find it in the default location);
-                                        updated the installation instructions accordingly.
-2005-10-05 ROwen        Bug fix: Windows path joining via string concatenation was broken;
-                                        switched to os.path.join for all path joining.
-                                        Bug fix: Windows search for xpa was broken ("break" only breaks one level).
-2005-10-11 ROwen        MacOS X: add /usr/local/bin to env var PATH and set env var DISPLAY, if necessary
-                                        (because apps do not see the user's shell modifications to env variables).
-2005-10-13 ROwen        MacOS X and Windows: add ds9 and xpa to the PATH if found
-                                        MacOS X: look for xpaget in <applications>/ds9.app as well as on the PATH
-                                        Windows: look for xpaget in <program files>\\xpa\ as well as ...\ds9\
-2005-10-31 ROwen        Bug fix: showArray mis-handled byteswapped arrays.
-2005-11-02 ROwen        Improved fix for byteswapped arrays that avoids copying the array
-                                        (based on code by Tim Axelrod).
-2005-11-04 ROwen        Simplified byte order test as suggested by Rick White.
-2006-06-01 Stephen Doe  Downloaded RO package to evaluate DS9 interface for CIAO.  Stripped all references to RO package from this file (so it can be used without the rest of the RO package).  Converted it from using numarray to numpy for use in Sherpa Python package.
-2006-06-13 Stephen Doe  Removed findApp, all references to Mac or Windows operating systems.  Porting CIAO to Linux and OS X, so treat these all as Unix systems for now.  Worry about Mac, Windows backends later.  (This also means that ds9 and xpaget, xpaset must be in the PATH.)
-2006-08-04 Stephen Doe  Increase timeout interval.
-2008-05-28 Stephen Doe  Always raise exception on error (doRaise=True always)
-2008-11-25 Stephen Doe  Search PATH for access to application, rather than shell out to use 'which' -- PATH sometimes not correctly inherited by shell via Popen, for csh on some Mac, Solaris machines.
 """
 
 from collections.abc import Mapping
@@ -143,22 +39,6 @@ import numpy as np
 from sherpa.utils.err import RuntimeErr, TypeErr
 
 __all__ = ["setup", "xpaget", "xpaset", "DS9Win"]
-
-
-def _addToPATH(newPath: str) -> None:
-    """Add newPath to the PATH environment variable.
-    Do nothing if newPath already in PATH.
-    """
-    pathSep = ":"
-    pathStr = os.environ.get("PATH", "")
-    if newPath in pathStr:
-        return
-
-    if pathStr:
-        pathStr = pathStr + pathSep + newPath
-    else:
-        pathStr = newPath
-    os.environ["PATH"] = pathStr
 
 
 def _findUnixApp(appName: str) -> str:
@@ -385,22 +265,6 @@ _FloatTypes = (np.float32, np.float64)
 _ComplexTypes = (np.complex64, np.complex128)
 
 
-def _expandPath(fname: str,
-                extraArgs: str = ""
-                ) -> str:
-    """Expand a file path and protect it such that spaces are allowed.
-    Inputs:
-    - fname                file path to expand
-    - extraArgs        extra arguments that are to be appended
-                            to the file path
-    """
-    filepath = os.path.abspath(os.path.expanduser(fname))
-    # if windows, change \ to / to work around a bug in ds9
-    filepath = filepath.replace("\\", "/")
-    # quote with "{...}" to allow ds9 to handle spaces in the file path
-    return f"{{{filepath}{extraArgs}}}"
-
-
 def _formatOptions(kargs: Mapping[str, Any]) -> str:
     """Returns a string: "key1=val1,key2=val2,..."
     (where keyx and valx are string representations)
@@ -576,59 +440,6 @@ class DS9Win:
             cmd=f'array [{_formatOptions(arryDict)}]',
             data=arr.tobytes(),
         )
-
-        for keyValue in kargs.items():
-            self.xpaset(cmd=' '.join(keyValue))
-
-# showBinFile is commented out because it is broken with ds9 3.0.3
-# (apparently due to a bug in ds9) and because it wasn't very useful
-#        def showBinFile(self, fname, **kargs):
-#                """Display a binary file in ds9.
-#
-#                The following keyword arguments are used to specify the array:
-#                - xdim                # of points along x
-#                - ydim                # of points along y
-#                - dim                # of points along x = along y (only use for a square array)
-#                - zdim                # of points along z
-#                - bitpix        number of bits/pixel; negative if floating
-#                - arch        one of bigendian or littleendian (intel)
-#
-#                The remaining keywords are extras treated as described
-#                in the module comment.
-#
-#                Note: integer data must be UInt8, Int16 or Int32
-#                (i.e. the formats supported by FITS).
-#                """
-#                arryDict = _splitDict(kargs, _ArrayKeys)
-#                if not arryDict:
-#                        raise RuntimeError("must specify dim (or xdim and ydim) and bitpix")
-#
-#                arrInfo = "[%s]" % (_formatOptions(arryDict),)
-#                filePathPlusInfo = _expandPath(fname, arrInfo)
-#
-#                self.xpaset(cmd='file array "%s"' % (filePathPlusInfo,))
-#
-#                for keyValue in kargs.iteritems():
-#                        self.xpaset(cmd=' '.join(keyValue))
-
-    def showFITSFile(self,
-                     fname: str,
-                     **kargs) -> None:
-        """Display a fits file in ds9.
-
-        Inputs:
-        - fname        name of file (including path information, if necessary)
-        kargs: see Extra Keyword Arguments in the module doc string for information.
-        Keywords that specify array info (see doc for showBinFile for the list)
-        must NOT be included.
-        """
-        filepath = _expandPath(fname)
-        self.xpaset(cmd=f'file "{filepath}"')
-
-        # remove array info keywords from kargs; we compute all that
-        arrKeys = _splitDict(kargs, _ArrayKeys)
-        if arrKeys:
-            raise RuntimeErr('badarr', arrKeys.keys())
 
         for keyValue in kargs.items():
             self.xpaset(cmd=' '.join(keyValue))

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -62,7 +62,7 @@ def _findUnixApp(appName: str) -> None:
         raise RuntimeErr('notonpath', appName)
 
 
-def setup(doRaise: bool = True) -> str | None:
+def setup() -> str | None:
     """Search for xpa and ds9 and set globals accordingly.
     Return None if all is well, else return an error string.
     The return value is also saved in global variable _SetupError.
@@ -90,11 +90,10 @@ def setup(doRaise: bool = True) -> str | None:
     if _SetupError:
         class _Popen(subprocess.Popen):
             def __init__(self, *args, **kargs):
-                setup(doRaise=True)
+                setup()
                 super().__init__(*args, **kargs)
 
-        if doRaise:
-            raise RuntimeErr('badwin', _ex)
+        raise RuntimeErr('badwin', _ex)
 
     else:
         _Popen = subprocess.Popen

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -130,11 +130,13 @@ History:
 2008-11-25 Stephen Doe  Search PATH for access to application, rather than shell out to use 'which' -- PATH sometimes not correctly inherited by shell via Popen, for csh on some Mac, Solaris machines.
 """
 
+from collections.abc import Mapping
 import os
 import sys
 import time
 import warnings
 import subprocess
+from typing import Any
 
 import numpy as np
 
@@ -143,7 +145,7 @@ from sherpa.utils.err import RuntimeErr, TypeErr
 __all__ = ["setup", "xpaget", "xpaset", "DS9Win"]
 
 
-def _addToPATH(newPath):
+def _addToPATH(newPath: str) -> None:
     """Add newPath to the PATH environment variable.
     Do nothing if newPath already in PATH.
     """
@@ -159,7 +161,7 @@ def _addToPATH(newPath):
     os.environ["PATH"] = pathStr
 
 
-def _findUnixApp(appName):
+def _findUnixApp(appName: str) -> str:
     """Search PATH to find first directory that has the application.
     Return the path if found.
     Raise RuntimeError if not found.
@@ -176,7 +178,7 @@ def _findUnixApp(appName):
     return appPath
 
 
-def _findDS9AndXPA():
+def _findDS9AndXPA() -> tuple[str, str]:
     """Locate ds9 and xpa, and add to PATH if not already there.
 
     Returns:
@@ -192,9 +194,9 @@ def _findDS9AndXPA():
     return (ds9Dir, xpaDir)
 
 
-def setup(doRaise=True,
-          debug=False
-          ):
+def setup(doRaise: bool = True,
+          debug: bool = False
+          ) -> str | None:
     """Search for xpa and ds9 and set globals accordingly.
     Return None if all is well, else return an error string.
     The return value is also saved in global variable _SetupError.
@@ -247,10 +249,10 @@ _OpenCheckInterval = 0.2  # seconds
 _MaxOpenTime = 60.0  # seconds
 
 
-def xpaget(cmd,
-           template=_DefTemplate,
-           doRaise=True
-           ):
+def xpaget(cmd: str,  # do not try to type the "this can be a list" version
+           template: str = _DefTemplate,
+           doRaise: bool = True
+           ) -> str:
     """Executes a simple xpaget command:
             xpaset -p <template> <cmd>
     returning the reply.
@@ -291,12 +293,12 @@ def xpaget(cmd,
             p.stderr.close()
 
 
-def xpaset(cmd,
-           data=None,
+def xpaset(cmd: str,
+           data: str | bytes | None = None,
            dataFunc=None,
-           template=_DefTemplate,
-           doRaise=True
-           ):
+           template: str = _DefTemplate,
+           doRaise: bool = True
+           ) -> None:
     """Executes a simple xpaset command:
             xpaset -p <template> <cmd>
     or else feeds data to:
@@ -383,9 +385,9 @@ _FloatTypes = (np.float32, np.float64)
 _ComplexTypes = (np.complex64, np.complex128)
 
 
-def _expandPath(fname,
-                extraArgs=""
-                ):
+def _expandPath(fname: str,
+                extraArgs: str = ""
+                ) -> str:
     """Expand a file path and protect it such that spaces are allowed.
     Inputs:
     - fname                file path to expand
@@ -399,7 +401,7 @@ def _expandPath(fname,
     return f"{{{filepath}{extraArgs}}}"
 
 
-def _formatOptions(kargs):
+def _formatOptions(kargs: Mapping[str, Any]) -> str:
     """Returns a string: "key1=val1,key2=val2,..."
     (where keyx and valx are string representations)
     """
@@ -437,17 +439,17 @@ class DS9Win:
                     Note: doOpen always raises RuntimeError on failure!
     """
     def __init__(self,
-                 template=_DefTemplate,
-                 doOpen=True,
-                 doRaise=True
-                 ):
+                 template: str = _DefTemplate,
+                 doOpen: bool = True,
+                 doRaise: bool = True
+                 ) -> None:
         self.template = str(template)
         self.doRaise = bool(doRaise)
         self.alreadyOpen = self.isOpen()
         if doOpen:
             self.doOpen()
 
-    def doOpen(self):
+    def doOpen(self) -> None:
         """Open the ds9 window (if necessary).
 
         Raise OSError or RuntimeError on failure, even if doRaise is False.
@@ -479,7 +481,7 @@ class DS9Win:
             if time.time() - startTime > _MaxOpenTime:
                 raise RuntimeErr('nowin', self.template)
 
-    def isOpen(self):
+    def isOpen(self) -> bool:
         """Return True if this ds9 window is open
         and available for communication, False otherwise.
         """
@@ -491,7 +493,7 @@ class DS9Win:
 
     def showArray(self,
                   arr,
-                  **kargs):
+                  **kargs) -> None:
         """Display a 2-d or 3-d grayscale integer numarray arrays.
         3-d images are displayed as data cubes, meaning one can
         view a single z at a time or play through them as a movie,
@@ -610,8 +612,8 @@ class DS9Win:
 #                        self.xpaset(cmd=' '.join(keyValue))
 
     def showFITSFile(self,
-                     fname,
-                     **kargs):
+                     fname: str,
+                     **kargs) -> None:
         """Display a fits file in ds9.
 
         Inputs:
@@ -632,8 +634,8 @@ class DS9Win:
             self.xpaset(cmd=' '.join(keyValue))
 
     def xpaget(self,
-               cmd
-               ):
+               cmd: str
+               ) -> str:
         """Execute a simple xpaget command and return the reply.
 
         The command is of the form:
@@ -651,10 +653,10 @@ class DS9Win:
         )
 
     def xpaset(self,
-               cmd,
-               data=None,
+               cmd: str,
+               data: str | bytes | None = None,
                dataFunc=None
-               ):
+               ) -> None:
         """Executes a simple xpaset command:
                 xpaset -p <template> <cmd>
         or else feeds data to:

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -118,6 +118,7 @@ def xpaget(cmd: str,
             p.stdin.close()
             errMsg = p.stderr.read()
             if errMsg:
+                errMsg = errMsg.decode()
                 fullErrMsg = f"{repr(fullCmd)} failed: {errMsg}"
                 raise RuntimeErr('cmdfail', fullCmd, errMsg)
 
@@ -170,7 +171,7 @@ def xpaset(cmd: str,
             p.stdin.close()
             reply = p.stdout.read()
             if reply:
-                errMsg = reply.strip()
+                errMsg = reply.strip().decode()
                 fullErrMsg = f"{repr(fullCmd)} failed: {errMsg}"
                 raise RuntimeErr('cmdfail', fullCmd, errMsg)
 

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -175,7 +175,6 @@ def xpaget(cmd: str,  # do not try to type the "this can be a list" version
 
 def xpaset(cmd: str,
            data: str | bytes | None = None,
-           dataFunc=None,
            template: str = _DefTemplate,
            doRaise: bool = True
            ) -> None:
@@ -188,11 +187,8 @@ def xpaset(cmd: str,
 
     Inputs:
     - cmd                command to execute
-    - data                data to write to xpaset's stdin; ignored if dataFunc specified.
+    - data                data to write to xpaset's stdin
                             If data[-1] is not \n then a final \n is appended.
-    - dataFunc        a function that takes one argument, a file-like object,
-                            and writes data to that file. If specified, data is ignored.
-                            Warning: if a final \n is needed, dataFunc must supply it.
     - template        xpa template; can be the ds9 window title
                             (as specified in the -title command-line option)
                             host:port, etc.
@@ -203,7 +199,7 @@ def xpaset(cmd: str,
     if anything is written to stdout or stderr.
     """
     # Would be better to make a sequence rather than have to quote arguments
-    if data or dataFunc:
+    if data:
         fullCmd = f'xpaset {template} "{cmd}"'
     else:
         fullCmd = f'xpaset -p {template} "{cmd}"'
@@ -465,8 +461,7 @@ class DS9Win:
 
     def xpaset(self,
                cmd: str,
-               data: str | bytes | None = None,
-               dataFunc=None
+               data: str | bytes | None = None
                ) -> None:
         """Executes a simple xpaset command:
                 xpaset -p <template> <cmd>
@@ -477,16 +472,13 @@ class DS9Win:
 
         Inputs:
         - cmd                command to execute
-        - data                data to write to xpaset's stdin; ignored if dataFunc specified
-        - dataFunc        a function that takes one argument, a file-like object,
-                                and writes data to that file. If specified, data is ignored.
+        - data                data to write to xpaset's stdin
 
         Raises RuntimeError if anything is written to stdout or stderr.
         """
         xpaset(
             cmd=cmd,
             data=data,
-            dataFunc=dataFunc,
             template=self.template,
             doRaise=self.doRaise,
         )

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -99,6 +99,7 @@ class Image(NoNewAttributesAfterInit):
         """
         return backend.get_region(coord)
 
+    # This version could be a staticmethod but derived classes can not be.
     def image(self,
               array,
               shape=None,
@@ -133,7 +134,8 @@ class Image(NoNewAttributesAfterInit):
         """Start the image viewer."""
         backend.open()
 
-    def set_wcs(self, keys):
+    @staticmethod
+    def set_wcs(keys):
         """Send the WCS informatiom to the image viewer.
 
         Parameters
@@ -238,7 +240,7 @@ class DataImage(Image):
 
     def image(self, shape=None, newframe=False, tile=False):
         Image.image(self, self.y, shape, newframe, tile)
-        Image.set_wcs(self, (self.eqpos, self.sky, self.name))
+        Image.set_wcs((self.eqpos, self.sky, self.name))
 
 
 class ModelImage(Image):
@@ -269,7 +271,7 @@ class ModelImage(Image):
 
     def image(self, shape=None, newframe=False, tile=False):
         Image.image(self, self.y, shape, newframe, tile)
-        Image.set_wcs(self, (self.eqpos, self.sky, self.name))
+        Image.set_wcs((self.eqpos, self.sky, self.name))
 
 
 class SourceImage(ModelImage):
@@ -327,7 +329,7 @@ class RatioImage(Image):
 
     def image(self, shape=None, newframe=False, tile=False):
         Image.image(self, self.y, shape, newframe, tile)
-        Image.set_wcs(self, (self.eqpos, self.sky, self.name))
+        Image.set_wcs((self.eqpos, self.sky, self.name))
 
 
 class ResidImage(Image):
@@ -361,7 +363,7 @@ class ResidImage(Image):
 
     def image(self, shape=None, newframe=False, tile=False):
         Image.image(self, self.y, shape, newframe, tile)
-        Image.set_wcs(self, (self.eqpos, self.sky, self.name))
+        Image.set_wcs((self.eqpos, self.sky, self.name))
 
 
 class PSFImage(DataImage):
@@ -382,7 +384,7 @@ class PSFKernelImage(DataImage):
         self.name = 'PSF_Kernel'
 
 
-class ComponentSourceImage(ModelImage):
+class ComponentSourceImage(SourceImage):
     """The unconvolved source component."""
 
     def prepare_image(self, data, model):

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -282,10 +282,16 @@ class DataImage(BaseImage):
         self.eqpos = getattr(data, 'eqpos', None)
         self.sky = getattr(data, 'sky', None)
         header = getattr(data, 'header', None)
-        if header is not None:
-            obj = header.get('OBJECT')
-            if obj is not None:
-                self.name = str(obj).replace(" ", "_")
+
+        # Clear out any previous version.
+        self.name = "Data"
+
+        if header is None:
+            return
+
+        obj = header.get('OBJECT')
+        if obj is not None:
+            self.name = str(obj).replace(" ", "_")
 
 
 class ModelImage(BaseImage):
@@ -386,6 +392,8 @@ class PSFKernelImage(DataImage):
 
         psfdata = psf.get_kernel(data)
         super().prepare_image(psfdata)
+        # What is the best name here?
+        self.name = "PSF_Kernel"
 
 
 class ComponentSourceImage(SourceImage):

--- a/sherpa/image/ds9_backend.py
+++ b/sherpa/image/ds9_backend.py
@@ -21,6 +21,9 @@
 from os import access, R_OK
 import time
 
+import numpy as np
+
+from sherpa.astro.io.wcs import WCS
 from sherpa.utils.err import DS9Err
 
 from . import DS9
@@ -40,13 +43,13 @@ imager = DS9.DS9Win(template=DS9._DefTemplate, doOpen=False)
 # relying on.
 #
 
-def close():
+def close() -> None:
     """Stop the image viewer."""
     if imager.isOpen():
         imager.xpaset("quit")
 
 
-def delete_frames():
+def delete_frames() -> None:
     """Delete all the frames open in the image viewer."""
     if not imager.isOpen():
         raise DS9Err('open')
@@ -57,7 +60,7 @@ def delete_frames():
         raise DS9Err('delframe') from exc
 
 
-def get_region(coord):
+def get_region(coord: str) -> str:
     """Return the region defined in the image viewer.
 
     Parameters
@@ -91,10 +94,10 @@ def get_region(coord):
         raise DS9Err('retreg') from exc
 
 
-def image(arr,
-          newframe=False,
-          tile=False
-          ):
+def image(arr: np.ndarray,
+          newframe: bool = False,
+          tile: bool = False
+          ) -> None:
     """Send the data to the image viewer to display.
 
     Parameters
@@ -128,7 +131,7 @@ def image(arr,
     except BaseException as exc:
         raise DS9Err('newframe') from exc
 
-def _set_wcs(eqpos, sky, name):
+def _set_wcs(eqpos: WCS | None, sky: WCS | None, name: str) -> str:
     """Convert the settings into a string to send via XPA"""
 
     # DS9 can be very particular about the WCS settings, so attempt to
@@ -178,7 +181,7 @@ def _set_wcs(eqpos, sky, name):
     return ('\n'.join(out) + '\n')
 
 
-def wcs(keys):
+def wcs(keys: tuple[WCS | None, WCS | None, str]) -> None:
     """Send the WCS informatiom to the image viewer.
 
     Parameters
@@ -200,12 +203,12 @@ def wcs(keys):
         raise DS9Err('setwcs') from exc
 
 
-def open():
+def open() -> None:
     """Start the image viewer."""
     imager.doOpen()
 
 
-def set_region(reg, coord):
+def set_region(reg: str, coord: str) -> None:
     """Set the region to display in the image viewer.
 
     Parameters
@@ -239,7 +242,7 @@ def set_region(reg, coord):
         raise DS9Err('badreg', str(reg)) from exc
 
 
-def xpaget(arg):
+def xpaget(arg: str) -> str:
     """Query the image viewer via XPA.
 
     Retrieve the results of a query to the image viewer.
@@ -259,7 +262,7 @@ def xpaget(arg):
     return imager.xpaget(arg)
 
 
-def xpaset(arg, data=None):
+def xpaset(arg: str, data: str | bytes | None = None) -> None:
     """Send the image viewer a command via XPA.
 
     Send a command to the image viewer.

--- a/sherpa/image/ds9_backend.py
+++ b/sherpa/image/ds9_backend.py
@@ -31,6 +31,8 @@ from . import DS9
 
 imager = DS9.DS9Win(template=DS9._DefTemplate, doOpen=False)
 
+name: str = "ds9"
+
 
 # The except blocks would ideally catch explicit errors; the present
 # catch-anything approach means that we lose potentially-useful

--- a/sherpa/image/dummy_backend.py
+++ b/sherpa/image/dummy_backend.py
@@ -26,6 +26,10 @@ from sherpa.astro.io.wcs import WCS
 imager = None
 """The DS9 window, or None"""
 
+# If this file is xxx_backend.py then 'name = "xxx"'.
+name: str = "dummy"
+"""The name of the backend."""
+
 
 def close() -> None:
     """Stop the image viewer."""

--- a/sherpa/image/dummy_backend.py
+++ b/sherpa/image/dummy_backend.py
@@ -18,22 +18,26 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import numpy as np
+
+from sherpa.astro.io.wcs import WCS
+
 
 imager = None
 """The DS9 window, or None"""
 
 
-def close():
+def close() -> None:
     """Stop the image viewer."""
     pass
 
 
-def delete_frames():
+def delete_frames() -> None:
     """Delete all the frames open in the image viewer."""
     pass
 
 
-def get_region(coord):
+def get_region(coord: str) -> str:
     """Return the region defined in the image viewer.
 
     Parameters
@@ -48,13 +52,13 @@ def get_region(coord):
        The region, or regions, or the empty string.
 
     """
-    pass
+    return ""
 
 
-def image(array,
-          newframe=False,
-          tile=False
-          ):
+def image(array: np.ndarray,
+          newframe: bool = False,
+          tile: bool = False
+          ) -> None:
     """Send the data to the image viewer to display.
 
     Parameters
@@ -70,7 +74,7 @@ def image(array,
     pass
 
 
-def wcs(keys):
+def wcs(keys: tuple[WCS | None, WCS | None, str]) -> None:
     """Send the WCS informatiom to the image viewer.
 
     Parameters
@@ -82,12 +86,12 @@ def wcs(keys):
     pass
 
 
-def open():
+def open() -> None:
     """Start the image viewer."""
     pass
 
 
-def set_region(reg, coord):
+def set_region(reg: str, coord: str) -> None:
     """Set the region to display in the image viewer.
 
     Parameters
@@ -102,7 +106,7 @@ def set_region(reg, coord):
     pass
 
 
-def xpaget(arg):
+def xpaget(arg: str) -> str:
     """Query the image viewer via XPA.
 
     Retrieve the results of a query to the image viewer.
@@ -117,10 +121,10 @@ def xpaget(arg):
     returnval : str
 
     """
-    pass
+    return ""
 
 
-def xpaset(arg, data=None):
+def xpaset(arg: str, data: str | bytes | None = None) -> None:
     """Send the image viewer a command via XPA.
 
     Send a command to the image viewer.

--- a/sherpa/image/dummy_backend.py
+++ b/sherpa/image/dummy_backend.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2009,2010,2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2009,2010,2016,2025
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,44 +18,119 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+
 imager = None
+"""The DS9 window, or None"""
 
 
-def close(*args, **kwargs):
+def close():
+    """Stop the image viewer."""
     pass
 
 
-def delete_frames(*args, **kwargs):
+def delete_frames():
+    """Delete all the frames open in the image viewer."""
     pass
 
 
-def get_region(*args, **kwargs):
+def get_region(coord):
+    """Return the region defined in the image viewer.
+
+    Parameters
+    ----------
+    coord : str
+       The name of the coordinate system (the empty string means
+       to use the current system).
+
+    Returns
+    -------
+    region : str
+       The region, or regions, or the empty string.
+
+    """
     pass
 
 
-def image(*args, **kwargs):
+def image(array,
+          newframe=False,
+          tile=False
+          ):
+    """Send the data to the image viewer to display.
+
+    Parameters
+    ----------
+    array
+       The pixel values
+    newframe
+       Should the pixels be displayed in a new frame?
+    tile
+       Should the display be tiled?
+
+    """
     pass
 
 
-def _set_wcs(*args, **kwargs):
+def wcs(keys):
+    """Send the WCS informatiom to the image viewer.
+
+    Parameters
+    ----------
+    keys
+       The eqpos and sky transforms, and the name of the display.
+
+    """
     pass
 
 
-def wcs(*args, **kwargs):
+def open():
+    """Start the image viewer."""
     pass
 
 
-def open(*args, **kwargs):
+def set_region(reg, coord):
+    """Set the region to display in the image viewer.
+
+    Parameters
+    ----------
+    reg : str
+       The region to display.
+    coord : str
+       The name of the coordinate system (the empty string means
+       to use the current system).
+
+    """
     pass
 
 
-def set_region(*args, **kwargs):
+def xpaget(arg):
+    """Query the image viewer via XPA.
+
+    Retrieve the results of a query to the image viewer.
+
+    Parameters
+    ----------
+    arg : str
+       A command to send to the image viewer via XPA.
+
+    Returns
+    -------
+    returnval : str
+
+    """
     pass
 
 
-def xpaget(*args, **kwargs):
-    pass
+def xpaset(arg, data=None):
+    """Send the image viewer a command via XPA.
 
+    Send a command to the image viewer.
 
-def xpaset(*args, **kwargs):
+    Parameters
+    ----------
+    arg : str
+       A command to send to the image viewer via XPA.
+    data : optional
+       The data for the command.
+
+    """
     pass

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019, 2023
+#  Copyright (C) 2007, 2015-2016, 2017-2019, 2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -24,11 +24,13 @@ import pytest
 
 import tempfile
 import os
-import sherpa
+
 from sherpa.image import Image, DataImage, ModelImage, RatioImage, \
     ResidImage
 
+from sherpa.utils.err import DS9Err, RuntimeErr
 from sherpa.utils.testing import requires_ds9
+
 
 # Create a rectangular array for the tests just to ensure that
 # there are no issues with Fortran/C order.
@@ -100,8 +102,8 @@ def get_arr_from_imager(im, yexp):
 
 @requires_ds9
 def test_ds9():
-    ctor = sherpa.image.ds9_backend.DS9.DS9Win
-    im = ctor(sherpa.image.ds9_backend.DS9._DefTemplate, False)
+    from sherpa.image import DS9
+    im = DS9.DS9Win(DS9._DefTemplate, False)
     im.doOpen()
     im.showArray(data.y)
     data_out = get_arr_from_imager(im, data.y)
@@ -233,3 +235,35 @@ def test_image_getregion(coordsys):
     assert float(toks[0]) == pytest.approx(8.5)
     assert float(toks[1]) == pytest.approx(7.0)
     assert float(toks[2]) == pytest.approx(0.8)
+
+
+@requires_ds9
+def test_xpaget_error_not_open():
+    """Check the error is raised."""
+    im = Image()
+    with pytest.raises(DS9Err, match="^Imager not open$"):
+        _ = im.xpaget("not a command")
+
+
+@requires_ds9
+def test_xpaget_error():
+    """Check the error is raised."""
+    im = Image()
+    im.open()
+    command = "not a command"
+    msg = rf"^'xpaget sherpa \"{command}\"' failed: b'XPA\$ERROR " + \
+        "undefined command for this xpa "
+    with pytest.raises(RuntimeErr, match=msg):
+        _ = im.xpaget(command)
+
+
+@requires_ds9
+def test_xpaset_error():
+    """Check the error is raised."""
+    im = Image()
+    im.open()
+    command = "not a command"
+    msg = rf"^'xpaset -p sherpa \"{command}\"' failed: b'XPA\$ERROR " + \
+        "undefined command for this xpa "
+    with pytest.raises(RuntimeErr, match=msg):
+        im.xpaset(command)

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -251,7 +251,7 @@ def test_xpaget_error():
     im = Image()
     im.open()
     command = "not a command"
-    msg = rf"^'xpaget sherpa \"{command}\"' failed: b'XPA\$ERROR " + \
+    msg = rf"^'xpaget sherpa \"{command}\"' failed: XPA\$ERROR " + \
         "undefined command for this xpa "
     with pytest.raises(RuntimeErr, match=msg):
         _ = im.xpaget(command)
@@ -263,7 +263,7 @@ def test_xpaset_error():
     im = Image()
     im.open()
     command = "not a command"
-    msg = rf"^'xpaset -p sherpa \"{command}\"' failed: b'XPA\$ERROR " + \
+    msg = rf"^'xpaset -p sherpa \"{command}\"' failed: XPA\$ERROR " + \
         "undefined command for this xpa "
     with pytest.raises(RuntimeErr, match=msg):
         im.xpaset(command)

--- a/sherpa/ui/tests/test_ui_image.py
+++ b/sherpa/ui/tests/test_ui_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2023
+#  Copyright (C) 2021, 2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -51,7 +51,8 @@ from sherpa.data import Data2D
 from sherpa.models import basic
 
 from sherpa.stats import Chi2Gehrels
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, IdentifierErr
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DS9Err, \
+    IdentifierErr
 from sherpa.utils.testing import requires_ds9
 
 
@@ -97,7 +98,9 @@ def example_psf():
     return psf
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 @pytest.mark.parametrize("shape", [None, (9, 9)])
 def test_load_arrays2d(session, shape):
     """Does load_arrays work with 2D data?"""
@@ -126,7 +129,9 @@ def test_load_arrays2d(session, shape):
         assert got.shape == pytest.approx(shape)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_data_image(session):
     from sherpa.image import DataImage
 
@@ -147,7 +152,29 @@ def test_get_data_image(session):
     assert y[2, 5] == pytest.approx(100.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+def test_data_image_show(session, check_str):
+    from sherpa.image import DataImage
+
+    s = session()
+    s.set_data(Data2D('example', [1, 1, 1], [-5, -4, -3], [2, 3, 4],
+                      shape=(1, 3)))
+
+    obj = s.get_data_image()
+    check_str(str(obj),
+              ["name   = Data",
+               "y      = [[2,3,4]]",
+               "eqpos  = None",
+               "sky    = None",
+               ""
+               ])
+
+
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_model_image(session):
     from sherpa.image import ModelImage
 
@@ -170,7 +197,9 @@ def test_get_model_image(session):
     assert y[3, 3] == pytest.approx(102.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_model_component_image(session):
     from sherpa.image import ComponentModelImage
 
@@ -196,7 +225,9 @@ def test_get_model_component_image(session):
     assert y[3, 3] == pytest.approx(100.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_model_component_image_with_convolution(session):
     """What happens if there's a convolution component in play?"""
 
@@ -231,7 +262,9 @@ def test_get_model_component_image_with_convolution(session):
     assert y[3, 3] == pytest.approx(42.25302)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_source_image(session):
     """Note that here there's no difference of source and model"""
     from sherpa.image import SourceImage
@@ -255,7 +288,9 @@ def test_get_source_image(session):
     assert y[3, 3] == pytest.approx(102.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_source_component_image(session):
     """Note that here there's no difference of source and model"""
     from sherpa.image import ComponentSourceImage
@@ -279,7 +314,9 @@ def test_get_source_component_image(session):
     assert y[3, 3] == pytest.approx(100.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_source_component_image_with_convolution(session):
     """There is a difference thanks to the PSF"""
     from sherpa.image import ComponentSourceImage
@@ -307,7 +344,9 @@ def test_get_source_component_image_with_convolution(session):
     assert y[3, 3] == pytest.approx(100.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_resid_image(session):
     from sherpa.image import ResidImage
 
@@ -331,7 +370,9 @@ def test_get_resid_image(session):
     assert y[3, 3] == pytest.approx(-71.0983)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_ratio_image(session):
     from sherpa.image import RatioImage
 
@@ -355,7 +396,9 @@ def test_get_ratio_image(session):
     assert y[3, 3] == pytest.approx(0.302958)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_psf_image(session):
     from sherpa.image import PSFImage
 
@@ -379,7 +422,9 @@ def test_get_psf_image(session):
     assert obj.y == pytest.approx(y)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_kernel_image(session):
     from sherpa.image import PSFKernelImage
 
@@ -441,7 +486,9 @@ def check_xpa_resid(backend):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_data(session):
     from sherpa.image import backend
 
@@ -456,7 +503,9 @@ def test_image_data(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_model(session):
     from sherpa.image import backend
 
@@ -473,7 +522,9 @@ def test_image_model(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_model_component(session):
     from sherpa.image import backend
 
@@ -490,7 +541,9 @@ def test_image_model_component(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_model_component_with_convolution(session):
     """The convolution component changes the data."""
     from sherpa.image import backend
@@ -511,7 +564,9 @@ def test_image_model_component_with_convolution(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_source(session):
     from sherpa.image import backend
 
@@ -530,7 +585,9 @@ def test_image_source(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_source_component(session):
     from sherpa.image import backend
 
@@ -549,7 +606,9 @@ def test_image_source_component(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_source_component_with_convolution(session):
     """Unlike model, this does not change the component."""
     from sherpa.image import backend
@@ -570,7 +629,9 @@ def test_image_source_component_with_convolution(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_resid(session):
     from sherpa.image import backend
 
@@ -587,7 +648,9 @@ def test_image_resid(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_ratio(session):
     from sherpa.image import backend
 
@@ -606,7 +669,9 @@ def test_image_ratio(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_fit(session):
     from sherpa.image import backend
 
@@ -637,7 +702,9 @@ def test_image_fit(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_psf(session):
     from sherpa.image import backend
 
@@ -660,7 +727,9 @@ def test_image_psf(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_kernel(session):
     from sherpa.image import backend
 
@@ -680,3 +749,103 @@ def test_image_kernel(session):
     # Check the same reagion as test_image_psf
     grid = '0\n0.166667\n0\n0.166667\n0.166667\n0\n0\n0\n0.166667\n0.166667\n0\n0\n0.166667\n0\n0\n0\n'
     check_xpa(backend, 'data image 4 5 4 4 yes', grid)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+@pytest.mark.parametrize("coord", ["", "image"])
+def test_image_getregion_starts_empty(session, coord):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+    outreg = s.image_getregion()
+    assert outreg == ""
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+def test_image_setregion_invalid_string(session):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+
+    # "rect" is not part of https://ds9.si.edu/doc/ref/region.html
+    reg = "rect(2,3,3,4)"
+    with pytest.raises(DS9Err,
+                       match=rf"^Could not use rect\(2,3,3,4\) as a "
+                       "region or region file$"):
+        s.image_setregion(reg)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+@pytest.mark.parametrize("coord", ["", "image"])
+def test_image_setregion_string(session, coord):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+
+    inreg = "circle(2,3,3)"
+    s.image_setregion(inreg, coord)
+    outreg = s.image_getregion()
+    assert outreg == f"{inreg};"
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+@pytest.mark.parametrize("coord", ["", "image"])
+def test_image_setregions_string(session, coord):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+
+    # Add a "blank" region, and box gets changed by DS9 to
+    # include the rotation angle
+    inreg1 = "circle(2,3,3)"
+    inreg2 = "box(1,2,4,5)"
+    s.image_setregion(f"{inreg1};;{inreg2}", coord)
+
+    outreg = s.image_getregion()
+    assert outreg == f"{inreg1};box(1,2,4,5,0);"
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+@pytest.mark.parametrize("coord", ["", "image"])
+def test_image_setregion_file(session, coord, tmp_path):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+
+    inreg = "circle(2,3,3)"
+    regfile = tmp_path / "store.reg"
+    regfile.write_text(inreg)
+
+    s.image_setregion(str(regfile), coord)
+    outreg = s.image_getregion()
+    assert outreg == f"{inreg};"

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -19659,8 +19659,9 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        The XPA access point of the ds9 image viewer lets commands and
-        queries to be sent to the viewer.
+        The `XPA access point <https://ds9.si.edu/doc/ref/xpa.html>`_ of
+        the ds9 image viewer lets commands and queries to be sent to
+        the viewer.
 
         Examples
         --------
@@ -19675,7 +19676,10 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-TODO: check the ds9 link when it is working
     # DOC-TODO: is there a link of ds9 commands we can link to?
-    def image_xpaset(self, arg: str, data=None) -> None:
+    def image_xpaset(self,
+                     arg: str,
+                     data: str | bytes | None = None
+                     ) -> None:
         """Return the result of an XPA call to the image viewer.
 
         Send a command to the image viewer.
@@ -19704,8 +19708,9 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        The XPA access point of the ds9 image viewer lets commands and
-        queries to be sent to the viewer.
+        The `XPA access point <https://ds9.si.edu/doc/ref/xpa.html>`_ of
+        the ds9 image viewer lets commands and queries to be sent to
+        the viewer.
 
 
         Examples
@@ -19728,4 +19733,4 @@ class Session(NoNewAttributesAfterInit):
         >>> image_xpaset('saveimage png /tmp/img.png')
 
         """
-        return sherpa.image.Image.xpaset(arg, data)
+        sherpa.image.Image.xpaset(arg, data)


### PR DESCRIPTION
Most of this code has been moved into

- #2462
- #2465 
- #2458 
- #2459

They don't implement the `Image` class re-work that this PR does, which is the only reason it has been left as is (for reference).

# Summary

Code cleanup and removal of unused capabilities from the sherpa.image module. Add related typing statements.

# Details

This was originally developed as part of #2411 but it makes sense to pull it out into a separate PR. If there are significant changes to be made I'd like to make them in a follow-up PR to simplify the existing PRs that depend on this.

The aim is

- to add types to improve other parts of the code that uses `sherpa.image`
- pay off some technical debt

The sherpa.image area has seen little work recently, so

- add types
- clean up the code, including
  - use f-strings where appropriate, but use lazy logging where appropriate 
  - changing a method to a static method
- remove commented-out code
- remove unused functionality, including
  - the  `sherpa.image.DS9` code had a complicated setup routine used when it was loaded that seemed to be intended to allow ds9/xpa to be installed after it had been loaded and they would then be picked up; this was complicated, wasn't tested, couldn't actually be tested as far as I can tell, weasn't liked by the type checkers, and not used by Sherpa so it has been removed
    - during this some of the options that were being sent to `setup` have been removed as they are not used by Sherpa (a debug flag and the ability to just raise a warning rather than raise an exception); this could have all been done in one commit but it has been split into separate ones as I worked through what was actually going on and what Sherpa needed
  -  the `DS9Win.showFITSFile` method is not used by Sherpa, so remove it
  - the `DS9.xpaset` routine and  `DS9.DS9Win.xpaset` method had a `dataFunc` optional argument that the documentation suggested took a function (or `None`) but it wasn't used; as this is no sent by Sherpa remove it
- add some tests to cover features that were not being tested and take advantage of the  `pytest.mark.session` mark to reduce the default testing load (by default we only test the astro session now for those tests where the session was parametrized)
  - these tests allow us to check changed behavior for a couple of minor "fixes" made in this set of commits, including
    - decode a bytes array (stdout/err output) before including it in an error message
    - reset the `name` field of `DataImage` during `prepare_image` if the header `OBJECT` field is not set
- try to make the backend code behave a bit-more like the I/O and plot backends; I don't think it's worth pushing the backend too far as we may end up wanting to change from XPA to SAMP, in which case the API will likely change anyway (or maybe we decide to try adding a SAMP backend, or something else, but the main point is not in this commit)
  - add a name field (unused, but I prefer to have it to make things more obvious what is being used)
  - ensure the dummy version has the correct API and docstrings

I suggest reviewing this commit by commit since the changes appear "significant" when squashed into one file, and are hopefully clearer when split up.