### PR TITLE
DOCS: simplify an example to improve testing

### DIFF
--- a/docs/mcmc/index.rst
+++ b/docs/mcmc/index.rst
@@ -258,8 +258,6 @@ Run the chain
     >>> svals, accept, pvals = draws
     >>> pvals.shape
     (5, 1001)
-    >>> print(accept.sum() * 1.0 / 1000)
-    0.486
 
 Trace plots
 -----------


### PR DESCRIPTION
# Summary

Avoid a test failure from the documentation on macOS/ARM.

# Details

The attempt at printing the acceptance rate is problematic as I get 0.485 rather than 0.486 on a macOS ARM machine.  This then makes the `doctestplus` run fail. The existing approaches to dealing with this numerical difference (primarily adding "# doctest: +FLOAT_CMP") do not work here - as it's outside the ~ 1e-6 tolerance or whatever the `FLOAT_CMP` test uses is - so it is easiest just to remove this line (it was only informational anyway, so did not really add much to the text).

There is a question of why the acceptance rate depends on the architecture, but we have seen issues like this before and it is not "significantly" different, so I am just putting it down to magical numerical differences.