### PR TITLE
BUILD: add the disable_extern build option

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -221,8 +221,7 @@ replaced by its actual value, and the ``xspec_version`` line
 should be updated to match the output above::
 
     install_dir=${ASCDS_INSTALL}
-
-    configure=None
+    disable_extern=True
 
     disable_group=True
     disable_stk=True

--- a/helpers/deps/__init__.py
+++ b/helpers/deps/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014, 2016, 2022
+#  Copyright (C) 2014, 2016, 2022, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -64,11 +64,22 @@ def clean_deps():
             pass
 
 
-def build_deps(configure):
-    if os.path.exists('extern/built'):
+def build_deps(configure: list[str] | None) -> None:
+    """Run configure and make install for the extern code.
+
+    These steps can be avoided (for example, if building against CIAO)
+    if
+
+    - configure is None
+    - the file extern/built exists
+
+    """
+
+    if configure is None or os.path.exists('extern/built'):
         return
 
     with in_dir("extern"):
+        # Ensure the script is executable
         os.chmod(configure[0], 0o755)
 
         env = os.environ.copy()

--- a/helpers/sherpa_config.py
+++ b/helpers/sherpa_config.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014-2016, 2020, 2022, 2024-2025
+#  Copyright (C) 2014-2016, 2020, 2022, 2024-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -55,9 +55,10 @@ class sherpa_config(Command):
                     ('install_dir', None, "Directory where external dependencies must be installed (--prefix)"),
                     ('configure', None, "Additional configure flags for the external dependencies"),
                     ('group_cflags', None, "Additional cflags for building the grouping library"),
+                    ('disable_extern', None, "Disable building any of the extern code")
                     ]
 
-    def initialize_options(self):
+    def initialize_options(self) -> None:
         self.install_dir = os.path.join(os.getcwd(), 'build')
         self.fftw = None
         self.fftw_include_dirs = None
@@ -80,8 +81,9 @@ class sherpa_config(Command):
         self.group_cflags = None
         self.stk_location = None
         self.disable_stk = False
+        self.disable_extern = False
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         incdir = os.path.join(self.install_dir, 'include')
         libdir = os.path.join(self.install_dir, 'lib')
 
@@ -132,11 +134,20 @@ class sherpa_config(Command):
         if self.stk_location is None:
             self.stk_location = os.path.join(pydir, 'stk.so')
 
-    def build_configure(self):
+    def build_configure(self) -> list[str] | None:
+        """Set up fir building compiled code.
 
-        # can we find ascdm.h (if so we can support FITS region files as long
-        # as the other settings are set up to include ascdm)?
-        #
+        This handles setting up the optional extension modules as
+        well as building anything needed from the extern directory.
+
+        The return value is the configure command to setup the
+        extern code, or None if the extern code is not being built.
+
+        There is limited checks that these make sense, relying on the
+        build failing if they do not.
+
+        """
+
         if not self.disable_region:
             region_macros = None
             if self.region_use_cxc_parser:
@@ -152,15 +163,21 @@ class sherpa_config(Command):
             wcsext = build_ext(self, 'wcs')
             self.distribution.ext_modules.append(wcsext)
 
+        # It is easiest to build up configure even if it not going to
+        # be used.
+        #
         configure = ['./configure', '--prefix=' + self.install_dir,
                      '--with-pic', '--enable-standalone']
 
         if self.group_cflags is not None:
             configure.append(f'GROUP_CFLAGS="{self.group_cflags}"')
+
         if self.configure != 'None':
             configure.extend(self.configure.split(' '))
+
         if self.fftw != 'local':
             configure.append('--enable-fftw')
+
         if not self.disable_region and self.region != 'local':
             configure.append('--enable-region')
 
@@ -190,9 +207,12 @@ class sherpa_config(Command):
         if not self.disable_wcs and self.wcs != 'local':
             configure.append('--enable-wcs')
 
+        if self.disable_extern:
+            return None
+
         self.warn(f'built configure string {configure}')
         return configure
 
-    def run(self):
+    def run(self) -> None:
         configure = self.build_configure()
         build_deps(configure)

--- a/scripts/use_ciao_config
+++ b/scripts/use_ciao_config
@@ -70,7 +70,7 @@ fi
 echo "Updating $cfg"
 
 sed -i="" "s|#install_dir=build|install_dir=${CONDA_PREFIX}|" $cfg
-sed -i="" "s|#configure=None|configure=None|" $cfg
+sed -i="" "s|#disable_extern=True|disable_extern=True|" $cfg
 
 sed -i="" "s|#disable_group=True|disable_group=True|" $cfg
 sed -i="" "s|#disable_stk=True|disable_stk=True|" $cfg

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,10 @@
 # Directory where the external dependencies must be installed.
 #install_dir=build
 
+# Set when building CIAO or none of the code from the extern/ directory
+# is needed.
+#disable_extern=True
+
 # Additional configure flags for building extern dependencies
 # Set to 'None' (without quotes) to just override the default flags
 #configure=None


### PR DESCRIPTION
This is not needed if we take #2484

# Summary

Simplify building Sherpa within CIAO by setting the disable_extern setting in setup.cfg.

# Details

If the disable_extern option is set to True then the configure script in the extern directry is not run. This is equivalent to creating the file "extern/built" before building Sherpa (this option remains, so existing builds of Sherpa with CIAO should just work).

The scripts/use_ciao_config script has been updated to set it (and remove changing the "configure" option as it is no-longer relevant).
