### PR TITLE
CI: bump checkout action from 4.1.1 to 6.0.2

### DIFF
--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     #Checkout the code with a depth of 0 to grab the tags/branches as well
     - name: Checkout Code
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -84,7 +84,7 @@ jobs:
 
     #Checkout the code with a depth of 0 to grab the tags/branches as well
     - name: Checkout Code
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         path: sherpa
@@ -172,7 +172,7 @@ jobs:
         sudo tar -C /opt -xf MacOSX11.0.sdk.tar.xz
 
     - name: Checkout Code
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         path: sherpa

--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     #Checkout the code with a depth of 0 to grab the tags/branches as well
     - name: Checkout Code
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6.0.2
       with:
         fetch-depth: 0
 
@@ -84,7 +84,7 @@ jobs:
 
     #Checkout the code with a depth of 0 to grab the tags/branches as well
     - name: Checkout Code
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6.0.2
       with:
         fetch-depth: 0
         path: sherpa
@@ -172,7 +172,7 @@ jobs:
         sudo tar -C /opt -xf MacOSX11.0.sdk.tar.xz
 
     - name: Checkout Code
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6.0.2
       with:
         fetch-depth: 0
         path: sherpa

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -112,7 +112,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6.0.2
       with:
         submodules: 'True'
 

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -112,7 +112,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@v6
       with:
         submodules: 'True'
 

--- a/.github/workflows/ci-pip-arch.yml
+++ b/.github/workflows/ci-pip-arch.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
       # As we do not include an I/O backend it is not worth checking out the data submodule.
       #
       # with:

--- a/.github/workflows/ci-pip-arch.yml
+++ b/.github/workflows/ci-pip-arch.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@v6
       # As we do not include an I/O backend it is not worth checking out the data submodule.
       #
       # with:

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6.0.2
       with:
         submodules: 'True'
 

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@v6
       with:
         submodules: 'True'
 


### PR DESCRIPTION
# Summary

Version 4 of the checkout action uses Node.js 20 which is now deprecated on GitHub, so switch to the latest version of the action.

# Details

Here's the warning from the actions

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4.1.1, codecov/codecov-action@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

This change addresses the `actions/checkout` action only. I decided to pick the latest available version (6.0.2) and we can see whether it works.