### PR TITLE
Simplify and remove internal routines in sherpa/utils

### DIFF
--- a/sherpa/astro/models/__init__.py
+++ b/sherpa/astro/models/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #
-#  Copyright (C) 2007, 2016, 2018-2019, 2021-2025
+#  Copyright (C) 2007, 2016, 2018-2019, 2021-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -29,7 +29,7 @@ from sherpa.models.model import (ArithmeticModel,
                                  )
 
 from sherpa.astro.utils import apply_pileup
-from sherpa.utils import bool_cast, lgam
+from sherpa.utils import lgam
 from sherpa.utils.err import ModelErr
 from sherpa.utils.guess import _guess_ampl_scale, get_fwhm, \
     get_peak, get_position, guess_amplitude, guess_amplitude2d, \

--- a/sherpa/estmethods/__init__.py
+++ b/sherpa/estmethods/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2019-2021, 2023-2025
+#  Copyright (C) 2007, 2015, 2016, 2019-2021, 2023-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -20,7 +20,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 import logging
 from typing import Any, Protocol, SupportsFloat, TypeVar
@@ -32,7 +32,7 @@ from numpy.linalg import LinAlgError
 from sherpa.stats import StatCallback
 from sherpa.utils import NoNewAttributesAfterInit, \
     FuncCounter, OutOfBoundErr, Knuth_close, \
-    print_fields, is_iterable, list_to_open_interval, quad_coef, \
+    print_fields, list_to_open_interval, quad_coef, \
     demuller, zeroin
 from sherpa.utils.parallel import SupportsLock, SupportsProcess, \
     SupportsQueue, multi, ncpus, context, process_tasks
@@ -1157,7 +1157,7 @@ def c_get_delta_root(arg, dir, par_at_min):
 
     my_neg_pos = ConfBracket.neg_pos[dir]
 
-    if is_iterable(arg):
+    if isinstance(arg, Iterable):
         # return map( lambda x: my_neg_pos * abs( x - par_at_min ), arg )
         return arg
 
@@ -1217,7 +1217,7 @@ def c_print_status(myblog,
 
     msg = f"{p}\t"
 
-    if is_iterable(answer):
+    if isinstance(answer, Iterable):
         msg += list_to_open_interval(answer)
     elif answer is None:
         msg += '-----'

--- a/sherpa/fit.py
+++ b/sherpa/fit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2015, 2016, 2018-2025
+#  Copyright (C) 2009, 2015, 2016, 2018-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -20,7 +20,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from contextlib import nullcontext
 from functools import wraps
 import logging
@@ -39,7 +39,7 @@ from sherpa.optmethods import OptMethod, LevMar, NelderMead
 from sherpa.stats import Stat, Chi2, Chi2Gehrels, Cash, Chi2ModVar, \
     LeastSq, Likelihood
 from sherpa.utils import NoNewAttributesAfterInit, print_fields, erf, \
-    bool_cast, is_iterable, list_to_open_interval, sao_fcmp, formatting
+    bool_cast, list_to_open_interval, sao_fcmp, formatting
 from sherpa.utils.err import DataErr, EstErr, FitErr, SherpaErr
 from sherpa.utils.types import ArrayType, FitFunc, IdType, IdTypes, \
     OptReturn, StatFunc, StatResults
@@ -406,6 +406,11 @@ class FitResults(NoNewAttributesAfterInit):
             out.append(self.param_warnings)
 
         return "\n".join(out)
+
+
+def is_iterable(val: Any) -> bool:
+    """Can we iterate over this item?"""
+    return isinstance(val, Iterable)
 
 
 class ErrorEstResults(NoNewAttributesAfterInit):

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2015, 2016, 2018-2025
+#  Copyright (C) 2009, 2015, 2016, 2018-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -67,7 +67,7 @@ and then ends the session.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from configparser import ConfigParser
 import contextlib
 import copy
@@ -85,8 +85,7 @@ from sherpa.optmethods import LevMar, NelderMead
 from sherpa.plot.backends import BaseBackend, BasicBackend, PLOT_BACKENDS
 from sherpa.stats import Stat, Likelihood, LeastSq, Chi2XspecVar
 from sherpa.utils import NoNewAttributesAfterInit, erf, \
-    bool_cast, parallel_map, dataspace1d, histogram1d, get_error_estimates, \
-    is_iterable_not_str
+    bool_cast, parallel_map, dataspace1d, histogram1d, get_error_estimates
 from sherpa.utils.err import ArgumentTypeErr, ConfidenceErr, \
     IdentifierErr, PlotErr, StatErr
 from sherpa.utils.numeric_types import SherpaFloat
@@ -3956,7 +3955,7 @@ def get_per_plot_kwargs(nplots: int,
     ## kwstore: list[dict[str, Any]]
     kwstore = [{} for _ in range(nplots)]
     for key, val in kwargs.items():
-        if is_iterable_not_str(val):
+        if not isinstance(val, str) and isinstance(val, Iterable):
             nval = len(val)
             if nval != nplots:
                 raise ValueError(f"keyword '{key}': expected "

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015-2025
+#  Copyright (C) 2010, 2015-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -20,7 +20,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from configparser import ConfigParser
 import copy
 import copyreg as copy_reg
@@ -69,7 +69,7 @@ import sherpa.stats
 from sherpa.stats import Stat, UserStat
 import sherpa.utils
 from sherpa.utils import NoNewAttributesAfterInit, is_subclass, \
-    is_iterable_not_str, export_method, send_to_pager
+    export_method, send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, \
     DataErr, IdentifierErr, IOErr, ModelErr, ParameterErr, PlotErr, \
     SessionErr
@@ -2162,7 +2162,7 @@ class Session(NoNewAttributesAfterInit):
         # - 1 to [1]
         # - ["foo", 2] is not changed.
         #
-        if is_iterable_not_str(idvals):
+        if not isinstance(idvals, str) and isinstance(idvals, Iterable):
             out = [self._fix_id(idval) for idval in idvals]
             if len(out) == 0:
                 raise ArgumentErr("id list is empty")
@@ -14203,7 +14203,9 @@ class Session(NoNewAttributesAfterInit):
             # heuristics may need updating in the future.
             #
             if getargs and allow_multiple_ids and \
-               is_iterable_not_str(getargs[0]):
+               not isinstance(getargs[0], str) and \
+               isinstance(getargs[0], Iterable):
+
                 def getid(id, recalc=True):
                     return getfunc(id, *getargs[1:], recalc=True)
 

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -2631,10 +2631,6 @@ def func_counter(func):
     return nfev, func_counter_wrapper
 
 
-def is_sequence(start, mid, end) -> bool:
-    return start < mid < end
-
-
 def Knuth_close(x, y, tol, myop=operator.__or__) -> bool:
     """Check whether two floating-point numbers are close together.
 
@@ -3343,7 +3339,7 @@ def apache_muller(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
             else:
                 xminus = 1.0e128
 
-            if is_sequence(xa, xplus, xb):
+            if xa < xplus < xb:
                 x = xplus
             else:
                 x = xminus
@@ -3356,7 +3352,7 @@ def apache_muller(fcn, xa, xb, fa=None, fb=None, args=(), maxfev=32,
             # print
 
             # sanity check
-            if not is_sequence(xa, x, xb):
+            if not (xa < x < xb):
                 x = (xa + xb) / 2.0
 
             y = myfcn(x, *args)

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2018-2025
+#  Copyright (C) 2007, 2015, 2016, 2018-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -100,7 +100,7 @@ T = TypeVar("T")
 # This logic was found in several modules so centralize it. Note that
 # this is not added to __all__.
 #
-def is_subclass(t1, t2):
+def is_subclass(t1, t2) -> bool:
     """Is t2 a subclass of t1 but not the same as t1?"""
     return inspect.isclass(t1) and issubclass(t1, t2) and (t1 is not t2)
 
@@ -1073,20 +1073,25 @@ def filter_bins(mins: Sequence[float | None],
     return mask
 
 
-def bool_cast(val):
-    """Convert a string to a boolean.
+# Sherpa has used bool_cast to deal with boolean conversion, and this
+# was to handle users of "old" Sherpa, and users of the S-Lang version
+# of Sherpa.
+#
+def bool_cast(val: Any) -> bool:
+    """Convert a scalar value to a boolean.
+
+    .. versionchanged:: 4.18.1
+       The input value must be a scalar. The support for converting an
+       array of values has been removed.
 
     Parameters
     ----------
-    val : bool, str or sequence
+    val : bool, str
        The input value to decode.
 
     Returns
     -------
-    flag : bool or ndarray
-       True or False if val is considered to be a true or false term.
-       If val is a sequence then the return value is an ndarray of
-       the same size.
+    flag : bool
 
     Notes
     -----
@@ -1099,10 +1104,7 @@ def bool_cast(val):
 
     """
 
-    if type(val) in (tuple, list, np.ndarray):
-        return np.asarray([bool_cast(item) for item in val], bool)
-
-    if type(val) == str:
+    if isinstance(val, str):
         # since built in bool() only returns false for empty strings
         vlo = val.lower()
         if vlo in ('false', 'off', 'no', '0', 'f', 'n'):
@@ -1111,6 +1113,12 @@ def bool_cast(val):
         if vlo in ('true', 'on', 'yes', '1', 't', 'y'):
             return True
 
+        raise TypeError(f"unknown boolean value: '{val}'")
+
+    # As bool([1, 2, 3]) is True (False if empty) protect against
+    # accidentally converting some form of a sequence.
+    #
+    if isinstance(val, Iterable):
         raise TypeError(f"unknown boolean value: '{val}'")
 
     # use built in bool cast
@@ -2642,16 +2650,6 @@ def is_in(arg, seq):
     return False
 
 
-def is_iterable(arg) -> bool:
-    return isinstance(arg, (list, tuple, np.ndarray)) or np.iterable(arg)
-
-
-def is_iterable_not_str(arg: Any) -> bool:
-    """It is iterable but not a string."""
-
-    return not isinstance(arg, str) and isinstance(arg, Iterable)
-
-
 def is_sequence(start, mid, end) -> bool:
     return start < mid < end
 
@@ -3649,8 +3647,7 @@ def send_to_pager(txt: str,
         return
 
     # Assume a filename
-    clobber = bool_cast(clobber)
-    if os.path.isfile(filename) and not clobber:
+    if os.path.isfile(filename) and not bool_cast(clobber):
         raise IOErr('filefound', filename)
 
     with open(filename, 'w', encoding="UTF-8") as fh:

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -2631,25 +2631,6 @@ def func_counter(func):
     return nfev, func_counter_wrapper
 
 
-def is_in(arg, seq):
-    """DEPRECATED.
-
-    .. deprecated:: 4.17.0
-       Use the Python `in` operator instead.
-
-    """
-    # This is FutureWarning rather than DeprecationWarning to make
-    # sure users see the message.
-    #
-    warnings.warn("is_in is deprecated in 4.17.0: use Python's in instead",
-                  FutureWarning)
-    for x in seq:
-        if arg == x:
-            return True
-
-    return False
-
-
 def is_sequence(start, mid, end) -> bool:
     return start < mid < end
 

--- a/sherpa/utils/tests/test_utils_unit.py
+++ b/sherpa/utils/tests/test_utils_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018 - 2024
+#  Copyright (C) 2016, 2018-2024, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -557,18 +557,16 @@ def test_interpolate_sent_a_callable():
         interpolate([1.5, 2.5], [1, 2, 3], [2, 4, 3], function=True)
 
 
-@pytest.mark.parametrize("arg,badval",
-                         [("truthy", None),
-                          ("falsey", None),
-                          ("ya", None),
-                          ("nah", None),
-                          ("2", None),
-                          ([1, 0, "1", "0", "bob"], "bob")])
-def test_bool_cast_invalid(arg, badval):
+@pytest.mark.parametrize("arg",
+                         ["truthy", "falsey", "ya", "nah", "2", [], [1, 0]])
+def test_bool_cast_invalid(arg):
     """Check error handling"""
 
-    emsg = arg if badval is None else badval
-    with pytest.raises(TypeError, match=f"^unknown boolean value: '{emsg}'$"):
+    # Since the error message for the arrays would include [], the
+    # need to protect them in the regexp complicates the check, so do
+    # not test the full string.
+    #
+    with pytest.raises(TypeError, match=f"^unknown boolean value: '"):
         bool_cast(arg)
 
 


### PR DESCRIPTION
# Summary

Simplify and remove internal routines in sherpa/utils.

# Details

The main aim is to simplify the bool_cast routine so that it no-longer supports being sent an iterable (i.e. a sequence of boolean-like values). This functionality was only used in tests and so was not needed, as well as making typing statements harder to understand.

This work was part of #2415 and in an initial review @hamogu requested a clean up of several internal routines in sherpa/utils - that is, routines not exposed via the `__all__` sequence. The point made by @hamogu was that these routines do not provide any value as

a) their re-use is limited
b) it is just-as-easy to understand the code if the actual code is used in-line rather than call a separate function
c) it avoids the need for some TypeGuard statements which were added in #2415

So we remove these routines: `is_iterable` and `is_iterable_not_str`.

I then noticed that I'd labelled another internal routine as deprecated in 4.17.0, so remove it now (this is shorter than the standard Python deprecation cycle, but this is an internal routine and easy to replace). We could argue that `is_iterable***` should be labelled as deprecated, but I am not convinced that it's worth it here.

In checking these, I noticed that the `is_sequence` routine is only used in two places, and is a case where it's at-least as easy to understand when inlined rather than as a separate routine. So we remove it.