### PR TITLE
DOCS: fix a typo in an example

### DIFF
--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -7105,7 +7105,7 @@ class Session(sherpa.ui.utils.Session):
         Set 'core_bkg.rmf' as the RMF for the background of data set
         'core':
 
-        >>> load_bkg_arf('core', 'core_bkg.rmf')
+        >>> load_bkg_rmf('core', 'core_bkg.rmf')
 
         """
         if arg is None:


### PR DESCRIPTION
# Summary

Fix an example in the documentation for load_bkg_rmf.

# Details

There was a copy-and-past error in the docstring for load_bkg_rmf from when it was copied over from load_bkg_arf.

This was originally found when developing #2447 but is separate from that work.