### PR TITLE
Reallow ds9 on macos tests

### DIFF
--- a/.github/scripts/setup_ds9.sh
+++ b/.github/scripts/setup_ds9.sh
@@ -6,7 +6,10 @@
 # would need to identify x86 versus ARM, as well as update the OS).
 #
 
-ds9_base_url=https://ds9.si.edu/download/
+# The download/ version is the "latest" release whereas archive/ includes
+# older releases.
+# ds9_base_url=https://ds9.si.edu/download
+ds9_base_url=https://ds9.si.edu/archive
 
 if [[ "x${CONDA_PREFIX}" == "x" ]];
 then
@@ -15,7 +18,8 @@ then
 fi
 
 if [ "`uname -s`" == "Darwin" ] ; then
-    ds9_os=darwinbigsurx86
+    ds9_os=darwinbigsur
+    ds9_platform=x86
 else
     echo "* installing dev environment"
 
@@ -24,10 +28,14 @@ else
     sudo apt-get install -qq libx11-dev libsm-dev libxrender-dev
 
     # set os-specific variables
-    ds9_os=ubuntu20
+    ds9_os=ubuntu24
+    ds9_platform=x86
 fi
 
 echo "* ds9_os=$ds9_os"
+echo "* ds9_platform=$ds9_platform"
+
+ds9_label=${ds9_os}${ds9_platform}
 
 download () {
   echo "* downloading $1"
@@ -38,12 +46,12 @@ download () {
 }
 
 # Tarballs to fetch
-ds9_tar=ds9.${ds9_os}.8.6.tar.gz
-xpa_tar=xpa.${ds9_os}.2.1.20.tar.gz
+ds9_tar=ds9.${ds9_label}.8.7.tar.gz
+xpa_tar=xpa.${ds9_label}.2.1.20.tar.gz
 
 # Fetch them
-download $ds9_base_url/$ds9_os/$ds9_tar
-download $ds9_base_url/$ds9_os/$xpa_tar
+download $ds9_base_url/$ds9_label/$ds9_tar
+download $ds9_base_url/$ds9_label/$xpa_tar
 
 # untar them; assume $CONDA_PREFIX/bin is in the path
 echo "* unpacking ds9/XPA"

--- a/.github/scripts/setup_ds9.sh
+++ b/.github/scripts/setup_ds9.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash -e
 
-# As of early 2025 we do not download the Darwin version (i.e. this
-# script should not be run on a macOS machine), but the implementation
-# is left in place (although it is known to fail if run as the script
-# would need to identify x86 versus ARM, as well as update the OS).
-#
-
 # The download/ version is the "latest" release whereas archive/ includes
 # older releases.
 # ds9_base_url=https://ds9.si.edu/download
@@ -18,8 +12,8 @@ then
 fi
 
 if [ "`uname -s`" == "Darwin" ] ; then
-    ds9_os=darwinbigsur
-    ds9_platform=x86
+    ds9_os=darwinsonoma
+    ds9_platform=arm64
 else
     echo "* installing dev environment"
 

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -41,6 +41,7 @@ jobs:
             matplotlib-version: 3
             bokeh-version: 3
             xspec-version: 12.14.0i
+            skip-ds9: "true"
 
           - name: MacOS ARM Full Build (Python 3.11)
             os: macos-14
@@ -140,11 +141,14 @@ jobs:
     # been tied to XSPEC, which is why this rule checks for XSPEC
     # support.
     #
-    # The DS9 tests have been shown to be problematic on macOS/GitHub
-    # so we do not install DS9 on this platform.
+    # The DS9 tests are not run on macOS intel, and it is easiest to
+    # do this with a check on a matrix value. For macOS the environment
+    # must contain XPA_METHOD=local. This setting should not affect any
+    # other tests, so we always set it for the tests (even if not macOS
+    # or DS9 tests are not being run).
     #
     - name: Conda Setup (DS9)
-      if: matrix.xspec-version != '' && runner.os != 'macOS'
+      if: matrix.xspec-version != '' && matrix.skip-ds9 != 'true'
       run: |
         source ${conda_loc}/etc/profile.d/conda.sh
         conda activate build
@@ -196,23 +200,26 @@ jobs:
       env:
         XSPECVER: ${{ matrix.xspec-version }}
         FITS: ${{ matrix.fits }}
+        SKIPDS9: ${{ matrix.skip-ds9 }}
       run: |
-        if [ -n "${XSPECVER}" ]; then XSPECTEST="-x -d"; fi
+        # XSPEC testing also means DS9 testing, apart from
+        # for macOS/Intel.
+        #
+        if [ -n "${XSPECVER}" ]; then
+          if [ "$SKIPDS9" == "true" ]; then
+            XSPECTEST="-x";
+          else
+            XSPECTEST="-x -d";
+          fi
+        fi
         if [ -n "${FITS}" ] ; then FITSTEST="-f ${FITS}"; fi
         smokevars="${XSPECTEST} ${FITSTEST} -v 3"
-
-        # special case the macOS build as we currently do not
-        # include DS9; as we know the XSPECVER/FITS sittings for
-        # this it is hard-coded
-        if [ "$RUNNER_OS" == "macOS" ]; then
-          smokevars="-x -f ${FITS} -v 3"
-        fi
 
         echo "** smoke test: ${smokevars}"
         source ${conda_loc}/etc/profile.d/conda.sh
         conda activate build
         cd /home
-        sherpa_smoke ${smokevars}
+        XPA_METHOD=local sherpa_smoke ${smokevars}
 
     - name: Internal check
       if: matrix.test-data == 'submodule' && matrix.install-type != 'develop'
@@ -246,7 +253,7 @@ jobs:
         source ${conda_loc}/etc/profile.d/conda.sh
         conda activate build
         conda install -yq pytest-cov
-        pytest --pyargs sherpa --cov sherpa --cov-report xml:${{ github.workspace }}/coverage.xml
+        XPA_METHOD=local pytest --pyargs sherpa --cov sherpa --cov-report xml:${{ github.workspace }}/coverage.xml
 
     - name: sherpa_test Tests
       if: matrix.test-data == 'package' || matrix.test-data == 'none'
@@ -255,7 +262,7 @@ jobs:
         conda activate build
         conda install -yq pytest-cov
         cd $HOME
-        sherpa_test --cov sherpa --cov-report xml:${{ github.workspace }}/coverage.xml
+        XPA_METHOD=local sherpa_test --cov sherpa --cov-report xml:${{ github.workspace }}/coverage.xml
 
     - name: upload coverage
       uses: codecov/codecov-action@v5


### PR DESCRIPTION
# Summary

Force XPA_METHOD to local for the CI DS9 tests to allow the macOS/ARM build to include DS9 when testing.  There is no functional change.

# Details

This requires #2453

In #1938 we removed the support for DS9 testing for macOS on the GitHub CI runs because they were failing. It looks like this was because the macOS version of DS9 has trouble with the default XPA_METHOD setting (inet), so switch all the tests to use XPA_METHOD=local (even those not using DS9 because it should not matter). Only the ARM build is supported because the Intel build test runs slowly.

As a side note, the CIAO version of DS9 automatically forces the local setting for XPA_METHOD, which is why this was not seen in CIAO builds for macOS.

There is an argument to be said that we should force the local method for communicating with DS9 (unless over-ridden), but that is a surprisingly more-involved change and IS done in some planned follow-up work: #2459