### PR TITLE
BUILD: ensure PYTHONPATH set for sherpa_smoke runs

### DIFF
--- a/.github/scripts/setup_ds9.sh
+++ b/.github/scripts/setup_ds9.sh
@@ -6,7 +6,10 @@
 # would need to identify x86 versus ARM, as well as update the OS).
 #
 
-ds9_base_url=https://ds9.si.edu/download/
+# The download/ version is the "latest" release whereas archive/ includes
+# older releases.
+# ds9_base_url=https://ds9.si.edu/download
+ds9_base_url=https://ds9.si.edu/archive
 
 if [[ "x${CONDA_PREFIX}" == "x" ]];
 then
@@ -15,7 +18,8 @@ then
 fi
 
 if [ "`uname -s`" == "Darwin" ] ; then
-    ds9_os=darwinbigsurx86
+    ds9_os=darwinbigsur
+    ds9_platform=x86
 else
     echo "* installing dev environment"
 
@@ -24,10 +28,14 @@ else
     sudo apt-get install -qq libx11-dev libsm-dev libxrender-dev
 
     # set os-specific variables
-    ds9_os=ubuntu20
+    ds9_os=ubuntu24
+    ds9_platform=x86
 fi
 
 echo "* ds9_os=$ds9_os"
+echo "* ds9_platform=$ds9_platform"
+
+ds9_label=${ds9_os}${ds9_platform}
 
 download () {
   echo "* downloading $1"
@@ -38,12 +46,12 @@ download () {
 }
 
 # Tarballs to fetch
-ds9_tar=ds9.${ds9_os}.8.6.tar.gz
-xpa_tar=xpa.${ds9_os}.2.1.20.tar.gz
+ds9_tar=ds9.${ds9_label}.8.7.tar.gz
+xpa_tar=xpa.${ds9_label}.2.1.20.tar.gz
 
 # Fetch them
-download $ds9_base_url/$ds9_os/$ds9_tar
-download $ds9_base_url/$ds9_os/$xpa_tar
+download $ds9_base_url/$ds9_label/$ds9_tar
+download $ds9_base_url/$ds9_label/$xpa_tar
 
 # untar them; assume $CONDA_PREFIX/bin is in the path
 echo "* unpacking ds9/XPA"

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -196,6 +196,7 @@ jobs:
       env:
         XSPECVER: ${{ matrix.xspec-version }}
         FITS: ${{ matrix.fits }}
+        INSTALLTYPE: ${{ matrix.install-type }}
       run: |
         if [ -n "${XSPECVER}" ]; then XSPECTEST="-x -d"; fi
         if [ -n "${FITS}" ] ; then FITSTEST="-f ${FITS}"; fi
@@ -211,8 +212,13 @@ jobs:
         echo "** smoke test: ${smokevars}"
         source ${conda_loc}/etc/profile.d/conda.sh
         conda activate build
+        srcdir=`pwd`
         cd /home
-        sherpa_smoke ${smokevars}
+        if [ "$INSTALLTYPE" == "install" ]; then
+          sherpa_smoke ${smokevars}
+        else
+          PYTHONPATH=$srcdir sherpa_smoke ${smokevars}
+        fi
 
     - name: Internal check
       if: matrix.test-data == 'submodule' && matrix.install-type != 'develop'

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -165,11 +165,17 @@ jobs:
     - name: Smoke Test
       env:
         FITS: ${{ matrix.fits-pkg }}
+        INSTALLTYPE: ${{ matrix.install-type }}
       run: |
         smokevars="-v 3"
         if [ ${FITS} != '' ] ; then
             smokevars="-f ${FITS} ${smokevars}"
         fi
         echo "** smoke test: ${smokevars}"
+        srcdir=`pwd`
         cd ${HOME}
-        sherpa_smoke ${smokevars}
+        if [ "$INSTALLTYPE" == "install" ]; then
+          sherpa_smoke ${smokevars}
+        else
+          PYTHONPATH=$srcdir sherpa_smoke ${smokevars}
+        fi


### PR DESCRIPTION
# Summary

Ensure that the necessary ancillary libraries are available for the sherpa_smoke tests in the CI runs. There is no functional change in the code.

# Details

The develop build needs the PYTHONPATH environment set so that sherpa_smoke can find the group and stk libraries (this is primarily to avoid extra screen messages as the soke test doesn't exercise either the stack or group code).

This requires #2453 in order for the tests to pass.
