### PR TITLE
BUILD: use the conda fftw package

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -161,6 +161,19 @@ jobs:
         conda activate build
         source .github/scripts/setup_xspec.sh
 
+    # Install FFTW3 rather than build it ourselves (but not for XSPEC
+    # builds as that uses the XSPEC version).
+    #
+    - name: Install FFTW (no XSPEC)
+      if: matrix.xspec-version == ''
+      run: |
+        source ${conda_loc}/etc/profile.d/conda.sh
+        conda install fftw
+        sed -i="" "s|#fftw=local|fftw=local|" setup.cfg
+        sed -i="" "s|#fftw_include_dirs=build/include|fftw_include_dirs=${CONDA_PREFIX}/include|" setup.cfg
+        sed -i="" "s|#fftw_lib_dirs=build/lib|fftw_lib_dirs=${CONDA_PREFIX}/lib|" setup.cfg
+        sed -i="" "s|#fftw_libraries=fftw3|fftw_libraries=fftw3|" setup.cfg
+
     - name: Build Sherpa (install)
       if: matrix.install-type == 'install'
       env:

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -168,7 +168,11 @@ jobs:
       if: matrix.xspec-version == ''
       run: |
         source ${conda_loc}/etc/profile.d/conda.sh
+        conda activate build
         conda install fftw
+        echo "*** [${CONDA_PREFIX}]"
+        conda list fftw
+        echo "***"
         sed -i="" "s|#fftw=local|fftw=local|" setup.cfg
         sed -i="" "s|#fftw_include_dirs=build/include|fftw_include_dirs=${CONDA_PREFIX}/include|" setup.cfg
         sed -i="" "s|#fftw_lib_dirs=build/lib|fftw_lib_dirs=${CONDA_PREFIX}/lib|" setup.cfg

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -173,6 +173,9 @@ jobs:
         sed -i="" "s|#fftw_include_dirs=build/include|fftw_include_dirs=${CONDA_PREFIX}/include|" setup.cfg
         sed -i="" "s|#fftw_lib_dirs=build/lib|fftw_lib_dirs=${CONDA_PREFIX}/lib|" setup.cfg
         sed -i="" "s|#fftw_libraries=fftw3|fftw_libraries=fftw3|" setup.cfg
+        echo "*** setup.cfg (start)"
+        git diff setup.cfg
+        echo "*** setup.cfg (end)"
 
     - name: Build Sherpa (install)
       if: matrix.install-type == 'install'

--- a/pytest.ini
+++ b/pytest.ini
@@ -60,28 +60,29 @@ doctest_norecursedirs =
     sherpa/ui
     sherpa/utils
 
+# Some pages need an I/O library, but there is no way to specify
+# "astropy or pycrates", so pick astropy as the more-generic version.
+#
 doctest_subpackage_requires =
+    sherpa/astro/data.py = astropy
     sherpa/astro/io/crates_backend.py = pycrates
     sherpa/astro/io/pyfits_backend.py = astropy
+    sherpa/optmethods/optscipy.py = scipy
+    sherpa/optmethods/optoptimagic.py = optimagic
     sherpa/plot/pylab_backend.py = matplotlib
     sherpa/plot/pylab_area_backend.py = matplotlib
     sherpa/plot/__init__.py = matplotlib
     sherpa/plot/bokeh_backend.py = bokeh
-    sherpa/optmethods/optscipy.py = scipy
-    sherpa/optmethods/optoptimagic.py = optimagic
-    docs/evaluation/simulate.rst = matplotlib astropy
-    docs/mcmc/index.rst = matplotlib
+    docs/evaluation/* = matplotlib
+    docs/evaluation/examples.rst = astropy group sherpa.astro.xspec._xspec
+    docs/evaluation/simulate.rst = astropy group
+    docs/fit/* = matplotlib
+    docs/fit/poisson.rst = astropy group
+    docs/mcmc/index.rst = arviz matplotlib
+    docs/models/index.rst = matplotlib
     docs/model_classes/usermodel.rst = matplotlib
     docs/plots/* = matplotlib
-    docs/ui/index.rst = matplotlib
-    docs/models/index.rst = matplotlib
-    docs/quick.rst = matplotlib
-    docs/evaluation/* = matplotlib
-    docs/mcmc/index.rst = arviz
     docs/plots/backends.rst = matplotlib bokeh
     docs/plots/bokeh_backend.rst = bokeh
-    docs/evaluation/examples.rst = group sherpa.astro.xspec._xspec
-    # pycrates OR astropy would do, but the syntax does not allow to specify alternatives, so just pick one
-    docs/evaluation/examples.rst = astropy
-    docs/fit/poisson.rst = group
-    sherpa/astro/data.py = astropy
+    docs/quick.rst = matplotlib
+    docs/ui/index.rst = matplotlib


### PR DESCRIPTION
# Summary

Use the conda fftw package rather than build it from extern/ for the conda CI runs. There is no functional change.

# Details

Does this make things faster?
