### PR TITLE
Allow building with GCC 15 (std=C23)

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -22,7 +22,12 @@ if [ "`uname -s`" == "Darwin" ] ; then
     tar -C ${GITHUB_WORKSPACE}/../11.0SDK -xf MacOSX11.0.sdk.tar.xz
 
 else
-    compilers="gcc_linux-64=14.2 gxx_linux-64=14.2 gfortran_linux-64"
+    if [ -n "${COMPILERVER}" ]; then
+        cver="${COMPILERVER}"
+    else
+        cver="14.2"
+    fi
+    compilers="gcc_linux-64=${cver} gxx_linux-64=${cver} gfortran_linux-64"
 
     if [ -n "${MATPLOTLIBVER}" ]; then
         #Installed for qt-main deps which is needed for the QtAgg backend to work for matplotlib

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -65,6 +65,7 @@ jobs:
             numpy-version: "2.3.2"
             install-type: develop
             test-data: none
+            compiler-version: "15.2"
 
           - name: Linux Full Build (Python 3.13)
             os: ubuntu-latest
@@ -130,6 +131,7 @@ jobs:
         MATPLOTLIBVER: ${{ matrix.matplotlib-version }}
         BOKEHVER: ${{ matrix.bokeh-version }}
         XSPECVER: ${{ matrix.xspec-version }}
+        COMPILERVER: ${{ matrix.compiler-version }}
       run: |
         curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh -o conda-installer.sh
         bash conda-installer.sh -b -p ${conda_loc}
@@ -263,4 +265,3 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ${{ github.workspace }}/coverage.xml
         verbose: true
-

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -43,16 +43,13 @@ if installed:
 
 * :term:`Astropy`: for reading and writing files in
   :term:`FITS` format.
-* :term:`matplotlib`: for visualisation of
+* :term:`matplotlib` or :term:`bokeh`: for visualisation of
   one-dimensional data or models, one- or two- dimensional
   error analysis, and the results of Monte-Carlo Markov Chain
-  runs. There are no known incompatibilities with matplotlib, but there
-  has only been limited testing. Please
-  `report any problems <https://github.com/sherpa/sherpa/issues/>`_
-  you find.
+  runs.
 * `scipy <https://www.scipy.org>`_ for the `sherpa.optmethods.optscipy`
   module, which provides an interface to several optimizers from Scipy.
-* `optimagic <https://optimagic.readthedocs.io>`_ for the 
+* `optimagic <https://optimagic.readthedocs.io>`_ for the
   `sherpa.optmethods.optoptimagic` module which provides an interface to `optimagic.minimize`.
   Optimagic provides a single interface to dozens of optimizers, many of which
   rely on other external packages that need to be `installed separately

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -36,6 +36,7 @@ Sherpa has the following requirements:
 * Python 3.11 to 3.14 (there is no support for free-threaded Python)
 * NumPy
 * Linux or OS-X (patches to add Windows support are welcome)
+* C and C++ compiler that support the gnu11 and c++ standards respectively
 
 Sherpa can take advantage of the following Python packages
 if installed:
@@ -195,6 +196,27 @@ Configuring the build
 The Sherpa build is controlled by the ``setup.cfg`` file in the
 root of the Sherpa source tree. These configuration options
 include:
+
+.. _build-standards:
+
+Compiler standards
+^^^^^^^^^^^^^^^^^^
+
+The C and C++ code in Sherpa requires compilers that support the
+``gnu11`` and ``c++11`` standards. The build system automatically
+adds the necessary flags to the ``CFLAGS`` and ``CXXFLAGS`` environment
+variables, unless they already contain the string ``-std=``.
+
+The values added to these flags are defined by the::
+
+  c_standard = -std=gnu11
+  cxx_standard = -std=c++11
+
+settings in the ``sherpa_config`` section of the ``setup.cfg`` file.
+If the setting is changed to be empty - e.g. ``c_standard`` - then no
+attempt is made to change the corresponding environment variable.
+
+.. _build-fftw:
 
 FFTW
 ^^^^

--- a/helpers/sherpa_config.py
+++ b/helpers/sherpa_config.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014-2016, 2020, 2022, 2024-2025
+#  Copyright (C) 2014-2016, 2020, 2022, 2024-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -55,6 +55,8 @@ class sherpa_config(Command):
                     ('install_dir', None, "Directory where external dependencies must be installed (--prefix)"),
                     ('configure', None, "Additional configure flags for the external dependencies"),
                     ('group_cflags', None, "Additional cflags for building the grouping library"),
+                    ('c_standard', None, "Added to CFLAGS unless -std= is already present or value is empty"),
+                    ('cxx_standard', None, "Added to CXXFLAGS unless -std= is already present or value is empty"),
                     ]
 
     def initialize_options(self):
@@ -78,6 +80,8 @@ class sherpa_config(Command):
         self.disable_group = False
         self.configure = '--disable-maintainer-mode --enable-stuberrorlib --disable-shared --enable-shared=libgrp,stklib'
         self.group_cflags = None
+        self.c_standard = '-std=gnu11'
+        self.cxx_standard = '-std=c++11'
         self.stk_location = None
         self.disable_stk = False
 
@@ -193,6 +197,40 @@ class sherpa_config(Command):
         self.warn(f'built configure string {configure}')
         return configure
 
+    def setup_standard(self, name: str, value: str) -> None:
+        """Ensure the standard is included in the env variable, if not empty.
+
+        Parameters
+        ----------
+        name
+           Assumed to be CFLAGS or CXXFLAGS
+        value
+           The value to add: shjould be empty (skip) or "-std=...".
+
+        """
+
+        if value == "":
+            return
+
+        oldval = os.environ.get(name, None)
+        if oldval is None:
+            os.environ[name] = value
+            self.warn(f"* setting {name} to {value}")
+            return
+
+        # It there's alrady a standard, skip the setting
+        if "-std=" in oldval:
+            return
+
+        os.environ[name] = f"{oldval} {value}"
+        self.warn(f"* adding {value} to {name}")
+
     def run(self):
+
+        # Setup CFLAGS/CXXFLAGS for building the compiled code.
+        #
+        self.setup_standard("CFLAGS", self.c_standard)
+        self.setup_standard("CXXFLAGS", self.cxx_standard)
+
         configure = self.build_configure()
         build_deps(configure)

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,12 @@
 # Set to 'None' (without quotes) to just override the default flags
 #configure=None
 
+# C/C++ standards. These are added to CFLAGS/CXXFLAGS if the environment
+# variable is added or does not contain the text "-std=".
+#
+#c_standard = -std=gnu11
+#cxx_standard = -std=c++11
+
 # GROUP Python module
 #disable_group=True
 #group_location=build/lib/python2.7/site-packages/group.so


### PR DESCRIPTION
# Summary

Building Sherpa now requires a C compiler that supports the gnu11 standard and a C++ compiler that supports the C++11 standard. The build will now add the appropriate arguments to the CFLAGS and CXXFLAGS environment variable unless they already contain "-std=" arguments. The c_standard and cxx_standard options in the setup.cfg file can be used to change the standard. This allows Sherpa to be built with GCC 15.

# Details

Originally this PR changed the extern code to allow it to build with GCC 15, but it turns out you can actually do this with just

    CFLAGS="-std=gnu11" pip install .

Rather than make all users have to set this variable, the build now enforces the standard requirements when building by setting (or adding to) the CFLAGS environment variable, apart from two cases

- the environment variable exists and contains the string "-std="
- the sherpa_config.c_standard setting in setup.cfg is set to the empty string

Since we are at it, we explicitly mark the C++ code as requiring C++11 via the cxx_standard setting.

The aim is to provide enough flexibility to let users work with variant compilers, but still allow the default case to build easily with GCC 15.