### PR TITLE
Correctly document model parameters in some XSPEC models

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -528,7 +528,7 @@ noted as not being supported::
       .. versionadded: ???
          This model requires XSPEC 12.13.0 or later.
 
-      Parameters
+      Attributes
       ----------
       Tmax
       beta

--- a/scripts/add_xspec_model.py
+++ b/scripts/add_xspec_model.py
@@ -98,7 +98,7 @@ def create_xspec_model(version: Version,
     modelname
        XSPEC model name (as given in the model.dat file)
     allow_exists
-       If False then the model can not already exists.
+       If False then the model can not already exist.
 
     """
 

--- a/sherpa/astro/utils/tests/test_astro_utils_xspec.py
+++ b/sherpa/astro/utils/tests/test_astro_utils_xspec.py
@@ -414,7 +414,7 @@ kT      keV     1.    0.008   0.008   64.0      64.0      .01
 class XSapec(XSAdditiveModel):
     """XSPEC AdditiveModel: apec
 
-    Parameters
+    Attributes
     ----------
     kT
     norm
@@ -496,7 +496,7 @@ class XSonlynorm(XSAdditiveModel):
     .. versionadded:: ???
        This model requires XSPEC 9.2.34 or later.
 
-    Parameters
+    Attributes
     ----------
     norm
 
@@ -576,7 +576,7 @@ nH      cm^-3   1.0   1.e-6  1.e-5  1.e19  1.e20   -0.01
 class XSabcd(XSMultiplicativeModel):
     """XSPEC MultiplicativeModel: abcd
 
-    Parameters
+    Attributes
     ----------
     nH
 
@@ -648,7 +648,7 @@ class XSabcd(XSMultiplicativeModel):
     .. versionadded:: ???
        This model requires XSPEC 3.4.0 or later.
 
-    Parameters
+    Attributes
     ----------
     nH
 
@@ -722,7 +722,7 @@ order    " "  -1.   -3.    -3.      -1.       -1.       -1
 class XSrgsxsrc(XSConvolutionKernel):
     """XSPEC ConvolutionKernel: rgsxsrc
 
-    Parameters
+    Attributes
     ----------
     order
 
@@ -797,7 +797,7 @@ class XSrgsxsrc(XSConvolutionKernel):
     .. versionadded:: ???
        This model requires XSPEC 11.0.4 or later.
 
-    Parameters
+    Attributes
     ----------
     order
 
@@ -869,7 +869,7 @@ xs   ""    10    1 2  20 30  0.01
 class XSabcd(XSAdditiveModel):
     """XSPEC AdditiveModel: abcd
 
-    Parameters
+    Attributes
     ----------
     xs
     norm
@@ -944,7 +944,7 @@ xs   ""    10    1 2  20 30  0.01
 class XSabcd(XSAdditiveModel):
     """XSPEC AdditiveModel: abcd
 
-    Parameters
+    Attributes
     ----------
     xs
     norm

--- a/sherpa/astro/utils/xspec.py
+++ b/sherpa/astro/utils/xspec.py
@@ -855,7 +855,11 @@ def simple_wrap(modelname: str,
         out += f'{t1}   This model requires XSPEC ' + \
             f'{internal[0]}.{internal[1]}.{internal[2]} or later.\n\n'
 
-    out += f'{t1}Parameters\n'
+    # These are not parameters to __init__ but attributes, so label
+    # them as such (using Parameters leads to subtly-different output
+    # from sphinx).
+    #
+    out += f'{t1}Attributes\n'
     out += f'{t1}----------\n'
     for par in mdl.pars:
         out += f'{t1}{par.name}\n'
@@ -867,6 +871,9 @@ def simple_wrap(modelname: str,
     if internal is not None:
         # This may not be the correct URL, such as the redshift variant, but
         # but it should be close.
+        #
+        # This code could try to access the URL to note ones where the
+        # name is not right.
         cname = mdl.name.capitalize()
 
         out += '\n'

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -2668,7 +2668,7 @@ class XSbcie(XSAdditiveModel):
     .. versionadded:: 4.16.1
        This model requires XSPEC 12.14.0 or later.
 
-    Parameters
+    Attributes
     ----------
     kT
         The plasma temperature in keV.
@@ -2726,7 +2726,7 @@ class XSbcoolflow(XSAdditiveModel):
     .. versionadded:: 4.16.1
        This model requires XSPEC 12.14.0 or later.
 
-    Parameters
+    Attributes
     ----------
     lowT
         The low temperature in keV.
@@ -2786,7 +2786,7 @@ class XSbcph(XSAdditiveModel):
     .. versionadded:: 4.16.1
        This model requires XSPEC 12.14.0 or later.
 
-    Parameters
+    Attributes
     ----------
     peakT
         The peak temperature in keV.
@@ -2840,7 +2840,7 @@ class XSbequil(XSAdditiveModel):
     .. versionadded:: 4.16.1
        This model requires XSPEC 12.14.0 or later.
 
-    Parameters
+    Attributes
     ----------
     kT
         The temperature in keV.
@@ -4086,7 +4086,7 @@ class XSbvcie(XSAdditiveModel):
     .. versionadded:: 4.16.1
        This model requires XSPEC 12.14.0 or later.
 
-    Parameters
+    Attributes
     ----------
     kT
         The plasma temperature in keV.
@@ -4154,7 +4154,7 @@ class XSbvcoolflow(XSAdditiveModel):
     .. versionadded:: 4.16.1
        This model requires XSPEC 12.14.0 or later.
 
-    Parameters
+    Attributes
     ----------
     lowT
         The low temperature in keV.
@@ -4229,7 +4229,7 @@ class XSbvcph(XSAdditiveModel):
     .. versionadded:: 4.16.1
        This model requires XSPEC 12.14.0 or later.
 
-    Parameters
+    Attributes
     ----------
     peakT
         The peak temperature in keV.
@@ -4298,7 +4298,7 @@ class XSbvequil(XSAdditiveModel):
     .. versionadded:: 4.16.1
        This model requires XSPEC 12.14.0 or later.
 
-    Parameters
+    Attributes
     ----------
     kT
         The temperature in keV.
@@ -5095,7 +5095,7 @@ class XSbvvcie(XSAdditiveModel):
     .. versionadded:: 4.16.1
        This model requires XSPEC 12.14.0 or later.
 
-    Parameters
+    Attributes
     ----------
     kT
         The plasma temperature in keV.
@@ -6760,7 +6760,7 @@ class XScie(XSAdditiveModel):
     .. versionadded:: 4.16.1
        This model requires XSPEC 12.14.0 or later.
 
-    Parameters
+    Attributes
     ----------
     kT
         The plasma temperature in keV.
@@ -8308,7 +8308,7 @@ class XSfeklor(XSAdditiveModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     norm
        The total emission (in photom/cm^2/s) in the line.
@@ -11492,7 +11492,7 @@ class XSvagauss(XSAdditiveModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.14.1 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        The line wavelength in Angstrom.
@@ -11775,7 +11775,7 @@ class XSvcie(XSAdditiveModel):
     .. versionadded:: 4.16.1
        This model requires XSPEC 12.14.0 or later.
 
-    Parameters
+    Attributes
     ----------
     kT
         The plasma temperature in keV.
@@ -12310,7 +12310,7 @@ class XSvlorentz(XSAdditiveModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        Line energy in keV
@@ -13098,7 +13098,7 @@ class XSvvcie(XSAdditiveModel):
     .. versionadded:: 4.16.1
        This model requires XSPEC 12.14.0 or later.
 
-    Parameters
+    Attributes
     ----------
     kT
         The plasma temperature in keV.
@@ -13541,7 +13541,7 @@ class XSvvoigt(XSAdditiveModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        Line energy in keV.
@@ -14351,7 +14351,7 @@ class XSzfeklor(XSAdditiveModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     Redshift
     norm
@@ -14551,7 +14551,7 @@ class XSzlorentz(XSAdditiveModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
         The line energy, in keV.
@@ -14633,7 +14633,7 @@ class XSzvagauss(XSAdditiveModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.14.1 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        The line wavelength in Angstrom.
@@ -14724,7 +14724,7 @@ class XSzvlorentz(XSAdditiveModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        Line energy in keV
@@ -14771,7 +14771,7 @@ class XSzvoigt(XSAdditiveModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        The line energy, in keV.
@@ -14821,7 +14821,7 @@ class XSzvvoigt(XSAdditiveModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        Line energy in keV.
@@ -15561,7 +15561,7 @@ class XSlorabs(XSMultiplicativeModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        The line energy in keV.
@@ -16567,7 +16567,7 @@ class XSvgabs(XSMultiplicativeModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.14.1 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        The line energy in keV.
@@ -16614,7 +16614,7 @@ class XSvlorabs(XSMultiplicativeModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        The line energy in keV.
@@ -16654,7 +16654,7 @@ class XSvoigtabs(XSMultiplicativeModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        The line energy in keV.
@@ -16754,7 +16754,7 @@ class XSvvoigtabs(XSMultiplicativeModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        The line energy in keV.
@@ -17088,7 +17088,7 @@ class XSzgabs(XSMultiplicativeModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.14.1 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        The line energy in keV.
@@ -17138,7 +17138,7 @@ class XSzvgabs(XSMultiplicativeModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.14.1 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        The line energy in keV.
@@ -17262,7 +17262,7 @@ class XSzlorabs(XSMultiplicativeModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        The line energy in keV.
@@ -17380,7 +17380,7 @@ class XSzvlorabs(XSMultiplicativeModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        The line energy in keV.
@@ -17427,7 +17427,7 @@ class XSzvoigtabs(XSMultiplicativeModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        The line energy in keV.
@@ -17478,7 +17478,7 @@ class XSzvvoigtabs(XSMultiplicativeModel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     LineE
        The line energy in keV.
@@ -18802,7 +18802,7 @@ class XSrgsext(XSConvolutionKernel):
     .. versionadded:: 4.17.1
        This model requires XSPEC 12.15.0 or later.
 
-    Parameters
+    Attributes
     ----------
     order
         The order, which must be -1 to -3 inclusive.


### PR DESCRIPTION
# Summary

Correctly label some XSPEC model parameters in the documentation. This changes how the model parameters are displayed in the sphinx/read-the-docs documentation. There is no functional change to the code.

# Details

This was found when updating the code to support XSPEC 12.15.1 in #2393 but it is independent of that work so can be taken now.

The basic change is that some XSPEC models reference model parameter names (which are field names, hence "Attributes" in the terminology of sphinx/docstrings) were being described as "Parameters" (which is meant to be values used when calling the class initiializer, which is definitely not is done here). So

a) change the docstrings where necessary
b) change the code used to autogenerate this (for new models)
c) change the tests for part b

# Examples

Here's the `XSvgabs` read-the-docs page in 4.18.0: https://sherpa.readthedocs.io/en/4.18.0/model_classes/api/sherpa.astro.xspec.XSvgabs.html#xsvgabs

and with this PR: https://sherpa--2439.org.readthedocs.build/en/2439/model_classes/api/sherpa.astro.xspec.XSvgabs.html#xsvgabs

The information is the same but the presentation is slightly different.