### PR TITLE
Update arviz

### DIFF
--- a/.github/scripts/setup_ds9.sh
+++ b/.github/scripts/setup_ds9.sh
@@ -6,7 +6,10 @@
 # would need to identify x86 versus ARM, as well as update the OS).
 #
 
-ds9_base_url=https://ds9.si.edu/download/
+# The download/ version is the "latest" release whereas archive/ includes
+# older releases.
+# ds9_base_url=https://ds9.si.edu/download
+ds9_base_url=https://ds9.si.edu/archive
 
 if [[ "x${CONDA_PREFIX}" == "x" ]];
 then
@@ -15,7 +18,8 @@ then
 fi
 
 if [ "`uname -s`" == "Darwin" ] ; then
-    ds9_os=darwinbigsurx86
+    ds9_os=darwinbigsur
+    ds9_platform=x86
 else
     echo "* installing dev environment"
 
@@ -24,10 +28,14 @@ else
     sudo apt-get install -qq libx11-dev libsm-dev libxrender-dev
 
     # set os-specific variables
-    ds9_os=ubuntu20
+    ds9_os=ubuntu24
+    ds9_platform=x86
 fi
 
 echo "* ds9_os=$ds9_os"
+echo "* ds9_platform=$ds9_platform"
+
+ds9_label=${ds9_os}${ds9_platform}
 
 download () {
   echo "* downloading $1"
@@ -38,12 +46,12 @@ download () {
 }
 
 # Tarballs to fetch
-ds9_tar=ds9.${ds9_os}.8.6.tar.gz
-xpa_tar=xpa.${ds9_os}.2.1.20.tar.gz
+ds9_tar=ds9.${ds9_label}.8.7.tar.gz
+xpa_tar=xpa.${ds9_label}.2.1.20.tar.gz
 
 # Fetch them
-download $ds9_base_url/$ds9_os/$ds9_tar
-download $ds9_base_url/$ds9_os/$xpa_tar
+download $ds9_base_url/$ds9_label/$ds9_tar
+download $ds9_base_url/$ds9_label/$xpa_tar
 
 # untar them; assume $CONDA_PREFIX/bin is in the path
 echo "* unpacking ds9/XPA"

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -43,15 +43,12 @@ jobs:
             bokeh-pkg: 'bokeh>=3,<4'
             ncores: 1
 
-          - name: Linux Build (w/o Astropy or Xspec)
+          - name: Linux Build (w/o Matplotlib, w/o Astropy or Xspec)
             os: ubuntu-latest
             python-version: "3.11"
             numpy-pkg: 'numpy'
             install-type: install
             test-data: package
-            matplotlib-pkg: 'matplotlib>=3,<4'
-            bokeh-pkg: 'bokeh>=3,<4'
-            arviz-pkg: 'arviz'
             optimagic-pkg: 'optimagic'
 
           - name: Linux Build (w/o Matplotlib, Xspec, or test data)
@@ -62,11 +59,14 @@ jobs:
             fits-pkg: 'astropy'
             test-data: none
 
-          - name: Linux Build (submodule data w/o Matplotlib or Xspec)
+          - name: Linux Build (submodule data without or Xspec)
             os: ubuntu-latest
             python-version: "3.12"
             numpy-pkg: 'numpy'
             install-type: develop
+            matplotlib-pkg: 'matplotlib>=3,<4'
+            bokeh-pkg: 'bokeh>=3,<4'
+            arviz-pkg: 'arviz>=1.0.0'
             fits-pkg: 'astropy'
             test-data: submodule
 

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -43,7 +43,7 @@ jobs:
             bokeh-pkg: 'bokeh>=3,<4'
             ncores: 1
 
-          - name: Linux Build (w/o Matplotlib, w/o Astropy or Xspec)
+          - name: Linux Build (w/o Matplotlib, Astropy or Xspec)
             os: ubuntu-latest
             python-version: "3.11"
             numpy-pkg: 'numpy'
@@ -59,7 +59,7 @@ jobs:
             fits-pkg: 'astropy'
             test-data: none
 
-          - name: Linux Build (submodule data without or Xspec)
+          - name: Linux Build (submodule data without Xspec)
             os: ubuntu-latest
             python-version: "3.12"
             numpy-pkg: 'numpy'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,7 +140,9 @@ extensions = [
 # of servers
 # but adding to the astropy list.
 intersphinx_mapping['bokeh'] = ('https://docs.bokeh.org/en/latest/', None)
-intersphinx_mapping['arviz'] = ('https://python.arviz.org/en/latest/', None)
+# Arviz uses xarray data structures. We don't need a link to Arviz itself, but we do need one to xarray.
+# intersphinx_mapping['arviz'] = ('https://python.arviz.org/en/latest/', None)
+intersphinx_mapping['xarray'] = ('https://xarray.pydata.org/en/latest/', None)
 intersphinx_mapping['optimagic'] = ('https://optimagic.readthedocs.io/en/latest/', None)
 
 # Settings for matplotlib sphinx extension

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -21,5 +21,5 @@ dependencies:
     - sphinx-astropy
     - sphinx_rtd_theme>=3.0.0
     - bokeh
-    - arviz<1.0.0
+    - arviz>=1.0.0
     - optimagic

--- a/docs/mcmc/index.rst
+++ b/docs/mcmc/index.rst
@@ -354,8 +354,9 @@ Connections to ArviZ
 It serves as a backend-agnostic tool for diagnosing and visualizing Bayesian inference and
 provides different plotting and statistical diagnostic functions for MCMC chains that
 are not implemented in Sherpa itself. If the ArviZ package is installed,
-`~sherpa.sim.mcmc_to_arviz` can be used to convert the MCMC results to an
-`arviz.data.inference_data.InferenceData` object.
+`~sherpa.sim.mcmc_to_arviz` can be used to convert the MCMC results to a
+`~xarray.ore.datatree.DataTree` object, which is the data structure that all
+ArviZ routines use.
 
 .. plot::
     :include-source:
@@ -366,8 +367,7 @@ are not implemented in Sherpa itself. If the ArviZ package is installed,
         >>> import arviz as az
         >>> from sherpa.sim import mcmc_to_arviz
         >>> dataset = mcmc_to_arviz(mcmc=mcmc, fit=f, list_of_draws=[draws])
-        >>> _ = az.plot_pair(dataset, kind=["scatter", "kde"], kde_kwargs={"fill_last": False},
-        ...     marginals=True, point_estimate="median", figsize=(12, 12))
+        >>> _ = az.plot_pair(dataset)
 
 See the `ArviZ <https://python.arviz.org>`_ documentation for more details on the
 available plotting functions and statistical diagnostics.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ doc = [
   "matplotlib",
   "bokeh",
   "scipy",
-  "arviz",
+  "arviz>=1.0.0",
   "optimagic",
 ]
 

--- a/sherpa/sim/__init__.py
+++ b/sherpa/sim/__init__.py
@@ -1010,7 +1010,7 @@ class ReSampleData(NoNewAttributesAfterInit):
         return result
 
 
-# The return value is InterferenceData, but this is not imported on the module
+# The return value is xarray.core.datatree.DataTree, but this is not imported on the module
 # level, so we can't use it in the type hint.
 def mcmc_to_arviz(mcmc : MCMC, fit: Fit, list_of_draws : list[tuple],
                   ):
@@ -1037,12 +1037,9 @@ def mcmc_to_arviz(mcmc : MCMC, fit: Fit, list_of_draws : list[tuple],
 
     Returns
     -------
-    inference_data: arviz.InferenceData
-        An ArviZ InferenceData object containing the posterior and log likelihood data.
+    inference_data: xarray.core.datatree.DataTree
+        A DataTree containing the posterior and log likelihood data.
     """
-
-    from arviz.data.base import dict_to_dataset
-    from arviz.data.inference_data import InferenceData
 
     pnames = [p.fullname for p in fit.model.get_thawed_pars()]
 
@@ -1058,29 +1055,26 @@ def mcmc_to_arviz(mcmc : MCMC, fit: Fit, list_of_draws : list[tuple],
             raise ValueError("All chains must have the same number of steps. " +
                 f"Chain {i} contains {draw[0].shape[0]} steps, but the first chain has {len(list_of_draws[0][0])} steps.")
 
+    from arviz import from_dict
+
     datadict = {}
     for i, p in enumerate(pnames):
         datadict[p] = np.stack([draw[2][i, :] for draw in list_of_draws])
     attrs = {'name': fit.model.name,
-             'created_at': datetime.now().isoformat(),
-             'inference_library': 'sherpa',
-             'inference_library_version': sherpa.__version__,
-             'sampler_name': mcmc.get_sampler_name(),
-             'sampler_opt': mcmc.get_sampler(),
-             'stat_name': fit.stat.name,
+                'created_at': datetime.now().isoformat(),
+                'creation_library': 'sherpa',
+                'creation_library_version': sherpa.__version__,
+                'creation_library_language': 'python',
+                'inference_library': 'sherpa',
+                'inference_library_version': sherpa.__version__,
+                'sampler_name': mcmc.get_sampler_name(),
+                'sampler_opt': mcmc.get_sampler(),
+                'stat_name': fit.stat.name,
+                }
 
-             }
-    posterior = dict_to_dataset(datadict,
-                                attrs = attrs,
-                                library=sherpa,
-                                )
-    log_likelihood_data = {'obs': np.stack([draw[0] for draw in list_of_draws])}
-    log_likelihood = dict_to_dataset(log_likelihood_data,
-                                     attrs = attrs,
-                                     library=sherpa,
-                                     )
+    data = {"posterior": datadict,
+            "log_likelihood": {'obs': np.stack([draw[0] for draw in list_of_draws])}}
 
-    return InferenceData(
-            **{"posterior": posterior, "log_likelihood": log_likelihood},
-            attrs = attrs,
-        )
+    return from_dict(data=data,
+                    name=fit.model.name,
+                    attrs={'/': attrs, 'posterior': attrs, 'log_likelihood': attrs})


### PR DESCRIPTION
## Summary
Sherpa has a function to turn MCMC output into the format used by the arviz package. This PR updates the API for compatability with arviz >=1.0.0

## Details
There are two commits: The first one changes Sherpa itself, the second one the CI setup.
The second steo is necessary, because we used to run the tests that depends on arviz with Python 3.10 and we need a more modern Python version for that now.

The change is not backwards compatible for arviz versions, i.e. it will no longer work for arviz < 1.0.0. They did a significant cur in API for their 1.0.0 release and this is not a widely used feature in Sherpa. We can expect users to upgrade to the current verion of arviz (actually, at the time of writing, arviz has already releases 1.1).

closes #2427
