### PR TITLE
BUILD: change location of DS9 artifacts

### DIFF
--- a/.github/scripts/setup_ds9.sh
+++ b/.github/scripts/setup_ds9.sh
@@ -6,7 +6,10 @@
 # would need to identify x86 versus ARM, as well as update the OS).
 #
 
-ds9_base_url=https://ds9.si.edu/download/
+# The download/ version is the "latest" release whereas archive/ includes
+# older releases.
+# ds9_base_url=https://ds9.si.edu/download
+ds9_base_url=https://ds9.si.edu/archive
 
 if [[ "x${CONDA_PREFIX}" == "x" ]];
 then
@@ -15,7 +18,8 @@ then
 fi
 
 if [ "`uname -s`" == "Darwin" ] ; then
-    ds9_os=darwinbigsurx86
+    ds9_os=darwinbigsur
+    ds9_platform=x86
 else
     echo "* installing dev environment"
 
@@ -24,10 +28,14 @@ else
     sudo apt-get install -qq libx11-dev libsm-dev libxrender-dev
 
     # set os-specific variables
-    ds9_os=ubuntu20
+    ds9_os=ubuntu24
+    ds9_platform=x86
 fi
 
 echo "* ds9_os=$ds9_os"
+echo "* ds9_platform=$ds9_platform"
+
+ds9_label=${ds9_os}${ds9_platform}
 
 download () {
   echo "* downloading $1"
@@ -38,12 +46,12 @@ download () {
 }
 
 # Tarballs to fetch
-ds9_tar=ds9.${ds9_os}.8.6.tar.gz
-xpa_tar=xpa.${ds9_os}.2.1.20.tar.gz
+ds9_tar=ds9.${ds9_label}.8.7.tar.gz
+xpa_tar=xpa.${ds9_label}.2.1.20.tar.gz
 
 # Fetch them
-download $ds9_base_url/$ds9_os/$ds9_tar
-download $ds9_base_url/$ds9_os/$xpa_tar
+download $ds9_base_url/$ds9_label/$ds9_tar
+download $ds9_base_url/$ds9_label/$xpa_tar
 
 # untar them; assume $CONDA_PREFIX/bin is in the path
 echo "* unpacking ds9/XPA"


### PR DESCRIPTION
# Summary

Update the DS9 used in the CI tests. There is no functional change.

# Details

The download/ directory for DS9 contains the "latest" version, whereas the archive/ directory also contains older versions. So switch to use the archive/ directory to avoid issues where the download/ directory gets cleared out of the version that we currently test against.

As part of this, bump the DS9 version from 8.6 to 8.7 which requires bumping up the Ubuntu version, and to add "platform" support to the code (at the moment it's all x86 but if we add back the macOS testing or maybe aarch64 then it will become important to handle).