### PR TITLE
Update the typing statements for the top-level sherpa module

### DIFF
--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2014-2016, 2019-2025
+#  Copyright (C) 2007, 2014-2016, 2019-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -40,7 +40,7 @@ import os
 import os.path
 import subprocess
 import sys
-from typing import Any, Optional
+from typing import Any
 
 from . import _version
 __version__ = _version.get_versions()['version']
@@ -178,7 +178,7 @@ def _make_citation(version: str,
     return out
 
 
-def _get_citation_hardcoded(version: str) -> Optional[str]:
+def _get_citation_hardcoded(version: str) -> str | None:
     """Retrieve the citation information.
 
     Parameters
@@ -871,7 +871,7 @@ def get_config() -> str:
 
 def smoke(verbosity: int = 0,
           require_failure: bool = False,
-          fits: Optional[str] = None,
+          fits: str | None = None,
           xspec: bool = False,
           ds9: bool = False) -> None:
     """Run Sherpa's "smoke" test.


### PR DESCRIPTION
# Summary

Update the typing statements in the top-level sherpa code to use more-modern idioms. There is no functional change.

# Details

Replace "Optional[str]" with "str | None". This was originally in #2403 but it is completely separate from those changes.