### PR TITLE
Filter out new PytestDeprecationWarning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -47,6 +47,7 @@ doctest_norecursedirs =
     sherpa/astro/tests
     sherpa/astro/utils
     sherpa/astro/xspec
+    sherpa/astro/io/xstable.py  # see discussion in https://github.com/sherpa/sherpa/issues/2421
     sherpa/conftest.py
     sherpa/estmethods
     sherpa/image


### PR DESCRIPTION
## Summary
Deal with updates in the pytest that change the `importorskip` handling

## Details
In the past, pytest used to capture `ImportError` with the original intent being to skip tests where a dependent module is not installed. That behavior has recently changed since there are other reasons an import could fail (e.g. 
a compilation error or a broken installation). Those cases would have silently passed in the past, but are now caught by pytest. From about v9.2 on pytests checks if a package exists and imports. It it exists, but does not import, then the error is not a "missing package" and it will be raised.

Our import of the `sherpa.astro.xspec` module works like that - it will fail with an `ImportError` if XSPEC is not installed, but the Python module itself does exist. So, pytest will no longer catch that error and we see statement like #2421. 

To make matters more complicated, the import to the failing test in that case is not in the sherpa test code itself, but it's coming when `pytest-doctestplus` imports the `sherpa.astro.xspec` module. (It imports all module to check if there are any doctests in there that should be executed).

This is such an insect chain of events that I suggest to simply remove that module from the list of modules that `pytest-doctestplus` searches for tests that are embedded in the docstrings of that module.
