### PR TITLE
Track filenames on load  WIP

### DIFF
--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -186,7 +186,7 @@ def _save_entries(out: OutType,
     store
        A container with keys. The elements of the container are
        passed to tostatement to create the string that is then
-       written to fh.
+       saved in out.
     tostatement : func
        A function which accepts two arguments, the key and value
        from store, and returns a string. The reason for the name
@@ -374,9 +374,6 @@ def _save_pha_grouping(out: OutType,
     bid
        If not ``None`` then this indicates that the background dataset
        is to be used.
-    fh : None or file-like
-       If ``None``, the information is printed to standard output,
-       otherwise the information is added to the file handle.
     """
 
     _save_pha_array(out, state, pha, "grouping", id, bid=bid)
@@ -1718,10 +1715,10 @@ def save_all(state: SessionType,
 
     _save_id(out, state)
 
-    if fh is None:
-        fh = sys.stdout
+    outfh = sys.stdout if fh is None else fh
 
-    write = lambda msg: fh.write(f"{msg}\n")
+    def write(msg: str) -> None:
+        outfh.write(f"{msg}\n")
 
     # Hard code the required imports.
     #

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -891,7 +891,10 @@ def _save_fit_method(out: OutType, state: SessionType) -> None:
         # return 'set_method_opt("{}", {})'.format(key, val)
         return 'set_method_opt("%s", %s)' % (key, val)
 
-    _save_entries(out, state.get_method_opt(), tostatement)
+    _save_entries(out,
+                  # state.get_method_opt(),  # all values
+                  state._current_method_changed,  # changed values only
+                  tostatement)
     _output_nl(out)
 
 
@@ -921,7 +924,10 @@ def _save_iter_method(out: OutType, state: SessionType) -> None:
         # so it makes no difference.
         return f'set_iter_method_opt("{key}", {val})'
 
-    _save_entries(out, state.get_iter_method_opt(), tostatement)
+    _save_entries(out,
+                  # state.get_iter_method_opt(),  # all values
+                  state._current_itermethod_changed,  # changed values only
+                  tostatement)
     _output_nl(out)
 
 

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -42,8 +42,9 @@ from sherpa.astro import io
 from sherpa.astro.io.wcs import WCS
 
 from sherpa.data import Data, Data1D, Data1DInt, Data2D, Data2DInt
+from sherpa.instrument import ConvolutionKernel, PSFModel
 from sherpa.models import Model
-from sherpa.models.basic import UserModel
+from sherpa.models.basic import TableModel, TableModelBase, UserModel
 from sherpa.models.parameter import Parameter
 from sherpa.utils.types import IdType
 
@@ -1023,21 +1024,21 @@ def _handle_model(out: OutType,
 
     """
 
-    typename = mod.type
     modelname = _get_cpt_name(mod)
     found_xspec = False
-    if typename == "usermodel":
+    if isinstance(mod, UserModel):
         _handle_usermodel(out, mod, modelname)
 
-    elif typename == "psfmodel":
+    elif isinstance(mod, PSFModel):
         cmd = f'load_psf("{mod._name}", "{mod.kernel.name}")'
         _output(out, cmd)
 
-    elif typename in ["fixedtablemodel", "interpolatedtablemodel1d"]:
+    elif isinstance(mod, (TableModel, TableModelBase)):
+        # Use of TableModel is deprecated.
         cmd = f'load_table_model("{modelname}", "{mod.filename}")'
         _output(out, cmd)
 
-    elif typename == "xstablemodel":
+    elif xspec is not None and isinstance(mod, xspec.XSTableModel):
         cmd = f'load_xstable_model("{modelname}", "{mod.filename}"'
         if mod.etable:
             cmd += ', etable=True'
@@ -1048,21 +1049,20 @@ def _handle_model(out: OutType,
 
     else:
         # Normal case:  create an instance of the model.
-        cmd = f'create_model_component("{typename}", "{modelname}")'
+        cmd = f'create_model_component("{mod.type}", "{modelname}")'
         _output(out, cmd)
 
-        # Is this an XSPEC model? We only care if it's the first
-        # one we find.
+        # Is this an XSPEC model?
         #
-        if not found_xspec and xspec is not None:
-            found_xspec = isinstance(mod, xspec.XSModel)
+        if xspec is not None:
+            found_xspec |= isinstance(mod, xspec.XSModel)
 
     # QUS: should this be included in the above checks?
     #      @DougBurke doesn't think so, as the "normal
     #      case" above should probably be run , but there's
     #      no checks to verify this.
     #
-    if typename == "convolutionkernel":
+    if isinstance(mod, ConvolutionKernel):
         # Create general convolution kernel with load_conv
         cmd = f'load_conv("{modelname}", "{mod.kernel.name}")'
         _output(out, cmd)

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -23,13 +23,41 @@
 This module is used by ``sherpa.astro.ui.utils`` and is not
 intended for public use. The API and semantics of the
 routines in this module are subject to change.
+
+The aim is that each load_xxx call from the
+sherpa.astro.ui.utils.Session object will fill a "FileStore"
+dictionary which will indicate what the call was (so it can be
+re-created). The FileStore dataclass is a simple way to store this
+information.
+
+There are three issues that complicate this:
+
+1) For non-PHA datasets we can just index on the "idval" argument,
+   but PHA files also add in responses and backrounds (which also
+   use the IdType as an index). This means that there are some
+   cases where we have multiple levels of access.
+
+2) PHA responses can be automatically loaded (using the ANCRFILE,
+   BACKFILE, and RESPFILE keywords)
+
+   These are indicated by storing a None rather than a FileStore
+   object.
+
+3) PHA2 files can load in multiple datasets with a single call
+   (and the id argument may not match the values associated
+   with the dataset). So we need a way to associate those datasets
+   read in from a single call, as well as knowing when they have
+   been deleted.
+
 """
 
 from collections.abc import Callable, Mapping
 from contextlib import suppress
+import copy
+from dataclasses import KW_ONLY, dataclass
 import inspect
 import logging
-import os
+from pathlib import Path
 import sys
 import textwrap
 from types import ModuleType
@@ -38,7 +66,6 @@ from typing import TYPE_CHECKING, Any, TextIO, TypedDict
 import numpy
 
 from sherpa.astro.data import DataIMG, DataPHA, DataARF, DataRMF
-from sherpa.astro import io
 from sherpa.astro.io.wcs import WCS
 
 from sherpa.data import Data, Data1D, Data1DInt, Data2D, Data2DInt
@@ -46,6 +73,7 @@ from sherpa.instrument import ConvolutionKernel, PSFModel
 from sherpa.models import Model
 from sherpa.models.basic import TableModel, TableModelBase, UserModel
 from sherpa.models.parameter import Parameter
+from sherpa.utils import get_keyword_defaults
 from sherpa.utils.types import IdType
 
 if TYPE_CHECKING:
@@ -93,8 +121,685 @@ else:
 ParameterType = Any
 
 
-def _output(out: OutType, msg: str, indent: int = 0) -> None:
-    """Output the line"""
+def _id_to_str(id: IdType) -> str:
+    """Convert a data set identifier to a string value.
+
+    Parameters
+    ----------
+    id : int or str
+       The data set identifier.
+
+    Returns
+    -------
+    out : str
+       A string representation of the identifier for use
+       in the Python serialization.
+    """
+
+    if isinstance(id, string_types):
+        return f'"{id}"'
+
+    return str(id)
+
+
+def showval(v: Any) -> str:
+    """How to display a "value" for a function call."""
+
+    # Special case certain values.
+    # Is this check too generic?
+    #
+    try:
+        return v.__name__
+    except AttributeError:
+        pass
+
+    if isinstance(v, str):
+        return f'"{v}"'
+
+    # Should there be some attempt to replace 'np.int64(0)' by '0'?
+    return str(v)
+
+
+def remove_default_args(func: Callable,
+                        kwargs: Mapping[str, Any]
+                        ) -> dict[str, Any]:
+    """Remove elements from kwargs that match the defaults for func."""
+
+    out = {}
+    defaults = get_keyword_defaults(func)
+    for k, v in kwargs.items():
+        try:
+            if v == defaults[k]:
+                continue
+        except KeyError:
+            # The function may have **kwargs in its signature, so we
+            # want to just pass those on.
+            pass
+
+        out[k] = v
+
+    return out
+
+
+@dataclass
+class FileStore:
+    """Record how a dataset was read in."""
+
+    loadfunc: Callable
+    """The function to load the data."""
+
+    idval: IdType
+    """The dataset identifier."""
+
+    filename: Path
+    """The location of the file.
+
+    This is assumed to contain the full path to the file.
+    """
+
+    _: KW_ONLY
+
+    # For now we only need to store keyword arguments.
+    #
+    kwargs: Mapping[str, Any]
+    """Named arguments used to read in the file."""
+
+    autoloaded: bool = False
+    """Was the file auto-loaded?"""
+
+    def show(self) -> str:
+        """How to load the data, ignoring the autoloaded setting."""
+
+        idstr = _id_to_str(self.idval)
+        out = f'{self.loadfunc.__name__}({idstr}, '
+        out += f'"{self.filename}"'
+
+        # For now remove the default arguments as we can not track
+        # what arguments were actually used when the file was loaded.
+        #
+        kwargs = remove_default_args(self.loadfunc, self.kwargs)
+        for k, v in kwargs.items():
+            out += f", {k}={showval(v)}"
+
+        return f"{out})"
+
+
+# FileStores are indexed by IdType, but it can be an id,
+# resp_id, or bkg_id.
+#
+FileDict = dict[IdType, FileStore]
+
+
+class Storage:
+    """Store the mapping from dataset identifier to FileStore."""
+
+    # Alternative designs include:
+    #
+    # - have a seprate Storage instance just for backgrounds
+    #   (i.e. drop the "bkg" fields).
+    # - instead of separating out the different types (data, background,
+    #   responses), store information based on the dataset identifier.
+    #
+    def __init__(self) -> None:
+        self.data: FileDict = {}
+        """For load_data and related."""
+
+        self.arf: dict[IdType, FileDict] = {}
+        """For load_arf. Indexed by (id, resp_id)."""
+
+        self.rmf: dict[IdType, FileDict] = {}
+        """For load_rmf. Indexed by (id, resp_id)."""
+
+        self.bkg: dict[IdType, FileDict] = {}
+        """For the load_bkg call, indexed by (id, bkg_id)."""
+
+        self.bkg_arf: dict[IdType, dict[IdType, FileDict]] = {}
+        """For load_bkg_arf. Indexed by (id, bkg_id, resp_id)."""
+
+        self.bkg_rmf: dict[IdType, dict[IdType, FileDict]] = {}
+        """For load_bkg_arf. Indexed by (id, bkg_id, resp_id)."""
+
+    def clean(self, idval: IdType) -> None:
+        """Remove any information about the given identifier."""
+
+        for field in [self.data, self.arf, self.rmf, self.bkg,
+                      self.bkg_arf, self.bkg_rmf]:
+            with suppress(KeyError):
+                del field[idval]
+
+    def clean_bkg(self, idval: IdType) -> None:
+        """Remove any background information about the given identifier."""
+
+        for field in [self.bkg, self.bkg_arf, self.bkg_rmf]:
+            with suppress(KeyError):
+                del field[idval]
+
+    def reset_arf(self,
+                  idval: IdType,
+                  resp_id: IdType) -> None:
+        """Reset the ARF information for this resonse.
+
+        This removes any resp_id field but makes sure that the idval
+        field is set (even if empty). Is this worth keeping?
+
+        """
+
+        if idval in self.arf:
+            with suppress(KeyError):
+                del self.arf[idval][resp_id]
+        else:
+            self.arf[idval] = {}
+
+    def reset_rmf(self,
+                  idval: IdType,
+                  resp_id: IdType) -> None:
+        """Reset the RMF information for this resonse.
+
+        This removes any resp_id field but makes sure that the idval
+        field is set (even if empty). Is this worth keeping?
+
+        """
+
+        if idval in self.rmf:
+            with suppress(KeyError):
+                del self.rmf[idval][resp_id]
+        else:
+            self.rmf[idval] = {}
+
+    def reset_bkg_arf(self,
+                      idval: IdType,
+                      bkg_id: IdType,
+                      resp_id: IdType) -> None:
+        """Reset the background ARF information for this resonse.
+
+        This removes any resp_id field but makes sure that the bkg_id
+        field is set (even if empty). Is this worth keeping?
+
+        """
+
+        if idval in self.bkg_arf:
+            if bkg_id in self.bkg_arf[idval]:
+                with suppress(KeyError):
+                    del self.bkg_arf[idval][bkg_id][resp_id]
+            else:
+                self.bkg_arf[idval][bkg_id] = {}
+
+        else:
+            self.bkg_arf[idval] = {bkg_id: {}}
+
+    def reset_bkg_rmf(self,
+                      idval: IdType,
+                      bkg_id: IdType,
+                      resp_id: IdType) -> None:
+        """Reset the background RMF information for this resonse.
+
+        This removes any resp_id field but makes sure that the bkg_id
+        field is set (even if empty). Is this worth keeping?
+
+        """
+
+        if idval in self.bkg_rmf:
+            if bkg_id in self.bkg_rmf[idval]:
+                with suppress(KeyError):
+                    del self.bkg_rmf[idval][bkg_id][resp_id]
+            else:
+                self.bkg_rmf[idval][bkg_id] = {}
+
+        else:
+            self.bkg_rmf[idval] = {bkg_id: {}}
+
+    def reset_bkg(self,
+                  idval: IdType,
+                  bkg_id: IdType) -> None:
+        """Reset the background information for this resonse.
+
+        This removes any resp_id data but makes sure that the bkg_id
+        field is set (even if empty). Is this worth keeping?
+
+        """
+
+        for field in [self.bkg, self.bkg_arf, self.bkg_rmf]:
+            if idval in field:
+                with suppress(KeyError):
+                    del field[idval][bkg_id]
+            else:
+                field[idval] = {}
+
+    def copy(self, fromid: IdType, toid: IdType) -> None:
+        """Copy the store info about the given identifier."""
+
+        def copy_store(old: FileStore) -> FileStore:
+            # Update the id value.
+            store = copy.copy(old)
+            store.idval = toid
+            return store
+
+        # Note that the base dataset may not have any storage data,
+        # but the ancillary products (such as ARF or background)
+        # could, so this can not exit early.
+        #
+        old = self.data.get(fromid)
+        if old is not None:
+            self.add(toid, copy_store(old))
+
+        # Copy over any filestores for PHA responses.
+        # This is a bit messy.
+        #
+        pair = self.arf.get(fromid, {})
+        for resp_id, old in pair.items():
+            self.add_arf(toid, resp_id, copy_store(old))
+
+        pair = self.rmf.get(fromid, {})
+        for resp_id, old in pair.items():
+            self.add_rmf(toid, resp_id, copy_store(old))
+
+        pair = self.bkg.get(fromid, {})
+        for bkg_id, old in pair.items():
+            self.add_bkg(toid, bkg_id, copy_store(old))
+
+        triple = self.bkg_arf.get(fromid, {})
+        for bkg_id, pair in triple.items():
+            for resp_id, old in pair.items():
+                self.add_bkg_arf(toid, bkg_id, resp_id, copy_store(old))
+
+        triple = self.bkg_rmf.get(fromid, {})
+        for bkg_id, pair in triple.items():
+            for resp_id, old in pair.items():
+                self.add_bkg_rmf(toid, bkg_id, resp_id, copy_store(old))
+
+    def add(self,
+            idval: IdType,
+            store: FileStore) -> None:
+        """Add the store to the data field.
+
+        This cleans out any existing data that may have been
+        related to this identifier.
+
+        Parameters
+        ----------
+        idval
+           The dataset identifier.
+        store
+           The information to store.
+
+        """
+
+        self.data[idval] = store
+
+        # An alternative would be to always set the field to the empty
+        # dictionary.
+        #
+        for elem in [self.arf, self.rmf, self.bkg,
+                     self.bkg_arf, self.bkg_rmf]:
+            with suppress(KeyError):
+                del elem[idval]
+
+    def _add_pair(self,
+                  output: dict[IdType, FileDict],
+                  key1: IdType,
+                  key2: IdType,
+                  store: FileStore) -> None:
+        """Add the data for (key1, key2) setting.
+
+        Parameters
+        ----------
+        output
+           The dictionary to change.
+        key1
+           The dataset identifier.
+        key2
+           The second identifier.
+        store
+           The information to store.
+
+        """
+
+        try:
+            output1 = output[key1]
+        except KeyError:
+            output1 = {}
+            output[key1] = output1
+
+        output1[key2] = store
+
+    def _add_triple(self,
+                    output: dict[IdType, dict[IdType, FileDict]],
+                    key1: IdType,
+                    key2: IdType,
+                    key3: IdType,
+                    store: FileStore) -> None:
+        """Add the data for (key1, key2, key3) setting.
+
+        Parameters
+        ----------
+        output
+           The dictionary to change.
+        key1
+           The dataset identifier.
+        key2
+           The bkg_id identifier.
+        key3
+           The resp_id identifier.
+        store
+           The information to store.
+
+        """
+
+        try:
+            output1 = output[key1]
+        except KeyError:
+            output1 = {}
+            output[key1] = output1
+
+        try:
+            output2 = output1[key2]
+        except KeyError:
+            output2 = {}
+            output1[key2] = output2
+
+        output2[key3] = store
+
+    def add_arf(self,
+                idval: IdType,
+                resp_id: IdType,
+                store: FileStore) -> None:
+        """Add the ARF call.
+
+        Parameters
+        ----------
+        idval
+           The dataset identifier.
+        resp_id
+           The response identifier.
+        store
+           The information to store.
+
+        """
+        self._add_pair(self.arf, idval, resp_id, store)
+
+    def add_rmf(self,
+                idval: IdType,
+                resp_id: IdType,
+                store: FileStore) -> None:
+        """Add the RMF call.
+
+        Parameters
+        ----------
+        idval
+           The dataset identifier.
+        resp_id
+           The response identifier.
+        store
+           The information to store.
+
+        """
+        self._add_pair(self.rmf, idval, resp_id, store)
+
+    def add_bkg(self,
+                idval: IdType,
+                bkg_id: IdType,
+                store: FileStore) -> None:
+        """Add the background call.
+
+        This will remove any associated background response
+        elements.
+
+        Parameters
+        ----------
+        idval
+           The dataset identifier.
+        bkg_id
+           The background identifier.
+        store
+           The information to store.
+
+        """
+        self._add_pair(self.bkg, idval, bkg_id, store)
+
+        # An alternative would be to always set the field to the empty
+        # dictionary.
+        #
+        for elem in [self.bkg_arf, self.bkg_rmf]:
+            with suppress(KeyError):
+                del elem[idval][bkg_id]
+
+    def add_bkg_arf(self,
+                    idval: IdType,
+                    bkg_id: IdType,
+                    resp_id: IdType,
+                    store: FileStore) -> None:
+        """Add the background ARF call.
+
+        Parameters
+        ----------
+        idval
+           The dataset identifier.
+        bkg_id
+           The background identifier.
+        resp_id
+           The response identifier.
+        store
+           The information to store.
+
+        """
+        self._add_triple(self.bkg_arf, idval, bkg_id, resp_id, store)
+
+    def add_bkg_rmf(self,
+                    idval: IdType,
+                    bkg_id: IdType,
+                    resp_id: IdType,
+                    store: FileStore) -> None:
+        """Add the background RMF call.
+
+        Parameters
+        ----------
+        idval
+           The dataset identifier.
+        bkg_id
+           The background identifier.
+        resp_id
+           The response identifier.
+        store
+           The information to store.
+
+        """
+        self._add_triple(self.bkg_rmf, idval, bkg_id, resp_id, store)
+
+    def get(self,
+            idval: IdType) -> FileStore | None:
+        """Return the information for the identifier.
+
+        Parameters
+        ----------
+        idval
+           The dataset identifier.
+
+        Returns
+        -------
+        store
+           This will be None if there is no information for the
+           identifier.
+
+        """
+
+        return self.data.get(idval)
+
+    def _get_pair(self,
+                  stores: dict[IdType, FileDict],
+                  key1: IdType,
+                  key2: IdType) -> FileStore | None:
+        """Return the data for the (key1, key2) setting.
+
+        Parameters
+        ----------
+        outputs
+           The dictionary to read from.
+        key1
+           The dataset identifier.
+        key2
+           The second identifier.
+        store
+           The information to store.
+
+        """
+
+        stores1 = stores.get(key1)
+        if stores1 is None:
+            return None
+
+        return stores1.get(key2)
+
+    def _get_triple(self,
+                    stores: dict[IdType, dict[IdType, FileDict]],
+                    key1: IdType,
+                    key2: IdType,
+                    key3: IdType) -> FileStore | None:
+        """Return the data for the (key1, key2, key3) setting.
+
+        Parameters
+        ----------
+        outputs
+           The dictionary to read from.
+        key1
+           The dataset identifier.
+        key2
+           The second identifier.
+        store
+           The information to store.
+
+        """
+
+        stores1 = stores.get(key1)
+        if stores1 is None:
+            return None
+
+        stores2 = stores1.get(key2)
+        if stores2 is None:
+            return None
+
+        return stores2.get(key3)
+
+    def get_arf(self,
+                idval: IdType,
+                resp_id: IdType) -> FileStore | None:
+        """Return the ARF for the given identifiers.
+
+        Parameters
+        ----------
+        idval
+           The dataset identifier.
+        resp_id
+           The response identifier.
+
+        Returns
+        -------
+        store
+           This will be None if there is no information for the
+           identifier.
+
+        """
+
+        return self._get_pair(self.arf, idval, resp_id)
+
+    def get_rmf(self,
+                idval: IdType,
+                resp_id: IdType) -> FileStore | None:
+        """Return the RMF for the given identifiers.
+
+        Parameters
+        ----------
+        idval
+           The dataset identifier.
+        resp_id
+           The response identifier.
+
+        Returns
+        -------
+        store
+           This will be None if there is no information for the
+           identifier.
+
+        """
+
+        return self._get_pair(self.rmf, idval, resp_id)
+
+    def get_bkg(self,
+                idval: IdType,
+                bkg_id: IdType) -> FileStore | None:
+        """Return the background for the given identifiers.
+
+        Parameters
+        ----------
+        idval
+           The dataset identifier.
+        bkg_id
+           The background identifier.
+
+        Returns
+        -------
+        store
+           This will be None if there is no information for the
+           identifier.
+
+        """
+
+        return self._get_pair(self.bkg, idval, bkg_id)
+
+    def get_bkg_arf(self,
+                    idval: IdType,
+                    bkg_id: IdType,
+                    resp_id: IdType) -> FileStore | None:
+        """Return the background ARF for the given identifiers.
+
+        Parameters
+        ----------
+        idval
+           The dataset identifier.
+        bkg_id
+           The background identifier.
+        resp_id
+           The response identifier.
+
+        Returns
+        -------
+        store
+           This will be None if there is no information for the
+           identifier.
+
+        """
+        return self._get_triple(self.bkg_arf, idval, bkg_id, resp_id)
+
+    def get_bkg_rmf(self,
+                    idval: IdType,
+                    bkg_id: IdType,
+                    resp_id: IdType) -> FileStore | None:
+        """Return the background RMF for the given identifiers.
+
+        Parameters
+        ----------
+        idval
+           The dataset identifier.
+        bkg_id
+           The background identifier.
+        resp_id
+           The response identifier.
+
+        Returns
+        -------
+        store
+           This will be None if there is no information for the
+           identifier.
+
+        """
+        return self._get_triple(self.bkg_rmf, idval, bkg_id, resp_id)
+
+
+def _output(out: OutType,
+            msg: str,
+            indent: int = 0
+            ) -> None:
+    """Output the line (if it exists)."""
+
     space = ' ' * (indent * 4)
     out["main"].append(textwrap.indent(msg, space))
 
@@ -151,27 +856,6 @@ def _remove_banner(out: OutType, orig_pos: int) -> None:
     out["main"].pop()
 
 
-def _id_to_str(id: IdType) -> str:
-    """Convert a data set identifier to a string value.
-
-    Parameters
-    ----------
-    id : int or str
-       The data set identifier.
-
-    Returns
-    -------
-    out : str
-       A string representation of the identifier for use
-       in the Python serialization.
-    """
-
-    if isinstance(id, string_types):
-        return f'"{id}"'
-
-    return str(id)
-
-
 def _save_entries(out: OutType,
                   store: Mapping[str, Any],
                   tostatement: Callable[[str, Any], str]) -> None:
@@ -202,114 +886,6 @@ def _save_entries(out: OutType,
     for key in keys:
         cmd = tostatement(key, store[key])
         _output(out, cmd)
-
-
-def _save_response(out: OutType,
-                   label: str,
-                   respfile: str,
-                   id: IdType,
-                   rid: IdType,
-                   bid: MaybeIdType = None) -> None:
-    """Save the ARF or RMF
-
-    Parameters
-    ----------
-    out : dict
-       The output state
-    label : str
-       Either ``arf`` or ``rmf``.
-    respfile : str
-       The name of the ARF or RMF.
-    id : id or str
-       The Sherpa data set identifier.
-    rid
-       The Sherpa response identifier for the data set.
-    bid
-       If not ``None`` then this indicates that this is the ARF for
-       a background dataset, and which such data set to use.
-    """
-
-    id = _id_to_str(id)
-    rid = _id_to_str(rid)
-
-    cmd = f'load_{label}({id}, "{respfile}", resp_id={rid}'
-    if bid is not None:
-        cmd += f", bkg_id={_id_to_str(bid)}"
-
-    cmd += ")"
-    _output(out, cmd)
-
-
-def _save_arf_response(out: OutType,
-                       state: SessionType,  # currently unused
-                       pha: DataPHA,
-                       id: IdType,
-                       rid: IdType,
-                       bid: MaybeIdType = None) -> None:
-    """Save the ARF.
-
-    Parameters
-    ----------
-    out : dict
-       The output state
-    state
-    pha : DataPHA
-       The PHA object
-    id : id or str
-       The Sherpa data set identifier.
-    rid
-       The Sherpa response identifier for the data set.
-    bid
-       If not ``None`` then this indicates that this is the ARF for
-       a background dataset, and which such data set to use.
-    """
-
-    arf, _ = pha.get_response(rid)
-    if arf is None:
-        return
-
-    if TYPE_CHECKING:
-        # We currently do not do much with arf, but add the type
-        # anyway.
-        assert isinstance(arf, DataARF)
-
-    _save_response(out, 'arf', arf.name, id, rid, bid=bid)
-
-
-def _save_rmf_response(out: OutType,
-                       state: SessionType,  # currently unused
-                       pha: DataPHA,
-                       id: IdType,
-                       rid: IdType,
-                       bid: MaybeIdType = None) -> None:
-    """Save the RMF.
-
-    Parameters
-    ----------
-    out : dict
-       The output state
-    state : Session
-    pha : DataPHA
-       The PHA object
-    id : id or str
-       The Sherpa data set identifier.
-    rid
-       The Sherpa response identifier for the data set.
-    bid
-       If not ``None`` then this indicates that this is the RMF for
-       a background dataset, and which such data set to use.
-    """
-
-    _, rmf = pha.get_response(rid)
-    if rmf is None:
-        return
-
-    if TYPE_CHECKING:
-        # We currently do not do much with rmf, but add the type
-        # anyway.
-        assert isinstance(rmf, DataRMF)
-
-    _save_response(out, 'rmf', rmf.name, id, rid, bid=bid)
 
 
 def _save_pha_array(out: OutType,
@@ -515,16 +1091,64 @@ def _handle_filter(out: OutType,
     _remove_banner(out, orig_pos)
 
 
+def _load_from_store(out: OutType,
+                     store: FileStore,
+                     auto_load: bool
+                     ) -> None:
+    """Display the load call if wanted."""
+
+    if auto_load and store.autoloaded:
+        return
+
+    _output(out, store.show())
+
+
+def _load_bkg_manual(out: OutType,
+                     idval: IdType,
+                     bid: IdType,
+                     bpha: DataPHA) -> None:
+    """Manually create the background."""
+
+    idstr = _id_to_str(idval)
+    bkgidstr = _id_to_str(bid)
+    _save_dataset_bkg_manual(out, idstr, bkgidstr, bpha)
+
+
+def _load_arf_manual(out: OutType,
+                     arf: DataARF,
+                     idval: IdType,
+                     rid: IdType,
+                     bid: IdType | None = None
+                     ) -> None:
+    """Manually create the ARF."""
+
+    idstr = _id_to_str(idval)
+    ridstr = _id_to_str(rid)
+    bkgidstr = None if bid is None else _id_to_str(bid)
+    _save_dataset_arf_manual(out, idstr, arf, ridstr, bkgidstr=bkgidstr)
+
+
+def _load_rmf_manual(out: OutType,
+                     rmf: DataRMF,
+                     idval: IdType,
+                     rid: IdType,
+                     bid: IdType | None = None
+                     ) -> None:
+    """Manually create the RMF."""
+
+    idstr = _id_to_str(idval)
+    ridstr = _id_to_str(rid)
+    bkgidstr = None if bid is None else _id_to_str(bid)
+    _save_dataset_rmf_manual(out, idstr, rmf, ridstr, bkgidstr=bkgidstr)
+
+
 def _save_dataset_settings_pha(out: OutType,
                                state: SessionType,
-                               pha: DataType,
+                               pha: DataPHA,
                                idval: IdType,
                                auto_load: bool
                                ) -> None:
     """What settings need to be set for DataPHA"""
-
-    if not isinstance(pha, DataPHA):
-        return
 
     cmd_id = _id_to_str(idval)
 
@@ -538,69 +1162,38 @@ def _save_dataset_settings_pha(out: OutType,
     if pha.grouped:
         _output(out, f"group({cmd_id})")
 
-    # Check if this data set has associated data that is automatically
-    # loaded by Sherpa, so does not need to be included in the
-    # serialization.
-    #
-    try:
-        store = state._load_data_store[idval]
-    except KeyError:
-        store = None
-
-    if store is None:
-        store_arfs = {}
-        store_rmfs = {}
-    else:
-        store_arfs = store["arf_ids"]
-        store_rmfs = store["rmf_ids"]
-
-    if not auto_load:
-        store_arfs = {}
-        store_rmfs = {}
-
-    # Add responses and ARFs, if any.
+    # Do we need to load any responses (ARF, RMF, background)?  Note
+    # that this does not cover all cases; for instance if a PHA file
+    # was read in from a HDUList/crate then the responses may not have
+    # been marked as autoloaded (if there are any) and so will not be
+    # included below (with the default auto_load setting).
     #
     rids = pha.response_ids
     if len(rids) > 0:
         _output_banner(out, "Data Spectral Responses")
 
         for rid in rids:
-
             arf, rmf = pha.get_response(rid)
-
-            # Display the load command if:
-            #
-            # - the response exists
-            # - its name does not match the version that was
-            #   automatically loaded with the source dataset
-            #
-            want = False
             if arf is not None:
-                try:
-                    want = arf.name != store_arfs[rid]
-                except KeyError:
-                    want = True
+                astore = state._storage.get_arf(idval, rid)
+                if astore is not None:
+                    _load_from_store(out, astore, auto_load)
+                else:
+                    _load_arf_manual(out, arf, idval, rid)
 
-            if want:
-                _save_arf_response(out, state, pha, idval, rid)
-
-            want = False
             if rmf is not None:
-                try:
-                    want = rmf.name != store_rmfs[rid]
-                except KeyError:
-                    want = True
-
-            if want:
-                _save_rmf_response(out, state, pha, idval, rid)
+                rstore = state._storage.get_rmf(idval, rid)
+                if rstore is not None:
+                    _load_from_store(out, rstore, auto_load)
+                else:
+                    _load_rmf_manual(out, rmf, idval, rid)
 
     bids = pha.background_ids
     if len(bids) > 0:
 
-        # Only try to load the background if we have information in
-        # _load_bkg_store. Although there is support for PHA2
-        # background files, do not make use of this knowledge here as
-        # we do not have any such files to test on.
+        # Although there is support for PHA2 background files, do not
+        # make use of this knowledge here as we do not have any such
+        # files to test on.
         #
         _output_banner(out, "Load Background Data Sets")
         for bid in bids:
@@ -610,40 +1203,11 @@ def _save_dataset_settings_pha(out: OutType,
             if TYPE_CHECKING:
                 assert isinstance(bpha, DataPHA)
 
-            try:
-                bstore = state._load_bkg_store[idval][bid]
-            except KeyError:
-                bstore = None
-
-            # How are we checking for response files? It depends on
-            # whether the background was loaded with load_bkg,
-            # load_pha/data, or some other way?
-            #
+            bstore = state._storage.get_bkg(idval, bid)
             if bstore is not None:
-                store_arfs = bstore.get("arf_ids", {})
-                store_rmfs = bstore.get("rmf_ids", {})
-            elif store is not None and "bkg_arf_ids" in store:
-                store_arfs = store["bkg_arf_ids"][bid]
-                store_rmfs = store["bkg_rmf_ids"][bid]
+                _load_from_store(out, bstore, auto_load)
             else:
-                store_arfs = {}
-                store_rmfs = {}
-
-            if not auto_load:
-                store_arfs = {}
-                store_rmfs = {}
-
-            # Was this explicitly loaded?
-            #
-            bname = bpha.name
-            want = not auto_load or (bstore is not None and
-                                     bstore["filename"] == bname)
-            if want:
-                cmd = f'load_bkg({cmd_id}, "{bname}", bkg_id={cmd_bkg_id}'
-                if bstore is not None and "use_errors" in bstore:
-                    cmd += f", use_errors={bstore['use_errors']}"
-                cmd += ')'
-                _output(out, cmd)
+                _load_bkg_manual(out, idval, bid, bpha)
 
             # Only store group flags and quality flags if they were
             # changed from flags in the file
@@ -663,41 +1227,23 @@ def _save_dataset_settings_pha(out: OutType,
                 # the response?
                 #
                 _output_banner(out, "Background Spectral Responses")
+
                 for rid in rids:
                     bkg_arf, bkg_rmf = bpha.get_response(rid)
 
-                    # Display the load command if:
-                    #
-                    # - the response exists
-                    # - its name does not match the version that was
-                    #   automatically loaded with the dataset
-                    #
-                    # The latter is hard to check because the
-                    # background could have been loaded implicitly (so
-                    # use store as the check) or explicitly (use
-                    # bstore).
-                    #
-                    want = False
                     if bkg_arf is not None:
-                        try:
-                            want = bkg_arf.name != store_arfs[rid]
-                        except KeyError:
-                            want = True
+                        astore = state._storage.get_bkg_arf(idval, bid, rid)
+                        if astore is not None:
+                            _load_from_store(out, astore, auto_load)
+                        else:
+                            _load_arf_manual(out, bkg_arf, idval, rid, bid=bid)
 
-                    if want:
-                        _save_arf_response(out, state, bpha, idval,
-                                           rid, bid=bid)
-
-                    want = False
                     if bkg_rmf is not None:
-                        try:
-                            want = bkg_rmf.name != store_rmfs[rid]
-                        except KeyError:
-                            want = True
-
-                    if want:
-                        _save_rmf_response(out, state, bpha, idval,
-                                           rid, bid=bid)
+                        rstore = state._storage.get_bkg_rmf(idval, bid, rid)
+                        if rstore is not None:
+                            _load_from_store(out, rstore, auto_load)
+                        else:
+                            _load_rmf_manual(out, bkg_rmf, idval, rid, bid=bid)
 
     # Set energy units if applicable
     #
@@ -713,12 +1259,9 @@ def _save_dataset_settings_pha(out: OutType,
 
 def _save_dataset_settings_2d(out: OutType,
                               state: SessionType,  # currently unused
-                              data: DataType,
+                              data: DataIMG,
                               id: IdType) -> None:
     """What settings need to be set for Data2D/IMG?"""
-
-    if not isinstance(data, DataIMG):
-        return
 
     _output_banner(out, "Set Image Coordinates")
     _output(out, f"set_coord({_id_to_str(id)}, '{data.coord}')")
@@ -753,40 +1296,42 @@ def _save_data(out: OutType,
     if len(ids) == 0:
         return
 
-    # Try to only output a banner if the section contains a
-    # command/setting.
-    #
     _output_banner(out, "Load Data Sets")
 
-    # Special case PHA2 files, as
-    # - they create multiple ids in one go
-    # - some of those ids may get deleted or over-written
-    # So process them first.
+    # There are two sets of data ids:
+    #   a) state.list_data_ids()
+    #   b) the keys of state._storage.data
     #
-    seen = set()
-    for idval, store in state._load_data_store.items():
-        if "idvals" not in store:
+    # Entries in b can be converted to a simple 'load_xxx' call [*]
+    # whereas those only in set a require manual recreation.
+    #
+    # [*] This **assumes** that the data values have not been modified
+    #     after being read in.
+    #
+    # PHA2 datasets also complicate this, as a single load call will
+    # create multiple datasets (with a potentially different id
+    # value), and then some of these may get deleted.  We process
+    # these first, using state._multi_data_store.
+    #
+    for store, mids in state._multi_data_store.values():
+
+        # Write out a banner line indicating all the ids
+        # (we only do this once, which also means we only get the
+        # load_pha/data call once).
+        #
+        msg = f"# Load PHA2 into: {mids}"
+        if msg in out["main"]:
             continue
 
-        # Only bother processing the first version of this PHA2
-        # dataset, although note that the idval may no-longer be
-        # present (e.g.  delete_data) or over-written with a different
-        # dataset. Fortunately we can use the idvals array to find out
-        # what datasets were originally created.
+        _output(out, msg)
+        _save_dataset_store(out, store)
+
+        # Do we need to delete any of the PHA2 datasets?
         #
-        if idval in seen:
-            continue
-
-        _save_dataset_pha2(out, store)
-        seen = seen.union(store["idvals"])
-
-        # Add any delete_data calls for this dataset.
-        #
-        for delid in store["idvals"]:
-            if delid in state._load_data_store:
-                continue
-
-            _output(out, f"delete_data({_id_to_str(delid)})")
+        for idval in mids:
+            if idval not in ids:
+                idstr = _id_to_str(idval)
+                _output(out, f"delete_data({idstr})")
 
     for idval in ids:
         data = state.get_data(idval)
@@ -795,9 +1340,13 @@ def _save_data(out: OutType,
             assert isinstance(data, (Data1D, Data2D))
 
         _save_dataset(out, state, data, idval)
-        _save_dataset_settings_pha(out, state, data, idval,
-                                   auto_load=auto_load)
-        _save_dataset_settings_2d(out, state, data, idval)
+
+        if isinstance(data, DataPHA):
+            _save_dataset_settings_pha(out, state, data, idval,
+                                       auto_load=auto_load)
+
+        elif isinstance(data, DataIMG):
+            _save_dataset_settings_2d(out, state, data, idval)
 
         _handle_filter(out, state, data, idval)
 
@@ -1405,80 +1954,22 @@ def _save_xspec(out: OutType) -> None:
     _save_entries(out, xspec_state["modelstrings"], tostatement)
 
 
-def _save_dataset_file(out: OutType, idstr: str, dset: Data) -> None:
+def _save_dataset_store(out: OutType,
+                        store: FileStore
+                        ) -> None:
     """The data can be read in from a file."""
 
-    # TODO: this does not handle options like selecting the columns
-    #       from a file, or the number of columns.
-    #
-    ncols = None
-    if isinstance(dset, DataPHA):
-        # This path should no-longer be used, but leave in for now.
-        dtype = 'pha'
-    elif isinstance(dset, DataIMG):
-        dtype = 'image'
-    else:
-        dtype = 'data'
+    outstr = store.show()
+    if outstr in out["main"]:
+        # This indicates this is from a PHA2 file which has already
+        # been loaded.
+        return
 
-        # Can we estimate what ncols should be? This is a heuristic as
-        # it does not cover all cases.
-        #
-        if dset.staterror is not None:
-            # assume we read in independent axis/es, dependent axis,
-            # and then staterror.
-            ncols = len(dset.get_indep()) + 2
-
-    cmd = f'load_{dtype}({idstr}, "{dset.name}"'
-    if ncols is not None:
-        cmd += f", ncols={ncols}"
-
-    cmd += ")"
-    _output(out, cmd)
-
-
-def _save_dataset_pha(out: OutType, store: dict[str, Any]) -> None:
-    """The data can be read in from a PHA file."""
-
-    idval = store["id"]
-    filename = store["filename"]
-    idstr = _id_to_str(idval)
-
-    cmd = f'load_pha({idstr}, "{filename}"'
-    with suppress(KeyError):
-        cmd += f', use_errors={store["kwargs"]["use_errors"]}'
-
-    cmd += ")"
-    _output(out, cmd)
-
-
-def _save_dataset_pha2(out: OutType, store: dict[str, Any]) -> None:
-    """The data can be read in from a PHA2 file."""
-
-    idval = store["id"]
-    idvals = store["idvals"]
-    filename = store["filename"]
-    idstr = _id_to_str(idval)
-
-    _output(out, f"# Load PHA2 into: {idvals}")
-
-    cmd = f'load_pha({idstr}, "{filename}"'
-    with suppress(KeyError):
-        cmd += f', use_errors={store["kwargs"]["use_errors"]}'
-
-    cmd += ")"
-    _output(out, cmd)
+    _output(out, outstr)
 
 
 def _output_wcs_import(out: OutType) -> None:
-    """Import the WCS symbol if not done already.
-
-    Parameters
-    ----------
-    fh : None or a file handle
-       The file handle to write the message to. If fh is ``None``
-       then the standard output is used.
-
-    """
+    """Import the WCS symbol if not done already."""
 
     out["imports"].add("from sherpa.astro.io.wcs import WCS")
 
@@ -1535,6 +2026,113 @@ def _save_dataset_pha_manual(out: OutType, idstr: str, pha: DataPHA) -> None:
     # setarray("grouping")
 
 
+def _save_dataset_bkg_manual(out: OutType,
+                             idstr: str,
+                             bkgidstr: str,
+                             pha: DataPHA) -> None:
+    """Try to recreate the PHA"""
+
+    # There's no easy way to create a background dataset.
+    #
+    spacer = "              "
+    _output(out, f'bkg = DataPHA("{pha.name}",')
+    _output(out, f"{spacer}{pha.channel.tolist()},")
+    _output(out, f"{spacer}{pha.counts.tolist()})")
+    _output(out, f"set_bkg({idstr}, bkg, bkg_id={bkgidstr})")
+
+    def setval(key):
+        val = getattr(pha, key)
+        if val is None:
+            return
+
+        _output(out, f"set_{key}({idstr}, {val}, bkg_id={bkgidstr})")
+
+    def setarray(key):
+        val = getattr(pha, key)
+        if val is None:
+            return
+
+        _output(out, f"set_{key}({idstr}, {val.tolist()}, bkg_id={bkgidstr})")
+
+    setval("exposure")
+    setval("backscal")
+    setval("areascal")
+
+    setarray("staterror")
+    setarray("syserror")
+
+    # Unlike the PHA case, we set these here.
+    setarray("quality")
+    setarray("grouping")
+
+
+def _save_dataset_arf_manual(out: OutType,
+                             idstr: str,
+                             arf: DataARF,
+                             ridstr: str,
+                             bkgidstr: str | None = None
+                             ) -> None:
+    """Try to recreate the ARF.
+
+    This does not save any metadata.
+    """
+
+    # This is not likely to be useful.
+    #
+    spacer = "              "
+    _output(out, f'arf = DataARF("{arf.name}",')
+    _output(out, f"{spacer}numpy.array({arf.energ_lo.tolist()}),")
+    _output(out, f"{spacer}numpy.array({arf.energ_hi.tolist()}),")
+    _output(out, f"{spacer}{arf.specresp.tolist()})")
+    cmd = f"set_arf({idstr}, arf, resp_id={ridstr}"
+    if bkgidstr is not None:
+        cmd += ", bkg_id={bkgidstr}"
+
+    cmd += ")"
+    _output(out, cmd)
+
+
+def _save_dataset_rmf_manual(out: OutType,
+                             idstr: str,
+                             rmf: DataRMF,
+                             ridstr: str,
+                             bkgidstr: str | None = None
+                             ) -> None:
+    """Try to recreate the RMF.
+
+    This does not save any metadata. It also does not handle
+    sub-classes of DataRMF.
+
+    """
+
+    # This is not likely to be useful.
+    #
+    spacer = "              "
+    _output(out, f'rmf = DataRMF("{rmf.name}", {rmf.detchans},')
+    _output(out, f"{spacer}numpy.array({rmf.energ_lo.tolist()}),")
+    _output(out, f"{spacer}numpy.array({rmf.energ_hi.tolist()}),")
+    _output(out, f"{spacer}offset={rmf.offset},")
+    _output(out, f"{spacer}n_grp=numpy.array({rmf.n_grp.tolist()}),")
+    _output(out, f"{spacer}f_chan=numpy.array({rmf.f_chan.tolist()}),")
+    _output(out, f"{spacer}n_chan=numpy.array({rmf.n_chan.tolist()}),")
+
+    lastchar = "" if rmf.e_min is None else ","
+    _output(out, f"{spacer}matrix=numpy.array({rmf.n_grp.tolist()}){lastchar}")
+
+    if rmf.e_min is not None:
+        _output(out, f"{spacer}e_min=numpy.array({rmf.e_min.tolist()}),")
+        _output(out, f"{spacer}e_max=numpy.array({rmf.e_max.tolist()})")
+
+    _output(out, f"{spacer})")
+
+    cmd = f"set_rmf({idstr}, rmf, resp_id={ridstr}"
+    if bkgidstr is not None:
+        cmd += ", bkg_id={bkgidstr}"
+
+    cmd += ")"
+    _output(out, cmd)
+
+
 def _save_dataset(out: OutType,
                   state: SessionType,
                   data: Data,
@@ -1542,86 +2140,20 @@ def _save_dataset(out: OutType,
     """Given a dataset identifier, return the text needed to
     re-create it.
 
-    The data set design does not make it easy to tell:
-
-    - if the data was read in from a file, or by load_arrays
-      (and the name field set by the user)
-
-    - if the data has been modified - e.g. by a call to set_counts -
-      after it was loaded.
-
-    - if in the correct directory (so paths may be wrong)
-
-    The state._load_data_store dictionary is used to indicate PHA2
-    files.
+    The state._storage.data dictionary is intended to record how a
+    file was loaded, but there is no tracking of the data values
+    (e.g. the independent and dependent axes) to know if they have
+    been changed after loading. If there is no information in this
+    dictionary then the dataset is assumed to be manually created.
 
     """
 
-    # Do we have direct information on how this dataset was loaded?
-    # Note that identifiers associated with a PHA2 dataset have
-    # already been loaded.
-    #
-    try:
-        store = state._load_data_store[id]
-
-        # Is this a PHA2 dataset?
-        #
-        if "idvals" in store:
-            return
-
-        _save_dataset_pha(out, store)
+    store = state._storage.get(id)
+    if store is not None:
+        _save_dataset_store(out, store)
         return
 
-    except KeyError:
-        idval = id
-
-    idstr = _id_to_str(idval)
-
-    # If the name of the object is a file then we assume that the data
-    # was read in from that location, otherwise we recreate the data
-    # (i.e. do not read it in).  This will fail if the data was read
-    # in with a relative path name and the directory has since been
-    # changed, or the on-disk file has been removed.
-    #
-    # This logic should be moved into the DataXXX objects, since
-    # this is more extensible, and also the data object can
-    # retain knowledge of where the data came from.
-    #
-    # Checking for a valid file name is complicated:
-    #
-    # - crates
-    #
-    #   The backend can add in "VFS" syntax, such as "[opt
-    #   colnames=none]" to a file name. Hence the different code paths
-    #   below depending on the backend. The code could try to manually
-    #   remove any VFS syntax, but it's simpler to just try and read
-    #   in the file using crates (this automatically checks for .gz
-    #   versions of the file).
-    #
-    # - pyfits
-    #
-    #   The backend will read in gzip-enabled files so we need to
-    #   check for .gz as well as the file name when calling isfile.
-    #
-    infile = data.name
-    if TYPE_CHECKING:
-        assert io.backend is not None
-    if io.backend.__name__ == "sherpa.astro.io.crates_backend":
-        import pycrates  # type: ignore
-        try:
-            pycrates.read_file(infile)
-            exists = True
-        except OSError:
-            exists = False
-
-    else:
-        exists = os.path.isfile(infile)
-        if not exists and not infile.endswith(".gz"):
-            exists = os.path.isfile(f"{infile}.gz")
-
-    if exists:
-        _save_dataset_file(out, idstr, data)
-        return
+    idstr = _id_to_str(id)
 
     # We could use dataspace1d/2d but easiest to just use load_arrays.
     # The isinstance checks have to pick the more-specific classes
@@ -1687,7 +2219,7 @@ def _save_dataset(out: OutType,
             _output_add_wcs(out, idstr, "eqpos", data.eqpos)
 
     elif isinstance(data, Data2DInt):
-        msg = f"Unable to re-create Data2DInt data set '{idval}'"
+        msg = f"Unable to re-create Data2DInt data set '{idstr}'"
         warning(msg)
         _output(out, f'print("{msg}")')
 
@@ -1702,7 +2234,7 @@ def _save_dataset(out: OutType,
         _output(out, f"{spacer}Data2D)")
 
     else:
-        msg = f"Unable to re-create {data.__class__} data set '{idval}'"
+        msg = f"Unable to re-create {data.__class__} data set '{idstr}'"
         warning(msg)
         _output(out, f'print("{msg}")')
         return
@@ -1741,9 +2273,15 @@ def save_all(state: SessionType,
 
      1. numeric values may not be recorded to their full precision
 
-     2. data sets are not included in the file
+     2. data sets are not included in the file itself, so the data
+        files need to be available,
 
-     3. some settings and values may not be recorded.
+     3. and some settings and values may not be recorded (such as
+        header information).
+
+     .. versionchanged:: 4.19.0
+        Improved support for reporting optional arguments used when
+        loading a file.
 
      .. versionchanged:: 4.18.0
         Handling of PHA data has been improved, and the output now
@@ -1776,13 +2314,14 @@ def save_all(state: SessionType,
     include:
 
     - data sets changed from the version on disk - e.g. by calls to
-      `sherpa.astro.ui.set_counts`
+      `sherpa.astro.ui.set_counts`,
 
-    - any optional keywords to commands such as `load_data`
+    - user models may not be restored correctly,
 
-    - user models may not be restored correctly
+    - and only a subset of Sherpa commands are saved.
 
-    - only a subset of Sherpa commands are saved.
+    The file names used to originally load the data are used in the
+    file, with no attempt to handle changes in the working directory.
 
     Examples
     --------

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -1029,11 +1029,11 @@ def _handle_model(out: OutType,
     if isinstance(mod, UserModel):
         _handle_usermodel(out, mod, modelname)
 
-    elif isinstance(mod, PSFModel):
+    elif isinstance(mod, PSFModel) and mod.kernel is not None:
         cmd = f'load_psf("{mod._name}", "{mod.kernel.name}")'
         _output(out, cmd)
 
-    elif isinstance(mod, ConvolutionKernel):
+    elif isinstance(mod, ConvolutionKernel) and mod.kernel is not None:
         cmd = f'load_conv("{modelname}", "{mod.kernel.name}")'
         _output(out, cmd)
 
@@ -1280,14 +1280,11 @@ def _save_bkg_source(out: OutType,
             except:
                 the_bkg_full_model = None
 
-            have_source = the_bkg_source is not None
-            have_full_model = the_bkg_full_model is not None
-
-            if have_source:
+            if the_bkg_source is not None:
                 # This does not check for the dataset being a DataPHA
                 # object, since (at present) it has to be, as it's the
                 # only one to support backgrounds
-                if have_full_model:
+                if the_bkg_full_model is not None:
                     if repr(the_bkg_source) == repr(the_bkg_full_model):
                         cmd = f"set_bkg_full_model({cmd_id}, {the_bkg_full_model.name}, bkg_id={cmd_bkg_id})"
                     else:
@@ -1295,7 +1292,7 @@ def _save_bkg_source(out: OutType,
                 else:
                     cmd = f"set_bkg_source({cmd_id}, {the_bkg_source.name}, bkg_id={cmd_bkg_id})"
 
-            elif have_full_model:
+            elif the_bkg_full_model is not None:  # have_full_model:
                 cmd = f"set_bkg_full_model({cmd_id}, {the_bkg_full_model.name}, bkg_id={cmd_bkg_id})"
 
             else:

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -801,7 +801,7 @@ def _save_data(out: OutType,
         _handle_filter(out, state, data, idval)
 
 
-def _print_par(par: ParameterType) -> tuple[str, str]:
+def _print_par(par: ParameterType) -> tuple[str, str | None]:
     """Convert a Sherpa parameter to a string.
 
     Note that we have to be careful with XSParameter parameters,
@@ -814,14 +814,15 @@ def _print_par(par: ParameterType) -> tuple[str, str]:
 
     Returns
     -------
-    out_pars, out_link : (str, str)
+    out_pars, out_link : (str, str | None)
        A multi-line string serializing the contents of the
        parameter and then any link setting.
     """
 
-    linkstr = ""
     if par.link is not None:
-        linkstr = f"\nlink({par.fullname}, {par.link.fullname})\n"
+        linkstr = f"link({par.fullname}, {par.link.fullname})"
+    else:
+        linkstr = None
 
     unitstr = ""
     if isinstance(par.units, string_types):
@@ -1076,7 +1077,7 @@ def _handle_model(out: OutType,
 
 def _handle_parameters(out: OutType,
                        mod: Model
-                       ) -> str:
+                       ) -> list[str]:
     """Display the model parameters.
 
     Returns information on any parameter links.
@@ -1086,11 +1087,12 @@ def _handle_parameters(out: OutType,
     # Write out the parameters in the order they are stored in
     # the model.
     #
-    linkstr = ""
+    links = []
     for par in mod.pars:
         par_attributes, par_linkstr = _print_par(par)
         _output(out, par_attributes)
-        linkstr += par_linkstr
+        if par_linkstr is not None:
+            links.append(par_linkstr)
 
     # If the model is a PSFModel then there are a number of
     # attributes we want to set, but they are not stored in the
@@ -1122,7 +1124,7 @@ def _handle_parameters(out: OutType,
         if spacer:
             _output_nl(out)
 
-    return linkstr
+    return links
 
 
 def _save_model_components(out: OutType, state: SessionType) -> bool:
@@ -1154,17 +1156,26 @@ def _save_model_components(out: OutType, state: SessionType) -> bool:
     # Then, *after* processing all models in the for loop below, send
     # link commands to outfile -- *all* models need to be created before
     # *any* links between parameters can be established.
-    linkstr = ""
+    links = []
     found_xspec = False
     for modval in all_model_components:
 
         mod = eval(modval)
         found_xspec |= _handle_model(out, mod)
-        linkstr += _handle_parameters(out, mod)
+        newlinks = _handle_parameters(out, mod)
+        links.extend(newlinks)
+
+    _output_nl(out)
 
     # If there were any links made between parameters, send those
-    # link commands to outfile now; else, linkstr is just an empty string
-    _output(out, linkstr)
+    # link commands to outfile now, after all the model components
+    # have been created:
+    if links:
+        for linkstr in links:
+            _output(out, linkstr)
+
+        _output_nl(out)
+
     return found_xspec
 
 

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -183,49 +183,98 @@ def remove_default_args(func: Callable,
 
 @dataclass
 class FileStore:
-    """Record how a dataset was read in."""
+    """Record how a dataset was read in.
+
+    All arguments are given via the kwargs field, with the file name
+    stored in the filekey element. Most stores will also have an
+    argument storing the dataset identifier (the idkey element).
+
+    """
 
     loadfunc: Callable
     """The function to load the data."""
 
-    idval: IdType
-    """The dataset identifier."""
-
-    filename: Path
-    """The location of the file.
-
-    This is assumed to contain the full path to the file.
-    """
-
     _: KW_ONLY
 
-    # For now we only need to store keyword arguments.
+    # For now we only need to store keyword arguments (no need to
+    # store an args array). The kwargs field is copied in the
+    # __post_init__ call to make sure that changes to that version are
+    # not reflected in this object.
     #
     kwargs: Mapping[str, Any]
     """Named arguments used to read in the file."""
 
+    idkey: str | None = "id"
+    """The key in kwargs that stores the identifier (if present)."""
+
+    filekey: str = "filename"
+    """The key in kwargs that stores the file path."""
+
     autoloaded: bool = False
     """Was the file auto-loaded?"""
+
+    def __post_init__(self) -> None:
+        """Validation and clean up."""
+
+        # TODO: So, we do not make use of "missing id" argument here yet
+        assert self.idkey is not None, self.loadfunc.__name__
+
+        # Copy the keyword arguments.
+        self.kwargs = copy.copy(self.kwargs)
+
+        # Ensure the filename is:
+        # - present (identified by the filekey argument)
+        # - is stored as a Path
+        #
+        try:
+            fileval = self.kwargs[self.filekey]
+        except KeyError:
+            raise KeyError(f"kwargs does not contain a '{self.filekey}' element") from None
+
+        self.kwargs[self.filekey] = Path(fileval)
+
+        # Ensure that the identifier is set (if required).
+        #
+        if self.idkey is None:
+            return
+
+        try:
+            _ = self.kwargs[self.idkey]
+        except KeyError:
+            raise KeyError(f"kwargs does not contain a '{self.idkey}' element") from None
 
     def show(self) -> str:
         """How to load the data, ignoring the autoloaded setting."""
 
-        idstr = _id_to_str(self.idval)
-        out = f'{self.loadfunc.__name__}({idstr}, '
-        out += f'"{self.filename}"'
+        out = f'{self.loadfunc.__name__}('
 
-        # For now remove the default arguments as we can not track
-        # what arguments were actually used when the file was loaded.
+        # For now drop the argument names for the identifier and the
+        # filename.
+        #
+        if self.idkey is not None:
+            idstr = _id_to_str(self.kwargs[self.idkey])
+            out += f'{idstr}, '
+
+        filename = self.kwargs[self.filekey]
+        out += f'"{filename}"'
+
+        # Drop the default arguments as we can not track what
+        # arguments were actually used when the file was loaded.
+        # There is an argument to be said to always include them in
+        # case the defaults change.
         #
         kwargs = remove_default_args(self.loadfunc, self.kwargs)
         for k, v in kwargs.items():
+            if k in [self.idkey, self.filekey]:
+                continue
+
             out += f", {k}={showval(v)}"
 
         return f"{out})"
 
 
-# FileStores are indexed by IdType, but it can be an id,
-# resp_id, or bkg_id.
+# FileStores are indexed by IdType, but it can be an id, resp_id, or
+# bkg_id.
 #
 FileDict = dict[IdType, FileStore]
 
@@ -369,9 +418,10 @@ class Storage:
         """Copy the store info about the given identifier."""
 
         def copy_store(old: FileStore) -> FileStore:
-            # Update the id value.
+            # Update the id value. We assume that the idkey field
+            # is not None but do not enforce it.
             store = copy.copy(old)
-            store.idval = toid
+            store.kwargs[store.idkey] = toid
             return store
 
         # Note that the base dataset may not have any storage data,

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -925,6 +925,37 @@ def _save_iter_method(out: OutType, state: SessionType) -> None:
     _output_nl(out)
 
 
+def _save_estmethod_opts(out: OutType,
+                         state: SessionType
+                         ) -> None:
+    """Add any changed settingd for the estmethods."""
+
+    names = {"projection": "proj",
+             "confidence": "conf",
+             "covariance": "covar"}
+
+    # For now the state is queried for the changed values
+    # rather than to try and identify them directly.
+    #
+    for key, opts in state._estmethods_changed.items():
+        if not opts:
+            continue
+
+        _output_banner(out, f"Set {key} option")
+
+        try:
+            optkey = names[key]
+        except Exception:
+            # Just in case an option/name has been added or removed.
+            continue
+
+        def tostatement(key, val):
+            return 'set_%s_opt("%s", %s)' % (optkey, key, val)
+
+        _save_entries(out, opts, tostatement)
+        _output_nl(out)
+
+
 # for user models, try to access the function definition via
 # the inspect module and then re-create it in the script.
 # An alternative would be to use the marshal module, and
@@ -1774,6 +1805,7 @@ def save_all(state: SessionType,
     _save_statistic(out, state)
     _save_fit_method(out, state)
     _save_iter_method(out, state)
+    _save_estmethod_opts(out, state)
     req_xspec = _save_model_components(out, state)
     _save_psf_components(out, state)
     _save_models(out, state)

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -2368,7 +2368,7 @@ def save_all(state: SessionType,
 
      .. versionchanged:: 4.19.0
         Improved support for reporting optional arguments used when
-        loading a file.
+        loading a file. File paths are now always normalized.
 
      .. versionchanged:: 4.18.0
         Handling of PHA data has been improved, and the output now

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -43,6 +43,7 @@ from sherpa.astro.io.wcs import WCS
 
 from sherpa.data import Data, Data1D, Data1DInt, Data2D, Data2DInt
 from sherpa.models.basic import UserModel
+from sherpa.models.parameter import Parameter
 from sherpa.utils.types import IdType
 
 if TYPE_CHECKING:
@@ -1094,16 +1095,19 @@ def _save_model_components(out: OutType, state: SessionType) -> bool:
             _output(out, par_attributes)
             linkstr = linkstr + par_linkstr
 
-        # If the model is a PSFModel, could have special
-        # attributes "size" and "center" -- if so, record them.
+        # If the model is a PSFModel then there are a number of
+        # attributes we want to set, but they are not stored in the
+        # .pars attribute. Drop the "kernel" field as it is a string.
+        #
         if typename == "psfmodel":
             spacer = False
-            if hasattr(mod, "size") and mod.size is not None:
-                _output(out, f"{modelname}.size = {mod.size}")
-                spacer = True
+            for parname in ["size", "center", "radial", "norm"]:
+                parval = getattr(mod, parname, None)
+                if parval is None:
+                    continue
 
-            if hasattr(mod, "center") and mod.center is not None:
-                _output(out, f"{modelname}.center = {mod.center}")
+                val = parval.val if isinstance(parval, Parameter) else parval
+                _output(out, f"{modelname}.{parname} = {val}")
                 spacer = True
 
             if spacer:

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2015-2016, 2019, 2021, 2023-2025
+#  Copyright (C) 2015-2016, 2019, 2021, 2023-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -25,7 +25,7 @@ intended for public use. The API and semantics of the
 routines in this module are subject to change.
 """
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import suppress
 import inspect
 import logging
@@ -33,7 +33,7 @@ import os
 import sys
 import textwrap
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Mapping, TextIO, TypedDict
+from typing import TYPE_CHECKING, Any, TextIO, TypedDict
 
 import numpy
 
@@ -42,6 +42,7 @@ from sherpa.astro import io
 from sherpa.astro.io.wcs import WCS
 
 from sherpa.data import Data, Data1D, Data1DInt, Data2D, Data2DInt
+from sherpa.models import Model
 from sherpa.models.basic import UserModel
 from sherpa.models.parameter import Parameter
 from sherpa.utils.types import IdType
@@ -946,7 +947,7 @@ def _handle_usermodel(out: OutType,
 
     try:
         pycode = inspect.getsource(mod.calc)
-    except IOError:
+    except OSError:
         pycode = None
 
     # in case getsource can return None, have check here
@@ -999,6 +1000,131 @@ def _handle_usermodel(out: OutType,
     _output(out, f"{spaces})\n")
 
 
+def _get_cpt_name(mod: Model) -> str:
+    """Return the component name."""
+
+    # If we have a name "aa.bb" then return "bb" otherwise
+    # return the name unchanged.
+    #
+    name = mod.name
+    try:
+        return name.split(".")[1]
+    except IndexError:
+        return name
+
+
+def _handle_model(out: OutType,
+                  mod: Model
+                  ) -> bool:
+    """Dispatch on the model type.
+
+    Returns a value indicating whether this is an XSPEC model.
+
+    """
+
+    typename = mod.type
+    modelname = _get_cpt_name(mod)
+    found_xspec = False
+    if typename == "usermodel":
+        _handle_usermodel(out, mod, modelname)
+
+    elif typename == "psfmodel":
+        cmd = f'load_psf("{mod._name}", "{mod.kernel.name}")'
+        _output(out, cmd)
+
+    elif typename in ["fixedtablemodel", "interpolatedtablemodel1d"]:
+        cmd = f'load_table_model("{modelname}", "{mod.filename}")'
+        _output(out, cmd)
+
+    elif typename == "xstablemodel":
+        cmd = f'load_xstable_model("{modelname}", "{mod.filename}"'
+        if mod.etable:
+            cmd += ', etable=True'
+
+        cmd += ')'
+        _output(out, cmd)
+        found_xspec = True
+
+    else:
+        # Normal case:  create an instance of the model.
+        cmd = f'create_model_component("{typename}", "{modelname}")'
+        _output(out, cmd)
+
+        # Is this an XSPEC model? We only care if it's the first
+        # one we find.
+        #
+        if not found_xspec and xspec is not None:
+            found_xspec = isinstance(mod, xspec.XSModel)
+
+    # QUS: should this be included in the above checks?
+    #      @DougBurke doesn't think so, as the "normal
+    #      case" above should probably be run , but there's
+    #      no checks to verify this.
+    #
+    if typename == "convolutionkernel":
+        # Create general convolution kernel with load_conv
+        cmd = f'load_conv("{modelname}", "{mod.kernel.name}")'
+        _output(out, cmd)
+
+    if hasattr(mod, "integrate"):
+        cmd = f"{modelname}.integrate = {mod.integrate}"
+        _output(out, cmd)
+        _output_nl(out)
+
+    return found_xspec
+
+
+def _handle_parameters(out: OutType,
+                       mod: Model
+                       ) -> str:
+    """Display the model parameters.
+
+    Returns information on any parameter links.
+
+    """
+
+    # Write out the parameters in the order they are stored in
+    # the model.
+    #
+    linkstr = ""
+    for par in mod.pars:
+        par_attributes, par_linkstr = _print_par(par)
+        _output(out, par_attributes)
+        linkstr += par_linkstr
+
+    # If the model is a PSFModel then there are a number of
+    # attributes we want to set, but they are not stored in the
+    # .pars attribute. Not all are Parameter objects.
+    #
+    # Drop the "kernel" field as it should not be user settable.  Do
+    # not worry about other parameter attrbutes such as a frozen flag
+    # or limits.
+    #
+    # It is possible to loop over all attributes - e.g. drop ones
+    # beginning with "_", those that are callable, and those in
+    # the .pars attribute - rather than hard code the list, but as
+    # this is already special cased (the mod.type check) then it
+    # is not worth it at this time.
+    #
+    if mod.type == "psfmodel":
+        modelname = _get_cpt_name(mod)
+        spacer = False
+
+        for parname in ["size", "center", "radial", "norm"]:
+            parval = getattr(mod, parname, None)
+            if parval is None:
+                continue
+
+            val = parval.val if isinstance(parval, Parameter) else parval
+            _output(out, f"{modelname}.{parname} = {val}")
+            spacer = True
+
+        if spacer:
+            _output_nl(out)
+
+    return linkstr
+
+
 def _save_model_components(out: OutType, state: SessionType) -> bool:
     """Save the model components.
 
@@ -1015,13 +1141,11 @@ def _save_model_components(out: OutType, state: SessionType) -> bool:
 
     """
 
-    found_xspec = False
-
     # Try to be careful about the ordering of the components here.
     #
     all_model_components = state.list_model_components()
     if len(all_model_components) == 0:
-        return found_xspec
+        return False
 
     all_model_components.reverse()
     _output_banner(out, "Set Model Components and Parameters")
@@ -1031,87 +1155,12 @@ def _save_model_components(out: OutType, state: SessionType) -> bool:
     # link commands to outfile -- *all* models need to be created before
     # *any* links between parameters can be established.
     linkstr = ""
+    found_xspec = False
     for modval in all_model_components:
 
-        # get actual model instance from the name we are given
-        # then get model type, and name of this instance.
         mod = eval(modval)
-        typename = mod.type
-        modelname = mod.name.split(".")[1]
-
-        if typename == "usermodel":
-            _handle_usermodel(out, mod, modelname)
-
-        elif typename == "psfmodel":
-            cmd = f'load_psf("{mod._name}", "{mod.kernel.name}")'
-            _output(out, cmd)
-
-        elif typename in ["fixedtablemodel", "interpolatedtablemodel1d"]:
-            cmd = f'load_table_model("{modelname}", "{mod.filename}")'
-            _output(out, cmd)
-
-        elif typename == "xstablemodel":
-            cmd = f'load_xstable_model("{modelname}", "{mod.filename}"'
-            if mod.etable:
-                cmd += ', etable=True'
-
-            cmd += ')'
-            _output(out, cmd)
-            found_xspec = True
-
-        else:
-            # Normal case:  create an instance of the model.
-            cmd = f'create_model_component("{typename}", "{modelname}")'
-            _output(out, cmd)
-
-            # Is this an XSPEC model? We only care if it's the first
-            # one we find.
-            #
-            if not found_xspec and xspec is not None:
-                found_xspec = isinstance(mod, xspec.XSModel)
-
-        # QUS: should this be included in the above checks?
-        #      @DougBurke doesn't think so, as the "normal
-        #      case" above should probably be run , but there's
-        #      no checks to verify this.
-        #
-        if typename == "convolutionkernel":
-            # Create general convolution kernel with load_conv
-            cmd = f'load_conv("{modelname}", "{mod.kernel.name}")'
-            _output(out, cmd)
-
-        if hasattr(mod, "integrate"):
-            cmd = f"{modelname}.integrate = {mod.integrate}"
-            _output(out, cmd)
-            _output_nl(out)
-
-        # Write out the parameters in the order they are stored in
-        # the model. The original version of the code iterated
-        # through mod.__dict__.values() and picked out Parameter
-        # values.
-        #
-        for par in mod.pars:
-            par_attributes, par_linkstr = _print_par(par)
-            _output(out, par_attributes)
-            linkstr = linkstr + par_linkstr
-
-        # If the model is a PSFModel then there are a number of
-        # attributes we want to set, but they are not stored in the
-        # .pars attribute. Drop the "kernel" field as it is a string.
-        #
-        if typename == "psfmodel":
-            spacer = False
-            for parname in ["size", "center", "radial", "norm"]:
-                parval = getattr(mod, parname, None)
-                if parval is None:
-                    continue
-
-                val = parval.val if isinstance(parval, Parameter) else parval
-                _output(out, f"{modelname}.{parname} = {val}")
-                spacer = True
-
-            if spacer:
-                _output_nl(out)
+        found_xspec |= _handle_model(out, mod)
+        linkstr += _handle_parameters(out, mod)
 
     # If there were any links made between parameters, send those
     # link commands to outfile now; else, linkstr is just an empty string
@@ -1145,6 +1194,115 @@ def _save_psf_components(out: OutType, state: SessionType) -> None:
         _output(out, f"set_psf({cmd_id}, {psfmod._name})")
 
 
+def _save_source(out: OutType,
+                 state: SessionType,
+                 id: IdType
+                 ) -> None:
+    """Create the save_source/model/full_model line."""
+
+    cmd_id = _id_to_str(id)
+
+    # If a data set has a source model associated with it,
+    # set that here -- try to distinguish cases where
+    # source model is different from whole model.
+    # If not, just pass
+    try:
+        try:
+            the_source = state.get_source(id)
+        except:
+            the_source = None
+
+        try:
+            the_full_model = state.get_model(id)
+        except:
+            the_full_model = None
+
+        have_source = the_source is not None
+        have_full_model = the_full_model is not None
+
+        if have_source:
+            if have_full_model:
+                # for now assume that set_full_model is only
+                # used by PHA data sets.
+                try:
+                    is_pha = isinstance(state.get_data(id), DataPHA)
+                except:
+                    is_pha = False
+
+                if is_pha and repr(the_source) == repr(the_full_model):
+                    cmd = f"set_full_model({cmd_id}, {the_full_model.name})"
+                else:
+                    cmd = f"set_source({cmd_id}, {the_source.name})"
+            else:
+                cmd = f"set_source({cmd_id}, {the_source.name})"
+
+        elif have_full_model:
+            cmd = f"set_full_model({cmd_id}, {the_full_model.name})"
+
+        else:
+            return
+
+        _output(out, cmd)
+        _output_nl(out)
+    except:
+        pass
+
+
+def _save_bkg_source(out: OutType,
+                     state: SessionType,
+                     id: IdType
+                     ) -> None:
+    """Create the save_bkg_source/model/full_model line."""
+
+    # Set background models (if any) associated with backgrounds
+    # tied to this data set -- if none, then pass.  Again, try
+    # to distinguish cases where background "source" model is
+    # different from whole background model.
+    try:
+        bids = state.list_bkg_ids(id)
+        cmd_id = _id_to_str(id)
+
+        for bid in bids:
+            cmd_bkg_id = _id_to_str(bid)
+
+            try:
+                the_bkg_source = state.get_bkg_source(id, bkg_id=bid)
+            except:
+                the_bkg_source = None
+
+            try:
+                the_bkg_full_model = state.get_bkg_model(id, bkg_id=bid)
+            except:
+                the_bkg_full_model = None
+
+            have_source = the_bkg_source is not None
+            have_full_model = the_bkg_full_model is not None
+
+            if have_source:
+                # This does not check for the dataset being a DataPHA
+                # object, since (at present) it has to be, as it's the
+                # only one to support backgrounds
+                if have_full_model:
+                    if repr(the_bkg_source) == repr(the_bkg_full_model):
+                        cmd = f"set_bkg_full_model({cmd_id}, {the_bkg_full_model.name}, bkg_id={cmd_bkg_id})"
+                    else:
+                        cmd = f"set_bkg_source({cmd_id}, {the_bkg_source.name}, bkg_id={cmd_bkg_id})"
+                else:
+                    cmd = f"set_bkg_source({cmd_id}, {the_bkg_source.name}, bkg_id={cmd_bkg_id})"
+
+            elif have_full_model:
+                cmd = f"set_bkg_full_model({cmd_id}, {the_bkg_full_model.name}, bkg_id={cmd_bkg_id})"
+
+            else:
+                return
+
+            _output(out, cmd)
+            _output_nl(out)
+
+    except:
+        pass
+
+
 def _save_models(out: OutType, state: SessionType) -> None:
     """Save the source, pileup, and background models.
 
@@ -1163,98 +1321,8 @@ def _save_models(out: OutType, state: SessionType) -> None:
     orig_pos = _get_out_pos(out)
 
     for id in ids:
-        cmd_id = _id_to_str(id)
-
-        # If a data set has a source model associated with it,
-        # set that here -- try to distinguish cases where
-        # source model is different from whole model.
-        # If not, just pass
-        try:
-            try:
-                the_source = state.get_source(id)
-            except:
-                the_source = None
-
-            try:
-                the_full_model = state.get_model(id)
-            except:
-                the_full_model = None
-
-            have_source = the_source is not None
-            have_full_model = the_full_model is not None
-
-            if have_source:
-                if have_full_model:
-                    # for now assume that set_full_model is only
-                    # used by PHA data sets.
-                    try:
-                        is_pha = isinstance(state.get_data(id), DataPHA)
-                    except:
-                        is_pha = False
-
-                    if is_pha and repr(the_source) == repr(the_full_model):
-                        cmd = f"set_full_model({cmd_id}, {the_full_model.name})"
-                    else:
-                        cmd = f"set_source({cmd_id}, {the_source.name})"
-                else:
-                    cmd = f"set_source({cmd_id}, {the_source.name})"
-
-            elif have_full_model:
-                cmd = f"set_full_model({cmd_id}, {the_full_model.name})"
-
-            else:
-                continue
-
-            _output(out, cmd)
-            _output_nl(out)
-        except:
-            pass
-
-        # Set background models (if any) associated with backgrounds
-        # tied to this data set -- if none, then pass.  Again, try
-        # to distinguish cases where background "source" model is
-        # different from whole background model.
-        try:
-            bids = state.list_bkg_ids(id)
-            for bid in bids:
-                cmd_bkg_id = _id_to_str(bid)
-
-                try:
-                    the_bkg_source = state.get_bkg_source(id, bkg_id=bid)
-                except:
-                    the_bkg_source = None
-
-                try:
-                    the_bkg_full_model = state.get_bkg_model(id, bkg_id=bid)
-                except:
-                    the_bkg_full_model = None
-
-                have_source = the_bkg_source is not None
-                have_full_model = the_bkg_full_model is not None
-
-                if have_source:
-                    # This does not check for the dataset being a DataPHA
-                    # object, since (at present) it has to be, as it's the
-                    # only one to support backgrounds
-                    if have_full_model:
-                        if repr(the_bkg_source) == repr(the_bkg_full_model):
-                            cmd = f"set_bkg_full_model({cmd_id}, {the_bkg_full_model.name}, bkg_id={cmd_bkg_id})"
-                        else:
-                            cmd = f"set_bkg_source({cmd_id}, {the_bkg_source.name}, bkg_id={cmd_bkg_id})"
-                    else:
-                        cmd = f"set_bkg_source({cmd_id}, {the_bkg_source.name}, bkg_id={cmd_bkg_id})"
-
-                elif have_full_model:
-                    cmd = f"set_bkg_full_model({cmd_id}, {the_bkg_full_model.name}, bkg_id={cmd_bkg_id})"
-
-                else:
-                    continue
-
-                _output(out, cmd)
-                _output_nl(out)
-
-        except:
-            pass
+        _save_source(out, state, id)
+        _save_bkg_source(out, state, id)
 
     # separate out the pileup models from the source models
     #

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -1033,6 +1033,10 @@ def _handle_model(out: OutType,
         cmd = f'load_psf("{mod._name}", "{mod.kernel.name}")'
         _output(out, cmd)
 
+    elif isinstance(mod, ConvolutionKernel):
+        cmd = f'load_conv("{modelname}", "{mod.kernel.name}")'
+        _output(out, cmd)
+
     elif isinstance(mod, (TableModel, TableModelBase)):
         # Use of TableModel is deprecated.
         cmd = f'load_table_model("{modelname}", "{mod.filename}")'
@@ -1056,16 +1060,6 @@ def _handle_model(out: OutType,
         #
         if xspec is not None:
             found_xspec |= isinstance(mod, xspec.XSModel)
-
-    # QUS: should this be included in the above checks?
-    #      @DougBurke doesn't think so, as the "normal
-    #      case" above should probably be run , but there's
-    #      no checks to verify this.
-    #
-    if isinstance(mod, ConvolutionKernel):
-        # Create general convolution kernel with load_conv
-        cmd = f'load_conv("{modelname}", "{mod.kernel.name}")'
-        _output(out, cmd)
 
     if hasattr(mod, "integrate"):
         cmd = f"{modelname}.integrate = {mod.integrate}"

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -243,8 +243,16 @@ class FileStore:
         except KeyError:
             raise KeyError(f"kwargs does not contain a '{self.idkey}' element") from None
 
-    def show(self) -> str:
-        """How to load the data, ignoring the autoloaded setting."""
+    def show(self,
+             absolute: bool = True) -> str:
+        """How to load the data, ignoring the autoloaded setting.
+
+        Parameters
+        ----------
+        absolute
+           If True (the default) then use the full path otherwise
+           use a path relative to the current working directory.
+        """
 
         out = f'{self.loadfunc.__name__}('
 
@@ -255,8 +263,20 @@ class FileStore:
             idstr = _id_to_str(self.kwargs[self.idkey])
             out += f'{idstr}, '
 
+        # Can we clean up the filename?
         filename = self.kwargs[self.filekey]
-        out += f'"{filename.resolve()}"'
+        if absolute:
+            filename = filename.resolve()
+        else:
+            cwd = filename.cwd()
+            try:
+                filename = filename.resolve().relative_to(cwd)
+            except ValueError:
+                # If the file is not related to the working directory
+                # fall back to the full path.
+                pass
+
+        out += f'"{filename}"'
 
         # Drop the default arguments as we can not track what
         # arguments were actually used when the file was loaded.

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -298,6 +298,23 @@ class FileStore:
 #
 FileDict = dict[IdType, FileStore]
 
+"""
+add_pha_response(astore | None, rstore | None,
+                 idval, resp_id, bkg_id=None)
+
+astore | None, rstore | None = get_pha_response(idval, resp_id, bkg_id=None)
+
+how about add_psf? In that case we may need an enumeration and can
+go back to add_extra? With add_extra can fit in bkg, but then need
+to carry around bkg_id for routines that don't need it. Cam use
+**kwargs and then the enumeration can "record" this.
+
+
+add_extra(store: T, idval, **kwargs) -> None
+get_extra(idval, **kwargs) -> T
+   T since may want tuple[FileStore | None, FileStore | None] ....
+
+"""
 
 class Storage:
     """Store the mapping from dataset identifier to FileStore."""

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -833,17 +833,13 @@ def _print_par(par: ParameterType) -> tuple[str, str | None]:
     # hard min/max ranges?
     #
     parstrs = []
-    try:
+    with suppress(AttributeError):
         if par.hard_min_changed():
             parstrs.append(f'{par.fullname}.hard_min    = {par.hard_min}')
-    except AttributeError:
-        pass
 
-    try:
+    with suppress(AttributeError):
         if par.hard_max_changed():
             parstrs.append(f'{par.fullname}.hard_max    = {par.hard_max}')
-    except AttributeError:
-        pass
 
     parstrs.extend([f'{par.fullname}.default_val = {par.default_val}',
                     f'{par.fullname}.default_min = {par.default_min}',
@@ -1210,16 +1206,17 @@ def _save_source(out: OutType,
     # If a data set has a source model associated with it,
     # set that here -- try to distinguish cases where
     # source model is different from whole model.
-    # If not, just pass
-    try:
+    # If not, do nothing.
+    #
+    with suppress(Exception):
         try:
             the_source = state.get_source(id)
-        except:
+        except Exception:
             the_source = None
 
         try:
             the_full_model = state.get_model(id)
-        except:
+        except Exception:
             the_full_model = None
 
         have_source = the_source is not None
@@ -1231,7 +1228,7 @@ def _save_source(out: OutType,
                 # used by PHA data sets.
                 try:
                     is_pha = isinstance(state.get_data(id), DataPHA)
-                except:
+                except Exception:
                     is_pha = False
 
                 if is_pha and repr(the_source) == repr(the_full_model):
@@ -1249,8 +1246,6 @@ def _save_source(out: OutType,
 
         _output(out, cmd)
         _output_nl(out)
-    except:
-        pass
 
 
 def _save_bkg_source(out: OutType,
@@ -1260,10 +1255,11 @@ def _save_bkg_source(out: OutType,
     """Create the save_bkg_source/model/full_model line."""
 
     # Set background models (if any) associated with backgrounds
-    # tied to this data set -- if none, then pass.  Again, try
+    # tied to this data set -- if none, then do nothing.  Again, try
     # to distinguish cases where background "source" model is
     # different from whole background model.
-    try:
+    #
+    with suppress(Exception):
         bids = state.list_bkg_ids(id)
         cmd_id = _id_to_str(id)
 
@@ -1272,12 +1268,12 @@ def _save_bkg_source(out: OutType,
 
             try:
                 the_bkg_source = state.get_bkg_source(id, bkg_id=bid)
-            except:
+            except Exception:
                 the_bkg_source = None
 
             try:
                 the_bkg_full_model = state.get_bkg_model(id, bkg_id=bid)
-            except:
+            except Exception:
                 the_bkg_full_model = None
 
             if the_bkg_source is not None:
@@ -1300,9 +1296,6 @@ def _save_bkg_source(out: OutType,
 
             _output(out, cmd)
             _output_nl(out)
-
-    except:
-        pass
 
 
 def _save_models(out: OutType, state: SessionType) -> None:
@@ -1331,7 +1324,7 @@ def _save_models(out: OutType, state: SessionType) -> None:
     for id in ids:
         try:
             pname = state.get_pileup_model(id).name
-        except:
+        except Exception:
             continue
 
         cmd_id = _id_to_str(id)

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -1180,14 +1180,16 @@ def _handle_filter(out: OutType,
 
 def _load_from_store(out: OutType,
                      store: FileStore,
-                     auto_load: bool
+                     *,
+                     auto_load: bool,
+                     relative_path: bool
                      ) -> None:
     """Display the load call if wanted."""
 
     if auto_load and store.autoloaded:
         return
 
-    _output(out, store.show())
+    _output(out, store.show(absolute=not relative_path))
 
 
 def _load_bkg_manual(out: OutType,
@@ -1233,7 +1235,9 @@ def _save_dataset_settings_pha(out: OutType,
                                state: SessionType,
                                pha: DataPHA,
                                idval: IdType,
-                               auto_load: bool
+                               *,
+                               auto_load: bool,
+                               relative_path: bool
                                ) -> None:
     """What settings need to be set for DataPHA"""
 
@@ -1264,14 +1268,16 @@ def _save_dataset_settings_pha(out: OutType,
             if arf is not None:
                 astore = state._storage.get_arf(idval, rid)
                 if astore is not None:
-                    _load_from_store(out, astore, auto_load)
+                    _load_from_store(out, astore, auto_load=auto_load,
+                                     relative_path=relative_path)
                 else:
                     _load_arf_manual(out, arf, idval, rid)
 
             if rmf is not None:
                 rstore = state._storage.get_rmf(idval, rid)
                 if rstore is not None:
-                    _load_from_store(out, rstore, auto_load)
+                    _load_from_store(out, rstore, auto_load=auto_load,
+                                     relative_path=relative_path)
                 else:
                     _load_rmf_manual(out, rmf, idval, rid)
 
@@ -1292,7 +1298,8 @@ def _save_dataset_settings_pha(out: OutType,
 
             bstore = state._storage.get_bkg(idval, bid)
             if bstore is not None:
-                _load_from_store(out, bstore, auto_load)
+                _load_from_store(out, bstore, auto_load=auto_load,
+                                 relative_path=relative_path)
             else:
                 _load_bkg_manual(out, idval, bid, bpha)
 
@@ -1321,14 +1328,16 @@ def _save_dataset_settings_pha(out: OutType,
                     if bkg_arf is not None:
                         astore = state._storage.get_bkg_arf(idval, bid, rid)
                         if astore is not None:
-                            _load_from_store(out, astore, auto_load)
+                            _load_from_store(out, astore, auto_load=auto_load,
+                                             relative_path=relative_path)
                         else:
                             _load_arf_manual(out, bkg_arf, idval, rid, bid=bid)
 
                     if bkg_rmf is not None:
                         rstore = state._storage.get_bkg_rmf(idval, bid, rid)
                         if rstore is not None:
-                            _load_from_store(out, rstore, auto_load)
+                            _load_from_store(out, rstore, auto_load=auto_load,
+                                             relative_path=relative_path)
                         else:
                             _load_rmf_manual(out, bkg_rmf, idval, rid, bid=bid)
 
@@ -1356,7 +1365,9 @@ def _save_dataset_settings_2d(out: OutType,
 
 def _save_data(out: OutType,
                state: SessionType,
-               auto_load: bool
+               *,
+               auto_load: bool,
+               relative_path: bool
                ) -> None:
     """Save the data.
 
@@ -1371,6 +1382,9 @@ def _save_data(out: OutType,
     auto_load : bool
        If ``False`` then the output will contain `load_arf`,
        `load_rmf`, and `load_bkg` calls for ancillary PHA files.
+    relative_path : bool
+       Should paths be recorded as relative to the current working
+       directory?
 
     Notes
     -----
@@ -1411,7 +1425,7 @@ def _save_data(out: OutType,
             continue
 
         _output(out, msg)
-        _save_dataset_store(out, store)
+        _save_dataset_store(out, store, relative_path=relative_path)
 
         # Do we need to delete any of the PHA2 datasets?
         #
@@ -1426,11 +1440,12 @@ def _save_data(out: OutType,
             # Assert an actual type rather than the base type of Data
             assert isinstance(data, (Data1D, Data2D))
 
-        _save_dataset(out, state, data, idval)
+        _save_dataset(out, state, data, idval, relative_path=relative_path)
 
         if isinstance(data, DataPHA):
             _save_dataset_settings_pha(out, state, data, idval,
-                                       auto_load=auto_load)
+                                       auto_load=auto_load,
+                                       relative_path=relative_path)
 
         elif isinstance(data, DataIMG):
             _save_dataset_settings_2d(out, state, data, idval)
@@ -2042,11 +2057,13 @@ def _save_xspec(out: OutType) -> None:
 
 
 def _save_dataset_store(out: OutType,
-                        store: FileStore
+                        store: FileStore,
+                        *,
+                        relative_path: bool
                         ) -> None:
     """The data can be read in from a file."""
 
-    outstr = store.show()
+    outstr = store.show(absolute=not relative_path)
     if outstr in out["main"]:
         # This indicates this is from a PHA2 file which has already
         # been loaded.
@@ -2223,7 +2240,10 @@ def _save_dataset_rmf_manual(out: OutType,
 def _save_dataset(out: OutType,
                   state: SessionType,
                   data: Data,
-                  id: IdType) -> None:
+                  id: IdType,
+                  *,
+                  relative_path: bool
+                  ) -> None:
     """Given a dataset identifier, return the text needed to
     re-create it.
 
@@ -2237,7 +2257,7 @@ def _save_dataset(out: OutType,
 
     store = state._storage.get(id)
     if store is not None:
-        _save_dataset_store(out, store)
+        _save_dataset_store(out, store, relative_path=relative_path)
         return
 
     idstr = _id_to_str(id)
@@ -2351,7 +2371,8 @@ def _save_id(out: OutType, state: SessionType) -> None:
 def save_all(state: SessionType,
              fh: TextIO | None = None,
              *,
-             auto_load: bool = True
+             auto_load: bool = True,
+             relative_path: bool = False
              ) -> None:
     """Save the information about the current session to a file handle.
 
@@ -2368,7 +2389,8 @@ def save_all(state: SessionType,
 
      .. versionchanged:: 4.19.0
         Improved support for reporting optional arguments used when
-        loading a file. File paths are now always normalized.
+        loading a file. File paths are now always normalized. Added
+        the relative_path argument.
 
      .. versionchanged:: 4.18.0
         Handling of PHA data has been improved, and the output now
@@ -2386,6 +2408,9 @@ def save_all(state: SessionType,
     auto_load : bool, optional
        If ``False`` then the output will contain `load_arf`,
        `load_rmf`, and `load_bkg` calls for ancillary PHA files.
+    relative_path : bool, optional
+       Should paths be recorded as relative to the current working
+       directory?
 
     See Also
     --------
@@ -2432,7 +2457,7 @@ def save_all(state: SessionType,
             "main": []
            }
 
-    _save_data(out, state, auto_load=auto_load)
+    _save_data(out, state, auto_load=auto_load, relative_path=relative_path)
     _output_nl(out)
     _save_statistic(out, state)
     _save_fit_method(out, state)

--- a/sherpa/astro/ui/serialize.py
+++ b/sherpa/astro/ui/serialize.py
@@ -256,7 +256,7 @@ class FileStore:
             out += f'{idstr}, '
 
         filename = self.kwargs[self.filekey]
-        out += f'"{filename}"'
+        out += f'"{filename.resolve()}"'
 
         # Drop the default arguments as we can not track what
         # arguments were actually used when the file was loaded.

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -3382,6 +3382,125 @@ def test_restore_img_no_filter_model_psf(make_data_path, recwarn, check_str):
     recwarn.clear()
 
 
+@pytest.mark.xfail  # psf.radial.val is restored as 0 not 1
+@requires_fits
+def test_load_psf1d_from_file(check_str, tmp_path):
+    """Can we restore a 1D PSF read from a file?
+
+    See also test_load_psf1d_from_model.
+    """
+
+    psfpath = tmp_path / "psf.dat"
+    psfpath.write_text("1 5\n2 2\n3 1\n")
+
+    y = [12, 10, 6, 5, 0, 1, 0]
+    ui.load_arrays(1, [1, 2, 3, 4, 5, 6, 7], y)
+    g1 = ui.create_model_component("gauss1d", "g1")
+    g1.fwhm = 6
+    g1.pos.freeze()
+    g1.ampl = 10
+    ui.set_source(g1)
+
+    ui.load_psf("psf1", str(psfpath))
+    psf1 = ui.get_model_component("psf1")
+    ui.set_psf(psf1)
+    psf1.radial = 1
+
+    expected = np.asarray([6.76271251, 7.53260707, 5.32670844,
+                           3.25497179, 1.71855646, 0.78387108,
+                           1.45712215])
+    assert ui.get_model_plot().y == pytest.approx(expected)
+
+    restore()
+
+    assert ui.get_data().y == pytest.approx(y)
+
+    assert ui.list_psf_ids() == [1]
+    assert ui.list_model_components() == ["g1", "psf1"]
+    psf = ui.get_model_component("psf1")
+    assert psf.radial.val == pytest.approx(1)
+    assert ui.get_model_plot().y == pytest.approx(expected)
+
+    # As the tests above don't check the frozen state
+    g = ui.get_model_component("g1")
+    assert g.pos.frozen
+    assert g.pos.val == pytest.approx(0)
+
+
+@requires_fits
+def test_load_psf1d_from_model(check_str):
+    """Can we restore a 1D PSF read from a model?
+
+    See also test_load_psf1d_from_file.
+
+    This does not check the output text, just that the serialized
+    script can restore important values.
+
+    """
+
+    # Fake up a model expression to match that of the
+    # _from_file version.
+    #
+    # Apparently box1d is xlow <= x <= xhi.
+    b1 = ui.create_model_component("box1d", "b1")
+    b2 = ui.create_model_component("box1d", "b3")
+    b3 = ui.create_model_component("box1d", "b2")
+    mdl = b1 + b2 + b3
+    b1.ampl = 5
+    b2.xlow = 1.1
+    b2.xhi = 2
+    b3.xlow = 1.1
+    b3.xhi = 3
+    # Check evaluation just in case anything changes.
+    assert mdl([1, 2, 3, 4, 5]) == pytest.approx([5, 2, 1, 0, 0])
+
+    y = [12, 10, 6, 5, 0, 1, 0]
+    ui.load_arrays(1, [1, 2, 3, 4, 5, 6, 7], y)
+    g1 = ui.create_model_component("gauss1d", "g1")
+    g1.fwhm = 6
+    g1.pos.freeze()
+    g1.ampl = 10
+    ui.set_source(g1)
+
+    ui.load_psf("psf1", mdl)
+    psf1 = ui.get_model_component("psf1")
+    ui.set_psf(psf1)
+    # It looks like the radial setting isn't used in this case,
+    # unlike the _from_file version. So for now treat this as
+    # a regression test and do not fall over when the value is
+    # not restored.
+    psf1.radial = 1
+
+    # This does not match the _from_file case, so treat this as
+    # a regression test for now.
+    #
+    # expected = np.asarray([6.76271251, 7.53260707, 5.32670844,
+    #                        3.25497179, 1.71855646, 0.78387108,
+    #                        1.45712215])
+    expected = np.asarray([5.92225346, 6.93631282, 6.11951151,
+                           3.99128568, 2.26543146, 1.11970565,
+                           0.48204892])
+    assert ui.get_model_plot().y == pytest.approx(expected)
+
+    restore()
+
+    assert ui.get_data().y == pytest.approx(y)
+
+    assert ui.list_psf_ids() == [1]
+    assert ui.list_model_components() == ["b1", "b2", "b3", "g1", "psf1"]
+    psf = ui.get_model_component("psf1")
+    assert psf.radial.val == pytest.approx(0)  # NOTE: regression test
+    assert ui.get_model_plot().y == pytest.approx(expected)
+
+    # As the tests above don't check the frozen state
+    g = ui.get_model_component("g1")
+    assert g.pos.frozen
+    assert g.pos.val == pytest.approx(0)
+
+    nmdl = sum(ui.get_model_component(n) for n in ['b1', 'b2', 'b3'])
+    assert nmdl([1, 2, 3, 4, 5]) == pytest.approx([5, 2, 1, 0, 0])
+
+
 @requires_data
 @requires_fits
 def test_restore_table_model(make_data_path, check_str):

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -35,6 +35,8 @@ from sherpa.astro.models import JDPileup
 from sherpa.astro import ui
 from sherpa.astro.io.wcs import WCS
 
+from sherpa.data import Data1D
+
 from sherpa.models.basic import FixedTableModel
 
 from sherpa.utils.err import DataErr, \
@@ -3445,7 +3447,6 @@ def test_load_psf1d_from_file(check_str, tmp_path):
     assert g.pos.val == pytest.approx(0)
 
 
-@requires_fits
 def test_load_psf1d_from_model(check_str):
     """Can we restore a 1D PSF read from a model?
 
@@ -3517,6 +3518,72 @@ def test_load_psf1d_from_model(check_str):
 
     nmdl = sum(ui.get_model_component(n) for n in ['b1', 'b2', 'b3'])
     assert nmdl([1, 2, 3, 4, 5]) == pytest.approx([5, 2, 1, 0, 0])
+
+
+@pytest.mark.xfail  # XFAIL: 'convolutionkernel' is not a valid model type
+@requires_fits
+def test_load_conv_from_file(tmp_path):
+    """Very basic check of load_conv.
+
+    At present all we check is that we can restore a load_conv
+    statement.
+
+    """
+
+    convpath = tmp_path / "conv.dat"
+    convpath.write_text("1 5\n2 2\n3 1\n")
+
+    ui.load_conv("c1", str(convpath))
+
+    def check():
+        mdls = ui.list_model_components()
+        assert len(mdls) == 1
+        assert mdls[0] == "c1"
+
+        x1 = ui.get_model_component("c1")
+        assert x1.name == "convolutionkernel.c1"
+        assert isinstance(x1.kernel, Data1D)
+        assert x1.kernel.x == pytest.approx([1, 2, 3])
+        assert x1.kernel.y == pytest.approx([5, 2, 1])
+
+    check()
+    restore()  # XFAIL
+    check()
+
+
+@pytest.mark.xfail  # XFAIL: 'convolutionkernel' is not a valid model type
+def test_load_conv_from_model():
+    """Very basic check of load_conv.
+
+    At present all we check is that we can restore a load_conv
+    statement.
+
+    """
+
+    g1 = ui.create_model_component("gauss1d", "g1")
+    g1.fwhm = 5
+    g1.pos.freeze()
+
+    ui.load_conv("c1", g1)
+
+    def check():
+        mdls = ui.list_model_components()
+        assert len(mdls) == 2
+        assert mdls[0] == "c1"
+        assert mdls[1] == "g1"
+
+        x1 = ui.get_model_component("g1")
+        assert x1.name == "gauss1d.g1"
+        assert x1.fwhm.val == pytest.approx(5)
+        assert x1.pos.frozen
+
+        x2 = ui.get_model_component("c1")
+        assert x2.name == "convolutionkernel.c1"
+        assert x2.kernel == x1
+
+    check()
+    restore()  # XFAIL
+    check()
 
 
 @requires_data

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -23,6 +23,7 @@ corresponding functions in sherpa.astro.ui.utils.
 """
 
 from io import StringIO
+from pathlib import Path
 import re
 from typing import Any
 import warnings
@@ -2461,13 +2462,26 @@ def setup(hide_logging, clean_astro_ui):
         xspec.set_xsstate(old_xspec)
 
 
-def add_datadir_path(output):
+def add_datadir_path(output: str,
+                     relative_path: bool = False
+                     ) -> str:
     """Replace any @@ characters by the value of self.datadir,
     making sure that the replacement text does not end in a /."""
 
     dname = get_datadir()
     if dname.endswith('/'):
         dname = dname[:-1]
+
+    if relative_path:
+        # Some tests - particularly the documentation tests - can
+        # change the working directory, so allow for the paths to be
+        # different.
+        #
+        dpath = Path(dname)
+        try:
+            dname = str(dpath.relative_to(dpath.cwd()))
+        except ValueError:
+            dname = str(dpath)
 
     return re.sub('@@', dname, output, count=0)
 
@@ -2483,7 +2497,7 @@ def compileit(output: str) -> None:
         raise exc
 
 
-def compare(check_str, expected, **kwargs):
+def compare(check_str, expected: str, **kwargs) -> None:
     """Run save_all and check the output (saved to a
     StringIO object) to the string value expected.
 
@@ -2508,7 +2522,7 @@ def compare(check_str, expected, **kwargs):
         raise
 
 
-def restore():
+def restore() -> None:
     """Run save_all then call clean and try to restore
     the Sherpa state from the saved file. Will raise
     a test failure if there was an error when
@@ -2788,6 +2802,25 @@ def test_canonical_pha_load(make_data_path, check_str):
 
     canonical = add_datadir_path(_canonical_pha_basic_load)
     compare(check_str, canonical, auto_load=False)
+
+
+@requires_data
+@requires_fits
+@requires_group
+def test_canonical_pha_load_relative(make_data_path, check_str):
+    """Do we explicitly load the ancillary files (with relative paths)?"""
+
+    # This is setup_pha_basic but without the source model.
+    #
+    fname = make_data_path('3c273.pi')
+    ui.load_pha(1, fname)
+    ui.subtract()
+    ui.set_stat('chi2datavar')
+    ui.notice(0.5, 7)
+
+    canonical = add_datadir_path(_canonical_pha_basic_load,
+                                 relative_path=True)
+    compare(check_str, canonical, auto_load=False, relative_path=True)
 
 
 @requires_data

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -2905,6 +2905,28 @@ def test_canonical_empty_iterstat(check_str):
     compare(check_str, _canonical_empty_iterstat)
 
 
+@pytest.mark.xfail  # ISSUE: 2504
+def test_estmethod_opt(check_str):
+    """"Check other options for the estmethods
+
+    This does not check the actual output against a canonical
+    version, just whether we can restore the settings.
+    """
+
+    # Change proj, conf, and covar options. Use sigma as
+    # present in all methods.
+    #
+    ui.set_proj_opt('sigma', 1.8)
+    ui.set_conf_opt('sigma', 1.8)
+    ui.set_covar_opt('sigma', 1.8)
+
+    restore()
+
+    assert ui.get_proj_opt('sigma') == pytest.approx(1.8)
+    assert ui.get_conf_opt('sigma') == pytest.approx(1.8)
+    assert ui.get_covar_opt('sigma') == pytest.approx(1.8)
+
+
 @requires_data
 @requires_xspec
 @requires_fits

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -3920,6 +3920,30 @@ def test_link_par(check_str):
     assert m2.c0.link.name == "m1.c0 + sep.c0"
 
 
+def test_multi_link_par(check_str):
+    """Check we can set up multiple parameter links.
+
+    Unlike test_link_par we do not check the serialization,
+    just that it works.
+
+    """
+
+    m1 = ui.create_model_component("const1d", "m1")
+    m2 = ui.create_model_component("const1d", "m2")
+    sep = ui.create_model_component("const1d", "sep")
+
+    m1.c0.freeze()
+    ui.link(m2.c0, m1.c0)
+    ui.link(sep.c0, m2.c0 + 5)
+
+    restore()
+
+    assert m1.c0.link is None
+    assert m2.c0.link.name == "c0"   # TODO: why not "m1.c0"
+    assert sep.c0.link.name == "m2.c0 + 5"
+    assert m1.c0.frozen
+
+
 @pytest.mark.xfail
 @requires_data
 @requires_fits

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -782,8 +782,6 @@ group(1)
 
 ######### Data Spectral Responses
 
-load_arf(1, "@@/3c273.arf", resp_id=1)
-load_rmf(1, "@@/3c273.rmf", resp_id=1)
 
 ######### Load Background Data Sets
 
@@ -791,8 +789,6 @@ group(1, bkg_id=1)
 
 ######### Background Spectral Responses
 
-load_arf(1, "@@/3c273.arf", resp_id=1, bkg_id=1)
-load_rmf(1, "@@/3c273.rmf", resp_id=1, bkg_id=1)
 
 ######### Set Energy or Wave Units
 
@@ -951,7 +947,7 @@ con.offset.frozen  = True
 
 ######### Set Source, Pileup and Background Models
 
-set_full_model(1, (apply_rmf(apply_arf((38564.6089269 * powlaw1d.pl))) + polynom1d.con))
+set_full_model(1, apply_rmf(apply_arf(38565.0 * powlaw1d.pl)) + polynom1d.con)
 
 """
 
@@ -3976,6 +3972,11 @@ def test_pha_full_model(make_data_path, check_str):
     """
 
     ui.load_pha(make_data_path("3c273.pi"))
+
+    # Overwrite the exposure time to make the numeric checks below easier.
+    d = ui.get_data()
+    d.exposure = 38565
+
     ui.notice(1, 6)
 
     pl = ui.create_model_component("powlaw1d", "pl")
@@ -3994,14 +3995,15 @@ def test_pha_full_model(make_data_path, check_str):
     # Can not add lo/hi arguments as calc_model_sum fails.  This is a
     # regression test.
     #
-    expected = 1501.0484798733592
+    expected = 1501.053047504343
     assert ui.calc_model_sum() == pytest.approx(expected)
 
     with pytest.raises(IdentifierErr,
                        match=". You should use get_model instead.$"):
         ui.get_source()
 
-    assert ui.get_model().name == "apply_rmf(apply_arf(38564.6089269 * powlaw1d.pl)) + polynom1d.con"
+    expected_name = "apply_rmf(apply_arf(38565.0 * powlaw1d.pl)) + polynom1d.con"
+    assert ui.get_model().name == expected_name
 
     compare(check_str, add_datadir_path(_canonical_pha_full_model))
 

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -24,6 +24,7 @@ corresponding functions in sherpa.astro.ui.utils.
 
 from io import StringIO
 import re
+from typing import Any
 import warnings
 
 import numpy as np
@@ -33,7 +34,9 @@ import pytest
 
 from sherpa.astro.models import JDPileup
 from sherpa.astro import ui
+from sherpa.astro.instrument import ARF1D, RMF1D
 from sherpa.astro.io.wcs import WCS
+from sherpa.astro.ui.serialize import FileStore
 
 from sherpa.data import Data1D
 
@@ -44,6 +47,7 @@ from sherpa.utils.err import DataErr, \
 from sherpa.utils.testing import get_datadir, requires_data, \
     requires_xspec, has_package_from_list, requires_fits, \
     requires_group, requires_region, requires_wcs
+from sherpa.utils.types import IdType
 
 
 has_xspec = has_package_from_list("sherpa.astro.xspec")
@@ -656,8 +660,8 @@ load_bkg("x", "@@/MNLup_2138_0670580101_EMOS1_S001_specbg.fits", bkg_id="foo", u
 
 ######### Background Spectral Responses
 
-load_arf("x", "@@/MNLup_2138_0670580101_EMOS1_S001_spec.arf", resp_id=1, bkg_id="foo")
-load_rmf("x", "@@/MNLup_2138_0670580101_EMOS1_S001_spec.rmf", resp_id=1, bkg_id="foo")
+load_arf("x", "@@/MNLup_2138_0670580101_EMOS1_S001_spec.arf", bkg_id="foo")
+load_rmf("x", "@@/MNLup_2138_0670580101_EMOS1_S001_spec.rmf", bkg_id="foo")
 
 ######### Set Energy or Wave Units
 
@@ -1549,8 +1553,23 @@ group(1)
 
 ######### Data Spectral Responses
 
-load_arf(1, "test-arf", resp_id=1)
-load_rmf(1, "delta-rmf", resp_id=1)
+arf = DataARF("test-arf",
+              numpy.array([0.1, 0.2, 0.4, 0.8, 1.2]),
+              numpy.array([0.2, 0.4, 0.8, 1.2, 1.6]),
+              [1.0, 1.0, 1.0, 1.0, 1.0])
+set_arf(1, arf, resp_id=1)
+rmf = DataRMF("delta-rmf", 5,
+              numpy.array([0.1, 0.2, 0.4, 0.8, 1.2]),
+              numpy.array([0.2, 0.4, 0.8, 1.2, 1.6]),
+              offset=1,
+              n_grp=numpy.array([1, 1, 1, 1, 1]),
+              f_chan=numpy.array([1, 2, 3, 4, 5]),
+              n_chan=numpy.array([1, 1, 1, 1, 1]),
+              matrix=numpy.array([1, 1, 1, 1, 1]),
+              e_min=numpy.array([0.1, 0.2, 0.4, 0.8, 1.2]),
+              e_max=numpy.array([0.2, 0.4, 0.8, 1.2, 1.6])
+              )
+set_rmf(1, rmf, resp_id=1)
 
 ######### Set Energy or Wave Units
 
@@ -1566,6 +1585,45 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
+
+
+######### Set Model Components and Parameters
+
+create_model_component("powlaw1d", "pl")
+pl.integrate = True
+
+pl.gamma.default_val = 1.5
+pl.gamma.default_min = -10.0
+pl.gamma.default_max = 10.0
+pl.gamma.val     = 1.5
+pl.gamma.min     = -10.0
+pl.gamma.max     = 10.0
+pl.gamma.units   = ""
+pl.gamma.frozen  = False
+
+pl.ref.default_val = 1.0
+pl.ref.default_min = -3.4028234663852886e+38
+pl.ref.default_max = 3.4028234663852886e+38
+pl.ref.val     = 1.0
+pl.ref.min     = -3.4028234663852886e+38
+pl.ref.max     = 3.4028234663852886e+38
+pl.ref.units   = ""
+pl.ref.frozen  = True
+
+pl.ampl.default_val = 2.0
+pl.ampl.default_min = 0.0
+pl.ampl.default_max = 3.4028234663852886e+38
+pl.ampl.val     = 2.0
+pl.ampl.min     = 0.0
+pl.ampl.max     = 3.4028234663852886e+38
+pl.ampl.units   = ""
+pl.ampl.frozen  = False
+
+
+
+######### Set Source, Pileup and Background Models
+
+set_source(1, powlaw1d.pl)
 
 """
 
@@ -1584,6 +1642,13 @@ set_areascal(1, 0.001)
 
 ######### Load Background Data Sets
 
+bkg = DataPHA("ex",
+              [1, 2, 3, 4, 5],
+              [4, 1, 0, 0, 1])
+set_bkg(1, bkg, bkg_id=1)
+set_exposure(1, 500, bkg_id=1)
+set_backscal(1, 0.01, bkg_id=1)
+set_areascal(1, 0.02, bkg_id=1)
 
 ######### Set Energy or Wave Units
 
@@ -2332,8 +2397,8 @@ load_pha(2, "@@/9774.pi")
 
 ######### Background Spectral Responses
 
-load_arf(2, "@@/3c273.arf", resp_id=1, bkg_id=1)
-load_rmf(2, "@@/3c273.rmf", resp_id=1, bkg_id=1)
+load_arf(2, "@@/3c273.arf", bkg_id=1)
+load_rmf(2, "@@/3c273.rmf", bkg_id=1)
 
 ######### Set Energy or Wave Units
 
@@ -2407,9 +2472,15 @@ def add_datadir_path(output):
     return re.sub('@@', dname, output, count=0)
 
 
-def compileit(output):
+def compileit(output: str) -> None:
     # Let it just throw an exception in case of failure.
-    compile(output, "test.py", "exec")
+    try:
+        compile(output, "test.py", "exec")
+    except SyntaxError as exc:
+        print("** INVALID Python code")
+        print(output)
+        print("** INVALID Python code")
+        raise exc
 
 
 def compare(check_str, expected, **kwargs):
@@ -2430,7 +2501,11 @@ def compare(check_str, expected, **kwargs):
     # but ensures that the program can compile.
     #
     compileit(output)
-    check_str(output, expected.split("\n"))
+    try:
+        check_str(output, expected.split("\n"))
+    except:
+        print(f"OUTPUT:\n{output}")
+        raise
 
 
 def restore():
@@ -3492,7 +3567,6 @@ def test_restore_load_arrays_pha(check_str):
     assert pha.counts == pytest.approx([12, 2, 1, 0, 1])
 
 
-@requires_fits  # only needed because of incorrect serialization
 @requires_group
 def test_restore_load_arrays_pha_response(check_str):
     """Can we re-create a load_arrays/DataPHA case?
@@ -3518,23 +3592,45 @@ def test_restore_load_arrays_pha_response(check_str):
     ui.set_arf(ui.create_arf(elo, ehi))
     ui.set_rmf(ui.create_rmf(elo, ehi))
 
+    ui.set_source(ui.powlaw1d.pl)
+    pl.ampl = 2
+    pl.gamma = 1.5
+
+    analysis = ui.get_analysis()
+    modelname = ui.get_model().name
+    exp_x, exp_y = ui.calc_model()
+
     compare(check_str, _canonical_load_arrays_pha_response)
 
-    # The error response likely depends on the backend, but it happens
-    # because the ARF "file name" - in this case "test-arf" - does not
-    # exist, hence the restoration fails.
-    #
-    with pytest.raises(IOErr):
-        restore()
+    restore()
 
-    # TODO: come up with tests once the state can be restored
+    assert ui.get_analysis() == analysis
+    assert ui.get_model().name == modelname
+
+    arf = ui.get_arf()
+    assert isinstance(arf, ARF1D)
+    assert arf.name == "test-arf"
+    assert arf.specresp == pytest.approx([1] * 5)
+
+    rmf = ui.get_rmf()
+    assert isinstance(rmf, RMF1D)
+    assert rmf.name == "delta-rmf"
+    assert rmf.matrix == pytest.approx([1] * 5)
+
+    got_x, got_y = ui.calc_model()
+    assert got_x[0] == pytest.approx(exp_x[0])
+    assert got_x[1] == pytest.approx(exp_x[1])
+    assert len(got_x) == 2
+
+    # If the convolved-model agrees then it is likely that the
+    # response was correctly saved (although in this case, with
+    # identity responses, it is not a perfect test).
+    #
+    assert got_y == pytest.approx(exp_y)
 
 
 def test_restore_load_arrays_pha_with_bkg(check_str):
     """Can we re-create a load_arrays/DataPHA with background?
-
-    This recreation is currently incomplete, so just test what is
-    expected (i.e. a regression test).
 
     """
 
@@ -3556,14 +3652,12 @@ def test_restore_load_arrays_pha_with_bkg(check_str):
     restore()
 
     assert ui.list_data_ids() == [1]
-    # assert ui.list_bkg_ids(1) == [1]
-    assert ui.list_bkg_ids(1) == []  # TODO: this is wrong
+    assert ui.list_bkg_ids(1) == [1]
 
     pha = ui.get_data()
-    # bkg = ui.get_bkg()  # TODO: this currently fails
+    bkg = ui.get_bkg()
 
-    # for got_obj, exp_obj in [(pha, dset), (bkg, bset)]:
-    for got_obj, exp_obj in [(pha, dset)]:
+    for got_obj, exp_obj in [(pha, dset), (bkg, bset)]:
         assert isinstance(got_obj, ui.DataPHA)
 
         for field in ["channel", "counts", "exposure",
@@ -3831,10 +3925,6 @@ def test_pha_full_model(make_data_path, check_str):
 def test_load_data(make_data_path, check_str):
     """Check load_data path for Data1D case with staterror"""
 
-    # Unfortunately we need to care about the backend here.
-    #
-    from sherpa.astro import io
-
     ui.set_stat("chi2datavar")
 
     infile = make_data_path("data1.dat")
@@ -3854,16 +3944,7 @@ def test_load_data(make_data_path, check_str):
                        match="data set '1' does not specify systematic errors"):
         ui.get_syserror()
 
-    if io.backend.name == "crates":
-        term = "@@/data1.dat"
-        idx = _canonical_load_data.find(term)
-        expected_output = _canonical_load_data[:idx] + term + \
-            "[opt colnames=none]" + \
-            _canonical_load_data[idx + len(term):]
-    else:
-        expected_output = _canonical_load_data
-
-    expected_output = add_datadir_path(expected_output)
+    expected_output = add_datadir_path(_canonical_load_data)
     compare(check_str, expected_output)
 
     restore()
@@ -4219,7 +4300,6 @@ def test_filter1d_excluded2():
         ui.get_dep(filter=True)
 
 
-@pytest.mark.xfail  # XFAIL: does not save the background
 def test_filter1d_pha_bkg_excluded():
     """Check what happens if all data filtered out from PHA bkg."""
 
@@ -4531,7 +4611,6 @@ def test_load_ascii(make_data_path):
     check()
 
 
-@pytest.mark.xfail  # does not include colkeys when loading in the data
 @requires_fits
 @requires_data
 def test_load_table_fits(make_data_path):
@@ -4558,3 +4637,267 @@ def test_load_table_fits(make_data_path):
     check()
     restore()
     check()
+
+
+# Ideally there would be a single routine to test the backends but
+# because
+#
+# - the need to close the pyfits object but not the crates one
+# - the fact the crates backend needs different functions to load
+#   the data
+# - the pyfits backend fails a test but the crates backend doesn't
+# - the crates backend can read in ASCII data but the pyfits one can
+#   not (since it is not been updated to use the AstroPy Table
+#   support)
+#
+# the test code has been split into per-backend versions and the
+# test logic written once.
+#
+def check_load_object(loadfunc: str,
+                      obj: Any,
+                      kwargs: dict[str, Any]
+                      ) -> None:
+    """Verify that the data can be restored.
+
+    The argument is assumed to be an I/O "object" rather than a
+    filename, so all we care about is that the restored data is the
+    "same" as the original data (with minimal checks).  This is not
+    guaranteed to check all possible variations but is a minimum.
+
+    """
+
+    func = getattr(ui, loadfunc)
+    func(obj, **kwargs)
+
+    datatype = type(ui.get_data())
+    exp_xs = ui.get_indep()
+    exp_ys = ui.get_dep()
+    exp_dy = ui.get_staterror()
+
+    restore()
+
+    data = ui.get_data()
+    assert isinstance(data, datatype)
+
+    got_xs = ui.get_indep()
+    got_ys = ui.get_dep()
+    got_dy = ui.get_staterror()
+
+    assert len(got_xs) == len(exp_xs)
+    for got_val, exp_val in zip(got_xs, exp_xs):
+        assert got_val == pytest.approx(exp_val)
+
+    assert got_ys == pytest.approx(exp_ys)
+    assert got_dy == pytest.approx(exp_dy)
+
+
+@requires_wcs  # for the image example
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("loadfunc,filename,kwargs,getfunc",
+                         [("load_table", "1838_rprofile_rmid.fits",
+                           {"colkeys": ["RMID", "SUR_BRI"]}, "read_file"),
+                          ("load_data", "1838_rprofile_rmid.fits",
+                           {"colkeys": ["RMID", "NET_COUNTS"]}, "read_file"),
+                          ("load_image", "psf_0.0_00_bin0.5.img", {},
+                           "read_file"),
+                          ("load_pha", "source.pi",  # this has no *FILE
+                           {"use_errors": True}, "read_pha"),
+                          # Unlike pyfits, we do not load in the *FILE values
+                          # so we can re-create this. If this gets changed
+                          # then the test will fail.
+                          ("load_pha", "9774.pi", {}, "read_pha"),
+                          # Use crates to read in an ASCII table
+                          ("load_data", "data1.dat[opt skip=1]", {},
+                           "read_file"),
+                          ("load_ascii", "data1.dat[opt skip=1]", {},
+                           "read_file")
+                         ])
+def test_load_object_crates(loadfunc: str,
+                            filename: str,
+                            kwargs: dict[str, Any],
+                            getfunc: str,
+                            make_data_path
+                            ) -> None:
+    """Check that we can restore a crates "file I/O object" being sent."""
+
+    from sherpa.astro.io import backend
+    if backend.name != "crates":
+        pytest.skip("test requires crates I/O backend")
+
+    infile = make_data_path(filename)
+
+    import pycrates
+    obj = getattr(pycrates, getfunc)(infile)
+    check_load_object(loadfunc, obj, kwargs)
+
+
+@requires_wcs  # for the image example
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("loadfunc,filename,kwargs",
+                         [("load_table", "1838_rprofile_rmid.fits",
+                           {"colkeys": ["RMID", "SUR_BRI"]}),
+                          ("load_data", "1838_rprofile_rmid.fits",
+                           {"colkeys": ["RMID", "NET_COUNTS"]}),
+                          ("load_image", "psf_0.0_00_bin0.5.img", {}),
+                          ("load_pha", "source.pi",  # this has no *FILE
+                           {"use_errors": True}),
+                          # The following fails as the *FILE values are
+                          # not restored, so the independent axis is not
+                          # in energy units. The crates backend does not
+                          # even load in the responses, so the behavior
+                          # is different.
+                          # XFAIL: DataErr: No instrument response found for dataset
+                          pytest.param("load_pha", "9774.pi", {},
+                                       marks=pytest.mark.xfail)
+                         ])
+def test_load_object_pyfits(loadfunc: str,
+                            filename: str,
+                            kwargs: dict[str, Any],
+                            make_data_path
+                            ) -> None:
+    """Check that we can restore a pyfits "file I/O object" being sent."""
+
+    from sherpa.astro.io import backend
+    if backend.name != "pyfits":
+        pytest.skip("test requires pyfits I/O backend")
+
+    infile = make_data_path(filename)
+
+    from astropy.io import fits
+    obj = fits.open(infile)
+
+    try:
+        check_load_object(loadfunc, obj, kwargs)
+    finally:
+        obj.close()
+
+
+# These tests check whether internal constraints hold on the filestore
+# dictionaries. This allows a number of situations to be checked
+# without having to create "save_all" outputs for all possibilities.
+#
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("loadfunc,filename,ids",
+                         [("load_data", "3c273.pi", [1]),
+                          ("load_pha", "3c273.pi", [1]),
+                          ("load_data", "3c120_pha2.gz", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+                          ("load_data", "img.fits", [1]),
+                          ("load_image", "img.fits", [1]),
+                          ("load_data", "data1.dat", [1]),
+                          ("load_ascii", "data1.dat", [1]),
+                         ])
+def test_store_deletion_removes_entries_after_load(loadfunc: str,
+                                                   filename: str,
+                                                   ids: list[IdType],
+                                                   make_data_path
+                                                   ) -> None:
+    """Check the stores are set and deleted"""
+
+    func = getattr(ui, loadfunc)
+    func(make_data_path(filename))
+
+    storage = ui._session._storage
+    assert len(storage.data) == len(ids)
+
+    for idval in ids:
+        ui.delete_data(idval)
+
+    # Everything should be removed now
+    #
+    for store in [storage.data, storage.arf, storage.rmf,
+                  storage.bkg, storage.bkg_arf, storage.bkg_rmf]:
+        assert len(store) == 0, store
+
+    assert len(ui._session._multi_data_store) == 0
+
+
+@requires_data
+@requires_fits
+def test_store_records_pha_autoload(make_data_path) -> None:
+    """Check we record the auto-loaded files for a PHA file."""
+
+    ui.load_pha("foo", make_data_path("9774.pi"))
+
+    state = ui._session
+    storage = state._storage
+    assert len(storage.data) == 1
+    assert isinstance(storage.data["foo"], FileStore)
+
+    # This is not a PHA2 file
+    assert len(state._multi_data_store) == 0
+
+    # There should be one "autoload" for the responses, but the data
+    # is stored differently for ARF/RMF and background data.
+    #
+    for store in [storage.arf, storage.rmf]:
+        assert isinstance(store, dict)
+        assert len(store) == 1, store
+        assert isinstance(store["foo"], dict)
+        assert len(store["foo"]) == 1
+        assert isinstance(store["foo"][1], FileStore), store
+        assert store["foo"][1].autoloaded, store
+
+    assert len(storage.bkg) == 1
+    assert isinstance(storage.bkg["foo"], dict)
+    assert len(storage.bkg["foo"]) == 1
+    assert isinstance(storage.bkg["foo"][1], FileStore)
+    assert storage.bkg["foo"][1].autoloaded
+
+    for store in [storage.bkg_arf, storage.bkg_rmf]:
+        assert len(store) == 1, store
+        assert isinstance(store["foo"], dict)
+        assert len(store["foo"]) == 1
+        assert isinstance(store["foo"][1], dict)
+        assert len(store["foo"][1]) == 1
+        assert isinstance(store["foo"][1][1], FileStore), store
+        assert store["foo"][1][1].autoloaded, store
+
+
+@requires_data
+@requires_fits
+def test_store_records_pha_no_autoload(make_data_path) -> None:
+    """Check we record the manually-loaded files for a PHA file."""
+
+    # Hide the ENERG_LO=0 warnings for ARF and RMF.
+    #
+    with warnings.catch_warnings(record=True):
+        # This has no *FILE keywords pointing to files
+        ui.load_pha("foo", make_data_path("target_sr.pha"))
+        ui.load_arf("foo", make_data_path("target_sr.arf"))
+        ui.load_rmf("foo", make_data_path("swxpc0to12s6_20130101v014.rmf"))
+
+        # use the same files for the background
+        ui.load_bkg("foo", make_data_path("target_sr.pha"))
+        ui.load_bkg_arf("foo", make_data_path("target_sr.arf"))
+        ui.load_bkg_rmf("foo", make_data_path("swxpc0to12s6_20130101v014.rmf"))
+
+    state = ui._session
+    storage = state._storage
+    assert len(storage.data) == 1
+    assert isinstance(storage.data["foo"], FileStore)
+
+    # This is not a PHA2 file
+    assert len(state._multi_data_store) == 0
+
+    for store in [storage.arf, storage.rmf]:
+        assert isinstance(store, dict)
+        assert len(store) == 1, store
+        assert isinstance(store["foo"], dict)
+        assert len(store["foo"]) == 1
+        assert isinstance(store["foo"][1], FileStore), store
+
+    assert len(storage.bkg) == 1
+    assert isinstance(storage.bkg["foo"], dict)
+    assert len(storage.bkg["foo"]) == 1
+    assert isinstance(storage.bkg["foo"][1], FileStore)
+
+    for store in [storage.bkg_arf, storage.bkg_rmf]:
+        assert len(store) == 1, store
+        assert isinstance(store["foo"], dict)
+        assert len(store["foo"]) == 1
+        assert isinstance(store["foo"][1], dict)
+        assert len(store["foo"][1]) == 1
+        assert isinstance(store["foo"][1][1], FileStore)

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -37,7 +37,7 @@ from sherpa.astro.io.wcs import WCS
 
 from sherpa.models.basic import FixedTableModel
 
-from sherpa.utils.err import ArgumentErr, DataErr, \
+from sherpa.utils.err import DataErr, \
     IdentifierErr, IOErr, StatErr
 from sherpa.utils.testing import get_datadir, requires_data, \
     requires_xspec, has_package_from_list, requires_fits, \
@@ -1743,6 +1743,47 @@ set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
+_canonical_load_arrays_pha_with_bkg = """import numpy
+from sherpa.astro.ui import *
+
+######### Load Data Sets
+
+load_arrays(1,
+            [1, 2, 3, 4, 5],
+            [12, 2, 1, 0, 1],
+            DataPHA)
+set_exposure(1, 100)
+set_backscal(1, 0.002)
+set_areascal(1, 0.001)
+
+######### Load Background Data Sets
+
+
+######### Set Energy or Wave Units
+
+set_analysis(1, quantity="channel", type="rate", factor=0)
+
+
+######### Set Statistic
+
+set_stat("chi2gehrels")
+
+
+######### Set Fitting Method
+
+set_method("levmar")
+
+set_method_opt("epsfcn", 1.1920928955078125e-07)
+set_method_opt("factor", 100.0)
+set_method_opt("ftol", 1.1920928955078125e-07)
+set_method_opt("gtol", 1.1920928955078125e-07)
+set_method_opt("maxfev", None)
+set_method_opt("numcores", 1)
+set_method_opt("verbose", 0)
+set_method_opt("xtol", 1.1920928955078125e-07)
+
+"""
+
 _canonical_load_arrays_data2d = """import numpy
 from sherpa.astro.ui import *
 
@@ -2530,6 +2571,49 @@ set_bkg_source("csc", powlaw1d.bpl, bkg_id=1)
 
 """
 
+_canonical_copy_data_pha_bkg_resp = """import numpy
+from sherpa.astro.ui import *
+
+######### Load Data Sets
+
+load_pha(2, "@@/9774.pi")
+
+######### Data Spectral Responses
+
+
+######### Load Background Data Sets
+
+
+######### Background Spectral Responses
+
+load_arf(2, "@@/3c273.arf", resp_id=1, bkg_id=1)
+load_rmf(2, "@@/3c273.rmf", resp_id=1, bkg_id=1)
+
+######### Set Energy or Wave Units
+
+set_analysis(2, quantity="energy", type="rate", factor=0)
+
+
+######### Set Statistic
+
+set_stat("chi2gehrels")
+
+
+######### Set Fitting Method
+
+set_method("levmar")
+
+set_method_opt("epsfcn", 1.1920928955078125e-07)
+set_method_opt("factor", 100.0)
+set_method_opt("ftol", 1.1920928955078125e-07)
+set_method_opt("gtol", 1.1920928955078125e-07)
+set_method_opt("maxfev", None)
+set_method_opt("numcores", 1)
+set_method_opt("verbose", 0)
+set_method_opt("xtol", 1.1920928955078125e-07)
+
+"""
+
 if has_xspec:
     from sherpa.astro import xspec
 
@@ -2855,7 +2939,6 @@ def test_restore_pha_basic(make_data_path):
 
 
 @requires_data
-@requires_xspec
 @requires_fits
 @requires_group
 def test_canonical_pha_load(make_data_path, check_str):
@@ -3506,6 +3589,50 @@ def test_restore_load_arrays_pha_response(check_str):
     # TODO: come up with tests once the state can be restored
 
 
+def test_restore_load_arrays_pha_with_bkg(check_str):
+    """Can we re-create a load_arrays/DataPHA with background?
+
+    This recreation is currently incomplete, so just test what is
+    expected (i.e. a regression test).
+
+    """
+
+    dset = ui.DataPHA("ex", [1, 2, 3, 4, 5], [12, 2, 1, 0, 1])
+    dset.exposure = 100
+    dset.backscal = 0.002
+    dset.areascal = 0.001
+
+    bset = ui.DataPHA("ex", [1, 2, 3, 4, 5], [4, 1, 0, 0, 1])
+    bset.exposure = 500
+    bset.backscal = 0.01
+    bset.areascal = 0.02
+
+    ui.set_data(dset)
+    ui.set_bkg(bset)
+
+    compare(check_str, _canonical_load_arrays_pha_with_bkg)
+
+    restore()
+
+    assert ui.list_data_ids() == [1]
+    # assert ui.list_bkg_ids(1) == [1]
+    assert ui.list_bkg_ids(1) == []  # TODO: this is wrong
+
+    pha = ui.get_data()
+    # bkg = ui.get_bkg()  # TODO: this currently fails
+
+    # for got_obj, exp_obj in [(pha, dset), (bkg, bset)]:
+    for got_obj, exp_obj in [(pha, dset)]:
+        assert isinstance(got_obj, ui.DataPHA)
+
+        for field in ["channel", "counts", "exposure",
+                      "backscal", "areascal"]:
+            got = getattr(got_obj, field)
+            expected = getattr(exp_obj, field)
+
+            assert got == pytest.approx(expected)
+
+
 def test_restore_load_arrays_data2d(check_str):
     """Can we re-create a load_arrays/Data2D case
 
@@ -3937,12 +4064,7 @@ def test_restore_pha2(make_data_path, check_str):
 @requires_data
 @requires_fits
 def test_restore_pha2_delete(make_data_path, check_str):
-    """Can we restore a pha2 file after deleting files?
-
-    This is a regression test so we can see as soon as things have
-    changed, rather than marking it as xfail.
-
-    """
+    """Can we restore a pha2 file after deleting files?"""
 
     # Note: not including .gz for the file name
     ui.load_pha(make_data_path("3c120_pha2"))
@@ -4124,6 +4246,30 @@ def test_filter1d_excluded2():
 
     with pytest.raises(DataErr, match="^mask excludes all data$"):
         ui.get_dep(filter=True)
+
+
+@pytest.mark.xfail  # XFAIL: does not save the background
+def test_filter1d_pha_bkg_excluded():
+    """Check what happens if all data filtered out from PHA bkg."""
+
+    ui.load_arrays(1, [1, 2], [10, 20], ui.DataPHA)
+    bkg = ui.DataPHA("bkg", [1, 2], [2, 3])
+    ui.set_bkg(bkg)
+
+    ui.ignore(lo=2)
+    ui.ignore(bkg_id=1)
+
+    def check():
+        assert ui.get_data().mask == pytest.approx([True, False])
+        assert ui.get_bkg().mask is False
+        assert ui.get_data().get_filter() == "1"
+        assert ui.get_bkg().get_filter() == ""  # regression test
+        assert ui.get_data().get_filter_expr() == "1 Channel"
+        assert ui.get_bkg().get_filter_expr() == " Channel"  # regression test
+
+    check()
+    restore()
+    check()
 
 
 def test_filter2d_excluded1():
@@ -4315,7 +4461,129 @@ def test_copy_data_pha(make_data_path):
         assert ui.get_staterror(2) == pytest.approx(evals)
 
     check_data()
-
     restore()
+    check_data()
+
+
+@requires_data
+@requires_fits
+@requires_group
+def test_copy_data_pha_bkg_resp(make_data_path, check_str):
+    """Can we copy a PHA dataset and track it?
+
+    This adds backround responses to test_copy_data_pha.
+
+    """
+
+    # This auto-loads response and background
+    ui.load_pha(make_data_path("9774.pi"))
+
+    # load in responses for the background (these are not
+    # correct for this dataset but that is not important here).
+    #
+    ui.load_rmf(make_data_path("3c273.rmf"), bkg_id=1)
+    ui.load_arf(make_data_path("3c273.arf"), bkg_id=1)
+
+    ui.copy_data(1, 2)
+    ui.delete_data(1)
+
+    # Check the serialization as we want to check that the source
+    # responses are not included but the background ones are.
+    #
+    expected_output = add_datadir_path(_canonical_copy_data_pha_bkg_resp)
+    compare(check_str, expected_output)
+
+    def check_data():
+        assert ui.list_data_ids() == [2]
+        assert ui.list_bkg_ids(2) == [1]
+        assert ui.get_data(2).name.endswith("/9774.pi")
+        assert ui.get_arf(2).name.endswith("/9774.arf")
+        assert ui.get_rmf(2).name.endswith("/9774.rmf")
+
+        assert ui.get_arf(2, bkg_id=1).name.endswith("/3c273.arf")
+        assert ui.get_rmf(2, bkg_id=1).name.endswith("/3c273.rmf")
 
     check_data()
+    restore()
+    check_data()
+
+
+def test_copy_data_manual():
+    """What happens when we copy a manually-created dataset?"""
+
+    ui.load_arrays("y", [1, 2, 3, 4, 5], [4, 5, 6, 7, 8])
+    ui.ignore_id("y", lo=3, hi=4)
+    ui.copy_data("y", "x")
+
+    # Check that the copied data has also been filtered.
+    yy = ui.get_dep("y", filter=True)
+    yx = ui.get_dep("x", filter=True)
+    assert len(yy) == 3
+
+    def check_data():
+        assert ui.list_data_ids() == ["x", "y"]
+
+        assert ui.get_dep("x", filter=True) == pytest.approx(yy)
+        assert ui.get_dep("y", filter=True) == pytest.approx(yy)
+
+    check_data()
+    restore()
+    check_data()
+
+
+@requires_fits
+@requires_data
+def test_load_ascii(make_data_path):
+    """Check we can restore a load-ascii call."""
+
+    ui.set_stat("chi2datavar")
+
+    infile = make_data_path("sim.poisson.1.dat")
+    ui.load_ascii(infile)
+
+    def check():
+        assert isinstance(ui.get_data(), ui.Data1D)
+
+        y = ui.get_dep()
+        assert len(y) == 50
+        assert y[0:5] == pytest.approx([27, 27, 20, 28, 27])
+
+        xs = ui.get_indep()
+        assert len(xs) == 1
+        assert xs[0][0:5] == pytest.approx([0.5, 1, 1.5, 2, 2.5])
+
+        dy = ui.get_staterror()
+        assert dy == pytest.approx(np.sqrt(y))
+
+    check()
+    restore()
+    check()
+
+
+@pytest.mark.xfail  # does not include colkeys when loading in the data
+@requires_fits
+@requires_data
+def test_load_table_fits(make_data_path):
+    """Check we can restore a load-table call."""
+
+    infile = make_data_path("1838_rprofile_rmid.fits")
+    ui.load_table(infile, colkeys=["RMID", "COUNTS", "ERR_COUNTS"])
+
+    def check():
+        assert isinstance(ui.get_data(), ui.Data1D)
+
+        y = ui.get_dep()
+        assert len(y) == 38
+        assert y[0:5] == pytest.approx([1529, 2014, 2385, 2158, 2013])
+
+        xs = ui.get_indep()
+        assert len(xs) == 1
+        assert xs[0][0:5] == pytest.approx([12.5, 17.5, 22.5, 27.5, 32.5])
+
+        dy = ui.get_staterror()
+        assert dy[0:3] == pytest.approx([39.1024295920, 44.8776113446,
+                                         48.8364617883])
+
+    check()
+    restore()
+    check()

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -2905,7 +2905,6 @@ def test_canonical_empty_iterstat(check_str):
     compare(check_str, _canonical_empty_iterstat)
 
 
-@pytest.mark.xfail  # ISSUE: 2504
 def test_estmethod_opt(check_str):
     """"Check other options for the estmethods
 

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -1257,6 +1257,8 @@ set_method_opt("verbose", 0)
 load_psf("p0", "@@/psf_0.0_00_bin1.img")
 p0.size = (26, 26)
 p0.center = (13, 13)
+p0.radial = 0.0
+p0.norm = 1.0
 
 create_model_component("gauss2d", "g1")
 g1.integrate = True
@@ -3402,7 +3404,6 @@ def test_restore_img_no_filter_model_psf(make_data_path, recwarn, check_str):
     recwarn.clear()
 
 
-@pytest.mark.xfail  # psf.radial.val is restored as 0 not 1
 @requires_fits
 def test_load_psf1d_from_file(check_str, tmp_path):
     """Can we restore a 1D PSF read from a file?
@@ -3486,8 +3487,7 @@ def test_load_psf1d_from_model(check_str):
     ui.set_psf(psf1)
     # It looks like the radial setting isn't used in this case,
     # unlike the _from_file version. So for now treat this as
-    # a regression test and do not fall over when the value is
-    # not restored.
+    # a regression test.
     psf1.radial = 1
 
     # This does not match the _from_file case, so treat this as
@@ -3508,7 +3508,7 @@ def test_load_psf1d_from_model(check_str):
     assert ui.list_psf_ids() == [1]
     assert ui.list_model_components() == ["b1", "b2", "b3", "g1", "psf1"]
     psf = ui.get_model_component("psf1")
-    assert psf.radial.val == pytest.approx(0)  # NOTE: regression test
+    assert psf.radial.val == pytest.approx(1)
     assert ui.get_model_plot().y == pytest.approx(expected)
 
     # As the tests above don't check the frozen state

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -3520,7 +3520,6 @@ def test_load_psf1d_from_model(check_str):
     assert nmdl([1, 2, 3, 4, 5]) == pytest.approx([5, 2, 1, 0, 0])
 
 
-@pytest.mark.xfail  # XFAIL: 'convolutionkernel' is not a valid model type
 @requires_fits
 def test_load_conv_from_file(tmp_path):
     """Very basic check of load_conv.
@@ -3547,11 +3546,10 @@ def test_load_conv_from_file(tmp_path):
         assert x1.kernel.y == pytest.approx([5, 2, 1])
 
     check()
-    restore()  # XFAIL
+    restore()
     check()
 
 
-@pytest.mark.xfail  # XFAIL: 'convolutionkernel' is not a valid model type
 def test_load_conv_from_model():
     """Very basic check of load_conv.
 
@@ -3581,8 +3579,10 @@ def test_load_conv_from_model():
         assert x2.name == "convolutionkernel.c1"
         assert x2.kernel == x1
 
+    buff = StringIO(); ui.save_all(buff)
+
     check()
-    restore()  # XFAIL
+    restore()
     check()
 
 

--- a/sherpa/astro/ui/tests/test_serialize.py
+++ b/sherpa/astro/ui/tests/test_serialize.py
@@ -85,14 +85,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
@@ -110,13 +102,7 @@ set_stat("leastsq")
 
 set_method("neldermead")
 
-set_method_opt("finalsimplex", 9)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("initsimplex", 0)
-set_method_opt("iquad", 1)
 set_method_opt("maxfev", 5000)
-set_method_opt("reflect", True)
-set_method_opt("step", None)
 set_method_opt("verbose", 1)
 
 """
@@ -134,13 +120,7 @@ set_stat("leastsq")
 
 set_method("neldermead")
 
-set_method_opt("finalsimplex", 9)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("initsimplex", 0)
-set_method_opt("iquad", 1)
 set_method_opt("maxfev", 5000)
-set_method_opt("reflect", True)
-set_method_opt("step", None)
 set_method_opt("verbose", 1)
 
 
@@ -149,9 +129,6 @@ set_method_opt("verbose", 1)
 set_iter_method("sigmarej")
 
 set_iter_method_opt("grow", 1)
-set_iter_method_opt("hrej", 3)
-set_iter_method_opt("lrej", 3)
-set_iter_method_opt("maxiters", 5)
 
 """
 
@@ -195,14 +172,6 @@ set_stat("chi2datavar")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 
 ######### Set Model Components and Parameters
@@ -338,14 +307,6 @@ set_stat("chi2datavar")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
@@ -402,14 +363,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 
 ######### Set Model Components and Parameters
@@ -510,14 +463,6 @@ set_stat("chi2xspecvar")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 
 ######### Set Model Components and Parameters
@@ -728,13 +673,6 @@ set_stat("chi2gehrels")
 
 set_method("gridsearch")
 
-set_method_opt("ftol", 1.1920928955078125e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("method", None)
-set_method_opt("num", 16)
-set_method_opt("numcores", 1)
-set_method_opt("sequence", None)
-set_method_opt("verbose", 0)
 
 """
 
@@ -763,14 +701,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
@@ -810,14 +740,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 
 ######### Set Model Components and Parameters
@@ -979,14 +901,6 @@ set_stat("cash")
 
 set_method("neldermead")
 
-set_method_opt("finalsimplex", 9)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("initsimplex", 0)
-set_method_opt("iquad", 1)
-set_method_opt("maxfev", None)
-set_method_opt("reflect", True)
-set_method_opt("step", None)
-set_method_opt("verbose", 0)
 
 
 ######### Set Model Components and Parameters
@@ -1086,14 +1000,6 @@ set_stat("cstat")
 
 set_method("neldermead")
 
-set_method_opt("finalsimplex", 9)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("initsimplex", 0)
-set_method_opt("iquad", 1)
-set_method_opt("maxfev", None)
-set_method_opt("reflect", True)
-set_method_opt("step", None)
-set_method_opt("verbose", 0)
 
 """
 
@@ -1124,14 +1030,6 @@ set_stat("cstat")
 
 set_method("neldermead")
 
-set_method_opt("finalsimplex", 9)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("initsimplex", 0)
-set_method_opt("iquad", 1)
-set_method_opt("maxfev", None)
-set_method_opt("reflect", True)
-set_method_opt("step", None)
-set_method_opt("verbose", 0)
 
 
 ######### Set Model Components and Parameters
@@ -1242,14 +1140,6 @@ set_stat("cstat")
 
 set_method("neldermead")
 
-set_method_opt("finalsimplex", 9)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("initsimplex", 0)
-set_method_opt("iquad", 1)
-set_method_opt("maxfev", None)
-set_method_opt("reflect", True)
-set_method_opt("step", None)
-set_method_opt("verbose", 0)
 
 
 ######### Set Model Components and Parameters
@@ -1342,14 +1232,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 
 ######### Set Model Components and Parameters
@@ -1382,14 +1264,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 
 ######### Set Model Components and Parameters
@@ -1450,14 +1324,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 
 ######### Set Model Components and Parameters
@@ -1561,14 +1427,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
@@ -1602,14 +1460,6 @@ set_stat("cash")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
@@ -1633,14 +1483,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
@@ -1680,14 +1522,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
@@ -1732,14 +1566,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
@@ -1773,14 +1599,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.1920928955078125e-07)
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.1920928955078125e-07)
-set_method_opt("gtol", 1.1920928955078125e-07)
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.1920928955078125e-07)
 
 """
 
@@ -1806,14 +1624,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
@@ -1932,14 +1742,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 
 ######### Set Model Components and Parameters
@@ -2002,14 +1804,6 @@ set_stat("chi2datavar")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
@@ -2034,14 +1828,6 @@ set_stat("chi2")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
@@ -2086,14 +1872,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
@@ -2295,14 +2073,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
@@ -2360,14 +2130,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
 
 """
 
@@ -2412,14 +2174,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.1920928955078125e-07)  # doctest: +FLOAT_CMP
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.1920928955078125e-07)  # doctest: +FLOAT_CMP
-set_method_opt("gtol", 1.1920928955078125e-07)  # doctest: +FLOAT_CMP
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.1920928955078125e-07)  # doctest: +FLOAT_CMP
 
 """
 
@@ -2477,14 +2231,6 @@ set_stat("cstat")
 
 set_method("neldermead")
 
-set_method_opt("finalsimplex", 9)
-set_method_opt("ftol", 1.19209289551e-07)  # doctest: +FLOAT_CMP
-set_method_opt("initsimplex", 0)
-set_method_opt("iquad", 1)
-set_method_opt("maxfev", None)
-set_method_opt("reflect", True)
-set_method_opt("step", None)
-set_method_opt("verbose", 0)
 
 
 ######### Set Model Components and Parameters
@@ -2603,14 +2349,6 @@ set_stat("chi2gehrels")
 
 set_method("levmar")
 
-set_method_opt("epsfcn", 1.1920928955078125e-07)
-set_method_opt("factor", 100.0)
-set_method_opt("ftol", 1.1920928955078125e-07)
-set_method_opt("gtol", 1.1920928955078125e-07)
-set_method_opt("maxfev", None)
-set_method_opt("numcores", 1)
-set_method_opt("verbose", 0)
-set_method_opt("xtol", 1.1920928955078125e-07)
 
 """
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1924,17 +1924,17 @@ class Session(sherpa.ui.utils.Session):
         >>> set_data('src', dat)
 
         """
-        try:
-            return self.unpack_pha(filename, *args, **kwargs)
-        except Exception:
-            try:
-                return self.unpack_image(filename, *args, **kwargs)
-            except Exception:
-                try:
-                    return self.unpack_table(filename, *args, **kwargs)
-                except Exception:
-                    # If this errors out then so be it
-                    return self.unpack_ascii(filename, *args, **kwargs)
+
+        for func in [self.unpack_pha,
+                     self.unpack_image,
+                     self.unpack_table]:
+            with suppress(Exception):
+                return func(filename, *args, **kwargs)
+
+        # If this errors out then so be it. Perhaps it should
+        # raise an error related to unpack_data.
+        #
+        return self.unpack_ascii(filename, *args, **kwargs)
 
     def load_ascii_with_errors(self,
                                id,

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from functools import partial
 import logging
 import os
-from typing import Any
+from typing import Any, Type
 import sys
 from types import MethodType
 
@@ -1541,7 +1541,11 @@ class Session(sherpa.ui.utils.Session):
     # as it's needed in multiple places (ideally in the
     # DataX class documentation, but users may not find it)
     # DOC-TODO: what do the shape arguments for Data2D/Data2DInt mean?
-    def load_table(self, id, filename=None, ncols=2, colkeys=None,
+    def load_table(self,
+                   id,
+                   filename=None,
+                   ncols: int = 2,
+                   colkeys: Sequence[str] | None = None,
                    dstype=Data1D) -> None:
         """Load a FITS binary file as a data set.
 
@@ -1652,16 +1656,26 @@ class Session(sherpa.ui.utils.Session):
 
         """
         if filename is None:
-            id, filename = filename, id
+            idval = self.get_default_id()
+            filename = id
+        else:
+            idval = self._fix_id(id)
 
-        self.set_data(id, self.unpack_table(filename, ncols, colkeys, dstype))
+        data = self.unpack_table(filename, ncols, colkeys, dstype)
+        self.set_data(idval, data)
 
     # DOC-TODO: should unpack_ascii be merged into unpack_table?
     # DOC-TODO: I am going to ignore the crates support here as
     # it is somewhat meaningless, since the crate could
     # have been read from a FITS binary table.
-    def unpack_ascii(self, filename, ncols=2, colkeys=None,
-                     dstype=Data1D, sep=' ', comment='#'):
+    def unpack_ascii(self,
+                     filename,
+                     ncols: int = 2,
+                     colkeys: Sequence[str] | None = None,
+                     dstype: Type[Data1D] = Data1D,
+                     sep: str = ' ',
+                     comment: str = '#'
+                     ) -> Data1D:
         """Unpack an ASCII file into a data structure.
 
         Parameters
@@ -1737,9 +1751,14 @@ class Session(sherpa.ui.utils.Session):
     # have been read from a FITS binary table.
     # DOC-TODO: how best to include datastack support?
     # DOC-TODO: what does shape mean here (how is it encoded)?
-    def load_ascii(self, id, filename=None, ncols=2, colkeys=None,
-                   dstype=Data1D, sep=' ',
-                   comment='#') -> None:
+    def load_ascii(self,
+                   id,
+                   filename=None,
+                   ncols: int = 2,
+                   colkeys: Sequence[str] | None = None,
+                   dstype: type[Data1D] = Data1D,
+                   sep: str = ' ',
+                   comment: str = '#') -> None:
         """Load an ASCII file as a data set.
 
         The standard behavior is to create a single data set, but
@@ -1846,11 +1865,15 @@ class Session(sherpa.ui.utils.Session):
 
         """
         if filename is None:
-            id, filename = filename, id
+            idval = self.get_default_id()
+            filename = id
+        else:
+            idval = self._fix_id(id)
 
-        self.set_data(id, self.unpack_ascii(filename, ncols=ncols,
-                                            colkeys=colkeys, dstype=dstype,
-                                            sep=sep, comment=comment))
+        data = self.unpack_ascii(filename, ncols=ncols,
+                                 colkeys=colkeys, dstype=dstype,
+                                 sep=sep, comment=comment)
+        self.set_data(idval, data)
 
     # DOC-NOTE: also in sherpa.utils
     def unpack_data(self, filename, *args, **kwargs):
@@ -1913,7 +1936,9 @@ class Session(sherpa.ui.utils.Session):
                     # If this errors out then so be it
                     return self.unpack_ascii(filename, *args, **kwargs)
 
-    def load_ascii_with_errors(self, id, filename=None,
+    def load_ascii_with_errors(self,
+                               id,
+                               filename=None,
                                colkeys: Sequence[str] | None = None,
                                sep: str = ' ',
                                comment: str = '#',
@@ -2019,13 +2044,16 @@ class Session(sherpa.ui.utils.Session):
         """
 
         if filename is None:
-            id, filename = filename, id
-        self.set_data(id, self.unpack_ascii(filename, ncols=4,
-                                            colkeys=colkeys,
-                                            dstype=Data1DAsymmetricErrs,
-                                            sep=sep, comment=comment))
+            idval = self.get_default_id()
+            filename = id
+        else:
+            idval = self._fix_id(id)
 
-        data = self.get_data(id)
+        data = self.unpack_ascii(filename, ncols=4,
+                                 colkeys=colkeys,
+                                 dstype=Data1DAsymmetricErrs,
+                                 sep=sep, comment=comment)
+        self.set_data(idval, data)
 
         if not delta:
             data.elo = data.y - data.elo
@@ -2165,7 +2193,10 @@ class Session(sherpa.ui.utils.Session):
     # DOC-NOTE: also in sherpa.utils without the support for
     #           multiple datasets.
     #
-    def load_data(self, id, filename=None, *args,
+    def load_data(self,
+                  id,
+                  filename=None,
+                  *args,
                   **kwargs) -> None:
         # pylint: disable=W1113
         """Load a data set from a file.
@@ -2234,10 +2265,13 @@ class Session(sherpa.ui.utils.Session):
 
         """
         if filename is None:
-            id, filename = filename, id
+            idval = self.get_default_id()
+            filename = id
+        else:
+            idval = self._fix_id(id)
 
         datasets = self.unpack_data(filename, *args, **kwargs)
-        self._load_data(id, datasets, filename=filename, kwargs=kwargs)
+        self._load_data(idval, datasets, filename=filename, kwargs=kwargs)
 
     def unpack_image(self, arg, coord='logical',
                      dstype=DataIMG):
@@ -2298,7 +2332,10 @@ class Session(sherpa.ui.utils.Session):
         """
         return sherpa.astro.io.read_image(arg, coord, dstype)
 
-    def load_image(self, id, arg=None, coord='logical',
+    def load_image(self,
+                   id,
+                   arg=None,
+                   coord: str = 'logical',
                    dstype=DataIMG) -> None:
         """Load an image as a data set.
 
@@ -2363,11 +2400,16 @@ class Session(sherpa.ui.utils.Session):
 
         """
         if arg is None:
-            id, arg = arg, id
-        self.set_data(id, self.unpack_image(arg, coord, dstype))
+            idval = self.get_default_id()
+            arg = id
+        else:
+            idval = self._fix_id(id)
+
+        data = self.unpack_image(arg, coord, dstype)
+        self.set_data(idval, data)
 
     # DOC-TODO: what does this return when given a PHA2 file?
-    def unpack_pha(self, arg, use_errors=False):
+    def unpack_pha(self, arg, use_errors: bool = False):
         """Create a PHA data structure.
 
         Any instrument or background data sets referenced in the
@@ -2472,7 +2514,9 @@ class Session(sherpa.ui.utils.Session):
                                         use_background=True)
 
     # DOC-TODO: how best to include datastack support?
-    def load_pha(self, id, arg=None,
+    def load_pha(self,
+                 id,
+                 arg=None,
                  use_errors: bool = False) -> None:
         """Load a PHA data set.
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -6303,15 +6303,18 @@ class Session(sherpa.ui.utils.Session):
 
         """
         if arf is None:
-            id, arf = arf, id
+            idval = self.get_default_id()
+            arf = id
+        else:
+            idval = self._fix_id(id)
 
         # store only the ARF dataset in the PHA response dict
         if type(arf) in (sherpa.astro.instrument.ARF1D,):
             arf = arf._arf
         _check_type(arf, sherpa.astro.data.DataARF, 'arf', 'an ARF data set')
 
-        data = self._get_pha_data(id, bkg_id)
-        data.set_arf(arf, resp_id)
+        data = self._get_pha_data(idval, bkg_id)
+        data.set_arf(arf, id=resp_id)
         # Set units of source dataset from channel to energy
         if data.units == 'channel':
             data._set_initial_quantity()
@@ -6370,7 +6373,9 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: add an example of a grating/multiple response
     # DOC-TODO: how to describe I/O backend support?
-    def load_arf(self, id, arg=None,
+    def load_arf(self,
+                 id,
+                 arg=None,
                  resp_id: IdType | None = None,
                  bkg_id: IdType | None = None
                  ) -> None:
@@ -6449,8 +6454,13 @@ class Session(sherpa.ui.utils.Session):
 
         """
         if arg is None:
-            id, arg = arg, id
-        self.set_arf(id, self.unpack_arf(arg), resp_id, bkg_id)
+            idval = self.get_default_id()
+            arg = id
+        else:
+            idval = self._fix_id(id)
+
+        arf = self.unpack_arf(arg)
+        self.set_arf(idval, arf, resp_id=resp_id, bkg_id=bkg_id)
 
     def get_bkg_arf(self,
                     id: IdType | None = None):
@@ -6498,12 +6508,16 @@ class Session(sherpa.ui.utils.Session):
         >>> set_arf(2, arf1, bkg_id=1)
 
         """
-        bkg_id = self._get_pha_data(id).default_background_id
-        resp_id = self._get_pha_data(id).primary_response_id
-        return self.get_arf(id, resp_id, bkg_id)
+        data = self._get_pha_data(id)
+        bkg_id = data.default_background_id
+        resp_id = data.primary_response_id
+        return self.get_arf(id, resp_id=resp_id, bkg_id=bkg_id)
 
     # DOC-TODO: how to describe I/O backend support?
-    def load_bkg_arf(self, id, arg=None) -> None:
+    def load_bkg_arf(self,
+                     id,
+                     arg=None
+                     ) -> None:
         """Load an ARF from a file and add it to the background of a
         PHA data set.
 
@@ -6558,11 +6572,19 @@ class Session(sherpa.ui.utils.Session):
         >>> load_bkg_arf('core', 'core_bkg.arf')
 
         """
+
+        # Note: this is very similar to load_arf
         if arg is None:
-            id, arg = arg, id
-        bkg_id = self._get_pha_data(id).default_background_id
-        resp_id = self._get_pha_data(id).primary_response_id
-        self.set_arf(id, self.unpack_arf(arg), resp_id, bkg_id)
+            idval = self.get_default_id()
+            arg = id
+        else:
+            idval = self._fix_id(id)
+
+        data = self._get_pha_data(idval)
+        bkg_id = data.default_background_id
+        resp_id = data.primary_response_id
+        arf = self.unpack_arf(arg)
+        self.set_arf(idval, arf, resp_id=resp_id, bkg_id=bkg_id)
 
     def load_multi_arfs(self, id, filenames, resp_ids=None) -> None:
         """Load multiple ARFs for a PHA data set.
@@ -6622,22 +6644,18 @@ class Session(sherpa.ui.utils.Session):
         >>> load_multi_arfs('lowstate', arfs, [1, 2, 3])
 
         """
-# if type(filenames) not in (list, tuple):
-#             raise ArgumentError('Filenames must be contained in a list')
-# if type(resp_ids) not in (list, tuple):
-#             raise ArgumentError('Response IDs must be contained in a list')
 
         if resp_ids is None:
             id, filenames, resp_ids = resp_ids, id, filenames
 
         filenames = list(filenames)
         resp_ids = list(resp_ids)
-
         if len(filenames) != len(resp_ids):
             raise ArgumentErr('multirsp')
 
+        idval = self._fix_id(id)
         for filename, resp_id in zip(filenames, resp_ids):
-            self.load_arf(id, filename, resp_id)
+            self.load_arf(idval, filename, resp_id=resp_id)
 
     def get_rmf(self,
                 id: IdType | None = None,
@@ -6781,15 +6799,18 @@ class Session(sherpa.ui.utils.Session):
 
         """
         if rmf is None:
-            id, rmf = rmf, id
+            idval = self.get_default_id()
+            rmf = id
+        else:
+            idval = self._fix_id(id)
 
         # store only the RMF dataset in the PHA response dict
         if type(rmf) in (sherpa.astro.instrument.RMF1D,):
             rmf = rmf._rmf
         _check_type(rmf, sherpa.astro.data.DataRMF, 'rmf', 'an RMF data set')
 
-        data = self._get_pha_data(id, bkg_id)
-        data.set_rmf(rmf, resp_id)
+        data = self._get_pha_data(idval, bkg_id)
+        data.set_rmf(rmf, id=resp_id)
         # Set units of source dataset from channel to energy
         if data.units == 'channel':
             data._set_initial_quantity()
@@ -6853,7 +6874,9 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: add an example of a grating/multiple response
     # DOC-TODO: how to describe I/O backend support?
-    def load_rmf(self, id, arg=None,
+    def load_rmf(self,
+                 id,
+                 arg=None,
                  resp_id: IdType | None = None,
                  bkg_id: IdType | None = None
                  ) -> None:
@@ -6937,8 +6960,13 @@ class Session(sherpa.ui.utils.Session):
 
         """
         if arg is None:
-            id, arg = arg, id
-        self.set_rmf(id, self.unpack_rmf(arg), resp_id, bkg_id)
+            idval = self.get_default_id()
+            arg = id
+        else:
+            idval = self._fix_id(id)
+
+        rmf = self.unpack_rmf(arg)
+        self.set_rmf(idval, rmf, resp_id=resp_id, bkg_id=bkg_id)
 
     def get_bkg_rmf(self,
                     id: IdType | None = None):
@@ -6981,12 +7009,16 @@ class Session(sherpa.ui.utils.Session):
         >>> set_rmf(2, arf1, bkg_id=1)
 
         """
-        bkg_id = self._get_pha_data(id).default_background_id
-        resp_id = self._get_pha_data(id).primary_response_id
-        return self.get_rmf(id, resp_id, bkg_id)
+        data = self._get_pha_data(id)
+        bkg_id = data.default_background_id
+        resp_id = data.primary_response_id
+        return self.get_rmf(id, resp_id=resp_id, bkg_id=bkg_id)
 
     # DOC-TODO: how to describe I/O backend support?
-    def load_bkg_rmf(self, id, arg=None) -> None:
+    def load_bkg_rmf(self,
+                     id,
+                     arg=None
+                     ) -> None:
         """Load a RMF from a file and add it to the background of a
         PHA data set.
 
@@ -7041,11 +7073,19 @@ class Session(sherpa.ui.utils.Session):
         >>> load_bkg_rmf('core', 'core_bkg.rmf')
 
         """
+
+        # Note: this is very similar to load_rmf
         if arg is None:
-            id, arg = arg, id
-        bkg_id = self._get_pha_data(id).default_background_id
-        resp_id = self._get_pha_data(id).primary_response_id
-        self.set_rmf(id, self.unpack_rmf(arg), resp_id, bkg_id)
+            idval = self.get_default_id()
+            arg = id
+        else:
+            idval = self._fix_id(id)
+
+        data = self._get_pha_data(idval)
+        bkg_id = data.default_background_id
+        resp_id = data.primary_response_id
+        rmf = self.unpack_rmf(arg)
+        self.set_rmf(idval, rmf, resp_id=resp_id, bkg_id=bkg_id)
 
     def load_multi_rmfs(self, id, filenames, resp_ids=None) -> None:
         """Load multiple RMFs for a PHA data set.
@@ -7105,22 +7145,18 @@ class Session(sherpa.ui.utils.Session):
         >>> load_multi_rmfs('lowstate', rmfs, [1, 2, 3])
 
         """
-# if type(filenames) not in (list, tuple):
-#             raise ArgumentError('Filenames must be contained in a list')
-# if type(resp_ids) not in (list, tuple):
-#             raise ArgumentError('Response IDs must be contained in a list')
 
         if resp_ids is None:
             id, filenames, resp_ids = resp_ids, id, filenames
 
         filenames = list(filenames)
         resp_ids = list(resp_ids)
-
         if len(filenames) != len(resp_ids):
             raise ArgumentErr('multirsp')
 
+        idval = self._fix_id(id)
         for filename, resp_id in zip(filenames, resp_ids):
-            self.load_rmf(id, filename, resp_id)
+            self.load_rmf(idval, filename, resp_id=resp_id)
 
     def get_bkg(self,
                 id: IdType | None = None,

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10370,6 +10370,23 @@ class Session(sherpa.ui.utils.Session):
                 kernel = self.unpack_data(filename_or_model,
                                           *args, **kwargs)
 
+        """
+
+maybe the unpack_xxx commands create a store (so we can get an
+"accurate" one). do not want to key just on the filename as they
+could get over-written (but then save_all would fail in this case
+anyway).
+
+Maybe unpack_foo saves foo with a filename/index and then we can
+ask for the last index (in the load_foo call that calls unpack_foo)
+to get at it. Or we just save the las tone.
+
+                # could try to make a FileStore here but hard...
+                assert len(args) == 0, args
+                ###assert False
+
+        """
+
         psf = sherpa.astro.instrument.PSFModel(modelname, kernel)
         if isinstance(kernel, Model):
             self.freeze(kernel)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -17302,7 +17302,8 @@ class Session(sherpa.ui.utils.Session):
         .. versionchanged:: 4.19.0
            PSF models now also save the radial and norm parameters, if
            available. Improved support for reporting optional
-           arguments used when loading a file.
+           arguments used when loading a file. File paths are now
+           always normalized.
 
         .. versionchanged:: 4.18.0
            Handling of PHA data has been improved, and the output now

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -17281,7 +17281,8 @@ class Session(sherpa.ui.utils.Session):
     def save_all(self,
                  outfile=None,
                  clobber: bool = False,
-                 auto_load: bool = True
+                 auto_load: bool = True,
+                 relative_path: bool = False
                  ) -> None:
         """Save the information about the current session to a text file.
 
@@ -17303,7 +17304,7 @@ class Session(sherpa.ui.utils.Session):
            PSF models now also save the radial and norm parameters, if
            available. Improved support for reporting optional
            arguments used when loading a file. File paths are now
-           always normalized.
+           always normalized. Added the relative_path argument.
 
         .. versionchanged:: 4.18.0
            Handling of PHA data has been improved, and the output now
@@ -17343,6 +17344,9 @@ class Session(sherpa.ui.utils.Session):
            such as backgrounds, ARFS, and RMFs, will be included in
            the output with `load_arf`, `load_rmf`, and `load_bkg`
            calls.
+        relative_path : bool, optional
+           Should paths be recorded as relative to the current working
+           directory?
 
         Raises
         ------
@@ -17431,7 +17435,8 @@ class Session(sherpa.ui.utils.Session):
                     raise IOErr('filefound', outfile)
 
             with open(outfile, 'w', encoding="UTF-8") as fh:
-                serialize.save_all(self, fh, auto_load=auto_load)
+                serialize.save_all(self, fh, auto_load=auto_load,
+                                   relative_path=relative_path)
 
         else:
             if outfile is not None:
@@ -17439,4 +17444,5 @@ class Session(sherpa.ui.utils.Session):
             else:
                 fh = sys.stdout
 
-            serialize.save_all(self, fh, auto_load=auto_load)
+            serialize.save_all(self, fh, auto_load=auto_load,
+                               relative_path=relative_path)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -10376,6 +10376,29 @@ class Session(sherpa.ui.utils.Session):
         self._add_model_component(psf)
         self._psf_models.append(psf)
 
+        # ARGH: load_psf does not fit into the "has id argument first"
+        #       pattern.
+        #
+        """
+        HOW TO HANDLE?
+
+        maybe we only sent in kwargs and so callers have to label
+        id and filename arguments
+
+        - copy_data needs access to id but can do so
+        - filename is harder, as not unique (e.g. can be called arg)
+          but we only need this if there is a
+          "check file exists" sort of check?
+
+        - could store the name of the argument giving the filename
+          (so we don't repeat ourselves), with a default of "filename"
+
+        I think there is at least one place where we have args and
+        not kwargs (but don't have any tests to check it out)
+
+        store = FileStore(self.load_psf
+        """
+
     load_psf.__doc__ = sherpa.ui.utils.Session.load_psf.__doc__
     load_psf.__annotations__ = sherpa.ui.utils.Session.load_psf.__annotations__
 

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -1663,10 +1663,10 @@ class Session(sherpa.ui.utils.Session):
         if not isinstance(filename, str):
             return
 
-        kwargs = {"ncols": ncols, "colkeys": colkeys,
+        kwargs = {"id": idval, "filename": filename,
+                  "ncols": ncols, "colkeys": colkeys,
                   "dstype": dstype}
-        store = FileStore(self.load_table, idval, Path(filename),
-                          kwargs=kwargs)
+        store = FileStore(self.load_table, kwargs=kwargs)
         self._storage.add(idval, store)
 
     # DOC-TODO: should unpack_ascii be merged into unpack_table?
@@ -1887,8 +1887,8 @@ class Session(sherpa.ui.utils.Session):
         if not isinstance(filename, str):
             return
 
-        store = FileStore(self.load_ascii, idval, Path(filename),
-                          kwargs=kwargs)
+        kwargs |= {"id": idval, "filename": filename}
+        store = FileStore(self.load_ascii, kwargs=kwargs)
         self._storage.add(idval, store)
 
     # DOC-NOTE: also in sherpa.utils
@@ -2086,10 +2086,9 @@ class Session(sherpa.ui.utils.Session):
         if not isinstance(filename, str):
             return
 
-        kwargs["func"] = func
-        kwargs["delta"] = delta
-        store = FileStore(self.load_ascii_with_errors, idval,
-                          Path(filename), kwargs=kwargs)
+        kwargs |= {"func": func, "delta": delta, "id": idval,
+                   "filename": filename}
+        store = FileStore(self.load_ascii_with_errors, kwargs=kwargs)
         self._storage.add(idval, store)
 
     def _load_datas(self,
@@ -2241,8 +2240,8 @@ class Session(sherpa.ui.utils.Session):
         #
         if isinstance(filename, str):
             # This assumes that len(args) == 0
-            store = FileStore(self.load_data, idval, Path(filename),
-                              kwargs=kwargs)
+            kwargs |= {"id": idval, "filename": filename}
+            store = FileStore(self.load_data, kwargs=kwargs)
         else:
             store = None
 
@@ -2412,9 +2411,9 @@ class Session(sherpa.ui.utils.Session):
         if not isinstance(arg, str):
             return
 
-        kwargs = {"coord": coord, "dstype": dstype}
-        store = FileStore(self.load_image, idval, Path(arg),
-                          kwargs=kwargs)
+        kwargs = {"id": idval, "arg": arg, "coord": coord,
+                  "dstype": dstype}
+        store = FileStore(self.load_image, kwargs=kwargs, filekey="arg")
         self._storage.add(idval, store)
 
     # DOC-TODO: what does this return when given a PHA2 file?
@@ -2544,15 +2543,17 @@ class Session(sherpa.ui.utils.Session):
         #
         for resp_id in data.response_ids:
             marf, mrmf = data.get_response(resp_id)
-            kwargs = {"resp_id": resp_id}
+            kwargs = {"id": idval, "resp_id": resp_id}
             if marf is not None:
-                store = FileStore(self.load_arf, idval, Path(marf.name),
-                                  kwargs=kwargs, autoloaded=True)
+                kwargs["arg"] = marf.name
+                store = FileStore(self.load_arf, kwargs=kwargs,
+                                  filekey="arg", autoloaded=True)
                 self._storage.add_arf(idval, resp_id, store)
 
             if mrmf is not None:
-                store = FileStore(self.load_rmf, idval, Path(mrmf.name),
-                                  kwargs=kwargs, autoloaded=True)
+                kwargs["arg"] = mrmf.name
+                store = FileStore(self.load_rmf, kwargs=kwargs,
+                                  filekey="arg", autoloaded=True)
                 self._storage.add_rmf(idval, resp_id, store)
 
         for bkg_id in data.background_ids:
@@ -2563,10 +2564,10 @@ class Session(sherpa.ui.utils.Session):
             bkg = data.get_background(bkg_id)
             assert bkg is not None
 
-            kwargs = {"bkg_id": bkg_id, "use_errors": use_errors}
-
-            store = FileStore(self.load_bkg, idval, Path(bkg.name),
-                              kwargs=kwargs, autoloaded=True)
+            kwargs = {"id": idval, "arg": bkg.name,
+                      "bkg_id": bkg_id, "use_errors": use_errors}
+            store = FileStore(self.load_bkg, kwargs=kwargs,
+                              filekey="arg", autoloaded=True)
             self._storage.add_bkg(idval, bkg_id, store)
 
             # Note that load_bkg_arf and load_bkg_rmf only change the
@@ -2575,15 +2576,17 @@ class Session(sherpa.ui.utils.Session):
             #
             for resp_id in bkg.response_ids:
                 marf, mrmf = bkg.get_response(resp_id)
-                kwargs = {"resp_id": resp_id, "bkg_id": bkg_id}
+                kwargs = {"id": idval, "resp_id": resp_id, "bkg_id": bkg_id}
                 if marf is not None:
-                    store = FileStore(self.load_arf, idval, Path(marf.name),
-                                      kwargs=kwargs, autoloaded=True)
+                    kwargs["arg"] = marf.name
+                    store = FileStore(self.load_arf, kwargs=kwargs,
+                                      filekey="arg", autoloaded=True)
                     self._storage.add_bkg_arf(idval, bkg_id, resp_id, store)
 
                 if mrmf is not None:
-                    store = FileStore(self.load_rmf, idval, Path(mrmf.name),
-                                      kwargs=kwargs, autoloaded=True)
+                    kwargs["arg"] = mrmf.name
+                    store = FileStore(self.load_rmf, kwargs=kwargs,
+                                      filekey="arg", autoloaded=True)
                     self._storage.add_bkg_rmf(idval, bkg_id, resp_id, store)
 
     # DOC-TODO: how best to include datastack support?
@@ -2752,9 +2755,9 @@ class Session(sherpa.ui.utils.Session):
         phasets = self.unpack_pha(arg, use_errors)
 
         if isinstance(arg, str):
-            kwargs = {"use_errors": use_errors}
-            store = FileStore(self.load_pha, idval, Path(arg),
-                              kwargs=kwargs)
+            kwargs = {"id": idval, "arg": arg, "use_errors": use_errors}
+            store = FileStore(self.load_pha, kwargs=kwargs,
+                              filekey="arg")
         else:
             store = None
 
@@ -6563,9 +6566,9 @@ class Session(sherpa.ui.utils.Session):
         if not isinstance(arg, str):
             return
 
-        kwargs = {"resp_id": resp_id, "bkg_id": bkg_id}
-        store = FileStore(self.load_arf, idval, Path(arg),
-                          kwargs=kwargs)
+        kwargs = {"id": idval, "arg": arg, "resp_id": resp_id,
+                  "bkg_id": bkg_id}
+        store = FileStore(self.load_arf, kwargs=kwargs, filekey="arg")
 
         # Ensure resp_id is not None for the key.
         if resp_id is None:
@@ -6705,8 +6708,8 @@ class Session(sherpa.ui.utils.Session):
         if not isinstance(arg, str):
             return
 
-        store = FileStore(self.load_bkg_arf, idval, Path(arg),
-                          kwargs={})
+        store = FileStore(self.load_bkg_arf, filekey="arg",
+                          kwargs={"id": idval, "arg": arg})
         self._storage.add_bkg_arf(idval, bkg_id, resp_id, store)
 
     def load_multi_arfs(self, id, filenames, resp_ids=None) -> None:
@@ -7108,9 +7111,9 @@ class Session(sherpa.ui.utils.Session):
         if not isinstance(arg, str):
             return
 
-        kwargs = {"resp_id": resp_id, "bkg_id": bkg_id}
-        store = FileStore(self.load_rmf, idval, Path(arg),
-                          kwargs=kwargs)
+        kwargs = {"id": idval, "arg": arg, "resp_id": resp_id,
+                  "bkg_id": bkg_id}
+        store = FileStore(self.load_rmf, kwargs=kwargs, filekey="arg")
 
         # Ensure resp_id is not None for the key.
         if resp_id is None:
@@ -7245,8 +7248,8 @@ class Session(sherpa.ui.utils.Session):
         if not isinstance(arg, str):
             return
 
-        store = FileStore(self.load_bkg_rmf, idval, Path(arg),
-                          kwargs={})
+        store = FileStore(self.load_bkg_rmf, filekey="arg",
+                          kwargs={"id": idval, "arg": arg})
         self._storage.add_bkg_rmf(idval, bkg_id, resp_id, store)
 
     def load_multi_rmfs(self, id, filenames, resp_ids=None) -> None:
@@ -8532,8 +8535,9 @@ class Session(sherpa.ui.utils.Session):
         bkgsets = self.unpack_bkg(arg, use_errors)
 
         if isinstance(arg, str):
-            kwargs = {"bkg_id": bkg_id, "use_errors": use_errors}
-            store = FileStore(self.load_bkg, idval, Path(arg),
+            kwargs = {"id": idval, "arg": arg, "bkg_id": bkg_id,
+                      "use_errors": use_errors}
+            store = FileStore(self.load_bkg, filekey="arg",
                               kwargs=kwargs)
         else:
             store = None

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -26,7 +26,8 @@ from dataclasses import dataclass
 from functools import partial
 import logging
 import os
-from typing import Any, Type
+from pathlib import Path
+from typing import Type
 import sys
 from types import MethodType
 
@@ -51,6 +52,7 @@ import sherpa.astro.io
 import sherpa.astro.plot
 import sherpa.astro.sim
 from sherpa.astro.ui import serialize
+from sherpa.astro.ui.serialize import FileStore
 import sherpa.astro.utils
 
 import sherpa.data
@@ -69,8 +71,8 @@ import sherpa.ui.utils
 from sherpa.ui.utils import _check_type, _check_str_type, _is_str
 
 import sherpa.utils
-from sherpa.utils import bool_cast, get_error_estimates, is_subclass, \
-    sao_arange, send_to_pager
+from sherpa.utils import bool_cast, get_error_estimates, \
+    is_subclass, sao_arange, send_to_pager
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
     IdentifierErr, ImportErr, IOErr, ModelErr
 from sherpa.utils.numeric_types import SherpaFloat
@@ -361,7 +363,8 @@ class Session(sherpa.ui.utils.Session):
         self._energyfluxplot = sherpa.astro.plot.EnergyFluxHistogram()
         self._photonfluxplot = sherpa.astro.plot.PhotonFluxHistogram()
 
-        # Used to identify PHA datasets.
+        # Store the information used to load in data files (and
+        # associated elements).
         #
         # These dictionaries are always cleared by set_data/bkg for
         # the IdType value, and a few other commands
@@ -369,18 +372,21 @@ class Session(sherpa.ui.utils.Session):
         # the relevant load_pha/data/bkg commands after they call
         # set_data/bkg.  This information is used by
         # .serialize.save_all to re-create the relevant load_xxx
-        # command. At present this is restricted to PHA data but could
-        # be extended for the other types (e.g. tables, images).  The
-        # value type of "dict[str, Any]" could have better typing, but
-        # leave as this generic form for now.
+        # command.
         #
         # Note that the automatically-loaded ancillary data for PHA
         # files (background, ARF, RMF) are included in this store so
         # that save_all knows that these files do not need to be
         # explicitly loaded.
         #
-        self._load_data_store: dict[IdType, dict[str, Any]] = {}
-        self._load_bkg_store: dict[IdType, dict[IdType, dict[str, Any]]] = {}
+        self._storage = serialize.Storage()
+
+        # PHA2 files need to be handled differently since
+        # - a single call creates multiple datasets
+        # - if one of these datasets is deleted it would be good to be
+        #   able to include this in the serialization.
+        #
+        self._multi_data_store: dict[IdType, tuple[FileStore, list[IdType]]] = {}
 
         # This is a new dictionary of XSPEC module settings.  It
         # is meant only to be populated by the save function, so
@@ -1041,59 +1047,48 @@ class Session(sherpa.ui.utils.Session):
     # Data
     ###########################################################################
 
+    def _clean_file_store(self, idval: IdType) -> None:
+        """Clean the internal file-store objects for this identifier."""
+
+        self._storage.clean(idval)
+
+        with suppress(KeyError):
+            del self._multi_data_store[idval]
+
     def delete_data(self, id: IdType | None = None) -> None:
         idval = self._fix_id(id)
         super().delete_data(idval)
-
-        # Ensure the load-bkg/data stores are cleared.
-        #
-        with suppress(KeyError):
-            del self._load_bkg_store[idval]
-
-        with suppress(KeyError):
-            del self._load_data_store[idval]
+        self._clean_file_store(idval)
 
     delete_data.__doc__ = sherpa.ui.utils.Session.delete_data.__doc__
 
-    def set_data(self, id, data=None) -> None:
+    def set_data(self,
+                 id: IdType | Data | None,
+                 data: Data | None = None
+                 ) -> None:
         if data is None:
             idval = self.get_default_id()
-            data = id
+            dval = id
         else:
             idval = self._fix_id(id)
+            dval = data
 
-        super().set_data(idval, data=data)
-
-        # Ensure the load-bkg/data stores are cleared.
-        #
-        with suppress(KeyError):
-            del self._load_bkg_store[idval]
-
-        with suppress(KeyError):
-            del self._load_data_store[idval]
+        super().set_data(idval, data=dval)
+        self._clean_file_store(idval)
 
     set_data.__doc__ = sherpa.ui.utils.Session.set_data.__doc__
 
+    # TODO: should we really do this, rather than perhaps just
+    # recording that a copy was made (as technically re-loading the
+    # data is different to calling copy_data).
+    #
     def copy_data(self, fromid: IdType, toid: IdType) -> None:
         super().copy_data(fromid, toid)
 
-        # Copy over the load-data information if it exists, otherwise
-        # ensure it is cleared out.
+        # Remove any filestore info for the toid.
         #
-        try:
-            old = self._load_data_store[fromid]
-
-            # Copy the dict rather than share a reference.
-            #
-            self._load_data_store[toid] = {k: v for k, v in old.items()}
-            self._load_data_store[toid]["id"] = toid
-
-        except KeyError:
-            with suppress(KeyError):
-                del self._load_bkg_store[toid]
-
-            with suppress(KeyError):
-                del self._load_data_store[toid]
+        self._clean_file_store(toid)
+        self._storage.copy(fromid, toid)
 
     copy_data.__doc__ = sherpa.ui.utils.Session.copy_data.__doc__
 
@@ -1664,6 +1659,16 @@ class Session(sherpa.ui.utils.Session):
         data = self.unpack_table(filename, ncols, colkeys, dstype)
         self.set_data(idval, data)
 
+        # Do not track load calls when the argument is not a string.
+        if not isinstance(filename, str):
+            return
+
+        kwargs = {"ncols": ncols, "colkeys": colkeys,
+                  "dstype": dstype}
+        store = FileStore(self.load_table, idval, Path(filename),
+                          kwargs=kwargs)
+        self._storage.add(idval, store)
+
     # DOC-TODO: should unpack_ascii be merged into unpack_table?
     # DOC-TODO: I am going to ignore the crates support here as
     # it is somewhat meaningless, since the crate could
@@ -1870,10 +1875,21 @@ class Session(sherpa.ui.utils.Session):
         else:
             idval = self._fix_id(id)
 
-        data = self.unpack_ascii(filename, ncols=ncols,
-                                 colkeys=colkeys, dstype=dstype,
-                                 sep=sep, comment=comment)
+        # This could remove default valus for unpack_ascii so that
+        # the serialization does not include them.
+        #
+        kwargs = {"ncols": ncols, "colkeys": colkeys,
+                  "dstype": dstype, "sep": sep, "comment": comment}
+        data = self.unpack_ascii(filename, **kwargs)
         self.set_data(idval, data)
+
+        # Do not track load calls when the argument is not a string.
+        if not isinstance(filename, str):
+            return
+
+        store = FileStore(self.load_ascii, idval, Path(filename),
+                          kwargs=kwargs)
+        self._storage.add(idval, store)
 
     # DOC-NOTE: also in sherpa.utils
     def unpack_data(self, filename, *args, **kwargs):
@@ -2049,10 +2065,10 @@ class Session(sherpa.ui.utils.Session):
         else:
             idval = self._fix_id(id)
 
+        kwargs = {"colkeys": colkeys, "sep": sep, "comment": comment}
         data = self.unpack_ascii(filename, ncols=4,
-                                 colkeys=colkeys,
                                  dstype=Data1DAsymmetricErrs,
-                                 sep=sep, comment=comment)
+                                 **kwargs)
         self.set_data(idval, data)
 
         if not delta:
@@ -2066,123 +2082,71 @@ class Session(sherpa.ui.utils.Session):
 
         data.staterror = staterror
 
-    def _load_data(self,
-                   id: IdType | None,
-                   datasets: Data | Sequence[Data],
-                   filename: str,
-                   kwargs: dict[str, Any]
-                   ) -> None:
-        """Load one or more datasets.
+        # Do not track load calls when the argument is not a string.
+        if not isinstance(filename, str):
+            return
+
+        kwargs["func"] = func
+        kwargs["delta"] = delta
+        store = FileStore(self.load_ascii_with_errors, idval,
+                          Path(filename), kwargs=kwargs)
+        self._storage.add(idval, store)
+
+    def _load_datas(self,
+                    idval: IdType,
+                    datasets: Sequence[DataPHA],
+                    store: FileStore | None,
+                    use_errors: bool
+                    ) -> None:
+        """Load in multiple datasets (at present PHA2 files).
 
         Used by load_data and load_pha.
 
         Parameters
         ----------
-        id : int, str, or None
-           The identifier for the data set to use. For multi-dataset
-           files, currently only PHA2, the id value indicates the
-           first dataset: if it is an integer then the numbering
-           starts at id, and if a string then a suffix of 1 to n is
-           added.  If not given then the default identifier is used,
-           as returned by `get_default_id`.
-        datasets : Data instance or iterable of Data instances
+        id : int, str
+           The identifier for the "first" data set to use: if it is an
+           integer then the numbering starts at id, and if a string
+           then a suffix of 1 to n is added.
+        datasets : iterable of DataPHA instances
            The data to load, either as a single item or, for
            multiple-dataset files, an iterable of them.
-        filename : str
-           The name of the file used to load the data (only used
-           when datasets is a sequence, which implies a PHA2 file).
-        kwargs : dict
-           The keyword arguments used in the load call (only used
-           for PHA2 data).
+        store
+           How was the file loaded? If it was loaded from a I/O
+           object then we do not record the provenance.
 
         """
 
-        if id is None:
-            idval = self.get_default_id()
-        else:
-            idval = self._fix_id(id)
-
-        def mk_pha_store(data: DataPHA) -> dict[str, Any]:
-            """The basic storage information for a PHA file."""
-
-            store = {"id": idval,
-                     "filename": filename,
-                     "kwargs": kwargs}
-
-            # What files were automatically loaded? Track the
-            # identifier and file name in case the user loads
-            # something different. If the code tracks the load
-            # commands then this logic could be removed.
-            #
-            # The responses can be None, so strip them out.
-            #
-            store["arf_ids"] = {}
-            store["rmf_ids"] = {}
-            for resp_id in data.response_ids:
-                arf, rmf = data.get_response(resp_id)
-                if arf is not None:
-                    store["arf_ids"][resp_id] = arf.name
-                if rmf is not None:
-                    store["rmf_ids"][resp_id] = rmf.name
-
-            store["bkg_ids"] = {
-                bkg_id: data.get_background(bkg_id).name
-                for bkg_id in data.background_ids
-            }
-
-            # The backgrounds can have responses.
-            #
-            store["bkg_arf_ids"] = {}
-            store["bkg_rmf_ids"] = {}
-            for bkg_id in data.background_ids:
-                bkg = data.get_background(bkg_id)
-                bkg_arfs = {}
-                bkg_rmfs = {}
-                for resp_id in bkg.response_ids:
-                    barf, brmf = bkg.get_response(resp_id)
-                    if barf is not None:
-                        bkg_arfs[resp_id] = barf.name
-                    if brmf is not None:
-                        bkg_rmfs[resp_id] = brmf.name
-
-                store["bkg_arf_ids"][bkg_id] = bkg_arfs
-                store["bkg_rmf_ids"][bkg_id] = bkg_rmfs
-
-            return store
-
-        if not np.iterable(datasets):
-            # set_data clears _load_data_store
-            self.set_data(idval, datasets)
-            if isinstance(datasets, DataPHA):
-                self._load_data_store[idval] = mk_pha_store(datasets)
-
-            return
-
-        # One issue with the following is that if there's
-        # only one dataset in phasets and id is a string then the
-        # output will be "foo1" rather than "foo" (when
-        # id="foo").  DJB thinks we can live with this.
+        # One issue with the following is that if there's only one
+        # dataset in phasets and id is a string then the output will
+        # be "foo1" rather than "foo" (when id="foo").
         #
         num = len(datasets)
         ids = []
-        for ctr, data in enumerate(datasets):
+        for ctr in range(num):
             try:
-                id_ = idval + ctr
+               ids.append(idval + ctr)
             except TypeError:
-                # id is assumed to be a string
-                id_ = idval + str(ctr + 1)
+                # Assume idval is a string
+                ids.append(f"{idval}{ctr + 1}")
 
+        # Note that store.idval is not guaranteed to match id_ in this
+        # loop.
+        #
+        # This slightly extends the meaning of the autoloaded flag but
+        # it indicates in the FileStore object that something is
+        # different here.
+        #
+        if store is not None:
+            store.autoloaded = True
+
+        for id_, data in zip(ids, datasets):
             self.set_data(id_, data)
-            ids.append(id_)
+            if store is not None:
+                self._storage.add(id_, store)
+                self._multi_data_store[id_] = (store, ids)
 
-            store = mk_pha_store(data)
-
-            # Note that since ids is a mutable argument, the final
-            # value stored in idvals will list all related
-            # identifiers.
-            #
-            store["idvals"] = ids
-            self._load_data_store[id_] = store
+            self._pha_filestore(id_, data, use_errors=use_errors)
 
         if num > 1:
             info("Multiple data sets have been input: %s-%s",
@@ -2271,7 +2235,43 @@ class Session(sherpa.ui.utils.Session):
             idval = self._fix_id(id)
 
         datasets = self.unpack_data(filename, *args, **kwargs)
-        self._load_data(idval, datasets, filename=filename, kwargs=kwargs)
+
+        # We record the load_data call, not the underlying "load_xxx"
+        # call.
+        #
+        if isinstance(filename, str):
+            # This assumes that len(args) == 0
+            store = FileStore(self.load_data, idval, Path(filename),
+                              kwargs=kwargs)
+        else:
+            store = None
+
+        try:
+            use_errors = kwargs["use_errors"]
+        except KeyError:
+            # This is only needed for PHA calls but set it here
+            # whatever the dataset. It should match the default for
+            # load_pha (it would be better to ask for this value
+            # rather than hard-code it but let the tests catch any
+            # drift in the code).
+            #
+            use_errors = False
+
+        if not np.iterable(datasets):
+            self.set_data(idval, datasets)
+            if store is not None:
+                self._storage.add(idval, store)
+
+            # If this is a PHA then hide the automatically-loaded
+            # responses (backround, arf/rmf, and background arf/rmf).
+            # We also need to know if the use_errors option was set.
+            #
+            if isinstance(datasets, DataPHA):
+                self._pha_filestore(idval, datasets, use_errors=use_errors)
+
+            return
+
+        self._load_datas(idval, datasets, store, use_errors=use_errors)
 
     def unpack_image(self, arg, coord='logical',
                      dstype=DataIMG):
@@ -2408,6 +2408,15 @@ class Session(sherpa.ui.utils.Session):
         data = self.unpack_image(arg, coord, dstype)
         self.set_data(idval, data)
 
+        # Do not track load calls when the argument is not a string.
+        if not isinstance(arg, str):
+            return
+
+        kwargs = {"coord": coord, "dstype": dstype}
+        store = FileStore(self.load_image, idval, Path(arg),
+                          kwargs=kwargs)
+        self._storage.add(idval, store)
+
     # DOC-TODO: what does this return when given a PHA2 file?
     def unpack_pha(self, arg, use_errors: bool = False):
         """Create a PHA data structure.
@@ -2512,6 +2521,70 @@ class Session(sherpa.ui.utils.Session):
         use_errors = bool_cast(use_errors)
         return sherpa.astro.io.read_pha(arg, use_errors=use_errors,
                                         use_background=True)
+
+    def _pha_filestore(self,
+                       idval: IdType,
+                       data: DataPHA,
+                       use_errors: bool
+                       ) -> None:
+        """Record the automatically loaded files.
+
+        Update the file store with information on what response files
+        were automatically loaded via the ANCRFILE, BACKFILE, and
+        RESPFILE keywords, and how they were loaded.
+
+        """
+
+        # We need to create the FileStore values for the
+        # automatically-loaded files. This has to re-create the logic
+        # that sherpa.astro.io.read_pha used to load the files in.
+        #
+        # The assumption is that none of these filenames can be I/O
+        # objects (i.e. they are all strings).
+        #
+        for resp_id in data.response_ids:
+            marf, mrmf = data.get_response(resp_id)
+            kwargs = {"resp_id": resp_id}
+            if marf is not None:
+                store = FileStore(self.load_arf, idval, Path(marf.name),
+                                  kwargs=kwargs, autoloaded=True)
+                self._storage.add_arf(idval, resp_id, store)
+
+            if mrmf is not None:
+                store = FileStore(self.load_rmf, idval, Path(mrmf.name),
+                                  kwargs=kwargs, autoloaded=True)
+                self._storage.add_rmf(idval, resp_id, store)
+
+        for bkg_id in data.background_ids:
+            # At this point we know bkg is not None but the API does
+            # not let us assert this, hence the need for a manual
+            # check.
+            #
+            bkg = data.get_background(bkg_id)
+            assert bkg is not None
+
+            kwargs = {"bkg_id": bkg_id, "use_errors": use_errors}
+
+            store = FileStore(self.load_bkg, idval, Path(bkg.name),
+                              kwargs=kwargs, autoloaded=True)
+            self._storage.add_bkg(idval, bkg_id, store)
+
+            # Note that load_bkg_arf and load_bkg_rmf only change the
+            # default response_id, so use the load_arf and load_rmf calls
+            # instead.
+            #
+            for resp_id in bkg.response_ids:
+                marf, mrmf = bkg.get_response(resp_id)
+                kwargs = {"resp_id": resp_id, "bkg_id": bkg_id}
+                if marf is not None:
+                    store = FileStore(self.load_arf, idval, Path(marf.name),
+                                      kwargs=kwargs, autoloaded=True)
+                    self._storage.add_bkg_arf(idval, bkg_id, resp_id, store)
+
+                if mrmf is not None:
+                    store = FileStore(self.load_rmf, idval, Path(mrmf.name),
+                                      kwargs=kwargs, autoloaded=True)
+                    self._storage.add_bkg_rmf(idval, bkg_id, resp_id, store)
 
     # DOC-TODO: how best to include datastack support?
     def load_pha(self,
@@ -2678,13 +2751,22 @@ class Session(sherpa.ui.utils.Session):
 
         phasets = self.unpack_pha(arg, use_errors)
 
-        # Only store the use_errors call if set (i.e. not the default).
-        #
-        kwargs = {}
-        if use_errors:
-            kwargs["use_errors"] = True
+        if isinstance(arg, str):
+            kwargs = {"use_errors": use_errors}
+            store = FileStore(self.load_pha, idval, Path(arg),
+                              kwargs=kwargs)
+        else:
+            store = None
 
-        self._load_data(idval, phasets, filename=arg, kwargs=kwargs)
+        if not np.iterable(phasets):
+            self.set_data(idval, phasets)
+            if store is not None:
+                self._storage.add(idval, store)
+
+            self._pha_filestore(idval, phasets, use_errors=use_errors)
+            return
+
+        self._load_datas(idval, phasets, store, use_errors=use_errors)
 
     def _get_pha_data(self,
                       id: IdType | None,
@@ -2856,8 +2938,9 @@ class Session(sherpa.ui.utils.Session):
         if filename is None:
             id, filename = filename, id
 
-        self.set_filter(id, self._read_user_model(filename, *args, **kwargs)[1],
-                        bkg_id=bkg_id, ignore=ignore)
+        idval = self._fix_id(id)
+        filt = self._read_user_model(filename, *args, **kwargs)[1]
+        self.set_filter(idval, filt, bkg_id=bkg_id, ignore=ignore)
 
     # DOC-TODO: does ncols make sense here? (have removed for now)
     # DOC-TODO: prob. needs a review as the existing ahelp documentation
@@ -2949,8 +3032,9 @@ class Session(sherpa.ui.utils.Session):
         if filename is None:
             id, filename = filename, id
 
+        idval = self._fix_id(id)
         grouping = self._read_user_model(filename, *args, **kwargs)[1]
-        self.set_grouping(id, grouping, bkg_id=bkg_id)
+        self.set_grouping(idval, grouping, bkg_id=bkg_id)
 
     def load_quality(self, id, filename=None,
                      bkg_id: IdType | None = None,
@@ -3028,8 +3112,9 @@ class Session(sherpa.ui.utils.Session):
         if filename is None:
             id, filename = filename, id
 
+        idval = self._fix_id(id)
         mdata = self._read_user_model(filename, *args, **kwargs)
-        self.set_quality(id, mdata[1], bkg_id=bkg_id)
+        self.set_quality(idval, mdata[1], bkg_id=bkg_id)
 
     def set_filter(self, id, val=None,
                    bkg_id: IdType | None = None,
@@ -3171,8 +3256,9 @@ class Session(sherpa.ui.utils.Session):
         if filename is None:
             id, filename = filename, id
 
-        self.set_staterror(id,
-                           self._read_user_model(filename, *args, **kwargs)[1], bkg_id=bkg_id)
+        idval = self._fix_id(id)
+        staterr = self._read_user_model(filename, *args, **kwargs)[1]
+        self.set_staterror(idval, staterr, bkg_id=bkg_id)
 
     # DOC-NOTE: also in sherpa.utils
     # DOC-NOTE: is ncols really 2 here? Does it make sense?
@@ -3258,8 +3344,9 @@ class Session(sherpa.ui.utils.Session):
         if filename is None:
             id, filename = filename, id
 
-        self.set_syserror(id,
-                          self._read_user_model(filename, *args, **kwargs)[1], bkg_id=bkg_id)
+        idval = self._fix_id(id)
+        syserr = self._read_user_model(filename, *args, **kwargs)[1]
+        self.set_syserror(idval, syserr, bkg_id=bkg_id)
 
     # also in sherpa.utils
     def set_dep(self, id, val=None,
@@ -6315,9 +6402,19 @@ class Session(sherpa.ui.utils.Session):
 
         data = self._get_pha_data(idval, bkg_id)
         data.set_arf(arf, id=resp_id)
+
         # Set units of source dataset from channel to energy
         if data.units == 'channel':
             data._set_initial_quantity()
+
+        # Ensure resp_id is not None for the key.
+        if resp_id is None:
+            resp_id = data.primary_response_id
+
+        if bkg_id is None:
+            self._storage.reset_arf(idval, resp_id)
+        else:
+            self._storage.reset_bkg_arf(idval, bkg_id, resp_id)
 
     def unpack_arf(self, arg):
         """Create an ARF data structure.
@@ -6462,6 +6559,24 @@ class Session(sherpa.ui.utils.Session):
         arf = self.unpack_arf(arg)
         self.set_arf(idval, arf, resp_id=resp_id, bkg_id=bkg_id)
 
+        # Do not track load calls when the argument is not a string.
+        if not isinstance(arg, str):
+            return
+
+        kwargs = {"resp_id": resp_id, "bkg_id": bkg_id}
+        store = FileStore(self.load_arf, idval, Path(arg),
+                          kwargs=kwargs)
+
+        # Ensure resp_id is not None for the key.
+        if resp_id is None:
+            data = self._get_pha_data(idval, bkg_id)
+            resp_id = data.primary_response_id
+
+        if bkg_id is None:
+            self._storage.add_arf(idval, resp_id, store)
+        else:
+            self._storage.add_bkg_arf(idval, bkg_id, resp_id, store)
+
     def get_bkg_arf(self,
                     id: IdType | None = None):
         """Return the background ARF associated with a PHA data set.
@@ -6586,6 +6701,14 @@ class Session(sherpa.ui.utils.Session):
         arf = self.unpack_arf(arg)
         self.set_arf(idval, arf, resp_id=resp_id, bkg_id=bkg_id)
 
+        # Do not track load calls when the argument is not a string.
+        if not isinstance(arg, str):
+            return
+
+        store = FileStore(self.load_bkg_arf, idval, Path(arg),
+                          kwargs={})
+        self._storage.add_bkg_arf(idval, bkg_id, resp_id, store)
+
     def load_multi_arfs(self, id, filenames, resp_ids=None) -> None:
         """Load multiple ARFs for a PHA data set.
 
@@ -6655,6 +6778,9 @@ class Session(sherpa.ui.utils.Session):
 
         idval = self._fix_id(id)
         for filename, resp_id in zip(filenames, resp_ids):
+            # Note that the save_all <serialization will store these
+            # individual calls, not the load_multi_arf call.
+            #
             self.load_arf(idval, filename, resp_id=resp_id)
 
     def get_rmf(self,
@@ -6811,9 +6937,19 @@ class Session(sherpa.ui.utils.Session):
 
         data = self._get_pha_data(idval, bkg_id)
         data.set_rmf(rmf, id=resp_id)
+
         # Set units of source dataset from channel to energy
         if data.units == 'channel':
             data._set_initial_quantity()
+
+        # Ensure resp_id is not None for the key.
+        if resp_id is None:
+            resp_id = data.primary_response_id
+
+        if bkg_id is None:
+            self._storage.reset_rmf(idval, resp_id)
+        else:
+            self._storage.reset_bkg_rmf(idval, bkg_id, resp_id)
 
     def unpack_rmf(self, arg):
         """Create a RMF data structure.
@@ -6968,6 +7104,24 @@ class Session(sherpa.ui.utils.Session):
         rmf = self.unpack_rmf(arg)
         self.set_rmf(idval, rmf, resp_id=resp_id, bkg_id=bkg_id)
 
+        # Do not track load calls when the argument is not a string.
+        if not isinstance(arg, str):
+            return
+
+        kwargs = {"resp_id": resp_id, "bkg_id": bkg_id}
+        store = FileStore(self.load_rmf, idval, Path(arg),
+                          kwargs=kwargs)
+
+        # Ensure resp_id is not None for the key.
+        if resp_id is None:
+            data = self._get_pha_data(idval, bkg_id)
+            resp_id = data.primary_response_id
+
+        if bkg_id is None:
+            self._storage.add_rmf(idval, resp_id, store)
+        else:
+            self._storage.add_bkg_rmf(idval, bkg_id, resp_id, store)
+
     def get_bkg_rmf(self,
                     id: IdType | None = None):
         """Return the background RMF associated with a PHA data set.
@@ -7087,6 +7241,14 @@ class Session(sherpa.ui.utils.Session):
         rmf = self.unpack_rmf(arg)
         self.set_rmf(idval, rmf, resp_id=resp_id, bkg_id=bkg_id)
 
+        # Do not track load calls when the argument is not a string.
+        if not isinstance(arg, str):
+            return
+
+        store = FileStore(self.load_bkg_rmf, idval, Path(arg),
+                          kwargs={})
+        self._storage.add_bkg_rmf(idval, bkg_id, resp_id, store)
+
     def load_multi_rmfs(self, id, filenames, resp_ids=None) -> None:
         """Load multiple RMFs for a PHA data set.
 
@@ -7156,6 +7318,9 @@ class Session(sherpa.ui.utils.Session):
 
         idval = self._fix_id(id)
         for filename, resp_id in zip(filenames, resp_ids):
+            # Note that the save_all <serialization will store these
+            # individual calls, not the load_multi_rmf call.
+            #
             self.load_rmf(idval, filename, resp_id=resp_id)
 
     def get_bkg(self,
@@ -7286,10 +7451,7 @@ class Session(sherpa.ui.utils.Session):
         data.set_background(bkg, bkg_idval)
 
         # Ensure the load-bkg store is cleared.
-        with suppress(KeyError):
-            del self._load_bkg_store[idval][bkg_idval]
-            if len(self._load_bkg_store[idval]) == 0:
-                del self._load_bkg_store[idval]
+        self._storage.reset_bkg(idval, bkg_idval)
 
     def list_bkg_ids(self,
                      id: IdType | None = None
@@ -8369,43 +8531,13 @@ class Session(sherpa.ui.utils.Session):
 
         bkgsets = self.unpack_bkg(arg, use_errors)
 
-        def mk_pha_store(data: DataPHA) -> dict[str, Any]:
-            """The basic storage information for a PHA file."""
-
-            store = {"id": idval,
-                     "filename": arg,
-                     }
-            if use_errors:
-                store["use_errors"] = use_errors
-
-            # What files were automatically loaded? Track the
-            # identifier and file name in case the user loads
-            # something different. If the code tracks the load
-            # commands then this logic could be removed.
-            #
-            # The responses can be None, so strip them out.
-            #
-            store["arf_ids"] = {}
-            store["rmf_ids"] = {}
-            for resp_id in data.response_ids:
-                arf, rmf = data.get_response(resp_id)
-                if arf is not None:
-                    store["arf_ids"][resp_id] = arf.name
-                if rmf is not None:
-                    store["rmf_ids"][resp_id] = rmf.name
-
-            # Unlike the load_pha/data case, there is no need
-            # to track background information here (as this is
-            # the background).
-            #
-            return store
-
-        # Store values for each bkg_id value, hence the idval is a
-        # dict of dicts, unlike the _load_data_store, which is just a
-        # dict.
-        #
-        fullstore = {}
-        self._load_bkg_store[idval] = fullstore
+        if isinstance(arg, str):
+            kwargs = {"bkg_id": bkg_id, "use_errors": use_errors}
+            store = FileStore(self.load_bkg, idval, Path(arg),
+                              kwargs=kwargs)
+        else:
+            store = None
+            self._storage.clean_bkg(idval)
 
         if np.iterable(bkgsets):
             # QUS: do we support PHA2 background files? Technically
@@ -8418,22 +8550,15 @@ class Session(sherpa.ui.utils.Session):
                 self.set_bkg(idval, bkg, bkgid)
                 bkgids.append(bkgid)
 
-                store = mk_pha_store(bkg)
-                store["bkg_id"] = bkgid
-
-                # Note that since bkgids is a mutable argument, the
-                # final value stored in bkgidvals will list all
-                # related identifiers.
-                #
-                fullstore[bkg_id] = store
+                if store is not None:
+                    self._storage.add_bkg(idval, bkgid, store)
 
         else:
             bkg_idval = self._fix_background_id(idval, bkg_id)
             self.set_bkg(idval, bkgsets, bkg_idval)
 
-            store = mk_pha_store(bkgsets)
-            store["bkg_id"] = bkg_idval
-            fullstore[bkg_idval] = store
+            if store is not None:
+                self._storage.add_bkg(idval, bkg_idval, store)
 
     def group(self,
               id: IdType | None = None,
@@ -17172,7 +17297,8 @@ class Session(sherpa.ui.utils.Session):
 
         .. versionchanged:: 4.19.0
            PSF models now also save the radial and norm parameters, if
-           available.
+           available. Improved support for reporting optional
+           arguments used when loading a file.
 
         .. versionchanged:: 4.18.0
            Handling of PHA data has been improved, and the output now
@@ -17233,11 +17359,13 @@ class Session(sherpa.ui.utils.Session):
         - data changed from the version on disk - e.g. by calls to
           `set_counts` - will not be restored correctly,
 
-        - any optional keywords to commands such as `load_data`,
-
         - user models may not be restored correctly,
 
         - and only a subset of Sherpa commands are saved.
+
+        The file names used to originally load the data are used in
+        the file, with no attempt to handle changes in the working
+        directory.
 
         The `save` command can also be used for storing a Sherpa
         session and avoids some of these issues. However, it is not

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -17069,10 +17069,6 @@ class Session(sherpa.ui.utils.Session):
 
         send_to_pager("\n".join(lines), outfile, clobber)
 
-    ###########################################################################
-    # Session Text Save Function
-    ###########################################################################
-
     def save_all(self,
                  outfile=None,
                  clobber: bool = False,
@@ -17081,14 +17077,22 @@ class Session(sherpa.ui.utils.Session):
         """Save the information about the current session to a text file.
 
         This differs to the `save` command in that the output is human
-        readable. Three consequences are:
+        readable, which means:
 
-         1. numeric values may not be recorded to their full precision
+         1. it is possible to read and edit the output of `save_all`,
 
-         2. data sets are not included in the file
+         2. numeric values may not be recorded to their full precision,
 
-         3. some settings and values may not be recorded (such as
+         3. data sets are not included in the file (e.g. the commmand
+            ``load_pha("src.pi")`` requires the file src.pi, and any
+            associated files, to exist),
+
+         4. and some settings and values may not be recorded (such as
             header information).
+
+        .. versionchanged:: 4.19.0
+           PSF models now also save the radial and norm parameters, if
+           available.
 
         .. versionchanged:: 4.18.0
            Handling of PHA data has been improved, and the output now
@@ -17136,8 +17140,7 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        save : Save the current Sherpa session to a file.
-        restore : Load in a Sherpa session from a file.
+        save, restore
 
         Notes
         -----

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -960,15 +960,22 @@ class Session(NoNewAttributesAfterInit):
         self._stats: dict[str, Stat] = {}
         self._estmethods: dict[str, EstMethod] = {}
 
-        modules = (sherpa.optmethods, sherpa.stats, sherpa.estmethods)
-        basetypes = (OptMethod, Stat, EstMethod)
-        objdicts = (self._methods, self._stats, self._estmethods)
-
-        for mod, base, odict in zip(modules, basetypes, objdicts):
+        for mod, base, odict in [
+                (sherpa.optmethods, OptMethod, self._methods),
+                (sherpa.stats, Stat, self._stats),
+                (sherpa.estmethods, EstMethod, self._estmethods)
+                ]:
             for name in mod.__all__:
                 cls = getattr(mod, name)
                 if is_subclass(cls, base):
                     odict[name.lower()] = cls()
+
+        # Store estmethod changed values directly for the
+        # serialization code.
+        #
+        self._estmethods_changed: dict[str, dict[str, Any]] = {}
+        for name in self._estmethods:
+            self._estmethods_changed[name] = {}
 
         # Note: levmar does not support the rng option so this
         # can be done before set_rng is called.
@@ -10684,11 +10691,14 @@ class Session(NoNewAttributesAfterInit):
         return meth.config[optname]
 
     def _set_estmethod_opt(self, methodname, optname, val):
-        meth = self._estmethods.get(methodname.lower())
+        lname = methodname.lower()
+        meth = self._estmethods.get(lname)
         if meth is None:
             raise ArgumentErr('badconf', methodname)
         self._check_estmethod_opt(meth, optname)
         meth.config[optname] = val
+        # store the change for the serialization code
+        self._estmethods_changed[lname][optname] = val
 
     def get_covar_opt(self, name=None):
         """Return one or all of the options for the covariance

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -986,6 +986,10 @@ class Session(NoNewAttributesAfterInit):
         # Add simplex as alias to neldermead
         self._methods['simplex'] = self._methods['neldermead']
 
+        # Store changes to options
+        self._current_method_changed: dict[str, Any] = {}
+        self._current_itermethod_changed: dict[str, Any] = {}
+
         reset_interpolators()
 
         # Should some of these dictionaries have more-restrictive
@@ -2657,6 +2661,7 @@ class Session(NoNewAttributesAfterInit):
         """
         self._check_method_opt(optname)
         self._current_method.config[optname] = val
+        self._current_method_changed[optname] = val
 
     def get_iter_method_name(self) -> str:
         """Return the name of the iterative fitting scheme.
@@ -2928,6 +2933,7 @@ class Session(NoNewAttributesAfterInit):
                 'badopt', optname, self._current_itermethod['name'])
 
         self._current_itermethod[optname] = val
+        self._current_itermethod_changed[optname] = val
 
     ###########################################################################
     # Statistics


### PR DESCRIPTION
# Summary

Improve the save_all serialization code so that it better handles datasets and ancillary information - such as ARF and RMF files - that were created rather than read in from a file.

# Details

[this has now been rebased onto #2476 to separate some code clean up and other bug fixes with these changes]

In #2377 the serialization code (that is used to create the `save_all` code) was updated to better handle PHA2 files. This was extended in the #2382 PR to better track the "ancillary" files that can be automatically loaded with a PHA file (ARF, RMF, and background). As noted at the time, the techniques could have been applied to track all loaded files, but it was too large a change at that time. Well, now is the time. These changes should not affect most users of `save_all`: it mainly improves the situation for users who may have manually created a dataset or response rather than read it in from a file.

We add a specialized type (`FileStore`) to track the load call (the function name and the arguments) which can then be used to re-create the call when creating the `save_all` output file. The `Session` object then contains a number of dictionaries that store this data: the key is the dataset identifier and the value is the `FileStore` object. In fact, the PHA support complicates this as without it we would only need to store information for "data" calls but now we have to also store background, ARF, RMF, background ARF, background RMF, and information used to track PHA2 files (which have multiple datasets created with a single call). So we introduce a `sherpa.astro.ui.serialize.Storage` class that contains dictionaries to store `data`, `arf`, `rmf`, `bkg`, `bkg_arf`, and `bkg_rmf`. This class has methods to store information in these structures (but not really for reading out the data, as that is assumed to just use the dictionary access directly). This is then stored as the `_storage` field of the `Session` class. There is a separate `_multi_data_store` structure which could perhaps be merged into `Storage`. TBD.
    
The idea is that `set_data` clears these values and they are filled by the `load_xxx` call (internally these all call `set_data` so we need to fill the store field(s) **after** the `set_data` call).
    
We also need to handle `delete_data` and `copy_data` (an alternative would be to track the actual `copy_data` call rather than converting it to a `load_xxx` call).
    
When tracking the file state we have a "trinary" situation (again because of PHA files):
    
- no direct load_xxx call

  This can be a used manually creating the response object but it can also be via an explicit call to `unpack_xxx` followed by `set_xxx`. This is indicated by there not being a value in the file store (but it's awkward because you either have `idval`, `resp_id` or `idval`, `bkg_id`, `resp_id` so there are a lot of nested dictionaries, which means following the logic is messy as all these have the same type of `IdType`).
    
  Previously the code did not recognize this for ARF/RMF files and backgrounds. The code now attempts to manually re-create the responses, but it is not guaranteed to be correct (e.g. if a `DataRMF` subclass is used or metadata is added and needed).
    
- a `load_xxx` call has been made, so there is a `FileStore` item to store
    
- the response (background, ARF, or RMF) was automatically loaded via the BACKFILE, ANCRFILE, or RESPFILE keywords
    
  In this case a `FileStore` object is synthesized to represent the actual `load_xxx` call, but marked with the `autoloaded` flag set to True. This can then be checked when serializing the code to determine whether to write out the call or not (since we added, in one of the recent changes, the option to always explicitly load the responses (as it can be better to understand what is actually needed).

There is also the fact that `load_xxx` can be called with a "I/O object" (`HDUList` or `Crate`). In this case we just treat this as "manually created" as it's too hard and unreliable to track the provenance of these objects.

 # Note on `FileStore`
    
I had originally set up the FileStore to have a number of subclasses, one for each load_xxx call (and actually, multiple for PHA files to handle different cases), but I decided it actually made the code more opaque.
    
# Four issues
    
a) PHA2 files can load multiple datasets with one call, which complicates the tracking. The `_multi_data_store` dictionary is used to find those ids which were created by a single call. This is partly needed so that a sequence like
    
        load_pha("pha2")  # this creates 1, 2, ..., 11, 12
        delete_data(1)
        delete_data(2)
        delete_data(10)
        delete_data(12)
    
can be re-created. The `autoloaded` flag is set for all the `FileStore` objects (there's actually only one, it is just stored in multiple places), mainly because it semantically makes sense.
    
b) there is *limited* support for tracking cases where a dataset is loaded in via a `load_xxx` call and then the values are changed by the used. This is currently only done for PHA data with the grouping and quality arrays.
    
c) we assume the file names and locations remain consistent: that is, if a user has called
    
        load_image("../bar/foo.fits")
    
then the file has not been moved, deleted, or changed.
    
d) Technically we allow IO backend objects to be sent to the calls rather than the filename (e.g. a AstroPy FITS HDU list). However, this is not well advertised, so maybe we can say that this is only expected to work for `unpack_xxx` calls and not `load_xxx` ones?

Alternate design
----------------
    
The tracking could instead have been made of the `unpack_xxx` calls, since all `load_xxx` calls end up calling `unpack_xxx`, and this would allow cases like `pha = unpack_pha(infile); set_data(pha)` to be tracked. However, it would complicate things even more (since the data cannot just be tracked by `IdType` because at the time of the `unpack_xxx` call we only have the filename), and the `save_all` serialization isn't meant to handle all cases, just "simple" cases (users who are handling more-complex situations are expected to be able to write their own scripts).
    
Known Issues
------------
    
These are issues with the current serialization code (but also the previous version too). We could track some sort of identifier for each file - e.g. the md5sum of the file - which could be used to identify some parts of issues b and c - but I argue that this is beyond the scope of the `save_all` call (i.e. this is just a limitation of how it works).