### PR TITLE
Simplify the XSPEC tests to not require a particular ATOMDB version

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_ui_unit.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_unit.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017, 2018, 2020 - 2025
+#  Copyright (C) 2017-2018, 2020-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -3219,8 +3219,11 @@ def test_guess_with_response_and_multiple_models(idval, clean_astro_ui, caplog, 
         ui.notice(lo=0.3, hi=6)
         ui.subtract(id=idval)
 
+    # Pick "simple" models that should not depend on things like the
+    # ATOMDB version.
+    #
     cpt1 = ui.create_model_component("xsphabs", "gal")
-    cpt2 = ui.create_model_component("xsapec", "src1")
+    cpt2 = ui.create_model_component("xspowerlaw", "src1")
     cpt3 = ui.create_model_component("xsgaussian", "src2")
     ui.set_model(id=idval, model=cpt1 * (cpt2 + cpt3))
 
@@ -3245,7 +3248,7 @@ def test_guess_with_response_and_multiple_models(idval, clean_astro_ui, caplog, 
     assert cpt1.nH.min == pytest.approx(0)
     assert cpt1.nH.max == pytest.approx(1e6)
 
-    expected = 3.539017671368409
+    expected = 2.293144719701809
     assert cpt2.norm.val == pytest.approx(expected / 1000)
     assert cpt2.norm.min == pytest.approx(expected / 1000 / 1000)
     assert cpt2.norm.max == pytest.approx(expected)

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015, 2016, 2018-2021, 2023-2025
+#  Copyright (C) 2015, 2016, 2018-2021, 2023-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -691,9 +691,6 @@ set_xschatter(0)
 set_xsabund("lodd")
 set_xscosmo(72, 0.02, 0.71)
 set_xsxsect("vern")
-set_xsxset("APECROOT", "3.0.9")
-set_xsxset("NEIAPECROOT", "3.0.9")
-set_xsxset("NEIVERS", "3.0.4")
 """
 
 _canonical_pha_load_bkg = """import numpy
@@ -2543,9 +2540,6 @@ set_xschatter(0)
 set_xsabund("angr")
 set_xscosmo(70, 0, 0.73)
 set_xsxsect("bcmc")
-set_xsxset("APECROOT", "3.0.9")
-set_xsxset("NEIAPECROOT", "3.0.9")
-set_xsxset("NEIVERS", "3.0.4")
 """
 
     _canonical_pha_basic += _canonical_extra

--- a/sherpa/conftest.py
+++ b/sherpa/conftest.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016-2025
+#  Copyright (C) 2016-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -34,7 +34,6 @@ except ImportError:
 
 import pytest
 
-from sherpa.utils.err import RuntimeErr
 from sherpa.utils.testing import get_datadir, set_datadir
 
 try:
@@ -843,25 +842,6 @@ def xsmodel():
         return cls(mname)
 
     return func
-
-
-@pytest.fixture(scope="session", autouse=True)
-def set_xspec_atomdb_version():
-    """Ensure the AtomDB abundance is 3.0.9 if XSPEC is enabled."""
-
-    if not has_xspec:
-        return
-
-    # XSPEC 12.15.0 switches the AtomDB version from 3.0.9 to 3.1.2
-    # and this can cause tests to fail. The tolerances could be
-    # changed but instead try setting the AtomDB
-    # version. Unfortunately the current interface is rather limited
-    # (see #2216), so this is done globally. Eventually this will
-    # (hopefully) be removed, or the settings updated.
-    #
-    xspec.set_xsxset("APECROOT", "3.0.9")
-    xspec.set_xsxset("NEIAPECROOT", "3.0.9")
-    xspec.set_xsxset("NEIVERS", "3.0.4")
 
 
 # Fixtures that control access to the tests, based on the availability


### PR DESCRIPTION
# Summary

Avoid requiring certain ATOMDB/NEI versions for the XSPEC tests. There is no functional change.

# Details

This is essentially a rework of #2398 by @nplee 

XSPEC 12.15.0 support - added in #2252 - needed to handle changes in ATOMDB version. However, with XSPEC 12.15.1 it has become obvious that the technique used (which was to force a particular set of versions) isn't going to work when we support multiple XSPEC versions (as the set of available ATOMDB models is currently updating rapidly, and so the set of data files included with XSPEC keeps on changing [*]).

So, remove this feature after changing tests that appear to be sensitive to the setting (these are tests which I chose to use an apec model but we can use  a simpler model such as powerlaw which doesn't depend on these data files).

The serialize tests  need updating (to remove the changes made in #2398). There are changes needed to support XSPEC 12.15.1, but they can be done in #2393

---

[*] not to mention the difference between the data provided in a source distribution to that in the XSPEC conda channel
