### PR TITLE
Change channel location where XSPEC if found

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  xspec_channel: "https://cxc.cfa.harvard.edu/conda/xspec"
+  xspec_channel: "https://cxc.cfa.harvard.edu/conda/test"
   # ensure conda environment is built outside the repository (to
   # avoid errors from meson)
   CONDA_BUILD_SYSROOT: ${{ github.workspace }}/../11.0SDK/MacOSX11.0.sdk


### PR DESCRIPTION
## Summary
Change channel location where XSPEC if found

## Details
From an email on sherpa-dev:
>>> I had consolidated the channels recently, we had a lot of dup packages and needed to save space. Using conda/test would be suggested for in CIAOX/T/sherpa xspec packages, and conda/ciao for released ones.

I'm picking the XSPEC from the last released CIAO version here, since that that we usually want to test compatibility with. PRs that explicitly change the XSPEC version of interface will have to be looked at separately.


## Note
Note that, at a time I'm opening the PR, CI will fail for #2421.
And any PR working on #2421 will fail because of the problem addressed here.  Thus, we will have to merge one of them even with CI failing or make a combined PR for both. I prefer the first approach since there are really separate issues and should be dealt with independently.