### PR TITLE
Explicit types for boolean parameters

### DIFF
--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -923,7 +923,12 @@ def smoke(verbosity: int = 0,
     smoke.run(verbosity=verbosity, require_failure=require_failure, fits=fits, xspec=xspec, ds9=ds9)
 
 
-def _smoke_cli(verbosity=0, require_failure=False, fits=None, xspec=False, ds9=False):
+def _smoke_cli(verbosity=0,
+               require_failure: bool = False,
+               fits=None,
+               xspec: bool = False,
+               ds9: bool = False
+               ) -> None:
     from optparse import OptionParser
     parser = OptionParser()
     parser.add_option("-v", "--verbosity", dest="verbosity",

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -899,7 +899,9 @@ class DataOgipResponse(Data1DInt):
 
         return elo, ehi
 
-    def _get_data_space(self, filter=False):
+    def _get_data_space(self,
+                        filter: bool = False
+                        ):
         # TODO: the class has no _lo/_hi attributes so what is this
         #       meant to do?
         return EvaluationSpace1D(self._lo, self._hi)
@@ -1017,10 +1019,14 @@ class DataARF(DataOgipResponse):
             self._lo = self.energ_lo[bin_mask]
             self._hi = self.energ_hi[bin_mask]
 
-    def get_indep(self, filter=False):
+    def get_indep(self,
+                  filter: bool = False
+                  ):
         return (self._lo, self._hi)
 
-    def get_dep(self, filter=False):
+    def get_dep(self,
+                filter: bool = False
+                ):
         return self._rsp
 
     def get_ylabel(self, yfunc=None) -> str:
@@ -1243,10 +1249,14 @@ class DataRMF(DataOgipResponse):
         self._hi = self.energ_hi[bin_mask]
         return bin_mask
 
-    def get_indep(self, filter=False):
+    def get_indep(self,
+                  filter: bool = False
+                  ):
         return (self._lo, self._hi)
 
-    def get_dep(self, filter=False):
+    def get_dep(self,
+                filter: bool = False
+                ):
         return self.apply_rmf(np.ones(self.energ_lo.shape, SherpaFloat))
 
 
@@ -1845,8 +1855,13 @@ will be removed. The identifiers can be integers or strings.
                      ) -> None:
         ...
 
-    def _set_related(self, attr, val, check_mask=True,
-                     allow_scalar=False, **kwargs):
+    def _set_related(self,
+                     attr: str,
+                     val: float | ArrayType | None,
+                     check_mask: bool = True,
+                     allow_scalar: bool = False,
+                     **kwargs
+                     ) -> None:
         """Set a field that must match the independent axes size.
 
         The value can be None, a scalar (if allow_scalar is set), or
@@ -2968,8 +2983,8 @@ It is an integer or string.
     def get_background_scale(self,
                              bkg_id: IdType = 1,
                              units='counts',
-                             group=True,
-                             filter=False
+                             group: bool = True,
+                             filter: bool = False
                              ):
         """Return the correction factor for the background dataset.
 
@@ -3049,7 +3064,11 @@ It is an integer or string.
         scale = src / bkg / nbkg
         return self._check_scale(scale, group=group, filter=filter)
 
-    def _check_scale(self, scale, group=True, filter=False):
+    def _check_scale(self,
+                     scale,
+                     group: bool = True,
+                     filter: bool = False
+                     ):
         """Ensure the scale value is positive and filtered/grouped.
 
         Parameters
@@ -3084,7 +3103,10 @@ It is an integer or string.
 
         return scale
 
-    def get_backscal(self, group=True, filter=False):
+    def get_backscal(self,
+                     group: bool = True,
+                     filter: bool = False
+                     ):
         """Return the background scaling of the PHA data set.
 
         Return the BACKSCAL setting [OGIP_92_007]_ for the PHA data
@@ -3131,7 +3153,10 @@ It is an integer or string.
 
         return self._check_scale(self.backscal, group, filter)
 
-    def get_areascal(self, group=True, filter=False):
+    def get_areascal(self,
+                     group: bool = True,
+                     filter: bool = False
+                     ):
         """Return the fractional area factor of the PHA data set.
 
         Return the AREASCAL setting [OGIP_92_007]_ for the PHA data
@@ -4420,7 +4445,11 @@ It is an integer or string.
                      ) -> np.ndarray:
         ...
 
-    def _fix_y_units(self, val, filter=False, response_id=None):
+    def _fix_y_units(self,
+                     val: ArrayType | None,
+                     filter: bool = False,
+                     response_id: IdType | None = None
+                     ) -> np.ndarray | None:
         """Rescale the data to match the 'y' axis."""
 
         if val is None:
@@ -4513,8 +4542,12 @@ It is an integer or string.
 
     # Note that use_evaluation_space is unused.
     #
-    def get_y(self, filter=False, yfunc=None, response_id=None,
-              use_evaluation_space=False):
+    def get_y(self,
+              filter: bool = False,
+              yfunc: ModelFunc | None = None,
+              response_id: IdType | None = None,
+              use_evaluation_space: bool = False
+              ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
 
         vals = Data.get_y(self, yfunc=yfunc)
         vallist = (vals,) if yfunc is None else vals
@@ -5787,7 +5820,10 @@ class DataIMG(Data2D):
 
     get_filter = get_filter_expr
 
-    def notice2d(self, val=None, ignore=False):
+    def notice2d(self,
+                 val=None,
+                 ignore: bool = False
+                 ):
         """Apply a 2D filter.
 
         Parameters
@@ -6221,13 +6257,17 @@ class DataIMGInt(DataIMG):
         self._check_data_space(ds)
         return ds
 
-    def get_x0(self, filter=False):
+    def get_x0(self,
+               filter: bool = False
+               ):
         if self.size is None:
             return None
         indep = self._data_space.get(filter)
         return (indep.x0lo + indep.x0hi) / 2.0
 
-    def get_x1(self, filter=False):
+    def get_x1(self,
+               filter: bool = False
+               ):
         if self.size is None:
             return None
         indep = self._data_space.get(filter)

--- a/sherpa/astro/datastack/ds.py
+++ b/sherpa/astro/datastack/ds.py
@@ -1,5 +1,6 @@
 #
-# Copyright (C) 2015, 2016, 2019, 2020, 2021  Smithsonian Astrophysical Observatory
+# Copyright (C) 2015, 2016, 2019-2021, 2025
+# Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -173,7 +174,10 @@ class DataStack():
                           summary=f'datastack with {data.shape[0]} datasets')
         return html_from_sections(self, htab)
 
-    def show_stack(self, outfile=None, clobber=False):
+    def show_stack(self,
+                   outfile=None,
+                   clobber: bool = False
+                   ):
         """Display basic information about the contents of the data stack.
 
         A brief summary of each data set in the stack is printed to the
@@ -251,7 +255,11 @@ class DataStack():
             self._add_dataset(dataid)
 
     # DOC-TODO This docstring can probably be expanded
-    def load_pha(self, id, arg=None, use_errors=False):
+    def load_pha(self,
+                 id,
+                 arg=None,
+                 use_errors: bool = False
+                 ):
         """Load multiple data arrays.
 
         This extends ``sherpa.astro.ui.load_arrays`` to load multiple

--- a/sherpa/astro/fake.py
+++ b/sherpa/astro/fake.py
@@ -32,10 +32,17 @@ from sherpa.utils.random import poisson_noise
 __all__ = ('fake_pha', )
 
 
-def fake_pha(data, model,
-             is_source=None, pileup_model=None,
-             add_bkgs=None, bkg_models=None, id=None,
-             method=None, rng=None, include_bkg_data=False):
+def fake_pha(data,
+             model,
+             is_source=None,
+             pileup_model=None,
+             add_bkgs=None,
+             bkg_models=None,
+             id=None,
+             method=None,
+             rng=None,
+             include_bkg_data: bool = False
+             ):
     """Simulate a PHA data set from a model.
 
     This function replaces the counts in a PHA dataset with simulated

--- a/sherpa/astro/instrument.py
+++ b/sherpa/astro/instrument.py
@@ -149,7 +149,7 @@ class RMFModel(CompositeModel, ArithmeticModel):
         # Used to rebin against finer or coarser energy grids
         self.rmfargs = ()
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False):
         self.model.startup(cache)
         CompositeModel.startup(self, cache)
 
@@ -198,7 +198,7 @@ class ARFModel(CompositeModel, ArithmeticModel):
         # Used to rebin against finer or coarser energy grids
         self.arfargs = ()
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False):
         self.model.startup(cache)
         CompositeModel.startup(self, cache)
 
@@ -251,7 +251,7 @@ class RSPModel(CompositeModel, ArithmeticModel):
         self.rmfargs = ()
         self.arfargs = ()
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False):
         self.model.startup(cache)
         CompositeModel.startup(self, cache)
 
@@ -289,7 +289,7 @@ class RMFModelPHA(RMFModel):
         if self.pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False):
         rmf = self._rmf  # original
 
         # Create a view of original RMF
@@ -373,7 +373,7 @@ class ARFModelPHA(ARFModel):
         if self.pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False):
         arf = self._arf  # original
         pha = self.pha
 
@@ -474,7 +474,7 @@ class RSPModelPHA(RSPModel):
         if self.pha.units == 'wavelength':
             self.xlo, self.xhi = self.lo, self.hi
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False):
         arf = self._arf
         rmf = self._rmf
 
@@ -847,7 +847,7 @@ class MultiResponseSumModel(CompositeModel, ArithmeticModel):
         self.elo, self.ehi, self.table = compile_energy_grid(grid)
         self.lo, self.hi = hc / self.ehi, hc / self.elo
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False):
         pha = self.pha
         if np.iterable(pha.mask):
             pha.notice_response(True)
@@ -1001,7 +1001,7 @@ class PileupRMFModel(CompositeModel, ArithmeticModel):
                                 f'apply_rmf({self.model.name})',
                                 (self.model,))
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False):
         pha = self.pha
         pha.notice_response(False)
         self.channel = pha.get_noticed_channels()
@@ -1143,7 +1143,10 @@ class PSFModel(_PSFModel):
         if hasattr(self.kernel, "set_coord"):
             self.kernel.set_coord(data.coord)
 
-    def get_kernel(self, data, subkernel=True):
+    def get_kernel(self,
+                   data,
+                   subkernel: bool = True
+                   ):
 
         indep, dep, kshape, lo, hi = self._get_kernel_data(data, subkernel)
 

--- a/sherpa/astro/io/__init__.py
+++ b/sherpa/astro/io/__init__.py
@@ -1222,7 +1222,7 @@ def read_pha(arg,
     return datasets
 
 
-def _empty_header(creator=False) -> Header:
+def _empty_header(creator: bool = False) -> Header:
     """Create an empty header."""
 
     out = Header([])

--- a/sherpa/astro/plot.py
+++ b/sherpa/astro/plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2016, 2019 - 2024
+#  Copyright (C) 2010, 2015, 2016, 2019-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -448,7 +448,10 @@ class SourcePlot(shplot.SourceHistogramPlot):
         # Should self.mask be applied to self.xlo/hi/y here?
         # If so, the plot method could be removed.
 
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
+    def plot(self,
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs):
         xlo = self.xlo
         xhi = self.xhi
         y = self.y
@@ -724,7 +727,9 @@ class RMFPlot(shplot.HistogramPlot):
         self.y = np.stack(y)
         self.title = rmf.name
 
-    def plot(self, overplot=False, clearwindow=True,
+    def plot(self,
+             overplot: bool = False,
+             clearwindow: bool = True,
              **kwargs):
         """Plot the data.
 
@@ -955,7 +960,10 @@ class OrderPlot(ModelHistogram):
         if len(self.xlo) != len(self.y):
             raise PlotErr("orderarrfail")
 
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
+    def plot(self,
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs):
         default_color = self.histo_prefs['color']
         count = 0
         for xlo, xhi, y, color in \
@@ -1111,7 +1119,10 @@ class DataIMGPlot(shplot.Image):
         self.ylabel = f'Y ({lbl})'
         self.title = img.name
 
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
+    def plot(self,
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs):
 
         super().plot(self.x0, self.x1, self.y, title=self.title,
                      xlabel=self.xlabel, ylabel=self.ylabel,

--- a/sherpa/astro/sim/fullbayes.py
+++ b/sherpa/astro/sim/fullbayes.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2016, 2017, 2020, 2021, 2023
+#  Copyright (C) 2011, 2016-2017, 2020-2021, 2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -37,9 +37,20 @@ class FullBayes(PragBayes):
                            'old_rr': None}
                           for arf in self.arfs]
 
-    def init(self, log=False, inv=False, defaultprior=True, priorshape=False,
-             priors=(), originalscale=True, scale=1, sigma_m=False, p_M=.5,
-             simarf=None, p_M_arf=.5, sigma_arf=0.1):
+    def init(self,
+             log: bool = False,
+             inv: bool = False,
+             defaultprior: bool = True,
+             priorshape: bool = False,
+             priors=(),
+             originalscale: bool = True,
+             scale=1,
+             sigma_m: bool = False,
+             p_M=.5,
+             simarf=None,
+             p_M_arf=.5,
+             sigma_arf=0.1
+             ):
         # nsubiters is missing from init() to indicate that nubiters=1 for
         # full bayes
 

--- a/sherpa/astro/sim/pragbayes.py
+++ b/sherpa/astro/sim/pragbayes.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2016, 2017, 2019, 2020, 2021, 2023
+#  Copyright (C) 2011, 2016-2017, 2019-2021, 2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -315,9 +315,19 @@ class PragBayes(MetropolisMH):
 
         self.simarf = None
 
-    def init(self, log=False, inv=False, defaultprior=True, priorshape=False,
-             priors=(), originalscale=True, scale=1, sigma_m=False, p_M=.5,
-             simarf=None, nsubiters=10):
+    def init(self,
+             log: bool = False,
+             inv: bool = False,
+             defaultprior: bool = True,
+             priorshape: bool = False,
+             priors=(),
+             originalscale: bool = True,
+             scale=1,
+             sigma_m: bool = False,
+             p_M=.5,
+             simarf=None,
+             nsubiters=10
+             ):
 
         # Note that nsubiters is used as a dummy parameter to indicate the
         # default value.  See the function WalkWithSubIters.__call__()

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -461,7 +461,10 @@ class Session(sherpa.ui.utils.Session):
     # Add ability to save attributes specific to the astro package.
     # Save XSPEC module settings that need to be restored.
     #
-    def save(self, filename='sherpa.save', clobber=False) -> None:
+    def save(self,
+             filename='sherpa.save',
+             clobber: bool = False
+             ) -> None:
         """Save the current Sherpa session to a file.
 
         Parameters
@@ -2366,7 +2369,10 @@ class Session(sherpa.ui.utils.Session):
         self.set_data(id, self.unpack_image(arg, coord, dstype))
 
     # DOC-TODO: what does this return when given a PHA2 file?
-    def unpack_pha(self, arg, use_errors=False):
+    def unpack_pha(self,
+                   arg,
+                   use_errors: bool = False
+                   ):
         """Create a PHA data structure.
 
         Any instrument or background data sets referenced in the
@@ -2418,7 +2424,10 @@ class Session(sherpa.ui.utils.Session):
         return sherpa.astro.io.read_pha(arg, use_errors=use_errors)
 
     # DOC-TODO: what does this return when given a PHA2 file?
-    def unpack_bkg(self, arg, use_errors: bool = False):
+    def unpack_bkg(self,
+                   arg,
+                   use_errors: bool = False
+                   ):
         """Create a PHA data structure for a background data set.
 
         Any instrument information referenced in the header of the PHA
@@ -2736,7 +2745,8 @@ class Session(sherpa.ui.utils.Session):
     #
     def load_filter(self, id, filename=None,
                     bkg_id: IdType | None = None,
-                    ignore=False, ncols=2,
+                    ignore: bool = False,
+                    ncols=2,
                     *args, **kwargs) -> None:
         # pylint: disable=W1113
         """Load the filter array from a file and add to a data set.
@@ -2988,7 +2998,7 @@ class Session(sherpa.ui.utils.Session):
 
     def set_filter(self, id, val=None,
                    bkg_id: IdType | None = None,
-                   ignore=False
+                   ignore: bool = False
                    ) -> None:
         """Set the filter array of a data set.
 
@@ -3275,7 +3285,10 @@ class Session(sherpa.ui.utils.Session):
     set_counts = set_dep
 
     # DOC-NOTE: also in sherpa.utils
-    def set_staterror(self, id, val=None, fractional= False,
+    def set_staterror(self,
+                      id,
+                      val=None,
+                      fractional: bool = False,
                       bkg_id: IdType | None = None
                       ) -> None:
         """Set the statistical errors on the dependent axis of a data set.
@@ -3339,7 +3352,10 @@ class Session(sherpa.ui.utils.Session):
         sherpa.ui.utils.set_error(d, "staterror", val, fractional=fractional)
 
     # DOC-NOTE: also in sherpa.utils
-    def set_syserror(self, id, val=None, fractional=False,
+    def set_syserror(self,
+                     id,
+                     val=None,
+                     fractional: bool = False,
                      bkg_id: IdType | None = None
                      ) -> None:
         """Set the systematic errors on the dependent axis of a data set.
@@ -3570,7 +3586,7 @@ class Session(sherpa.ui.utils.Session):
     #
     def get_staterror(self,
                       id: IdType | None = None,
-                      filter=False,
+                      filter: bool = False,
                       bkg_id: IdType | None = None
                       ):
         """Return the statistical error on the dependent axis of a data set.
@@ -3661,7 +3677,7 @@ class Session(sherpa.ui.utils.Session):
     #
     def get_syserror(self,
                      id: IdType | None = None,
-                     filter=False,
+                     filter: bool = False,
                      bkg_id: IdType | None = None
                      ):
         """Return the systematic error on the dependent axis of a data set.
@@ -3741,7 +3757,7 @@ class Session(sherpa.ui.utils.Session):
     #
     def get_error(self,
                   id: IdType | None = None,
-                  filter=False,
+                  filter: bool = False,
                   bkg_id: IdType | None = None
                   ):
         """Return the errors on the dependent axis of a data set.
@@ -3821,7 +3837,7 @@ class Session(sherpa.ui.utils.Session):
     # DOC-NOTE: also in sherpa.utils
     def get_indep(self,
                   id: IdType | None = None,
-                  filter=False,
+                  filter: bool = False,
                   bkg_id: IdType | None = None):
         """Return the independent axes of a data set.
 
@@ -4034,7 +4050,7 @@ class Session(sherpa.ui.utils.Session):
     # DOC-NOTE: also in sherpa.utils
     def get_dep(self,
                 id: IdType | None = None,
-                filter=False,
+                filter: bool = False,
                 bkg_id: IdType | None = None):
         """Return the dependent axis of a data set.
 
@@ -4134,7 +4150,7 @@ class Session(sherpa.ui.utils.Session):
 
     def get_rate(self,
                  id: IdType | None = None,
-                 filter=False,
+                 filter: bool = False,
                  bkg_id: IdType | None = None):
         """Return the count rate of a PHA data set.
 
@@ -4237,7 +4253,7 @@ class Session(sherpa.ui.utils.Session):
     # i.e. what are the X values for these points
     def get_specresp(self,
                      id: IdType | None = None,
-                     filter=False,
+                     filter: bool = False,
                      bkg_id: IdType | None = None):
         """Return the effective area values for a PHA data set.
 
@@ -4390,7 +4406,10 @@ class Session(sherpa.ui.utils.Session):
     def get_bkg_scale(self,
                       id: IdType | None = None,
                       bkg_id: IdType = 1,
-                      units='counts', group=True, filter=False):
+                      units='counts',
+                      group: bool = True,
+                      filter: bool = False
+                      ):
         """Return the background scaling factor for a background data set.
 
         Return the factor applied to the background component to scale
@@ -4637,8 +4656,13 @@ class Session(sherpa.ui.utils.Session):
 #
 
     # DOC-NOTE: also in sherpa.utils with a different interface
-    def save_arrays(self, filename, args, fields=None, ascii=True,
-                    clobber=False) -> None:
+    def save_arrays(self,
+                    filename,
+                    args,
+                    fields=None,
+                    ascii: bool = True,
+                    clobber: bool = False
+                    ) -> None:
         """Write a list of arrays to a file.
 
         Parameters
@@ -4692,9 +4716,12 @@ class Session(sherpa.ui.utils.Session):
                                      ascii=ascii, clobber=clobber)
 
     # DOC-NOTE: also in sherpa.utils with a different API
-    def save_source(self, id, filename=None,
+    def save_source(self,
+                    id,
+                    filename=None,
                     bkg_id: IdType | None = None,
-                    ascii=False, clobber=False
+                    ascii: bool = False,
+                    clobber: bool = False
                     ) -> None:
         """Save the model values to a file.
 
@@ -4778,9 +4805,12 @@ class Session(sherpa.ui.utils.Session):
                         bkg_id=bkg_id)
 
     # DOC-NOTE: also in sherpa.utils with a different API
-    def save_model(self, id, filename=None,
+    def save_model(self,
+                   id,
+                   filename=None,
                    bkg_id: IdType | None = None,
-                   ascii=False, clobber=False
+                   ascii: bool = False,
+                   clobber: bool = False
                    ) -> None:
         """Save the model values to a file.
 
@@ -4863,9 +4893,12 @@ class Session(sherpa.ui.utils.Session):
                         bkg_id=bkg_id)
 
     # DOC-NOTE: also in sherpa.utils with a different API
-    def save_resid(self, id, filename=None,
+    def save_resid(self,
+                   id,
+                   filename=None,
                    bkg_id: IdType | None = None,
-                   ascii=False, clobber=False
+                   ascii: bool = False,
+                   clobber: bool = False
                    ) -> None:
         """Save the residuals (data-model) to a file.
 
@@ -4937,9 +4970,12 @@ class Session(sherpa.ui.utils.Session):
                         bkg_id=bkg_id)
 
     # DOC-NOTE: also in sherpa.utils with a different API
-    def save_delchi(self, id, filename=None,
+    def save_delchi(self,
+                    id,
+                    filename=None,
                     bkg_id: IdType | None = None,
-                    ascii=True, clobber=False
+                    ascii: bool = True,
+                    clobber: bool = False
                     ) -> None:
         """Save the ratio of residuals (data-model) to error to a file.
 
@@ -5011,9 +5047,12 @@ class Session(sherpa.ui.utils.Session):
                         bkg_id=bkg_id)
 
     # DOC-NOTE: also in sherpa.utils with a different interface
-    def save_filter(self, id, filename=None,
+    def save_filter(self,
+                    id,
+                    filename=None,
                     bkg_id: IdType | None = None,
-                    ascii=True, clobber=False
+                    ascii: bool = True,
+                    clobber: bool = False
                     ) -> None:
         """Save the filter array to a file.
 
@@ -5106,9 +5145,12 @@ class Session(sherpa.ui.utils.Session):
                          ascii=ascii, clobber=clobber)
 
     # DOC-NOTE: also in sherpa.utils with a different interface
-    def save_staterror(self, id, filename=None,
+    def save_staterror(self,
+                       id,
+                       filename=None,
                        bkg_id: IdType | None = None,
-                       ascii=True, clobber=False
+                       ascii: bool = True,
+                       clobber: bool = False
                        ) -> None:
         """Save the statistical errors to a file.
 
@@ -5185,9 +5227,12 @@ class Session(sherpa.ui.utils.Session):
                        self.get_staterror, 'STAT_ERR')
 
     # DOC-NOTE: also in sherpa.utils with a different interface
-    def save_syserror(self, id, filename=None,
+    def save_syserror(self,
+                      id,
+                      filename=None,
                       bkg_id: IdType | None = None,
-                      ascii=True, clobber=False
+                      ascii: bool = True,
+                      clobber: bool = False
                       ) -> None:
         """Save the systematic errors to a file.
 
@@ -5262,9 +5307,12 @@ class Session(sherpa.ui.utils.Session):
                        self.get_syserror, 'SYS_ERR')
 
     # DOC-NOTE: also in sherpa.utils with a different interface
-    def save_error(self, id, filename=None,
+    def save_error(self,
+                   id,
+                   filename=None,
                    bkg_id: IdType | None = None,
-                   ascii=True, clobber=False
+                   ascii: bool = True,
+                   clobber: bool = False
                    ) -> None:
         """Save the errors to a file.
 
@@ -5345,9 +5393,12 @@ class Session(sherpa.ui.utils.Session):
         _save_errorcol(self, id, filename, bkg_id, clobber, ascii,
                        self.get_error, 'ERR')
 
-    def save_pha(self, id, filename=None,
+    def save_pha(self,
+                 id,
+                 filename=None,
                  bkg_id: IdType | None = None,
-                 ascii=False, clobber=False
+                 ascii: bool = False,
+                 clobber: bool = False
                  ) -> None:
         """Save a PHA data set to a file.
 
@@ -5428,10 +5479,13 @@ class Session(sherpa.ui.utils.Session):
     # but the existing logic used to create the ui module does not
     # handle KEYWORD_ONLY so for now do not do this. See #1901.
     #
-    def save_arf(self, id, filename=None,
+    def save_arf(self,
+                 id,
+                 filename=None,
                  resp_id=None,
                  bkg_id: IdType | None = None,
-                 ascii=False, clobber=False
+                 ascii: bool = False,
+                 clobber: bool = False
                  ) -> None:
         """Save an ARF data set to a file.
 
@@ -5528,10 +5582,12 @@ class Session(sherpa.ui.utils.Session):
     # but the existing logic used to create the ui module does not
     # handle KEYWORD_ONLY so for now do not do this. See #1901.
     #
-    def save_rmf(self, id, filename=None,
+    def save_rmf(self,
+                 id,
+                 filename=None,
                  resp_id=None,
                  bkg_id: IdType | None = None,
-                 clobber=False
+                 clobber: bool = False
                  ) -> None:
         """Save an RMF data set to a file.
 
@@ -5612,9 +5668,12 @@ class Session(sherpa.ui.utils.Session):
 
         sherpa.astro.io.write_rmf(filename, rmf, clobber=clobber)
 
-    def save_grouping(self, id, filename=None,
+    def save_grouping(self,
+                      id,
+                      filename=None,
                       bkg_id: IdType | None = None,
-                      ascii=True, clobber=False
+                      ascii: bool = True,
+                      clobber: bool = False
                       ) -> None:
         """Save the grouping scheme to a file.
 
@@ -5697,9 +5756,12 @@ class Session(sherpa.ui.utils.Session):
                                      fields=['CHANNEL', 'GROUPS'], ascii=ascii,
                                      clobber=clobber)
 
-    def save_quality(self, id, filename=None,
+    def save_quality(self,
+                     id,
+                     filename=None,
                      bkg_id: IdType | None = None,
-                     ascii=True, clobber=False
+                     ascii: bool = True,
+                     clobber: bool = False
                      ) -> None:
         """Save the quality array to a file.
 
@@ -5783,8 +5845,12 @@ class Session(sherpa.ui.utils.Session):
                                      clobber=clobber)
 
     # DOC-TODO: setting ascii=True is not supported for crates
-    def save_image(self, id, filename=None, ascii=False,
-                   clobber=False) -> None:
+    def save_image(self,
+                   id,
+                   filename=None,
+                   ascii: bool = False,
+                   clobber: bool = False
+                   ) -> None:
         """Save the pixel values of a 2D data set to a file.
 
         Parameters
@@ -5852,8 +5918,12 @@ class Session(sherpa.ui.utils.Session):
                                     ascii=ascii, clobber=clobber)
 
     # DOC-TODO: the output for an image is "excessive"
-    def save_table(self, id, filename=None, ascii=False,
-                   clobber=False) -> None:
+    def save_table(self,
+                   id,
+                   filename=None,
+                   ascii: bool = False,
+                   clobber: bool = False
+                   ) -> None:
         """Save a data set to a file as a table.
 
         Parameters
@@ -5922,9 +5992,12 @@ class Session(sherpa.ui.utils.Session):
                                     ascii=ascii, clobber=clobber)
 
     # DOC-NOTE: also in sherpa.utils
-    def save_data(self, id, filename=None,
+    def save_data(self,
+                  id,
+                  filename=None,
                   bkg_id: IdType | None = None,
-                  ascii=True, clobber=False
+                  ascii: bool = True,
+                  clobber: bool = False
                   ) -> None:
         """Save the data to a file.
 
@@ -9931,10 +10004,19 @@ class Session(sherpa.ui.utils.Session):
         if d.subtracted:
             d.unsubtract()
 
-    def fake_pha(self, id, arf=None, rmf=None, exposure=None,
-                 backscal=None, areascal=None, grouping=None,
-                 grouped=False, quality=None, bkg=None,
-                 method=None) -> None:
+    def fake_pha(self,
+                 id,
+                 arf=None,
+                 rmf=None,
+                 exposure=None,
+                 backscal=None,
+                 areascal=None,
+                 grouping=None,
+                 grouped: bool = False,
+                 quality=None,
+                 bkg=None,
+                 method=None
+                 ) -> None:
         """Simulate a PHA data set from a model.
 
         The function creates a simulated PHA data set based on a source
@@ -11107,8 +11189,11 @@ class Session(sherpa.ui.utils.Session):
 
         return (x, y)
 
-    def load_xstable_model(self, modelname, filename,
-                           etable=False) -> None:
+    def load_xstable_model(self,
+                           modelname,
+                           filename,
+                           etable: bool = False
+                           ) -> None:
         """Load a XSPEC table model.
 
         Create an additive ('atable', [1]), multiplicative
@@ -13058,13 +13143,13 @@ class Session(sherpa.ui.utils.Session):
                              id: IdType | None = None,
                              num=7500,
                              bins=75,
-                             correlated=False,
+                             correlated: bool = False,
                              numcores=None,
                              bkg_id: IdType | None = None,
                              scales=None,
                              model=None,
                              otherids: IdTypes = (),
-                             recalc=True,
+                             recalc: bool = True,
                              clip='hard'):
         """Return the data displayed by plot_energy_flux.
 
@@ -13205,13 +13290,13 @@ class Session(sherpa.ui.utils.Session):
                              id: IdType | None = None,
                              num=7500,
                              bins=75,
-                             correlated=False,
+                             correlated: bool = False,
                              numcores=None,
                              bkg_id: IdType | None = None,
                              scales=None,
                              model=None,
                              otherids: IdTypes = (),
-                             recalc=True,
+                             recalc: bool = True,
                              clip='hard'):
         """Return the data displayed by plot_photon_flux.
 
@@ -15019,7 +15104,8 @@ class Session(sherpa.ui.utils.Session):
     def sample_photon_flux(self, lo=None, hi=None,
                            id: IdType | None = None,
                            num=1,
-                           scales=None, correlated=False,
+                           scales=None,
+                           correlated: bool = False,
                            numcores=None,
                            bkg_id: IdType | None = None,
                            model=None,
@@ -15260,7 +15346,8 @@ class Session(sherpa.ui.utils.Session):
     def sample_energy_flux(self, lo=None, hi=None,
                            id: IdType | None = None,
                            num=1,
-                           scales=None, correlated=False,
+                           scales=None,
+                           correlated: bool = False,
                            numcores=None,
                            bkg_id: IdType | None = None,
                            model=None,
@@ -15500,10 +15587,14 @@ class Session(sherpa.ui.utils.Session):
 
     def sample_flux(self, modelcomponent=None, lo=None, hi=None,
                     id: IdType | None = None,
-                    num=1, scales=None, correlated=False,
+                    num=1,
+                    scales=None,
+                    correlated: bool = False,
                     numcores=None,
                     bkg_id: IdType | None = None,
-                    Xrays=True, confidence=68):
+                    Xrays: bool = True,
+                    confidence=68
+                    ):
         """Return the flux distribution of a model.
 
         For each iteration, draw the parameter values of the model

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -333,7 +333,13 @@ def range_overlap_1dint(axislist, lo, hi):
     return scale if ascending else scale[::-1]
 
 
-def _flux(data, lo, hi, src, eflux=False, srcflux=False):
+def _flux(data,
+          lo,
+          hi,
+          src,
+          eflux: bool = False,
+          srcflux: bool = False
+          ):
 
     if data.ndim != 1:
         raise DataErr("wrongdim", data.name, 1)

--- a/sherpa/astro/utils/smoke.py
+++ b/sherpa/astro/utils/smoke.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2020, 2021, 2022, 2023
+#  Copyright (C) 2016, 2018, 2020-2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -37,7 +37,12 @@ logger = logging.getLogger("sherpa")
 # without requiring external packages.
 
 
-def run(verbosity=0, require_failure=False, fits=None, xspec=False, ds9=False):
+def run(verbosity=0,
+        require_failure: bool = False,
+        fits=None,
+        xspec: bool = False,
+        ds9: bool = False
+        ) -> None:
     """
     Run the smoke tests.
 

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2015 - 2017, 2019 - 2025
+#  Copyright (C) 2008, 2015-2017, 2019-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -235,7 +235,9 @@ class DataSpace1D(EvaluationSpace1D):
         self.filter = filter
         super().__init__(_check_nomask(x))
 
-    def get(self, filter=False):
+    def get(self,
+            filter: bool = False
+            ):
         """
         Get a filtered representation of this data set. If `filter` is `False` this object is returned.
 
@@ -310,7 +312,9 @@ class IntegratedDataSpace1D(EvaluationSpace1D):
         self.filter = filter
         super().__init__(xlo, xhi)
 
-    def get(self, filter=False):
+    def get(self,
+            filter: bool = False
+            ):
         """
         Get a filtered representation of this data set. If `filter` is `False` this object is returned.
 
@@ -390,7 +394,9 @@ class DataSpace2D:
         if self.x_axis.size != self.y_axis.size:
             raise DataErr("mismatchn", "x0", "x1", self.x_axis.size, self.y_axis.size)
 
-    def get(self, filter=False):
+    def get(self,
+            filter: bool = False
+            ):
         """
         Get a filtered representation of this data set. If `filter` is `False` this object is returned.
 
@@ -464,7 +470,9 @@ class IntegratedDataSpace2D:
         if self.x_axis.size != self.y_axis.size:
             raise DataErr("mismatchn", "x0", "x1", self.x_axis.size, self.y_axis.size)
 
-    def get(self, filter=False):
+    def get(self,
+            filter: bool = False
+            ):
         """
         Get a filtered representation of this data set. If `filter` is `False` this object is returned.
 
@@ -541,7 +549,9 @@ class DataSpaceND:
         self.filter = filter
         self.indep = tuple(_check_nomask(d) for d in indep)
 
-    def get(self, filter=False):
+    def get(self,
+            filter: bool = False
+            ):
         """
         Get a filtered representation of this data set. If `filter` is `False` this object is returned.
 
@@ -1247,7 +1257,11 @@ class Data(NoNewAttributesAfterInit, BaseData):
               ) -> tuple[np.ndarray, ArrayType]:
         ...
 
-    def get_y(self, filter=False, yfunc=None, use_evaluation_space=False):
+    def get_y(self,
+              filter: bool = False,
+              yfunc: ModelFunc | None = None,
+              use_evaluation_space: bool = False
+              ) -> np.ndarray | tuple[np.ndarray, ArrayType]:
         """Return dependent axis in N-D view of dependent variable
 
         Parameters
@@ -1370,7 +1384,10 @@ class Data(NoNewAttributesAfterInit, BaseData):
 
         return syserr
 
-    def get_error(self, filter=False, staterrfunc=None):
+    def get_error(self,
+                  filter: bool = False,
+                  staterrfunc=None
+                  ):
         """Return the total error on the dependent variable.
 
         Parameters
@@ -1399,7 +1416,10 @@ class Data(NoNewAttributesAfterInit, BaseData):
         return calc_total_error(self.get_staterror(filter, staterrfunc),
                                 self.get_syserror(filter))
 
-    def get_yerr(self, filter=False, staterrfunc=None):
+    def get_yerr(self,
+                 filter: bool = False,
+                 staterrfunc=None
+                 ):
         """Return errors in dependent axis in N-D view of dependent variable.
 
         Parameters
@@ -1808,8 +1828,11 @@ class Data1D(Data):
               ) -> tuple[np.ndarray, ArrayType]:
         ...
 
-    def get_y(self, filter=False, yfunc=None,
-              use_evaluation_space=False):
+    def get_y(self,
+              filter: bool = False,
+              yfunc: ModelFunc | None = None,
+              use_evaluation_space: bool = False
+              ) -> np.ndarray | tuple[np.ndarray | ArrayType]:
         """Return the dependent axis.
 
         Parameters
@@ -2097,7 +2120,10 @@ class Data1DAsymmetricErrs(Data1D):
 
     # TODO: should we change get_error and get_staterror?
     #
-    def get_yerr(self, filter=False, staterrfunc=None):
+    def get_yerr(self,
+                 filter: bool = False,
+                 staterrfunc=None
+                 ):
         """Return the y error.
 
         The staterrfunc argument is currently ignored.
@@ -2764,7 +2790,9 @@ class Data2DInt(Data2D):
         indep = self._data_space.get(filter)
         return (indep.x0lo + indep.x0hi) / 2.0
 
-    def get_x1(self, filter=False) -> np.ndarray | None:
+    def get_x1(self,
+               filter: bool = False
+               ) -> np.ndarray | None:
         if self.size is None:
             return None
         indep = self._data_space.get(filter)

--- a/sherpa/instrument.py
+++ b/sherpa/instrument.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2016, 2018, 2019, 2020, 2021, 2022, 2023
+#  Copyright (C) 2008, 2016, 2018-2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -95,9 +95,18 @@ class Kernel(NoNewAttributesAfterInit):
 
     """
 
-    def __init__(self, dshape, kshape, norm=False, frozen=True,
-                 center=None, args=[], kwargs={},
-                 do_pad=False, pad_mask=None, origin=None):
+    def __init__(self,
+                 dshape,
+                 kshape,
+                 norm: bool = False,
+                 frozen: bool = True,
+                 center=None,
+                 args=[],
+                 kwargs={},
+                 do_pad: bool = False,
+                 pad_mask=None,
+                 origin=None
+                 ):
 
         # As these are low-level routines use Python exceptions
         # rather than the Sherpa-specific ones.
@@ -292,10 +301,23 @@ class ConvolutionKernel(Model):
 class PSFKernel(Kernel):
     "class for PSF convolution kernels"
 
-    def __init__(self, dshape, kshape, is_model=False, norm=True, frozen=True,
-                 center=None, size=None, lo=None, hi=None, width=None,
-                 args=[], kwargs={},
-                 pad_mask=None, do_pad=False, origin=None):
+    def __init__(self,
+                 dshape,
+                 kshape,
+                 is_model: bool = False,
+                 norm: bool = True,
+                 frozen: bool = True,
+                 center=None,
+                 size=None,
+                 lo=None,
+                 hi=None,
+                 width=None,
+                 args=[],
+                 kwargs={},
+                 pad_mask=None,
+                 do_pad: bool = False,
+                 origin=None
+                 ):
 
         self.is_model = is_model
         self.size = size
@@ -386,11 +408,23 @@ class PSFKernel(Kernel):
 class RadialProfileKernel(PSFKernel):
     "class for 1D radial profile PSF convolution kernels"
 
-    def __init__(self, dshape, kshape, is_model=False,
-                 norm=True, frozen=True,
-                 center=None, size=None, lo=None, hi=None, width=None,
-                 args=[], kwargs={},
-                 pad_mask=None, do_pad=False, origin=None):
+    def __init__(self,
+                 dshape,
+                 kshape,
+                 is_model: bool = False,
+                 norm: bool = True,
+                 frozen: bool = True,
+                 center=None,
+                 size=None,
+                 lo=None,
+                 hi=None,
+                 width=None,
+                 args=[],
+                 kwargs={},
+                 pad_mask=None,
+                 do_pad: bool = False,
+                 origin=None
+                 ):
 
         self.radialsize = None
         super().__init__(dshape, kshape, is_model, norm,
@@ -884,7 +918,10 @@ they do not match.
 
         self._set_model(PSFKernel(dshape, kshape, **kwargs))
 
-    def _get_kernel_data(self, data, subkernel=True):
+    def _get_kernel_data(self,
+                         data,
+                         subkernel: bool = True
+                         ):
         if self.kernel is None:
             raise PSFErr('notset')
 
@@ -939,7 +976,10 @@ they do not match.
 
         return (indep, dep, kshape, lo, hi)
 
-    def get_kernel(self, data, subkernel=True):
+    def get_kernel(self,
+                   data,
+                   subkernel: bool = True
+                   ):
         """Return a data object representing the kernel.
 
         Parameters

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -2272,7 +2272,7 @@ class Integrator1D(CompositeModel, RegriddableModel1D):
                                 f'integrate1d({self.model.name})',
                                 (self.model,))
 
-    def startup(self, cache=False):
+    def startup(self, cache: bool = False):
         self.model.startup(cache)
         self._errflag = 1
         CompositeModel.startup(self, cache)

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -509,7 +509,9 @@ class Plot(NoNewAttributesAfterInit):
     @staticmethod
     def vline(x, ymin=0, ymax=1,
               linecolor=None, linestyle=None, linewidth=None,
-              overplot=False, clearwindow=True):
+              overplot: bool = False,
+              clearwindow: bool = True
+              ):
         "Draw a line at constant x, extending over the plot."
         backend.vline(x, ymin=ymin, ymax=ymax, linecolor=linecolor,
                       linestyle=linestyle, linewidth=linewidth,
@@ -518,7 +520,9 @@ class Plot(NoNewAttributesAfterInit):
     @staticmethod
     def hline(y, xmin=0, xmax=1,
               linecolor=None, linestyle=None, linewidth=None,
-              overplot=False, clearwindow=True):
+              overplot: bool = False,
+              clearwindow: bool = True
+              ):
         "Draw a line at constant y, extending over the plot."
         backend.hline(y, xmin=xmin, xmax=xmax, linecolor=linecolor,
                       linestyle=linestyle, linewidth=linewidth,
@@ -529,7 +533,9 @@ class Plot(NoNewAttributesAfterInit):
         return {**self.plot_prefs, **kwargs}
 
     def plot(self, x, y, yerr=None, xerr=None, title=None, xlabel=None,
-             ylabel=None, overplot=False, clearwindow=True,
+             ylabel=None,
+             overplot: bool = False,
+             clearwindow: bool = True,
              **kwargs):
         """Plot the data.
 
@@ -606,7 +612,9 @@ class Contour(NoNewAttributesAfterInit):
         return {**self.contour_prefs, **kwargs}
 
     def contour(self, x0, x1, y, title=None, xlabel=None,
-                ylabel=None, overcontour=False, clearwindow=True,
+                ylabel=None,
+                overcontour: bool = False,
+                clearwindow: bool = True,
                 **kwargs):
         opts = self._merge_settings(kwargs)
         backend.contour(x0, x1, y, title=title,
@@ -642,7 +650,10 @@ class Point(NoNewAttributesAfterInit):
         """Return the plot preferences merged with user settings."""
         return {**self.point_prefs, **kwargs}
 
-    def point(self, x, y, overplot=True, clearwindow=False, **kwargs):
+    def point(self, x, y,
+              overplot: bool = True,
+              clearwindow: bool = False,
+              **kwargs):
         """Draw a point at the given location.
 
         Parameters
@@ -693,7 +704,10 @@ class Image(NoNewAttributesAfterInit):
         """Return the plot preferences merged with user settings."""
         return {**self.image_prefs, **kwargs}
 
-    def plot(self, x0, x1, y, overplot=True, clearwindow=False, **kwargs):
+    def plot(self, x0, x1, y,
+             overplot: bool = True,
+             clearwindow: bool = False,
+             **kwargs):
         """Draw a point at the given location.
 
         Parameters
@@ -743,7 +757,10 @@ class Histogram(NoNewAttributesAfterInit):
         return {**self.histo_prefs, **kwargs}
 
     def plot(self, xlo, xhi, y, yerr=None, title=None, xlabel=None,
-             ylabel=None, overplot=False, clearwindow=True, **kwargs):
+             ylabel=None,
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs):
         """Plot the data.
 
         Parameters
@@ -829,7 +846,10 @@ class HistogramPlot(Histogram):
         xhi = np.asarray(self.xhi)
         return (xlo + xhi) / 2
 
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
+    def plot(self,
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs):
         """Plot the data.
 
         This will plot the data sent to the prepare method.
@@ -861,7 +881,9 @@ class HistogramPlot(Histogram):
     @staticmethod
     def vline(x, ymin=0, ymax=1,
               linecolor=None, linestyle=None, linewidth=None,
-              overplot=False, clearwindow=True):
+              overplot: bool = False,
+              clearwindow: bool = True
+              ):
         "Draw a line at constant x, extending over the plot."
         backend.vline(x, ymin=ymin, ymax=ymax, linecolor=linecolor,
                       linestyle=linestyle, linewidth=linewidth,
@@ -870,7 +892,9 @@ class HistogramPlot(Histogram):
     @staticmethod
     def hline(y, xmin=0, xmax=1,
               linecolor=None, linestyle=None, linewidth=None,
-              overplot=False, clearwindow=True):
+              overplot: bool = False,
+              clearwindow: bool = True
+              ):
         "Draw a line at constant y, extending over the plot."
         backend.hline(y, xmin=xmin, xmax=xmax, linecolor=linecolor,
                       linestyle=linestyle, linewidth=linewidth,
@@ -964,7 +988,10 @@ class DataHistogramPlot(HistogramPlot):
     # so the superclass is over-ridden here to basically call
     # the base class.
     #
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
+    def plot(self,
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs):
         """Plot the data.
 
         This will plot the data sent to the prepare method.
@@ -1055,7 +1082,9 @@ class PDFPlot(HistogramPlot):
         """Return a HTML (string) representation of the PDF plot."""
         return backend.as_html_pdf(self)
 
-    def prepare(self, points, bins=12, normed=True, xlabel="x", name="x"):
+    def prepare(self, points, bins=12,
+                normed: bool = True,
+                xlabel="x", name="x"):
         """Create the data to plot.
 
         Parameters
@@ -1182,7 +1211,10 @@ class CDFPlot(Plot):
         self.ylabel = f"p(<={xlabel})"
         self.title = f"CDF: {name}"
 
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
+    def plot(self,
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs):
         """Plot the data.
 
         This will plot the data sent to the prepare method.
@@ -1257,7 +1289,10 @@ class LRHistogram(HistogramPlot):
         self.xlabel = "Likelihood Ratio"
         self.ylabel = "Frequency"
 
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
+    def plot(self,
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs):
         """Plot the data.
 
         This will plot the data sent to the prepare method.
@@ -1436,7 +1471,9 @@ class JointPlot(SplitPlot):
     # is likely that the former classes are only being used in tests,
     # so this support could be removed, but leave for now.
     #
-    def plottop(self, plot, *args, overplot=False, clearwindow=True,
+    def plottop(self, plot, *args,
+                overplot: bool = False,
+                clearwindow: bool = True,
                 **kwargs):
         """Display the top (fit-style) plot"""
 
@@ -1476,7 +1513,9 @@ class JointPlot(SplitPlot):
         kwargs['clearwindow'] = False
         plot.plot(*args, overplot=overplot, **kwargs)
 
-    def plotbot(self, plot, *args, overplot=False, **kwargs):
+    def plotbot(self, plot, *args,
+                overplot: bool = False,
+                **kwargs):
         """Display the bottom (residual-style) plot"""
 
         backend.set_jointplot(1, 0, self.rows, self.cols,
@@ -1588,7 +1627,10 @@ class DataPlot(Plot):
 
         self.title = data.name
 
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
+    def plot(self,
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs):
         """Plot the data.
 
         This will plot the data sent to the prepare method.
@@ -1749,7 +1791,10 @@ class DataContour(Contour):
          self.ylabel) = data.to_contour()
         self.title = data.name
 
-    def contour(self, overcontour=False, clearwindow=True, **kwargs):
+    def contour(self,
+                overcontour: bool = False,
+                clearwindow: bool = True,
+                **kwargs):
         super().contour(self.x0, self.x1, self.y, levels=self.levels,
                         title=self.title, xlabel=self.xlabel,
                         ylabel=self.ylabel, overcontour=overcontour,
@@ -1864,7 +1909,10 @@ class ModelPlot(Plot):
          self.xlabel, self.ylabel) = data.to_plot(yfunc=model)
         self.y = self.y[1]
 
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
+    def plot(self,
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs):
         """Plot the data.
 
         This will plot the data sent to the prepare method.
@@ -2085,7 +2133,10 @@ class ModelContour(Contour):
          self.ylabel) = data.to_contour(yfunc=model)
         self.y = self.y[1]
 
-    def contour(self, overcontour=False, clearwindow=True, **kwargs):
+    def contour(self,
+                overcontour: bool = False,
+                clearwindow: bool = True,
+                **kwargs):
         super().contour(self.x0, self.x1, self.y, levels=self.levels,
                         title=self.title, xlabel=self.xlabel,
                         ylabel=self.ylabel, overcontour=overcontour,
@@ -2199,7 +2250,10 @@ modelplot  = {model_title}
         self.dataplot = dataplot
         self.modelplot = modelplot
 
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
+    def plot(self,
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs):
         """Plot the data.
 
         This will plot the data sent to the prepare method.
@@ -2268,7 +2322,10 @@ modelcontour = {model_title}
         self.datacontour = datacontour
         self.modelcontour = modelcontour
 
-    def contour(self, overcontour=False, clearwindow=True, **kwargs):
+    def contour(self,
+                overcontour: bool = False,
+                clearwindow: bool = True,
+                **kwargs):
         # Note: the user arguments are applied to both plots
         self.datacontour.contour(overcontour=overcontour,
                                  clearwindow=clearwindow, **kwargs)
@@ -2996,7 +3053,9 @@ class Confidence1D(DataPlot):
         return backend.as_html_contour1d(self)
 
     def prepare(self, min=None, max=None, nloop=20,
-                delv=None, fac=1, log=False, numcores=None):
+                delv=None, fac=1,
+                log: bool = False,
+                numcores=None):
         """Set the data to plot.
 
         This defines the range over which the statistic will be
@@ -3160,7 +3219,10 @@ class Confidence1D(DataPlot):
         self.xerr = None
         self.yerr = None
 
-    def plot(self, overplot=False, clearwindow=True, **kwargs):
+    def plot(self,
+             overplot: bool = False,
+             clearwindow: bool = True,
+             **kwargs):
         if self.log:
             self.plot_prefs['xlog'] = True
 
@@ -3500,7 +3562,10 @@ class Confidence2D(DataContour, Point):
                 raise ConfidenceErr('thawed', par.fullname, fit.model.name)
 
     # TODO: should this be overcontour rather than overplot?
-    def contour(self, overplot=False, clearwindow=True, **kwargs):
+    def contour(self,
+                overplot: bool = False,
+                clearwindow: bool = True,
+                **kwargs):
 
         if self.log[0]:
             self.contour_prefs['xlog'] = True
@@ -3586,12 +3651,24 @@ class IntervalProjection(Confidence1D):
         self.fast = True
         super().__init__()
 
-    def prepare(self, fast=True, min=None, max=None, nloop=20,
-                delv=None, fac=1, log=False, numcores=None):
+    def prepare(self,
+                fast: bool = True,
+                min=None,
+                max=None,
+                nloop=20,
+                delv=None,
+                fac=1,
+                log: bool = False,
+                numcores=None):
         self.fast = fast
         super().prepare(min, max, nloop, delv, fac, log, numcores)
 
-    def calc(self, fit, par, methoddict=None, cache=True):
+    def calc(self,
+             fit,
+             par,
+             methoddict=None,
+             cache: bool = True
+             ):
         self.title = 'Interval-Projection'
         super().calc(fit=fit, par=par)
 
@@ -3696,7 +3773,12 @@ class IntervalUncertainty(Confidence1D):
 
     conf_type = "uncertainty"
 
-    def calc(self, fit, par, methoddict=None, cache=True):
+    def calc(self,
+             fit,
+             par,
+             methoddict=None,
+             cache: bool = True
+             ):
         self.title = 'Interval-Uncertainty'
         super().calc(fit=fit, par=par)
 
@@ -3782,14 +3864,29 @@ class RegionProjection(Confidence2D):
         self.fast = True
         super().__init__()
 
-    def prepare(self, fast=True, min=None, max=None, nloop=(10, 10),
-                delv=None, fac=4, log=(False, False),
-                sigma=(1, 2, 3), levels=None, numcores=None):
+    def prepare(self,
+                fast: bool = True,
+                min=None,
+                max=None,
+                nloop=(10, 10),
+                delv=None,
+                fac=4,
+                log=(False, False),
+                sigma=(1, 2, 3),
+                levels=None,
+                numcores=None
+                ):
         self.fast = fast
         super().prepare(min, max, nloop, delv, fac, log, sigma,
                         levels=levels, numcores=numcores)
 
-    def calc(self, fit, par0, par1, methoddict=None, cache=True):
+    def calc(self,
+             fit,
+             par0,
+             par1,
+             methoddict=None,
+             cache: bool = True
+             ):
         self.title = 'Region-Projection'
         super().calc(fit=fit, par0=par0, par1=par1)
 
@@ -3895,7 +3992,13 @@ class RegionUncertainty(Confidence2D):
 
     conf_type = "uncertainty"
 
-    def calc(self, fit, par0, par1, methoddict=None, cache=True):
+    def calc(self,
+             fit,
+             par0,
+             par1,
+             methoddict=None,
+             cache: bool = True
+             ):
         self.title = 'Region-Uncertainty'
         super().calc(fit=fit, par0=par0, par1=par1)
 

--- a/sherpa/plot/backends.py
+++ b/sherpa/plot/backends.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2020 - 2024
+#  Copyright (C) 2007, 2015, 2020-2025
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -273,7 +273,12 @@ class BaseBackend(metaclass=MetaBaseBackend):
         clist = clist * (n // len(clist) + 1)
         return clist[:n]
 
-    def set_subplot(self, row, col, nrows, ncols, clearaxes=True,
+    def set_subplot(self,
+                    row,
+                    col,
+                    nrows,
+                    ncols,
+                    clearaxes: bool = True,
                     **kwargs):
         """Select a plot space in a grid of plots or create new grid
 
@@ -302,8 +307,14 @@ class BaseBackend(metaclass=MetaBaseBackend):
         """
         pass
 
-    def set_jointplot(self, row, col, nrows, ncols, create=True,
-                      top=0, ratio=2):
+    def set_jointplot(self,
+                      row,
+                      col,
+                      nrows,
+                      ncols,
+                      create: bool = True,
+                      top=0,
+                      ratio=2):
         """Move to the plot, creating them if necessary.
 
         .. warning::
@@ -389,11 +400,13 @@ class BaseBackend(metaclass=MetaBaseBackend):
     def plot(self, x, y, *,
              xerr=None, yerr=None,
              title=None, xlabel=None, ylabel=None,
-             xlog=False, ylog=False,
-             overplot=False, clearwindow=True,
+             xlog: bool = False,
+             ylog: bool = False,
+             overplot: bool = False,
+             clearwindow: bool = True,
              label=None,
-             xerrorbars=False,
-             yerrorbars=False,
+             xerrorbars: bool = False,
+             yerrorbars: bool = False,
              color=None,
              linestyle='solid',
              linewidth=None,
@@ -440,11 +453,13 @@ class BaseBackend(metaclass=MetaBaseBackend):
     def histo(self, xlo, xhi, y, *,
               yerr=None,
               title=None, xlabel=None, ylabel=None,
-              overplot=False, clearwindow=True,
-              xlog=False, ylog=False,
+              overplot: bool = False,
+              clearwindow: bool = True,
+              xlog: bool = False,
+              ylog: bool = False,
               label=None,
-              xerrorbars=False,
-              yerrorbars=False,
+              xerrorbars: bool = False,
+              yerrorbars: bool = False,
               color=None,
               linestyle='solid',
               linewidth=None,
@@ -487,8 +502,10 @@ class BaseBackend(metaclass=MetaBaseBackend):
     def contour(self, x0, x1, y, *,
                 levels=None,
                 title=None, xlabel=None, ylabel=None,
-                overcontour=False, clearwindow=True,
-                xlog=False, ylog=False,
+                overcontour: bool = False,
+                clearwindow: bool = True,
+                xlog: bool = False,
+                ylog: bool = False,
                 label=None,
                 colors=None,
                 linestyles='solid',
@@ -519,7 +536,7 @@ class BaseBackend(metaclass=MetaBaseBackend):
     def image(self, x0, x1, y, *,
                aspect=1,
                title=None, xlabel=None, ylabel=None,
-               clearwindow=True,
+               clearwindow: bool = True,
                **kwargs):
         """Draw 2D image data.
 
@@ -546,7 +563,8 @@ class BaseBackend(metaclass=MetaBaseBackend):
     def vline(self, x, *,
               ymin=0, ymax=1,
               title=None, xlabel=None, ylabel=None,
-              overplot=False, clearwindow=True,
+              overplot: bool = False,
+              clearwindow: bool = True,
               linecolor=None,
               linestyle=None,
               linewidth=None,
@@ -570,7 +588,8 @@ class BaseBackend(metaclass=MetaBaseBackend):
     def hline(self, y, *,
               xmin=0, xmax=1,
               title=None, xlabel=None, ylabel=None,
-              overplot=False, clearwindow=True,
+              overplot: bool = False,
+              clearwindow: bool = True,
               linecolor=None,
               linestyle=None,
               linewidth=None,
@@ -864,11 +883,13 @@ class BasicBackend(BaseBackend):
     def plot(self, x, y, *,
              xerr=None, yerr=None,
              title=None, xlabel=None, ylabel=None,
-             xlog=False, ylog=False,
-             overplot=False, clearwindow=True,
+             xlog: bool = False,
+             ylog: bool = False,
+             overplot: bool = False,
+             clearwindow: bool = True,
              label=None,
-             xerrorbars=False,
-             yerrorbars=False,
+             xerrorbars: bool = False,
+             yerrorbars: bool = False,
              color=None,
              linestyle='solid',
              linewidth=None,
@@ -898,11 +919,13 @@ class BasicBackend(BaseBackend):
     def histo(self, xlo, xhi, y, *,
               yerr=None,
               title=None, xlabel=None, ylabel=None,
-              overplot=False, clearwindow=True,
-              xlog=False, ylog=False,
+              overplot: bool = False,
+              clearwindow: bool = True,
+              xlog: bool = False,
+              ylog: bool = False,
               label=None,
-              xerrorbars=False,
-              yerrorbars=False,
+              xerrorbars: bool = False,
+              yerrorbars: bool = False,
               color=None,
               linestyle='solid',
               linewidth=None,
@@ -927,8 +950,10 @@ class BasicBackend(BaseBackend):
     def contour(self, x0, x1, y, *,
                 levels=None,
                 title=None, xlabel=None, ylabel=None,
-                overcontour=False, clearwindow=True,
-                xlog=False, ylog=False,
+                overcontour: bool = False,
+                clearwindow: bool = True,
+                xlog: bool = False,
+                ylog: bool = False,
                 label=None,
                 colors=None,
                 linestyles='solid',
@@ -949,7 +974,8 @@ class BasicBackend(BaseBackend):
     def vline(self, x, *,
               ymin=0, ymax=1,
               title=None, xlabel=None, ylabel=None,
-              overplot=False, clearwindow=True,
+              overplot: bool = False,
+              clearwindow: bool = True,
               linecolor=None,
               linestyle=None,
               linewidth=None,
@@ -974,7 +1000,8 @@ class BasicBackend(BaseBackend):
     def hline(self, y, *,
               xmin=0, xmax=1,
               title=None, xlabel=None, ylabel=None,
-              overplot=False, clearwindow=True,
+              overplot: bool = False,
+              clearwindow: bool = True,
               linecolor=None,
               linestyle=None,
               linewidth=None,

--- a/sherpa/sim/__init__.py
+++ b/sherpa/sim/__init__.py
@@ -644,7 +644,13 @@ class MCMC(NoNewAttributesAfterInit):
         """
         self._set_sampler_opt(opt, value)
 
-    def get_draws(self, fit, sigma, niter=1000, cache=True, rng=None):
+    def get_draws(self,
+                  fit,
+                  sigma,
+                  niter=1000,
+                  cache: bool = True,
+                  rng=None
+                  ):
         """Run the pyBLoCXS MCMC algorithm.
 
         The function runs a Markov Chain Monte Carlo (MCMC) algorithm

--- a/sherpa/sim/mh.py
+++ b/sherpa/sim/mh.py
@@ -122,7 +122,10 @@ def rmvt(mu, sigma, dof, rng=None):
     return proposal
 
 
-def dmvt(x, mu, sigma, dof, log=True, norm=False):
+def dmvt(x, mu, sigma, dof,
+         log: bool = True,
+         norm: bool = False
+         ):
     """Probability Density of a multi-variate Student's t distribution
 
     """
@@ -152,7 +155,11 @@ def dmvt(x, mu, sigma, dof, log=True, norm=False):
     return val
 
 
-def dmvnorm(x, mu, sigma, log=True):
+def dmvnorm(x,
+            mu,
+            sigma,
+            log: bool = True
+            ):
     """
 
     Probability Density of a multi-variate Normal distribution
@@ -373,8 +380,16 @@ class MH(Sampler):
     def calc_fit_stat(self, proposed_params):
         return self.fcn(proposed_params)
 
-    def init(self, log=False, inv=False, defaultprior=True, priorshape=False,
-             priors=(), originalscale=True, scale=1, sigma_m=False):
+    def init(self,
+             log: bool = False,
+             inv: bool = False,
+             defaultprior: bool = True,
+             priorshape: bool = False,
+             priors=(),
+             originalscale: bool = True,
+             scale=1,
+             sigma_m: bool = False
+             ):
 
         if self._sigma is None or self._mu is None:
             raise AttributeError('sigma or mu is None, initialization failed')
@@ -464,7 +479,11 @@ class MH(Sampler):
 
         return (current, stat)
 
-    def update(self, stat, mu, init=True):
+    def update(self,
+               stat,
+               mu,
+               init: bool = True
+               ):
         """ include prior """
         if not self.defaultprior:
             x = mu.copy()
@@ -511,7 +530,11 @@ class MH(Sampler):
         # MH jumps from the best-fit parameter values at each iteration
         return rmvt(self._mu, self._sigma, self._dof, rng=self.rng)
 
-    def dmvt(self, x, log=True, norm=False):
+    def dmvt(self,
+             x,
+             log: bool = True,
+             norm: bool = False
+             ):
         return dmvt(x, self._mu, self._sigma, self._dof, log, norm)
 
     def accept_mh(self, current, current_stat, proposal, proposal_stat):
@@ -567,8 +590,17 @@ class MetropolisMH(MH):
         self.num_mh = 0
         self.num_metropolis = 0
 
-    def init(self, log=False, inv=False, defaultprior=True, priorshape=False,
-             priors=(), originalscale=True, scale=1, sigma_m=False, p_M=.5):
+    def init(self,
+             log: bool = False,
+             inv: bool = False,
+             defaultprior: bool = True,
+             priorshape: bool = False,
+             priors=(),
+             originalscale: bool = True,
+             scale=1,
+             sigma_m: bool = False,
+             p_M=.5
+             ):
 
         debug("Running Metropolis with Metropolis-Hastings")
 

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -68,8 +68,8 @@ from sherpa.sim.sample import ClipValue
 import sherpa.stats
 from sherpa.stats import Stat, UserStat
 import sherpa.utils
-from sherpa.utils import NoNewAttributesAfterInit, is_subclass, \
-    export_method, send_to_pager
+from sherpa.utils import NoNewAttributesAfterInit, bool_cast, \
+    is_subclass, export_method, send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \
     DataErr, IdentifierErr, IOErr, ModelErr, ParameterErr, PlotErr, \
     SessionErr
@@ -726,7 +726,11 @@ def set_dep(data, val) -> None:
     data.dep = dep
 
 
-def set_error(data, field, val, fractional=False) -> None:
+def set_error(data,
+              field,
+              val,
+              fractional: bool = False
+              ) -> None:
     """Set the error field.
 
     Parameters
@@ -754,7 +758,7 @@ def set_error(data, field, val, fractional=False) -> None:
 
     else:
         val = SherpaFloat(val)
-        if sherpa.utils.bool_cast(fractional):
+        if bool_cast(fractional):
             err = val * data.get_dep()
         else:
             err = np.array([val] * data.size)
@@ -762,7 +766,10 @@ def set_error(data, field, val, fractional=False) -> None:
     setattr(data, field, err)
 
 
-def set_filter(data, val, ignore=False) -> None:
+def set_filter(data,
+               val,
+               ignore: bool = False
+               ) -> None:
     """Set the filter field.
 
     Parameters
@@ -1199,7 +1206,10 @@ class Session(NoNewAttributesAfterInit):
         self._set_plot_types()
         self._set_contour_types()
 
-    def save(self, filename='sherpa.save', clobber=False) -> None:
+    def save(self,
+             filename='sherpa.save',
+             clobber: bool = False
+             ) -> None:
         """Save the current Sherpa session to a file.
 
         Parameters
@@ -1246,7 +1256,7 @@ class Session(NoNewAttributesAfterInit):
         """
 
         _check_str_type(filename, "filename")
-        clobber = sherpa.utils.bool_cast(clobber)
+        clobber = bool_cast(clobber)
 
         if os.path.isfile(filename) and not clobber:
             raise IOErr("filefound", filename)
@@ -1470,7 +1480,10 @@ class Session(NoNewAttributesAfterInit):
         covar_str += self.get_covar_results().format() + '\n\n'
         return covar_str
 
-    def show_stat(self, outfile=None, clobber=False) -> None:
+    def show_stat(self,
+                  outfile=None,
+                  clobber: bool = False
+                  ) -> None:
         """Display the current fit statistic.
 
         Parameters
@@ -1509,7 +1522,10 @@ class Session(NoNewAttributesAfterInit):
         txt = self._get_show_stat()
         send_to_pager(txt, outfile, clobber)
 
-    def show_method(self, outfile=None, clobber=False) -> None:
+    def show_method(self,
+                    outfile=None,
+                    clobber: bool = False
+                    ) -> None:
         """Display the current optimization method and options.
 
         Parameters
@@ -1554,7 +1570,10 @@ class Session(NoNewAttributesAfterInit):
         txt = self._get_show_method()
         send_to_pager(txt, outfile, clobber)
 
-    def show_fit(self, outfile=None, clobber=False) -> None:
+    def show_fit(self,
+                 outfile=None,
+                 clobber: bool = False
+                 ) -> None:
         """Summarize the fit results.
 
         Display the results of the last call to `fit`, including:
@@ -1593,7 +1612,9 @@ class Session(NoNewAttributesAfterInit):
 
     def show_data(self,
                   id: IdType | None = None,
-                  outfile=None, clobber=False) -> None:
+                  outfile=None,
+                  clobber: bool = False
+                  ) -> None:
         """Summarize the available data sets.
 
         Display information on the data sets that have been
@@ -1631,7 +1652,9 @@ class Session(NoNewAttributesAfterInit):
 
     def show_filter(self,
                     id: IdType | None = None,
-                    outfile=None, clobber=False) -> None:
+                    outfile=None,
+                    clobber: bool = False
+                    ) -> None:
         """Show any filters applied to a data set.
 
         Display any filters that have been applied to the independent
@@ -1672,7 +1695,9 @@ class Session(NoNewAttributesAfterInit):
 
     def show_model(self,
                    id: IdType | None = None,
-                   outfile=None, clobber=False) -> None:
+                   outfile=None,
+                   clobber: bool = False
+                   ) -> None:
         """Display the model expression used to fit a data set.
 
         This displays the model used to fit the data set, that is,
@@ -1716,7 +1741,9 @@ class Session(NoNewAttributesAfterInit):
 
     def show_source(self,
                     id: IdType | None = None,
-                    outfile=None, clobber=False) -> None:
+                    outfile=None,
+                    clobber: bool = False
+                    ) -> None:
         """Display the source model expression for a data set.
 
         This displays the source model for a data set, that is, the
@@ -1760,7 +1787,9 @@ class Session(NoNewAttributesAfterInit):
     # as the Notes section below is inadequate
     def show_kernel(self,
                     id: IdType | None = None,
-                    outfile=None, clobber=False) -> None:
+                    outfile=None,
+                    clobber: bool = False
+                    ) -> None:
         """Display any kernel applied to a data set.
 
         The kernel represents the subset of the PSF model that is used
@@ -1817,7 +1846,9 @@ class Session(NoNewAttributesAfterInit):
     # as the Notes section below is inadequate
     def show_psf(self,
                  id: IdType | None = None,
-                 outfile=None, clobber=False) -> None:
+                 outfile=None,
+                 clobber: bool = False
+                 ) -> None:
         """Display any PSF model applied to a data set.
 
         The PSF model represents the full model or data set that is
@@ -1870,7 +1901,10 @@ class Session(NoNewAttributesAfterInit):
         txt = self._get_show_psf(id)
         send_to_pager(txt, outfile, clobber)
 
-    def show_conf(self, outfile=None, clobber=False) -> None:
+    def show_conf(self,
+                  outfile=None,
+                  clobber: bool = False
+                  ) -> None:
         """Display the results of the last conf evaluation.
 
         The output includes the best-fit model parameter values,
@@ -1903,7 +1937,10 @@ class Session(NoNewAttributesAfterInit):
         txt = self._get_show_conf()
         send_to_pager(txt, outfile, clobber)
 
-    def show_proj(self, outfile=None, clobber=False) -> None:
+    def show_proj(self,
+                  outfile=None,
+                  clobber: bool = False
+                  ) -> None:
         """Display the results of the last proj evaluation.
 
         The output includes the best-fit model parameter values,
@@ -1936,7 +1973,10 @@ class Session(NoNewAttributesAfterInit):
         txt = self._get_show_proj()
         send_to_pager(txt, outfile, clobber)
 
-    def show_covar(self, outfile=None, clobber=False) -> None:
+    def show_covar(self,
+                   outfile=None,
+                   clobber: bool = False
+                   ) -> None:
         """Display the results of the last covar evaluation.
 
         The output includes the best-fit model parameter values,
@@ -1971,7 +2011,9 @@ class Session(NoNewAttributesAfterInit):
 
     def show_all(self,
                  id: IdType | None = None,
-                 outfile=None, clobber=False) -> None:
+                 outfile=None,
+                 clobber: bool = False
+                 ) -> None:
         """Report the current state of the Sherpa session.
 
         Display information about one or all of the data sets that
@@ -2048,7 +2090,10 @@ class Session(NoNewAttributesAfterInit):
                 funcs.append(func)
         return funcs
 
-    def list_functions(self, outfile=None, clobber=False) -> None:
+    def list_functions(self,
+                       outfile=None,
+                       clobber: bool = False
+                       ) -> None:
         """Display the functions provided by Sherpa.
 
         Unlike the other ``list_xxx`` commands, this does not
@@ -3466,7 +3511,11 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-NOTE: also in sherpa.astro.utils
     # DOC-TODO: does ncols make sense here? (have removed for now)
-    def load_filter(self, id, filename=None, ignore=False, ncols=2,
+    def load_filter(self,
+                    id,
+                    filename=None,
+                    ignore: bool = False,
+                    ncols=2,
                     *args, **kwargs) -> None:
         """Load the filter array from an ASCII file and add to a data set.
 
@@ -3532,7 +3581,11 @@ class Session(NoNewAttributesAfterInit):
                             filename, ncols=ncols, *args, **kwargs),
                         ignore=ignore)
 
-    def set_filter(self, id, val=None, ignore=False) -> None:
+    def set_filter(self,
+                   id,
+                   val=None,
+                   ignore: bool = False
+                   ) -> None:
         """Set the filter array of a data set.
 
         Parameters
@@ -3629,7 +3682,11 @@ class Session(NoNewAttributesAfterInit):
         set_dep(d, val)
 
     # DOC-NOTE: also in sherpa.utils
-    def set_staterror(self, id, val=None, fractional=False) -> None:
+    def set_staterror(self,
+                      id,
+                      val=None,
+                      fractional: bool = False
+                      ) -> None:
         """Set the statistical errors on the dependent axis of a data set.
 
         These values override the errors calculated by any statistic,
@@ -3687,7 +3744,11 @@ class Session(NoNewAttributesAfterInit):
         set_error(d, "staterror", val, fractional=fractional)
 
     # DOC-NOTE: also in sherpa.astro.utils
-    def set_syserror(self, id, val=None, fractional=False) -> None:
+    def set_syserror(self,
+                     id,
+                     val=None,
+                     fractional: bool = False
+                     ) -> None:
         """Set the systematic errors on the dependent axis of a data set.
 
         Parameters
@@ -3744,7 +3805,8 @@ class Session(NoNewAttributesAfterInit):
     # DOC-NOTE: also in sherpa.astro.utils
     def get_staterror(self,
                       id: IdType | None = None,
-                      filter=False):
+                      filter: bool = False
+                      ):
         """Return the statistical error on the dependent axis of a data set.
 
         The function returns the statistical errors on the values
@@ -3825,7 +3887,8 @@ class Session(NoNewAttributesAfterInit):
     # DOC-NOTE: also in sherpa.astro.utils
     def get_syserror(self,
                      id: IdType | None = None,
-                     filter=False):
+                     filter: bool = False
+                     ):
         """Return the systematic error on the dependent axis of a data set.
 
         The function returns the systematic errors on the values
@@ -3898,7 +3961,8 @@ class Session(NoNewAttributesAfterInit):
     # DOC-NOTE: also in sherpa.astro.utils
     def get_error(self,
                   id: IdType | None = None,
-                  filter=False):
+                  filter: bool = False
+                  ):
         """Return the errors on the dependent axis of a data set.
 
         The function returns the total errors (a quadrature addition
@@ -4022,7 +4086,8 @@ class Session(NoNewAttributesAfterInit):
     # DOC-NOTE: also in sherpa.astro.utils
     def get_dep(self,
                 id: IdType | None = None,
-                filter=False):
+                filter: bool = False
+                ):
         """Return the dependent axis of a data set.
 
         This function returns the data values (the dependent axis)
@@ -4084,7 +4149,8 @@ class Session(NoNewAttributesAfterInit):
 
     def get_dims(self,
                  id: IdType | None = None,
-                 filter=False):
+                 filter: bool = False
+                 ):
         """Return the dimensions of the data set.
 
         Parameters
@@ -4626,7 +4692,8 @@ class Session(NoNewAttributesAfterInit):
 
     def unpack_data(self, filename, ncols=2, colkeys=None,
                     dstype=sherpa.data.Data1D, sep=' ', comment='#',
-                    require_floats=True):
+                    require_floats: bool = True
+                    ):
         """Create a sherpa data object from an ASCII file.
 
         This function is used to read in columns from an ASCII
@@ -4734,7 +4801,8 @@ class Session(NoNewAttributesAfterInit):
     # DOC-NOTE: also in sherpa.astro.utils
     def load_data(self, id, filename=None, ncols=2, colkeys=None,
                   dstype=sherpa.data.Data1D, sep=' ', comment='#',
-                  require_floats=True) -> None:
+                  require_floats: bool = True
+                  ) -> None:
         """Load a data set from an ASCII file.
 
         Parameters
@@ -4917,7 +4985,9 @@ class Session(NoNewAttributesAfterInit):
         sherpa.io.write_arrays(filename, args, fields, **kwargs)
 
     # DOC-NOTE: also in sherpa.astro.utils with a different interface
-    def save_arrays(self, filename, args, fields=None, clobber=False, sep=' ',
+    def save_arrays(self, filename, args, fields=None,
+                    clobber: bool = False,
+                    sep=' ',
                     comment='#', linebreak='\n', format='%g'
                     ) -> None:
         """Write a list of arrays to an ASCII file.
@@ -4970,13 +5040,15 @@ class Session(NoNewAttributesAfterInit):
         ...             clobber=True)
 
         """
-        clobber = sherpa.utils.bool_cast(clobber)
+        clobber = bool_cast(clobber)
         _check_str_type(filename, "filename")
         sherpa.io.write_arrays(filename, args, fields, sep, comment, clobber,
                                linebreak, format)
 
     # DOC-NOTE: also in sherpa.utils with a different interface
-    def save_source(self, id, filename=None, clobber=False, sep=' ',
+    def save_source(self, id, filename=None,
+                    clobber: bool = False,
+                    sep=' ',
                     comment='#', linebreak='\n', format='%g'
                     ) -> None:
         """Save the model values to a file.
@@ -5047,12 +5119,14 @@ class Session(NoNewAttributesAfterInit):
         >>> save_source('jet', "jet.mdl", clobber=True)
 
         """
-        clobber = sherpa.utils.bool_cast(clobber)
+        clobber = bool_cast(clobber)
         self._save_type('source', id, filename, clobber=clobber, sep=sep,
                         comment=comment, linebreak=linebreak, format=format)
 
     # DOC-NOTE: also in sherpa.utils with a different interface
-    def save_model(self, id, filename=None, clobber=False, sep=' ',
+    def save_model(self, id, filename=None,
+                   clobber: bool = False,
+                   sep=' ',
                    comment='#', linebreak='\n', format='%g'
                    ) -> None:
         """Save the model values to a file.
@@ -5124,12 +5198,14 @@ class Session(NoNewAttributesAfterInit):
         >>> save_model('jet', "jet.mdl", clobber=True)
 
         """
-        clobber = sherpa.utils.bool_cast(clobber)
+        clobber = bool_cast(clobber)
         self._save_type('model', id, filename, clobber=clobber, sep=sep,
                         comment=comment, linebreak=linebreak, format=format)
 
     # DOC-NOTE: also in sherpa.utils with a different interface
-    def save_resid(self, id, filename=None, clobber=False, sep=' ',
+    def save_resid(self, id, filename=None,
+                   clobber: bool = False,
+                   sep=' ',
                    comment='#', linebreak='\n', format='%g'
                    ) -> None:
         """Save the residuals (data-model) to a file.
@@ -5195,12 +5271,14 @@ class Session(NoNewAttributesAfterInit):
         >>> save_resid('jet', "resid.dat", clobber=True)
 
         """
-        clobber = sherpa.utils.bool_cast(clobber)
+        clobber = bool_cast(clobber)
         self._save_type('resid', id, filename, clobber=clobber, sep=sep,
                         comment=comment, linebreak=linebreak, format=format)
 
     # DOC-NOTE: also in sherpa.utils with a different interface
-    def save_delchi(self, id, filename=None, clobber=False, sep=' ',
+    def save_delchi(self, id, filename=None,
+                    clobber: bool = False,
+                    sep=' ',
                     comment='#', linebreak='\n', format='%g'
                     ) -> None:
         """Save the ratio of residuals (data-model) to error to a file.
@@ -5266,13 +5344,14 @@ class Session(NoNewAttributesAfterInit):
         >>> save_resid('jet', "delchi.dat", clobber=True)
 
         """
-        clobber = sherpa.utils.bool_cast(clobber)
+        clobber = bool_cast(clobber)
         self._save_type('delchi', id, filename, clobber=clobber, sep=sep,
                         comment=comment, linebreak=linebreak, format=format)
 
     # DOC-NOTE: also in sherpa.astro.utils
     def save_data(self, id, filename=None, fields=None, sep=' ', comment='#',
-                  clobber=False, linebreak='\n', format='%g'
+                  clobber: bool = False,
+                  linebreak='\n', format='%g'
                   ) -> None:
         """Save the data to a file.
 
@@ -5345,7 +5424,7 @@ class Session(NoNewAttributesAfterInit):
         ...           fields=['x', 'y', 'staterror'])
 
         """
-        clobber = sherpa.utils.bool_cast(clobber)
+        clobber = bool_cast(clobber)
         if filename is None:
             id, filename = filename, id
 
@@ -5354,7 +5433,9 @@ class Session(NoNewAttributesAfterInit):
                              comment, clobber, linebreak, format)
 
     # DOC-NOTE: also in sherpa.astro.utils with a different interface
-    def save_filter(self, id, filename=None, clobber=False, sep=' ',
+    def save_filter(self, id, filename=None,
+                    clobber: bool = False,
+                    sep=' ',
                     comment='#', linebreak='\n', format='%g'
                     ) -> None:
         """Save the filter array to a file.
@@ -5414,7 +5495,7 @@ class Session(NoNewAttributesAfterInit):
         >>> save_filter('filt.dat')
 
         """
-        clobber = sherpa.utils.bool_cast(clobber)
+        clobber = bool_cast(clobber)
         if filename is None:
             id, filename = filename, id
 
@@ -5434,7 +5515,9 @@ class Session(NoNewAttributesAfterInit):
                          linebreak=linebreak, format=format)
 
     # DOC-NOTE: also in sherpa.astro.utils with a different interface
-    def save_staterror(self, id, filename=None, clobber=False, sep=' ',
+    def save_staterror(self, id, filename=None,
+                       clobber: bool = False,
+                       sep=' ',
                        comment='#', linebreak='\n', format='%g'
                        ) -> None:
         """Save the statistical errors to a file.
@@ -5503,7 +5586,7 @@ class Session(NoNewAttributesAfterInit):
         >>> save_staterror('jet', 'err.out', clobber=True)
 
         """
-        clobber = sherpa.utils.bool_cast(clobber)
+        clobber = bool_cast(clobber)
         if filename is None:
             id, filename = filename, id
 
@@ -5515,7 +5598,9 @@ class Session(NoNewAttributesAfterInit):
                          linebreak=linebreak, format=format)
 
     # DOC-NOTE: also in sherpa.astro.utils with a different interface
-    def save_syserror(self, id, filename=None, clobber=False, sep=' ',
+    def save_syserror(self, id, filename=None,
+                      clobber: bool = False,
+                      sep=' ',
                       comment='#', linebreak='\n', format='%g'
                       ) -> None:
         """Save the statistical errors to a file.
@@ -5582,7 +5667,7 @@ class Session(NoNewAttributesAfterInit):
         >>> save_syserror('jet', 'err.out', clobber=True)
 
         """
-        clobber = sherpa.utils.bool_cast(clobber)
+        clobber = bool_cast(clobber)
         if filename is None:
             id, filename = filename, id
 
@@ -5594,7 +5679,9 @@ class Session(NoNewAttributesAfterInit):
                          linebreak=linebreak, format=format)
 
     # DOC-NOTE: also in sherpa.astro.utils with a different interface
-    def save_error(self, id, filename=None, clobber=False, sep=' ',
+    def save_error(self, id, filename=None,
+                   clobber: bool = False,
+                   sep=' ',
                    comment='#', linebreak='\n', format='%g'
                    ) -> None:
         """Save the errors to a file.
@@ -5668,7 +5755,7 @@ class Session(NoNewAttributesAfterInit):
         >>> save_error('jet', 'err.out', clobber=True)
 
         """
-        clobber = sherpa.utils.bool_cast(clobber)
+        clobber = bool_cast(clobber)
         if filename is None:
             id, filename = filename, id
 
@@ -6150,7 +6237,7 @@ class Session(NoNewAttributesAfterInit):
     # Models
     ###########################################################################
 
-    def paramprompt(self, val=False) -> None:
+    def paramprompt(self, val: bool = False) -> None:
         """Should the user be asked for the parameter values when creating a model?
 
         When `val` is ``True``, calls to `set_model` will cause the user
@@ -6210,7 +6297,7 @@ class Session(NoNewAttributesAfterInit):
         gline.ampl parameter value [1] 1.0e-3,1.0e-7,1
 
         """
-        self._paramprompt = sherpa.utils.bool_cast(val)
+        self._paramprompt = bool_cast(val)
 
     def _add_model_types(self, module,
                          baselist=(sherpa.models.ArithmeticModel,)
@@ -6541,7 +6628,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         cmpt = self._model_components.get(name)
-        require = sherpa.utils.bool_cast(require)
+        require = bool_cast(require)
         if require and (cmpt is None):
             raise IdentifierErr('nomodelcmpt', name)
         return cmpt
@@ -9406,7 +9493,12 @@ class Session(NoNewAttributesAfterInit):
 
         return self._fit_results
 
-    def guess(self, id=None, model=None, limits=True, values=True):
+    def guess(self,
+              id=None,
+              model=None,
+              limits: bool = True,
+              values: bool = True
+              ):
         """Estimate the parameter values and ranges given the loaded data.
 
         The guess function can change the parameter values and
@@ -16701,7 +16793,10 @@ class Session(NoNewAttributesAfterInit):
     # Contours
     #
 
-    def _contour(self, plotobj, overcontour=False, **kwargs) -> None:
+    def _contour(self,
+                 plotobj,
+                 overcontour: bool = False,
+                 **kwargs) -> None:
         """Display a plot object
 
         Parameters
@@ -17500,7 +17595,7 @@ class Session(NoNewAttributesAfterInit):
                 otherids = ()
             ids, fit = self._get_fit(id, otherids)
             plotobj.prepare(min=min, max=max, nloop=nloop, delv=delv,
-                            fac=fac, log=sherpa.utils.bool_cast(log),
+                            fac=fac, log=bool_cast(log),
                             numcores=numcores)
             plotobj.calc(fit, par)
 
@@ -19220,10 +19315,10 @@ class Session(NoNewAttributesAfterInit):
         data = self.get_data_image(id)
         model = self.get_model_image(id)
         resid = self.get_resid_image(id)
-        deleteframes = sherpa.utils.bool_cast(deleteframes)
-        if deleteframes is True:
+        if bool_cast(deleteframes):
             sherpa.image.Image.open()
             sherpa.image.Image.delete_frames()
+
         data.image(None, False, tile)
         model.image(None, newframe, tile)
         resid.image(None, newframe, tile)


### PR DESCRIPTION
# Summary

Add typing statements to the boolean arguments for much of the code.

# Details

This was originally developed as part of https://github.com/sherpa/sherpa/pull/2411 but it makes sense to pull it out into a separate PR. If there are significant changes to be made I'd like to make them in a follow-up PR to simplify the existing PRs that depend on this.

This is primarily to change `foo=False` to `foo: bool = False` (ditto for `True`) in signatures. This is not particularly informative or illuminating, but it's an easy change to make and hopefully easy to review (if not particularly informative). In itself it does not really improve the typing code (there's no reduction in the number of errors from `pyright`, for instance). This started out as being restricted to the UI code, but it has since expanded to include most of the code. Some areas not changed

- the image code, as that is done in #2413 
- the actual backend code (pylab/bokeh) although the superclass (effectively the "dummy" backend) has the changes 
- by not marking a parameter - such as `verbose=False` in `sherpa.utils.NoRichardsonExtrapolation.__init__` I am indicating that "I have not looked at this code, probably because it needs a lot of thought and it is not worth it right now" ....

However, we do get a number of reductions in type errors because of the changes to `sherpa.utils.bool_cast`. This included support for converting an array/iterable of values as well as a scalar one, but this meant it was typed as returning `bool | np.ndarray` and, given the input, it was hard for the typing code to identify when it returned an array. This lead to a lot of errors when `bool_cast` was used as the type checker thought it could return an array when sent to a "scalar boolean value". It turns out the only use of this functionality was in a test case I'd added to check it reported an error when sent an invalid value. So, by removing this support we make `bool_cast` only support the scalar case, and thus reducing the number of errors. 

Using `pyright` version 1.1.407, the number of errors reported from several files were reduced:

|  | `ui/utils` | `astro/ui/utils` | `data` | `astro/data` |
| --- | --- | --- | --- | --- |
| before | 116 | 160 | 88 | 156 |
| after | 105 | 131 | 87 | 148 |

(some of these may be due to the other related typing changes in `sherpa.utils`, but the majority are due to `bool_cast`). Here is an example of the error report from `sherpa.data` that was removed thanks to the `bool_cast` change

```
/home/dburke/sherpa/sherpa-3/sherpa/data.py:782:18 - error: Type "NDArray[Any] | bool" is not assignable to declared type "bool"
  Type "NDArray[Any] | bool" is not assignable to type "bool"
    "ndarray[_AnyShape, dtype[Any]]" is not assignable to "bool" (reportAssignmentType)
```

The first commit is actually an unrelated change:

- I had missed importing `Any` in `sherpa.astro.ui.utils` in #2377, so add that in (fortunately only an issue when running a type checker on the code)

Now, `bool_cast` **could** 

- be removed, as it isn't really useful any more
- or be made to raise a deprecation warning if sent a string argument

I would much rather discuss this at a later time. If pressedm I would have a preference for the deprecation approach, since some users may have code that has `clobber="yes"` (or equivalent) thanks to historical documentation/suggestions and we don't want to make this code fail.