### PR TITLE
TEST: fix test that requires region support

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_data.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2025
+#  Copyright (C) 2025, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -24,9 +24,10 @@ from tempfile import NamedTemporaryFile
 
 from sherpa.astro.io.wcs import WCS
 from sherpa.astro import ui
-from sherpa.utils.testing import requires_fits, requires_wcs
+from sherpa.utils.testing import requires_fits, requires_wcs, requires_region
 
 
+@requires_region
 @requires_wcs
 @requires_fits
 def test_DataIMG_filter(caplog, clean_astro_ui):


### PR DESCRIPTION
# Summary

Mark a test a requiring the region library. There is no functional change.

# Details

This was missed in #2388 (as the test also requires WCS and it's not often we build with one and not the other).