### PR TITLE
CI: use pyproject test dependencies

### DIFF
--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -102,12 +102,12 @@ jobs:
     - name: Build Sherpa (install)
       if: matrix.install-type == 'install'
       run: |
-        pip install . --verbose
+        pip install .[test] --verbose
 
     - name: Build Sherpa (develop)
       if: matrix.install-type == 'develop'
       run: |
-        pip install -e . --verbose
+        pip install -e .[test] --verbose
 
     # This isn't always going to be used, but it is easiest to
     # always create it.
@@ -150,8 +150,6 @@ jobs:
     - name: Submodule test with pytest
       if: matrix.test-data == 'submodule'
       run: |
-        pip install -r test_requirements.txt
-        pip install pytest-cov
         cd $HOME
         pytest --cov=sherpa --cov-report=xml:${{ github.workspace }}/coverage.xml
 


### PR DESCRIPTION
# Summary

Internal change to the pip CI runs to use the pyproject test optional dependency table rather than rely on test_requirements.txt. There is no functional change.

# Details

This better matches the conda workflow, i.e. installing test dependencies via the project.optional-dependencies.test entry in pyproject.toml rather than rely on this information being repeated (in this case in test_requirements.txt).

Now, before the `pip install {-e} .[test]` line we do manually `pip install pytest-xvdb pytest-cov`, so most of the benefits of using the `test` "table" to install software is "lost", but this does remove having to worry about the `test_requirements.txt` file: should we remove it?

This was originally developed as part of #2393 as I tried to work out why the CI runs were failing (which ended up being due to a number of changes unrelated to neither the XSPEC code or how `pytest` was installed).