### PR TITLE
Disallow some XSPEC model combinations. Fix #2420

### DIFF
--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -60,6 +60,14 @@ from the XSPEC model library are supported, except for the `polconst`,
 `pollin`, `polpow`, and `smaug` models [5]_, since they need
 information obtained from the XFLT keywords in the PHA file.
 
+Note that some, but not all, of the restrictions from XSPEC are
+enforced here when combining models:
+
+- additive models can not multiplied or divided together,
+
+- and multiplicative models can not be added or subtracted from each
+  other.
+
 XSPEC version
 -------------
 
@@ -1870,6 +1878,10 @@ class XSAdditiveModel(XSModel):
 
     The XSPEC additive models are listed at [1]_.
 
+    .. versionchanged:: 4.19.0
+       Additive models can no-longer be multiplied or divided by
+       another additive model.
+
     .. versionchanged:: 4.18.0
        The "norm" parameter is now handled in the `calc` method rather
        than in the compiled code.
@@ -1894,6 +1906,73 @@ class XSAdditiveModel(XSModel):
             pars = tuple(list(pars) + [self.norm])
 
         XSModel.__init__(self, name, pars)
+
+    # Invalidate multiplication and division. At present it is not
+    # worth handling the more esoteric options (e.g.  mod/pow).
+    #
+    def _validate_lop(self, opstr: str, rhs) -> None:
+        if isinstance(rhs, XSAdditiveModel):
+            raise TypeError("Invalid operation: "
+                            f"{self.__class__.__name__}"
+                            f" {opstr} "
+                            f"{rhs.__class__.__name__}")
+
+        try:
+            # If this is a component model, check the components for
+            # other XSPEC models.
+            for cpt in rhs.parts:
+                if isinstance(cpt, XSAdditiveModel):
+                    raise TypeError("Invalid operation: "
+                                    f"{self.__class__.__name__}"
+                                    f" {opstr} "
+                                    f"{cpt.__class__.__name__}")
+
+        except AttributeError:
+            pass
+
+    def _validate_rop(self, opstr: str, lhs) -> None:
+        if isinstance(lhs, XSAdditiveModel):
+            raise TypeError("Invalid operation: "
+                            f"{lhs.__class__.__name__}"
+                            f" {opstr} "
+                            f"{self.__class__.__name__}")
+
+        try:
+            # If this is a component model, check the components for
+            # other XSPEC models.
+            for cpt in lhs.parts:
+                if isinstance(cpt, XSAdditiveModel):
+                    raise TypeError("Invalid operation: "
+                                    f"{cpt.__class__.__name__}"
+                                    f" {opstr} "
+                                    f"{self.__class__.__name__}")
+
+        except AttributeError:
+            pass
+
+    def __mul__(self, rhs):
+        self._validate_lop("*", rhs)
+        return super().__mul__(rhs)
+
+    def __rmul__(self, lhs):
+        self._validate_rop("*", lhs)
+        return super().__rmul__(lhs)
+
+    def __truediv__(self, rhs):
+        self._validate_lop("/", rhs)
+        return super().__truediv__(rhs)
+
+    def __rtruediv__(self, lhs):
+        self._validate_rop("/", lhs)
+        return super().__rtruediv__(lhs)
+
+    def __floordiv__(self, rhs):
+        self._validate_lop("//", rhs)
+        return super().__floordiv__(rhs)
+
+    def __rfloordiv__(self, lhs):
+        self._validate_rop("//", lhs)
+        return super().__rfloordiv__(lhs)
 
     def guess(self, dep, *args, **kwargs):
         """Set an initial guess for the normalization.
@@ -1932,6 +2011,10 @@ class XSMultiplicativeModel(XSModel):
 
     The XSPEC multiplicative models are listed at [1]_.
 
+    .. versionchanged:: 4.19.0
+       Multiplicative models can no-longer be added or subtracted by
+       another mutiplicative model.
+
     References
     ----------
 
@@ -1939,7 +2022,64 @@ class XSMultiplicativeModel(XSModel):
 
     """
 
-    pass
+    # Invalidate addition and subtraction. At present it is not worth
+    # handling the more esoteric options (e.g.  mod/pow).
+    #
+    def _validate_lop(self, opstr: str, rhs) -> None:
+        if isinstance(rhs, XSMultiplicativeModel):
+            raise TypeError("Invalid operation: "
+                            f"{self.__class__.__name__}"
+                            f" {opstr} "
+                            f"{rhs.__class__.__name__}")
+
+        try:
+            # If this is a component model, check the components for
+            # other XSPEC models.
+            for cpt in rhs.parts:
+                if isinstance(cpt, XSMultiplicativeModel):
+                    raise TypeError("Invalid operation: "
+                                    f"{self.__class__.__name__}"
+                                    f" {opstr} "
+                                    f"{cpt.__class__.__name__}")
+
+        except AttributeError:
+            pass
+
+    def _validate_rop(self, opstr: str, lhs) -> None:
+        if isinstance(lhs, XSMultiplicativeModel):
+            raise TypeError("Invalid operation: "
+                            f"{lhs.__class__.__name__}"
+                            f" {opstr} "
+                            f"{self.__class__.__name__}")
+
+        try:
+            # If this is a component model, check the components for
+            # other XSPEC models.
+            for cpt in lhs.parts:
+                if isinstance(cpt, XSMultiplicativeModel):
+                    raise TypeError("Invalid operation: "
+                                    f"{cpt.__class__.__name__}"
+                                    f" {opstr} "
+                                    f"{self.__class__.__name__}")
+
+        except AttributeError:
+            pass
+
+    def __add__(self, rhs):
+        self._validate_lop("+", rhs)
+        return super().__add__(rhs)
+
+    def __radd__(self, lhs):
+        self._validate_rop("+", lhs)
+        return super().__radd__(lhs)
+
+    def __sub__(self, rhs):
+        self._validate_lop("-", rhs)
+        return super().__sub__(rhs)
+
+    def __rsub__(self, lhs):
+        self._validate_rop("-", lhs)
+        return super().__rsub__(lhs)
 
 
 class XSConvolutionKernel(XSModel):

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -848,13 +848,14 @@ def test_apec_redshift_parameter_is_case_insensitive():
 
 
 @requires_xspec
-@pytest.mark.parametrize("op", [operator.add,
-                                operator.sub,
-                                operator.mul,
-                                operator.truediv,
-                                operator.floordiv
-                                ])
-def test_can_combine_additive(op, xsmodel):
+@pytest.mark.parametrize("op,opstr",
+                         [(operator.add, None),
+                          (operator.sub, None),
+                          (operator.mul, "\\*"),
+                          (operator.truediv, "/"),
+                          (operator.floordiv, "//")
+                          ])
+def test_can_combine_additive(op, opstr, xsmodel):
     """Check can combine additive models."""
 
     # Assume XSapec/XSgaussian exist.
@@ -866,17 +867,23 @@ def test_can_combine_additive(op, xsmodel):
     #
     _ = op(a1, 2)
     _ = op(2, a1)
-    _ = op(a1, a2)
+    if opstr is None:
+        _ = op(a1, a2)
+    else:
+        msg = f"^Invalid operation: XSapec {opstr} XSgaussian$"
+        with pytest.raises(TypeError, match=msg):
+            _ = op(a1, a2)
 
 
 @requires_xspec
-@pytest.mark.parametrize("op", [operator.add,
-                                operator.sub,
-                                operator.mul,
-                                operator.truediv,
-                                operator.floordiv
-                                ])
-def test_can_combine_multiplicative(op, xsmodel):
+@pytest.mark.parametrize("op,opstr",
+                         [(operator.add, "\\+"),
+                          (operator.sub, "-"),
+                          (operator.mul, None),
+                          (operator.truediv, None),
+                          (operator.floordiv, None)
+                          ])
+def test_can_combine_multiplicative(op, opstr, xsmodel):
     """Check can combine multiplicative models."""
 
     # Assume XSphabs/dust exists.
@@ -888,7 +895,12 @@ def test_can_combine_multiplicative(op, xsmodel):
     #
     _ = op(m1, 2)
     _ = op(2, m1)
-    _ = op(m1, m2)
+    if opstr is None:
+        _ = op(m1, m2)
+    else:
+        msg = f"^Invalid operation: XSphabs {opstr} XSdust$"
+        with pytest.raises(TypeError, match=msg):
+            _ = op(m1, m2)
 
 
 @requires_xspec
@@ -896,6 +908,9 @@ def test_can_combine_complex_models(xsmodel):
     """Can we create this 'interesting' model expression?
 
     This is a regression test.
+
+    The difference in behaviour is because we can not hook into the
+    BinaryOpModel __add__/... methods (which come from AdditiveModel).
 
     """
 
@@ -906,16 +921,26 @@ def test_can_combine_complex_models(xsmodel):
 
     # Test if we can catch combinations within BinaryOpModel combinations.
     #
-    _ = a1 * (1 + a2)
+    msg1 = "^Invalid operation: XSgaussian \\* XSapec$"
+    msg2 = "^Invalid operation: XSphabs \\+ XSconstant$"
+    with pytest.raises(TypeError, match=msg1):
+        _ = a1 * (1 + a2)
+
     _ = (1 + a1) * a2
 
-    _ = a1 * (m2 + a2)
+    with pytest.raises(TypeError, match=msg1):
+        _ = a1 * (m2 + a2)
+
     _ = (m1 + a1) * a2
 
-    _ = m1 + (1 * m2)
+    with pytest.raises(TypeError, match=msg2):
+        _ = m1 + (1 * m2)
+
     _ = (1 * m1) + m2
 
-    _ = m1 + (a2 * m2)
+    with pytest.raises(TypeError, match=msg2):
+        _ = m1 + (a2 * m2)
+
     _ = (a1 * m1) + m2
 
     _ = m1 + 1 + 2 + m2

--- a/sherpa/astro/xspec/tests/test_xspec.py
+++ b/sherpa/astro/xspec/tests/test_xspec.py
@@ -18,6 +18,8 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import operator
+
 import numpy
 
 import pytest
@@ -843,3 +845,78 @@ def test_apec_redshift_parameter_is_case_insensitive():
     mdl.REDshift = 0.2
     assert mdl.redshift.val == 0.2
     assert mdl.Redshift.val == 0.2
+
+
+@requires_xspec
+@pytest.mark.parametrize("op", [operator.add,
+                                operator.sub,
+                                operator.mul,
+                                operator.truediv,
+                                operator.floordiv
+                                ])
+def test_can_combine_additive(op, xsmodel):
+    """Check can combine additive models."""
+
+    # Assume XSapec/XSgaussian exist.
+    a1 = xsmodel("apec", "a1")
+    a2 = xsmodel("gaussian", "a2")
+
+    # Need to check can both "lhs" and "rhs" terms. It does not
+    # matter if the actual expression is sensible.
+    #
+    _ = op(a1, 2)
+    _ = op(2, a1)
+    _ = op(a1, a2)
+
+
+@requires_xspec
+@pytest.mark.parametrize("op", [operator.add,
+                                operator.sub,
+                                operator.mul,
+                                operator.truediv,
+                                operator.floordiv
+                                ])
+def test_can_combine_multiplicative(op, xsmodel):
+    """Check can combine multiplicative models."""
+
+    # Assume XSphabs/dust exists.
+    m1 = xsmodel("phabs", "m1")
+    m2 = xsmodel("dust", "m2")
+
+    # Need to check can both "lhs" and "rhs" terms. It does not
+    # matter if the actual expression is sensible.
+    #
+    _ = op(m1, 2)
+    _ = op(2, m1)
+    _ = op(m1, m2)
+
+
+@requires_xspec
+def test_can_combine_complex_models(xsmodel):
+    """Can we create this 'interesting' model expression?
+
+    This is a regression test.
+
+    """
+
+    a1 = xsmodel("gaussian", "a1")
+    a2 = xsmodel("apec", "a2")
+    m1 = xsmodel("phabs", "m1")
+    m2 = xsmodel("constant", "m2")
+
+    # Test if we can catch combinations within BinaryOpModel combinations.
+    #
+    _ = a1 * (1 + a2)
+    _ = (1 + a1) * a2
+
+    _ = a1 * (m2 + a2)
+    _ = (m1 + a1) * a2
+
+    _ = m1 + (1 * m2)
+    _ = (1 * m1) + m2
+
+    _ = m1 + (a2 * m2)
+    _ = (a1 * m1) + m2
+
+    _ = m1 + 1 + 2 + m2
+    _ = a1 * 1 * 2 * a2


### PR DESCRIPTION
# Summary

The `AdditiveModel` class allows models to be combined by all the supported Python operations - e.g. add, multiply, subtract, divide, and a few others - but in some cases this does not make sense. In particular, XSPEC has additive and multiplicative models which do not make sense to multiply/divide or add/subtract (respectively). This PR enforces this, which is a bit-closer to how XSPEC itself works. Fix #2420

# Details

As noted, this now disallows

```
>>> from sherpa.astro import xspec
>>> m1 = xspec.XSapec()
>>> m1 = m1
>>> m1
<XSapec model instance 'apec'>
>>> m1 + m1
<BinaryOpModel model instance 'apec + apec'>
>>> m1 * m1
Traceback (most recent call last):
  File "<python-input-5>", line 1, in <module>
    m1 * m1
    ~~~^~~~
  File "/lagado.real/sherpa/sherpa-1/sherpa/astro/xspec/__init__.py", line 1917, in __mul__
    raise TypeError("Invalid operation: "
                    f"{self.__class__.__name__} * "
                    f"{rhs.__class__.__name__}")
TypeError: Invalid operation: XSapec * XSapec
```

**However** the check doesn't fire if one of the sides is a "combined" model, so you can get the same as `m1 * m1` with a little-bit of ingenuity:

```
>>> m1 * (m1 + 1)
<BinaryOpModel model instance 'apec * (apec + 1.0)'>
```

Is this worth fixing? Actually, it's a bit-more annoying, since the following is also not dis-allowed:

```
>>> m1 + (2 * m1) * m1
<BinaryOpModel model instance 'apec + 2.0 * apec * apec'>
```

and I think you might want to catch an example like this (e.g. where instead of `2` there may be an absorption model).