### PR TITLE
Update the documentation to build with recent versions of Sphinx

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,17 +3,18 @@ name: sherpa
 channels:
   - conda-forge
   - astropy
+  - nodefaults
 
 dependencies:
   - bison
-  - python=3.10
+  - python=3.13
   - numpy
   - pandoc
   - matplotlib
   - astropy
   - pip
   - graphviz
-  - sphinx>=5.0,<8.0
+  - sphinx>=5.0
   - pip:
     - ipykernel
     - nbsphinx

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -20,5 +20,5 @@ dependencies:
     - sphinx-astropy
     - sphinx_rtd_theme>=3.0.0
     - bokeh
-    - arviz
+    - arviz<1.0.0
     - optimagic

--- a/docs/overview/guess.rst
+++ b/docs/overview/guess.rst
@@ -25,11 +25,10 @@ The sherpa.utils.guess module
       guess_fwhm
       param_apply_limits
       get_amplitude_position
+      get_position
       guess_amplitude
       guess_amplitude_at_ref
       guess_amplitude2d
-      guess_reference
-      get_position
       guess_position
       guess_bounds
       guess_reference

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,9 +4,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
-    python: "mambaforge-4.10"
+    python: "miniforge3-latest"
   jobs:
     pre_install:
       - git update-index --assume-unchanged docs/conf.py docs/environment.yml

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -13122,7 +13122,7 @@ class Session(sherpa.ui.utils.Session):
            of the covariance matrix). If the scales parameter is not
            given then the covariance matrix is evaluated for the
            current model and best-fit parameters.
-        model : model, optional
+        model : Model, optional
            The model to integrate. If left as `None` then the source
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
@@ -13149,12 +13149,8 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        get_photon_flux_hist : Return the data displayed by plot_photon_flux.
-        plot_energy_flux : Display the energy flux distribution.
-        plot_photon_flux : Display the photon flux distribution.
-        sample_energy_flux : Return the energy flux distribution of a model.
-        sample_flux : Return the flux distribution of a model.
-        sample_photon_flux : Return the photon flux distribution of a model.
+        get_photon_flux_hist, plot_energy_flux, plot_photon_flux,
+        sample_energy_flux, sample_flux, sample_photon_flux
 
         Examples
         --------
@@ -13268,7 +13264,7 @@ class Session(sherpa.ui.utils.Session):
            of the covariance matrix). If the scales parameter is not
            given then the covariance matrix is evaluated for the
            current model and best-fit parameters.
-        model : model, optional
+        model : Model, optional
            The model to integrate. If left as `None` then the source
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
@@ -13295,12 +13291,8 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        get_energy_flux_hist : Return the data displayed by plot_energy_flux.
-        plot_energy_flux : Display the energy flux distribution.
-        plot_photon_flux : Display the photon flux distribution.
-        sample_energy_flux : Return the energy flux distribution of a model.
-        sample_flux : Return the flux distribution of a model.
-        sample_photon_flux : Return the photon flux distribution of a model.
+        get_energy_flux_hist, plot_energy_flux, plot_photon_flux,
+        sample_energy_flux, sample_flux, sample_photon_flux
 
         Examples
         --------
@@ -14365,7 +14357,7 @@ class Session(sherpa.ui.utils.Session):
            of the covariance matrix). If the scales parameter is not
            given then the covariance matrix is evaluated for the
            current model and best-fit parameters.
-        model : model, optional
+        model : Model, optional
            The model to integrate. If left as `None` then the source
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
@@ -14392,18 +14384,10 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        calc_photon_flux : Integrate the unconvolved source model over a pass band.
-        calc_energy_flux : Integrate the unconvolved source model over a pass band.
-        covar : Estimate the confidence intervals using the confidence method.
-        get_energy_flux_hist : Return the data displayed by plot_energy_flux.
-        get_photon_flux_hist : Return the data displayed by plot_photon_flux.
-        plot_cdf : Plot the cumulative density function of an array.
-        plot_pdf : Plot the probability density function of an array.
-        plot_photon_flux : Display the photon flux distribution.
-        plot_trace : Create a trace plot of row number versus value.
-        sample_energy_flux : Return the energy flux distribution of a model.
-        sample_flux : Return the flux distribution of a model.
-        sample_photon_flux : Return the photon flux distribution of a model.
+        calc_photon_flux, calc_energy_flux, covar,
+        get_energy_flux_hist, get_photon_flux_hist, plot_cdf,
+        plot_pdf, plot_photon_flux, plot_trace, sample_energy_flux,
+        sample_flux, sample_photon_flux
 
         Examples
         --------
@@ -14537,7 +14521,7 @@ class Session(sherpa.ui.utils.Session):
            of the covariance matrix). If the scales parameter is not
            given then the covariance matrix is evaluated for the
            current model and best-fit parameters.
-        model : model, optional
+        model : Model, optional
            The model to integrate. If left as `None` then the source
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
@@ -14564,18 +14548,10 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        calc_photon_flux : Integrate the unconvolved source model over a pass band.
-        calc_energy_flux : Integrate the unconvolved source model over a pass band.
-        covar : Estimate the confidence intervals using the confidence method.
-        get_energy_flux_hist : Return the data displayed by plot_energy_flux.
-        get_photon_flux_hist : Return the data displayed by plot_photon_flux.
-        plot_cdf : Plot the cumulative density function of an array.
-        plot_pdf : Plot the probability density function of an array.
-        plot_energy_flux : Display the energy flux distribution.
-        plot_trace : Create a trace plot of row number versus value.
-        sample_energy_flux : Return the energy flux distribution of a model.
-        sample_flux : Return the flux distribution of a model.
-        sample_photon_flux : Return the photon flux distribution of a model.
+        calc_photon_flux, calc_energy_flux, covar,
+        get_energy_flux_hist, get_photon_flux_hist, plot_cdf,
+        plot_pdf, plot_energy_flux, plot_trace, sample_energy_flux,
+        sample_flux, sample_photon_flux
 
         Examples
         --------
@@ -15083,7 +15059,7 @@ class Session(sherpa.ui.utils.Session):
            The identifier of the background component to use. This
            should only be set when the line to be measured is in the
            background model.
-        model : model, optional
+        model : Model, optional
            The model to integrate. If left as `None` then the source
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
@@ -15102,7 +15078,7 @@ class Session(sherpa.ui.utils.Session):
 
         Returns
         -------
-        vals
+        vals : ndarray
            The return array has the shape ``(num, N+2)``, where ``N``
            is the number of free parameters in the fit and num is the
            `num` parameter.  The rows of this array contain the flux
@@ -15114,16 +15090,9 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        calc_photon_flux : Integrate the unconvolved source model over a pass band.
-        calc_energy_flux : Integrate the unconvolved source model over a pass band.
-        covar : Estimate the confidence intervals using the confidence method.
-        plot_cdf : Plot the cumulative density function of an array.
-        plot_pdf : Plot the probability density function of an array.
-        plot_energy_flux : Display the energy flux distribution.
-        plot_photon_flux : Display the photon flux distribution.
-        plot_trace : Create a trace plot of row number versus value.
-        sample_energy_flux : Return the energy flux distribution of a model.
-        sample_flux : Return the flux distribution of a model.
+        calc_photon_flux, calc_energy_flux, covar, plot_cdf, plot_pdf,
+        plot_energy_flux, plot_photon_flux, plot_trace,
+        sample_energy_flux, sample_flux
 
         Notes
         -----
@@ -15324,7 +15293,7 @@ class Session(sherpa.ui.utils.Session):
            The identifier of the background component to use. This
            should only be set when the line to be measured is in the
            background model.
-        model : model, optional
+        model : Model, optional
            The model to integrate. If left as `None` then the source
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
@@ -15343,7 +15312,7 @@ class Session(sherpa.ui.utils.Session):
 
         Returns
         -------
-        vals
+        vals : ndarray
            The return array has the shape ``(num, N+2)``, where ``N``
            is the number of free parameters in the fit and num is the
            `num` parameter.  The rows of this array contain the flux
@@ -15355,16 +15324,9 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        calc_photon_flux : Integrate the unconvolved source model over a pass band.
-        calc_energy_flux : Integrate the unconvolved source model over a pass band.
-        covar : Estimate the confidence intervals using the confidence method.
-        plot_cdf : Plot the cumulative density function of an array.
-        plot_pdf : Plot the probability density function of an array.
-        plot_energy_flux : Display the energy flux distribution.
-        plot_photon_flux : Display the photon flux distribution.
-        plot_trace : Create a trace plot of row number versus value.
-        sample_photon_flux : Return the flux distribution of a model.
-        sample_flux : Return the flux distribution of a model.
+        calc_photon_flux, calc_energy_flux, covar, plot_cdf, plot_pdf,
+        plot_energy_flux, plot_photon_flux, plot_trace,
+        sample_photon_flux, sample_flux
 
         Notes
         -----
@@ -15975,7 +15937,7 @@ class Session(sherpa.ui.utils.Session):
         bkg_id : int, str, or None, optional
            If set, use the model associated with the given background
            component rather than the source model.
-        model : model, optional
+        model : Model, optional
            The model to integrate. If left as `None` then the source
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
@@ -15990,12 +15952,8 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        calc_data_sum : Sum up the observed counts over a pass band.
-        calc_model_sum : Sum up the fitted model over a pass band.
-        calc_energy_flux : Integrate the unconvolved source model over a pass band.
-        calc_source_sum: Sum up the source model over a pass band.
-        set_analysis : Set the units used when fitting and displaying spectral data
-        set_model : Set the source model expression for a data set.
+        calc_data_sum, calc_model_sum, calc_energy_flux,
+        calc_source_sum, set_analysis, set_model
 
         Notes
         -----
@@ -16097,7 +16055,7 @@ class Session(sherpa.ui.utils.Session):
         bkg_id : int, str, or None, optional
            If set, use the model associated with the given background
            component rather than the source model.
-        model : model, optional
+        model : Model, optional
            The model to integrate. If left as `None` then the source
            model for the dataset will be used. This can be used to
            calculate the unabsorbed flux, as shown in the examples.
@@ -16112,12 +16070,8 @@ class Session(sherpa.ui.utils.Session):
 
         See Also
         --------
-        calc_data_sum : Sum up the data values over a pass band.
-        calc_model_sum : Sum up the fitted model over a pass band.
-        calc_source_sum: Sum up the source model over a pass band.
-        calc_photon_flux : Integrate the unconvolved source model over a pass band.
-        set_analysis : Set the units used when fitting and displaying spectral data
-        set_model : Set the source model expression for a data set.
+        calc_data_sum, calc_model_sum, calc_source_sum,
+        calc_photon_flux, set_analysis, set_model
 
         Notes
         -----

--- a/sherpa/astro/utils/__init__.py
+++ b/sherpa/astro/utils/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2016, 2020-2022, 2024-2025
+#  Copyright (C) 2008, 2016, 2020-2022, 2024-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -520,7 +520,7 @@ def calc_energy_flux(data, src, lo=None, hi=None):
 
     Returns
     -------
-    flux
+    flux : number
        The flux or flux density of the source model. For X-Spec
        models the flux units will be erg/cm^2/s and the flux
        density is either erg/cm^2/s/keV or erg/cm^2/s/Angstrom,
@@ -528,10 +528,7 @@ def calc_energy_flux(data, src, lo=None, hi=None):
 
     See Also
     --------
-    calc_data_sum : Sum up the data values over a pass band.
-    calc_model_sum : Sum up the fitted model over a pass band.
-    calc_source_sum : Sum up the source model over a pass band.
-    calc_photon_flux : Integrate the source model over a pass band.
+    calc_data_sum, calc_model_sum, calc_source_sum, calc_photon_flux
 
     Notes
     -----
@@ -592,7 +589,7 @@ def calc_photon_flux(data, src, lo=None, hi=None):
 
     Returns
     -------
-    flux
+    flux : number
        The flux or flux density of the source model. For X-Spec
        models the flux units will be photon/cm^2/s and the flux
        density is either photon/cm^2/s/keV or
@@ -600,10 +597,7 @@ def calc_photon_flux(data, src, lo=None, hi=None):
 
     See Also
     --------
-    calc_data_sum : Sum up the data values over a pass band.
-    calc_model_sum : Sum up the fitted model over a pass band.
-    calc_energy_flux : Integrate the source model over a pass band.
-    calc_source_sum : Sum up the source model over a pass band.
+    calc_data_sum, calc_model_sum, calc_energy_flux, calc_source_sum
 
     Notes
     -----

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2015 - 2017, 2019 - 2025
+#  Copyright (C) 2008, 2015-2017, 2019-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -708,11 +708,11 @@ class Filter:
 
         Parameters
         ----------
-        mins : sequence of values
+        mins : sequence
            The minimum value of the valid range (elements may be None
            to indicate no lower bound). When not None, it is treated
            as an inclusive limit, so points >= min are included.
-        maxes : sequence of values
+        maxes : sequence
            The maximum value of the valid range (elements may be None
            to indicate no upper bound). It is treated as an inclusive
            limit (points <= max) when integrated is False, and an

--- a/sherpa/plot/backend_utils.py
+++ b/sherpa/plot/backend_utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2022 - 2024
+#  Copyright (C) 2022-2024, 2026
 #  MIT
 #
 #
@@ -117,8 +117,8 @@ def add_kwargs_to_doc(param_doc):
     --------
 
     >>> param_doc = {'c' : ['int', 'thickness of line'],
-    ...              'title' : ['string', 'Title of figure (only use if `overplot=False`)'],
-    ...              'color': ['string or number',
+    ...              'title' : ['str', 'Title of figure (only use if `overplot=False`)'],
+    ...              'color': ['str or number',
     ...                  'any matplotlib color with a really long text attached to it that will not fit in one line of text in the docstring']}
     >>> @add_kwargs_to_doc(param_doc)
     ... def test_func2(a, *, title=None, color='None'):
@@ -141,9 +141,9 @@ def add_kwargs_to_doc(param_doc):
         ----------
         a : int
             Our stuff
-        title : string, default=None
+        title : str, default=None
             Title of figure (only use if `overplot=False`)
-        color : string or number, default=None
+        color : str or number, default=None
             any matplotlib color with a really long text attached to it that will not fit in one line of text in the docstring
 
     '''
@@ -155,10 +155,16 @@ def add_kwargs_to_doc(param_doc):
         for p, par in sig.parameters.items():
             if par.kind == par.KEYWORD_ONLY:
                 pdoc = param_doc.get(p, ['', ''])
-                out.append(' ' * indent + f'{p} : {pdoc[0]}, default={sig.parameters[p].default}')
+                outmsg = ' ' * indent + f'{p} : '
+                if pdoc[0] != '':
+                    outmsg += f'{pdoc[0]}, '
+                outmsg += f'default={sig.parameters[p].default}'
+                out.append(outmsg)
+
             if par.kind == par.VAR_KEYWORD:
                 pdoc = param_doc.get(p, ['', 'All other keyword parameters are passed to the plotting library.'])
                 out.append(' ' * indent + f'{p} : dict, optional')
+
             if par.kind in (par.KEYWORD_ONLY, par.VAR_KEYWORD):
                 for line in pdoc[1].split('\n'):
                     out.append(' ' * (indent + 4) + line)

--- a/sherpa/plot/backend_utils.py
+++ b/sherpa/plot/backend_utils.py
@@ -141,9 +141,9 @@ def add_kwargs_to_doc(param_doc):
         ----------
         a : int
             Our stuff
-        title : str, default=None
+        title : str or None, default=None
             Title of figure (only use if `overplot=False`)
-        color : str or number, default=None
+        color : str or number or None, default=None
             any matplotlib color with a really long text attached to it that will not fit in one line of text in the docstring
 
     '''

--- a/sherpa/plot/backend_utils.py
+++ b/sherpa/plot/backend_utils.py
@@ -117,8 +117,8 @@ def add_kwargs_to_doc(param_doc):
     --------
 
     >>> param_doc = {'c' : ['int', 'thickness of line'],
-    ...              'title' : ['str', 'Title of figure (only use if `overplot=False`)'],
-    ...              'color': ['str or number',
+    ...              'title' : ['str or None', 'Title of figure (only use if `overplot=False`)'],
+    ...              'color': ['str or number or None',
     ...                  'any matplotlib color with a really long text attached to it that will not fit in one line of text in the docstring']}
     >>> @add_kwargs_to_doc(param_doc)
     ... def test_func2(a, *, title=None, color='None'):

--- a/sherpa/plot/backends.py
+++ b/sherpa/plot/backends.py
@@ -472,12 +472,12 @@ class BaseBackend(metaclass=MetaBaseBackend):
 
         Parameters
         ----------
-        x0 : array-like or scalar number
+        xlo : array-like or scalar number
             lower bin boundary values
-        x1 : array-like or scalar number
+        xhi : array-like or scalar number
             upper bin boundary values
         y : array-like or scalar number
-            y values, same dimension as `x0`.
+            y values, same dimension as xlo.
         {kwargs}
         """
         pass
@@ -533,7 +533,7 @@ class BaseBackend(metaclass=MetaBaseBackend):
             independent axis in the first dimenation
         x1 : array-like
             independent axis in the second dimenation
-        y : array-like, with shape (len(x0), len(x1))
+        y : array-like
             dependent axis (i.e. image values) in 2D
             with shape (len(x0), len(x1))
         {kwargs}

--- a/sherpa/plot/backends.py
+++ b/sherpa/plot/backends.py
@@ -55,7 +55,7 @@ backend_indep_kwargs = {
 
 # DOC-NOTE: can xerr be asymmetric (i.e. be 2D)?
 #
-kwargs_doc = {'xerr': ['float or array-like, shape(N,) or shape(2, N)',
+kwargs_doc = {'xerr': ['float or array-like',
                        '''The errorbar sizes can be:
   - scalar: Symmetric +/- values for all data points.
   - shape(N,): Symmetric +/-values for each data point.
@@ -65,7 +65,7 @@ kwargs_doc = {'xerr': ['float or array-like, shape(N,) or shape(2, N)',
   - None: No errorbar.
 
 Note that all error arrays should have positive values.'''],
-              'yerr': ['float or array-like, shape(N,) or shape(2, N)',
+              'yerr': ['float or array-like',
                        '''The errorbar sizes can be:
   - scalar: Symmetric +/- values for all data points.
   - shape(N,): Symmetric +/-values for each data point.
@@ -79,7 +79,7 @@ Note that all error arrays should have positive values.'''],
                         'Plot title (can contain LaTeX formulas). Only used if a new plot is created.'],
               'xlabel': ['str',
                          'Axis label (can contain LaTeX formulas). Only used if a new plot is created.'],
-              'ylabel': ['string',
+              'ylabel': ['str',
                          'Axis label (can contain LaTeX formulas). Only used if a new plot is created.'],
               'xlog': ['bool',
                        'Should the x axis be logarithmic (default: linear)? Only used if a new plot is created.'],
@@ -87,6 +87,8 @@ Note that all error arrays should have positive values.'''],
                        'Should the y axis be logarithmic (default: linear)? Only used if a new plot is created.'],
               'overplot': ['bool',
                            'If `True`, the plot is added to an existing plot, if not a new plot is created.'],
+              'overcontour': ['bool',
+                           'If `True`, the contour is added to an existing plot, if not a new plot is created.'],
               'clearwindow': ['bool',
                               'If `True` the entire figure area is cleared to make space for a new plot.'],
               'xerrorbars': ['bool',
@@ -135,7 +137,7 @@ string, no marker shown), "." (dot), "o" (circle), "+", "s" (square),
 
 Some backends may accept additional values.'''],
               'alpha': ['float', 'Number between 0 and 1, setting the transparency.'],
-              'markerfacecolor': ['string', 'see `color`'],
+              'markerfacecolor': ['str', 'see `color`'],
               'markersize': ['float',
                              '''Size of a marker. The scale may also depend on the backend. `None`
 uses the backend-specific default.'''],

--- a/sherpa/plot/bokeh_backend.py
+++ b/sherpa/plot/bokeh_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2023-2025
+#  Copyright (C) 2023-2026
 #  MIT
 #
 #
@@ -303,12 +303,12 @@ class BokehBackend(BasicBackend):
 
         Parameters
         ----------
-        x0 : array-like or scalar number
+        xlo : array-like or scalar number
             lower bin boundary values
-        x1 : array-like or scalar number
+        xhi : array-like or scalar number
             upper bin boundary values
         y : array-like or scalar number
-            y values, same dimension as `x0`.
+            y values, same dimension as xlo.
         {kwargs}
         """
         if linecolor is not None:
@@ -656,7 +656,7 @@ class BokehBackend(BasicBackend):
             independent axis in the first dimension
         x1 : array-like
             independent axis in the second dimension
-        y : array-like, with shape (len(x0), len(x1))
+        y : array-like, with shape
             dependent axis (i.e. image values) in 2D
             with shape (len(x0), len(x1))
         {kwargs}

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2015, 2017, 2019-2025
+#  Copyright (C) 2010, 2015, 2017, 2019-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -270,12 +270,12 @@ class PylabBackend(BasicBackend):
 
         Parameters
         ----------
-        x0 : array-like or scalar number
+        xlo : array-like or scalar number
             lower bin boundary values
-        x1 : array-like or scalar number
+        xhi : array-like or scalar number
             upper bin boundary values
         y : array-like or scalar number
-            y values, same dimension as `x0`.
+            y values, same dimension as xlo.
         {kwargs}
         """
         if linecolor is not None:
@@ -620,7 +620,7 @@ class PylabBackend(BasicBackend):
             independent axis in the first dimension
         x1 : array-like
             independent axis in the second dimension
-        y : array-like, with shape (len(x0), len(x1))
+        y : array-like, with shape
             dependent axis (i.e. image values) in 2D
             with shape (len(x0), len(x1))
         {kwargs}

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -983,9 +983,9 @@ def filter_bins(mins: Sequence[float | None],
 
     Parameters
     ----------
-    mins : sequence of values
+    mins : sequence
        The minimum value of the valid range (elements may be None).
-    maxes : sequence of values
+    maxes : sequence
        The maximum value of the valid range (elements may be None).
     axislist: sequence of arrays
        The axis to apply the range to. There must be the same


### PR DESCRIPTION
# Summary

Allow the documentation to be built with recent versions of Sphinx and update the Read-The-Docs configuration to match.

# Details

The RTD setup has not been updated for a while, so take the time to do so:

- newer build OS (ubuntu-lts-latest)
- newer "python" version (miniforge3-latest; the existing RTD documentation is a bit unclear but it says all the `mambaforge` variants are deprecated so I assume switching to `miniforge3` makes sense)
  - the actual python version has been updated to 3.13
- the upper limit on sphinx has been removed (so we can use 9.1, which is the latest).
- added an upper-limit on arviz since we know version 1.0 is not compatible with Sherpa (issue #2427)

Note that the installation now tends to pick the "latest" version, at least for the low-level code, to (hopefully) reduce the need for future updates.

However, the cost of this is that Sphinx has got "pickier" about how we document methods (which is why we added a "sphinx < 8.0.0" requirement many moons ago), so there are are number of changes needed before we can do this, including

- be somewhat more-precise when giving a "type" for a parameter or a return value
  - this can include the fact that adding text like "len(x0)" or "shape(N)" ends up with Sphinx either failing to find a label for `x0` or for coming up with a link to a shape method which is completely unrelated to the intent, so we remove these (and rely on the text to describe these constraints)
- a module listing accidentally ended up with a repeated entry, which caused some issues 
- fix some documentation issues in the plotting backend
  - use the actual parameter names (`xlo`, `xhi`) rather than `x0`/`x1` for  the histogram routine

As part of this I also "cleaned up" several "See Also" sections, going from one-routine-per-line of the form "label : description", to "label1, label2, ...., labelN" because I originally added them this way because it seemed more-useful and the way it was done. However, it "wastes" more vertical screen space, and has the issue of requiring more work when even the label description changes. So I have been moving to the "multi-label" form when I can, but I just want to do this on an ad-hoc basis rather than change everything at once as it has the potential for causing a lot of review conflicts.
