### PR TITLE
Simplify the initialization of the DS9 module

### DIFF
--- a/.github/scripts/setup_ds9.sh
+++ b/.github/scripts/setup_ds9.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash -e
 
-# As of early 2025 we do not download the Darwin version (i.e. this
-# script should not be run on a macOS machine), but the implementation
-# is left in place (although it is known to fail if run as the script
-# would need to identify x86 versus ARM, as well as update the OS).
-#
-
 # The download/ version is the "latest" release whereas archive/ includes
 # older releases.
 # ds9_base_url=https://ds9.si.edu/download
@@ -18,8 +12,12 @@ then
 fi
 
 if [ "`uname -s`" == "Darwin" ] ; then
-    ds9_os=darwinbigsur
-    ds9_platform=x86
+    if [ "`uname -m`" != "arm64" ] ; then
+	echo "* DS9 testing not supported on `uname -s` : `uname -m`"
+	exit 0
+    fi
+    ds9_os=darwinsonoma
+    ds9_platform=arm64
 else
     echo "* installing dev environment"
 

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -41,6 +41,7 @@ jobs:
             matplotlib-version: 3
             bokeh-version: 3
             xspec-version: 12.14.0i
+            skip-ds9: "true"
 
           - name: MacOS ARM Full Build (Python 3.12)
             os: macos-14
@@ -140,11 +141,12 @@ jobs:
     # been tied to XSPEC, which is why this rule checks for XSPEC
     # support.
     #
-    # The DS9 tests have been shown to be problematic on macOS/GitHub
-    # so we do not install DS9 on this platform.
+    # The DS9 tests are not run on macOS intel as that platform is
+    # slow and depracated. It is easiest to do this with an explicit
+    # check of a matrix field.
     #
     - name: Conda Setup (DS9)
-      if: matrix.xspec-version != '' && runner.os != 'macOS'
+      if: matrix.xspec-version != '' && matrix.skip-ds9 != 'true'
       run: |
         source ${conda_loc}/etc/profile.d/conda.sh
         conda activate build
@@ -196,17 +198,19 @@ jobs:
       env:
         XSPECVER: ${{ matrix.xspec-version }}
         FITS: ${{ matrix.fits }}
+        SKIPDS9: ${{ matrix.skip-ds9 }}
       run: |
-        if [ -n "${XSPECVER}" ]; then XSPECTEST="-x -d"; fi
+        # XSPEC testing also means DS9 testing, apart from macOS/Intel.
+        #
+        if [ -n "${XSPECVER}" ]; then
+          if [ "${SKIPDS9}" == "true" ]; then
+            XSPECTEST="-x";
+          else
+            XSPECTEST="-x -d";
+          fi
+        fi
         if [ -n "${FITS}" ] ; then FITSTEST="-f ${FITS}"; fi
         smokevars="${XSPECTEST} ${FITSTEST} -v 3"
-
-        # special case the macOS build as we currently do not
-        # include DS9; as we know the XSPECVER/FITS sittings for
-        # this it is hard-coded
-        if [ "$RUNNER_OS" == "macOS" ]; then
-          smokevars="-x -f ${FITS} -v 3"
-        fi
 
         echo "** smoke test: ${smokevars}"
         source ${conda_loc}/etc/profile.d/conda.sh
@@ -263,4 +267,3 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ${{ github.workspace }}/coverage.xml
         verbose: true
-

--- a/sherpa/astro/io/wcs.py
+++ b/sherpa/astro/io/wcs.py
@@ -49,6 +49,11 @@ except ImportError:
         raise RuntimeError("No WCS support")
 
 
+__doctest_requires__ = {
+    '*': ['sherpa.astro.utils._wcs']
+}
+
+
 class WCS(NoNewAttributesAfterInit):
     """Represent a World Coordinate System transformation.
 

--- a/sherpa/astro/ui/tests/test_astro_session_image.py
+++ b/sherpa/astro/ui/tests/test_astro_session_image.py
@@ -243,7 +243,7 @@ def test_get_data_image_dataimg_repeated():
 
     # What is the name field now?
     obj = s.get_data_image()
-    assert obj.name == 'A_big_blob'  # ideally this would be "Data"
+    assert obj.name == 'Data'
 
 
 @requires_ds9

--- a/sherpa/astro/ui/tests/test_astro_session_image.py
+++ b/sherpa/astro/ui/tests/test_astro_session_image.py
@@ -340,7 +340,18 @@ def test_wcs_with_no_wcs(make_data_path, tmp_path, check_str):
 
     cts = wcsfile.read_text()
 
-    lines = []
+    lines = [
+        "WCSAXES =                    2 / Number of WCS axes",
+        "WCSNAME = 'PHYSICAL'           / Reference name for the coord. frame",
+        "CRPIX1  =                  1.0 / Reference pixel on axis 1",
+        "CRPIX2  =                  1.0 / Reference pixel on axis 2",
+        "CRVAL1  =                  1.0 / Value at ref. pixel on axis 1",
+        "CRVAL2  =                  1.0 / Value at ref. pixel on axis 2",
+        "CTYPE1  = 'x       '           / Type of co-ordinate on axis 1",
+        "CTYPE2  = 'y       '           / Type of co-ordinate on axis 2",
+        "CDELT1  =                  1.0 / Pixel size on axis 1",
+        "CDELT2  =                  1.0 / Pixel size on axis 2",
+    ]
 
     expected = [f"{l:80s}" for l in lines] + ["", ""]
     check_str(cts, expected)
@@ -423,7 +434,7 @@ def test_wcs_with_wcs(make_data_path, tmp_path):
 
 @requires_wcs
 @requires_ds9
-def test_read_image_only_sky(tmp_path):
+def test_read_image_only_sky(tmp_path, check_str):
     """Read in an image with "only" physical/sky transform image.
 
     The split between "physical" and "world" coordinate systems is
@@ -457,14 +468,25 @@ def test_read_image_only_sky(tmp_path):
 
     cts = wcsfile.read_text()
 
-    # For now this is easy to check.
+    # This is not as hard to check as test_wcs_with_wcs as we can use
+    # check_str.
     #
     ctslines = cts.split("\n")
-    assert len(ctslines) == 2
 
-    # Ends in two blank lines
-    assert ctslines[-2] == ctslines[-1]
-    assert ctslines[-1] == ""
+    lines = ["WCSAXES =                    2 / Number of WCS axes",
+             "WCSNAME = 'PHYSICAL'           / Reference name for the coord. frame",
+             "CRPIX1  =                  1.0 / Reference pixel on axis 1",
+             "CRPIX2  =                  1.0 / Reference pixel on axis 2",
+             "CRVAL1  =                101.0 / Value at ref. pixel on axis 1",
+             "CRVAL2  =                198.0 / Value at ref. pixel on axis 2",
+             "CTYPE1  = 'x       '           / Type of co-ordinate on axis 1",
+             "CTYPE2  = 'y       '           / Type of co-ordinate on axis 2",
+             "CDELT1  =                  2.0 / Pixel size on axis 1",
+             "CDELT2  =                  4.0 / Pixel size on axis 2"
+             ]
+
+    expected = [f"{l:80s}" for l in lines] + ["", ""]
+    check_str(cts, expected)
 
 
 @requires_wcs
@@ -517,7 +539,17 @@ def test_read_image_only_eqpos(tmp_path, check_str):
              "CTYPE2  = 'DEC--TAN'           / Type of co-ordinate on axis 2",
              "CDELT1  =                 -0.5 / Pixel size on axis 1",
              "CDELT2  =                 0.05 / Pixel size on axis 2",
-             "RADESYS = 'ICRS    '           / Reference frame for RA/DEC values"
+             "RADESYS = 'ICRS    '           / Reference frame for RA/DEC values",
+             "WCSAXESP=                    2 / Number of WCS axes",
+             "WCSNAMEP= 'PHYSICAL'           / Reference name for the coord. frame",
+             "CRPIX1P =                  1.0 / Reference pixel on axis 1",
+             "CRPIX2P =                  1.0 / Reference pixel on axis 2",
+             "CRVAL1P =                  1.0 / Value at ref. pixel on axis 1",
+             "CRVAL2P =                  1.0 / Value at ref. pixel on axis 2",
+             "CTYPE1P = 'x       '           / Type of co-ordinate on axis 1",
+             "CTYPE2P = 'y       '           / Type of co-ordinate on axis 2",
+             "CDELT1P =                  1.0 / Pixel size on axis 1",
+             "CDELT2P =                  1.0 / Pixel size on axis 2"
              ]
 
     expected = [f"{l:80s}" for l in lines] + ["", ""]

--- a/sherpa/astro/ui/tests/test_astro_session_image.py
+++ b/sherpa/astro/ui/tests/test_astro_session_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2022, 2025
+#  Copyright (C) 2022, 2025-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -44,7 +44,8 @@ from sherpa.astro.ui.utils import Session as AstroSession
 from sherpa.astro.data import DataIMG
 
 from sherpa.utils.err import ArgumentTypeErr
-from sherpa.utils.testing import requires_ds9, requires_region
+from sherpa.utils.testing import requires_data, requires_ds9, \
+    requires_region, requires_wcs
 
 
 def example_data():
@@ -197,3 +198,327 @@ def test_ignore2d_image():
     # 47 is from test_notice2d_image
     assert len(d.mask) == FILTER_NTOT
     assert d.mask.sum() == (FILTER_NTOT - FILTER_NSET)
+
+
+@requires_ds9
+def test_get_data_image_dataimg():
+    """Check that the OBJECT keyword is used"""
+
+    from sherpa.image import DataImage
+
+    s = AstroSession()
+    d = example_data()
+    d.header = {"OBJECT": "A big blob", "NOT_OBJ": "foo"}
+    s.set_data(d)
+
+    obj = s.get_data_image()
+    assert isinstance(obj, DataImage)
+    assert obj.name == 'A_big_blob'
+    assert obj.eqpos is None
+    assert obj.sky is None
+
+    assert d.y.ndim == 1
+    y = d.y.reshape((9, 9))
+    assert obj.y == pytest.approx(y)
+
+    # sanity check
+    assert y[2, 5] == pytest.approx(100.0)
+
+
+@requires_ds9
+def test_get_data_image_dataimg_repeated():
+    """If OBJECT is set and then not set, what happens?"""
+
+    s = AstroSession()
+    d = example_data()
+    d.header = {"OBJECT": "A big blob", "NOT_OBJ": "foo"}
+    s.set_data(d)
+
+    # This changes the name field (see test_get_data_image_dataimg)
+    _ = s.get_data_image()
+
+    d = example_data()
+    d.header = {"NOT_OBJ": "foo"}
+    s.set_data(d)
+
+    # What is the name field now?
+    obj = s.get_data_image()
+    assert obj.name == 'A_big_blob'  # ideally this would be "Data"
+
+
+@requires_ds9
+@requires_wcs
+def test_send_wcs(tmp_path, check_str):
+    """Check we can send WCS information to DS9.
+
+    Validating this is awkward and it has revealed some subtle issues
+    with how DS9 interacts with its preference settings (e.g. ICRS vs
+    FK5) that can result in subtle changes. Hence the need to be
+    explicit about the SKY WCS.
+
+    """
+
+    from sherpa.astro.io.wcs import WCS
+
+    s = AstroSession()
+    s.dataspace2d([4, 3])
+
+    # Set the WCS to something that is easy to check when returned
+    # from DS9.
+    #
+    d = s.get_data()
+    d.sky = WCS(type="LINEAR", name="physical", crval=[2000.0, 3000.0],
+                crpix=[0.5, 0.5], cdelt=[2.0, 2.0])
+
+    d.eqpos = WCS(type="WCS", name="world", crval=[50.5, -23.4],
+                  crpix=[2000.0, 3000.0], cdelt=[-0.036, 0.036],
+                  crota=0.0, epoch=2000.0, equinox=2000.0)
+
+    # This needs to call the image method, not just prepare_image
+    s.image_data()
+
+    resp = s.image_xpaget("wcs")
+    assert resp == "wcs\n"
+
+    # Is this the best way to check the WCS info that DS9 has?
+    # Ensure we use ICRS, since the results are slightly different
+    # if the FK5 system is in use.
+    #
+    s.image_xpaset("wcs sky icrs")
+    wcsfile = tmp_path / "test.wcs"
+    s.image_xpaset(f"wcs save {wcsfile}")
+
+    # How much does the output here depend on system info (e.g
+    # numerical precision) and is the order fixed across versions of
+    # DS9?
+    #
+    cts = wcsfile.read_text()
+
+    lines = ["WCSAXES =                    2 / Number of WCS axes",
+             "CRPIX1  =                  0.5 / Reference pixel on axis 1",
+             "CRPIX2  =                  0.5 / Reference pixel on axis 2",
+             "CRVAL1  =                 50.5 / Value at ref. pixel on axis 1",
+             "CRVAL2  =                -23.4 / Value at ref. pixel on axis 2",
+             "CTYPE1  = 'RA---TAN'           / Type of co-ordinate on axis 1",
+             "CTYPE2  = 'DEC--TAN'           / Type of co-ordinate on axis 2",
+             "CDELT1  =               -0.072 / Pixel size on axis 1",
+             "CDELT2  =                0.072 / Pixel size on axis 2",
+             "RADESYS = 'ICRS    '           / Reference frame for RA/DEC values",
+             "WCSAXESP=                    2 / Number of WCS axes",
+             "WCSNAMEP= 'PHYSICAL'           / Reference name for the coord. frame",
+             "CRPIX1P =                  1.0 / Reference pixel on axis 1",
+             "CRPIX2P =                  1.0 / Reference pixel on axis 2",
+             "CRVAL1P =               2001.0 / Value at ref. pixel on axis 1",
+             "CRVAL2P =               3001.0 / Value at ref. pixel on axis 2",
+             "CTYPE1P = 'x       '           / Type of co-ordinate on axis 1",
+             "CTYPE2P = 'y       '           / Type of co-ordinate on axis 2",
+             "CDELT1P =                  2.0 / Pixel size on axis 1",
+             "CDELT2P =                  2.0 / Pixel size on axis 2"
+             ]
+
+    # No idea why the two blank/empty lines
+    expected = [f"{l:80s}" for l in lines] + ["", ""]
+    check_str(cts, expected)
+
+
+# This test should not require the WCS library
+@requires_data
+@requires_ds9
+def test_wcs_with_no_wcs(make_data_path, tmp_path, check_str):
+    """What happens if the image has no WCS?
+
+    """
+
+    infile = make_data_path("img.fits")
+
+    s = AstroSession()
+    s.load_image(infile)
+    s.image_data()
+
+    wcsfile = tmp_path / "img.wcs"
+    s.image_xpaset(f"wcs save {wcsfile}")
+
+    cts = wcsfile.read_text()
+
+    lines = []
+
+    expected = [f"{l:80s}" for l in lines] + ["", ""]
+    check_str(cts, expected)
+
+
+@requires_data
+@requires_wcs
+@requires_ds9
+def test_wcs_with_wcs(make_data_path, tmp_path):
+    """What happens if the image has WCS?
+
+    """
+
+    infile = make_data_path("acisf07999_000N001_r0035_regevt3_srcimg.fits")
+
+    s = AstroSession()
+    s.load_image(infile)
+    s.image_data()
+
+    wcsfile = tmp_path / "img.wcs"
+    s.image_xpaset(f"wcs save {wcsfile}")
+
+    cts = wcsfile.read_text()
+
+    # The output is hard to check because of potential numerical
+    # differences. However, we do not care too much about the actual
+    # contents, so just check we approximately match. This is a
+    # specialized version of the check_str fixture.
+    #
+    lines = [
+        ("WCSAXES", int, 2),
+        ("CRPIX1", float, pytest.approx(1035.189941)),
+        ("CRPIX2", float, pytest.approx(-235.629883)),
+        ("CRVAL1", float, pytest.approx(149.88534733444996)),
+        ("CRVAL2", float, pytest.approx(2.6079504903528972)),
+        ("CTYPE1", str, "'RA---TAN'"),
+        ("CTYPE2", str, "'DEC--TAN'"),
+        ("CDELT1", float, pytest.approx(-1.36666666666671E-4)),
+        ("CDELT2", float, pytest.approx(0.00013666666666667)),
+        ("RADESYS", str, "'ICRS    '"),
+        ("WCSAXESP", int, 2),
+        ("WCSNAMEP", str, "'PHYSICAL'"),
+        ("CRPIX1P", float, pytest.approx(1.0)),
+        ("CRPIX2P", float, pytest.approx(1.0)),
+        ("CRVAL1P", float, pytest.approx(3062.3100585938)),
+        ("CRVAL2P", float, pytest.approx(4333.1298828125)),
+        ("CTYPE1P", str, "'x       '"),
+        ("CTYPE2P", str, "'y       '"),
+        ("CDELT1P", float, pytest.approx(1.0)),
+        ("CDELT2P", float, pytest.approx(1.0))
+    ]
+
+    ctslines = cts.split("\n")
+
+    # Check values then the number of lines
+    for gotval, expval in zip(ctslines, lines):
+        name, typeval, value = expval
+
+        assert gotval[8] == "=", gotval
+        assert gotval[:8].rstrip() == name, gotval
+
+        if typeval == str:
+            assert gotval[10:].startswith(value), (gotval, value)
+        else:
+            # We want to check the first non-string value
+            stripped = gotval[10:].lstrip()
+            idx = stripped.find(" ")
+            strippedval = typeval(stripped[:idx])
+
+            assert strippedval == value, (gotval, value)
+
+    ngot = len(ctslines)
+    nexp = len(lines) + 2
+    assert ngot == nexp
+
+    # Ends in two blank lines
+    assert ctslines[-2] == ctslines[-1]
+    assert ctslines[-1] == ""
+
+
+@requires_wcs
+@requires_ds9
+def test_read_image_only_sky(tmp_path):
+    """Read in an image with "only" physical/sky transform image.
+
+    The split between "physical" and "world" coordinate systems is
+    CIAO specific, so it's awkward to come up with a useful
+    example.
+
+    """
+
+    from sherpa.astro.io.wcs import WCS
+
+    y = np.arange(12)
+    x1, x0 = np.mgrid[1:4, 1:5]
+    img = DataIMG("phyx", x0.flatten(), x1.flatten(), y, shape=(3, 4))
+
+    # Add an OBJECT keyword
+    img.header["OBJECT"] = "x 23"
+
+    # Add a physical transform
+    crval = [100, 196]
+    crpix = [0.5, 0.5]
+    cdelt = [2, 4]
+    sky = WCS("physical", "LINEAR", crval, crpix, cdelt)
+    img.sky = sky
+
+    s = AstroSession()
+    s.set_data(img)
+    s.image_data()
+
+    wcsfile = tmp_path / "img.wcs"
+    s.image_xpaset(f"wcs save {wcsfile}")
+
+    cts = wcsfile.read_text()
+
+    # For now this is easy to check.
+    #
+    ctslines = cts.split("\n")
+    assert len(ctslines) == 2
+
+    # Ends in two blank lines
+    assert ctslines[-2] == ctslines[-1]
+    assert ctslines[-1] == ""
+
+
+@requires_wcs
+@requires_ds9
+def test_read_image_only_eqpos(tmp_path, check_str):
+    """Read in an image with "only" WCS transform image.
+
+    The split between "physical" and "world" coordinate systems is
+    CIAO specific, so it's awkward to come up with a useful
+    example.
+
+    """
+
+    from sherpa.astro.io.wcs import WCS
+
+    y = np.arange(12)
+    x1, x0 = np.mgrid[1:4, 1:5]
+    img = DataIMG("phyx", x0.flatten(), x1.flatten(), y, shape=(3, 4))
+
+    # Add an OBJECT keyword
+    img.header["OBJECT"] = "yy 23-4"
+
+    # Add a world transform
+    crval = [100, -5]
+    crpix = [0.5, 0.5]
+    cdelt = [-0.5, 0.05]
+    eqpos = WCS("world", "WCS", crval, crpix, cdelt)
+    img.eqpos = eqpos
+
+    s = AstroSession()
+    s.set_data(img)
+    s.image_data()
+
+    wcsfile = tmp_path / "img.wcs"
+    s.image_xpaset(f"wcs save {wcsfile}")
+
+    cts = wcsfile.read_text()
+
+    # This is not as hard to check as test_wcs_with_wcs as we can use
+    # check_str.
+    #
+    ctslines = cts.split("\n")
+
+    lines = ["WCSAXES =                    2 / Number of WCS axes",
+             "CRPIX1  =                  0.5 / Reference pixel on axis 1",
+             "CRPIX2  =                  0.5 / Reference pixel on axis 2",
+             "CRVAL1  =                100.0 / Value at ref. pixel on axis 1",
+             "CRVAL2  =                 -5.0 / Value at ref. pixel on axis 2",
+             "CTYPE1  = 'RA---TAN'           / Type of co-ordinate on axis 1",
+             "CTYPE2  = 'DEC--TAN'           / Type of co-ordinate on axis 2",
+             "CDELT1  =                 -0.5 / Pixel size on axis 1",
+             "CDELT2  =                 0.05 / Pixel size on axis 2",
+             "RADESYS = 'ICRS    '           / Reference frame for RA/DEC values"
+             ]
+
+    expected = [f"{l:80s}" for l in lines] + ["", ""]
+    check_str(cts, expected)

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -1,6 +1,6 @@
 #
 #  Copyright (C) 2006-2010, 2016-2021, 2025-2026
-#     Smithsonian Astrophysical Observatory
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,119 +18,16 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-r"""
-Interface for viewing images with the ds9 image viewer.
-Loosely based on XPA, by Andrew Williams.
+"""Interface for viewing images with the ds9 image viewer.
 
-For more information, see the XPA Access Points section
-of the ds9 reference manual (under Help in ds9).
+Loosely based on XPA, by Andrew Williams, with the original code by
+ROwen 2004-2005 and then the Sherpa team from 2006. This code has
+been simplified to only support the features that Sherpa needs.
 
-Requirements:
-
-*** Unix Requirements
-- ds9 and xpa must be installed somewhere on your $PATH
-
-*** MacOS X Requirements
-- The MacOS X ds9.app must be in one of the two *standard* locations
-  applications (e.g. ~/Applications or /Applications on English systems).
-  and/or, if you prefer:
-- xpa for darwin installed somewhere on your $PATH
-- ds9 for darwin installed somewhere on your $PATH
-
-  Note: as I write this, ds9 4.0b7 is out and the MacOS X application
-  does not include xpa. They plan to fix this, but if your ds9.app
-  does not include xpa then you MUST install darwin xpa.
-
-*** Windows Requirements
-- Mark Hammond's pywin32 package: <https://sourceforge.net/projects/pywin32/>
-- ds9 installed in the default directory (C:\Program Files\ds9\
-  on English systems)
-- xpa executables installed in the default directory (C:\Program Files\\xpa\)
-  or in the same directory as ds9.exe. Why might you choose the latter?
-  Because (at least for ds9 3.0.3) to use ds9 with xpa from the command line,
-  the xpa executables should be in with ds9.exe. Otherwise ds9 can't find
-  xpans when it starts up and so fails to register itself.
-
-Extra Keyword Arguments:
-Many commands take additional keywords as arguments. These are sent
-as separate commands after the main command is executed.
-Useful keywords for viewing images include: scale, orient and zoom.
-See the XPA Access Points section of the ds9 reference manual
-for more information. Note that the value of each keyword
-is sent as an unquoted string. If you want quotes, provide them
-as part of the value string.
-
-Template Argument:
-The template argument allows you to specify which copy of ds9
-or which other software you wish to command via xpa.
-One common use is to have multiple copies of ds9 on your own machine
-(often necessary because ds9 only has one window, grr).
-If you launch ds9 with the -title command-line option then you can
-send commands to that ds9 by using that title as the template.
-See the XPA documentation for other uses for template, such as talking
-to ds9 on a remote host.
-
-For a list of local servers try % xpaget xpans
-
-History:
-2004-04-15 ROwen        First release.
-2004-04-20 ROwen        showarry improvements:
-                                        - Accepts any array whose values can be represented as signed ints.
-                                        - Bug fix: x and y dimensions were swapped (#@$@# numarray)
-2004-04-29 ROwen        Added xpaset function.
-2004-05-05 ROwen        Added DS9Win class and moved the showXXX functions to it.
-                                        Added function xpaget.
-                                        Added template argument to xpaset.
-2004-10-15 ROwen        Bug fix: could only communicate with one ds9;
-                                        fixed by specifying port=0 when opening ds9.
-2004-11-02 ROwen        Improved Mac compatibility (now looks in [~]/Applications).
-                                        Made compatible with Windows, except showArray is broken;
-                                        this appears to be a bug in ds9 3.0.3.
-                                        loadFITSFile no longer tests the file name's extension.
-                                        showArray now handles most array types without converting the data.
-                                        Eliminated showBinFile because I could not get it to work;
-                                        this seems to be an bug or documentation bug in ds9.
-                                        Changed order of indices for 3-d images from (y,x,z) to (z,y,x).
-2004-11-17 ROwen        Corrected a bug in the subprocess version of xpaget.
-                                        Updated header comments for big-fixed version of subprocess.
-2004-12-01 ROwen        Bug fix in xpaset: terminate data with \n if not already done.
-                                        Modified to use subprocess module (imported from RO.Future
-                                        if Python is old enough not to include it).
-                                        Added __all__.
-2004-12-13 ROwen        Bug fix in DS9Win; the previous version was missing
-                                        the code that waited for DS9 to launch.
-2005-05-16 ROwen        Added doRaise argument to xpaget, xpaset and DS9Win;
-                                        the default is False so the default behavior has changed.
-2005-09-23 ROwen        Bug fix: used the warnings module without importing it.
-2005-09-27 ROwen        Added function setup.
-                                        Checks for xpa and ds9. If not found at import
-                                        then raise a warning make DS9Win. xpaset and xpaget
-                                        retry the check and raise RuntimeError on failure
-                                        (so you can install xpa and ds9 and run without reloading).
-                                        MacOS X: modified to launch X11 if not already running.
-2005-09-30 ROwen        Windwows: only look for xpa in ds9's directory
-                                        (since ds9 can't find it in the default location);
-                                        updated the installation instructions accordingly.
-2005-10-05 ROwen        Bug fix: Windows path joining via string concatenation was broken;
-                                        switched to os.path.join for all path joining.
-                                        Bug fix: Windows search for xpa was broken ("break" only breaks one level).
-2005-10-11 ROwen        MacOS X: add /usr/local/bin to env var PATH and set env var DISPLAY, if necessary
-                                        (because apps do not see the user's shell modifications to env variables).
-2005-10-13 ROwen        MacOS X and Windows: add ds9 and xpa to the PATH if found
-                                        MacOS X: look for xpaget in <applications>/ds9.app as well as on the PATH
-                                        Windows: look for xpaget in <program files>\\xpa\ as well as ...\ds9\
-2005-10-31 ROwen        Bug fix: showArray mis-handled byteswapped arrays.
-2005-11-02 ROwen        Improved fix for byteswapped arrays that avoids copying the array
-                                        (based on code by Tim Axelrod).
-2005-11-04 ROwen        Simplified byte order test as suggested by Rick White.
-2006-06-01 Stephen Doe  Downloaded RO package to evaluate DS9 interface for CIAO.  Stripped all references to RO package from this file (so it can be used without the rest of the RO package).  Converted it from using numarray to numpy for use in Sherpa Python package.
-2006-06-13 Stephen Doe  Removed findApp, all references to Mac or Windows operating systems.  Porting CIAO to Linux and OS X, so treat these all as Unix systems for now.  Worry about Mac, Windows backends later.  (This also means that ds9 and xpaget, xpaset must be in the PATH.)
-2006-08-04 Stephen Doe  Increase timeout interval.
-2008-05-28 Stephen Doe  Always raise exception on error (doRaise=True always)
-2008-11-25 Stephen Doe  Search PATH for access to application, rather than shell out to use 'which' -- PATH sometimes not correctly inherited by shell via Popen, for csh on some Mac, Solaris machines.
 """
 
 import os
+import shlex
 import sys
 import time
 import warnings
@@ -249,107 +146,106 @@ _OpenCheckInterval = 0.2  # seconds
 _MaxOpenTime = 60.0  # seconds
 
 
-def xpaget(cmd, template=_DefTemplate, doRaise=True):
-    """Executes a simple xpaget command:
-            xpaset -p <template> <cmd>
-    returning the reply.
+def xpaget(cmd: str,
+           template: str = _DefTemplate,
+           doRaise: bool = True
+           ) -> str:
+    """Executes a simple xpaget command, returning the reply.
 
-    Inputs:
-    - cmd                command to execute; may be a string or a list
-    - template        xpa template; can be the ds9 window title
-                            (as specified in the -title command-line option)
-                            host:port, etc.
-    - doRaise        if True, raise RuntimeError if there is a communications error,
-                            else issue a UserWarning warning
+    Parameters
+    ----------
+    cmd
+       The XPA command.
+    template
+       The target of the XPA call. It can be the ds9 window title,
+       a string giving "host:port", or other supported forms.
+    doRaise
+       Should an error from xpaget raise an exception?
 
-    Raises RuntimeError or issues a warning (depending on doRaise)
-    if anything is written to stderr.
+    Returns
+    -------
+    response
+       The response from DS9 to the query.
+
     """
-    # Would be better to make a sequence rather than have to quote arguments
-    fullCmd = 'xpaget %s "%s"' % (template, cmd,)
 
+    fullCmd = ['xpaget', template, cmd]
     with _Popen(args=fullCmd,
-                shell=True,
+                shell=False,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE) as p:
-        try:
-            p.stdin.close()
-            errMsg = p.stderr.read()
-            if errMsg:
-                errMsgStr = errMsg.decode()
-                if doRaise:
-                    raise RuntimeErr('cmdfail', fullCmd, errMsgStr)
 
-                fullErrMsg = f"{repr(fullCmd)} failed: {errMsgStr}"
-                warnings.warn(fullErrMsg)
+        p.stdin.close()
+        errMsg = p.stderr.read()
+        if errMsg:
+            errMsgStr = errMsg.decode()
+            cmdStr = shlex.join(fullCmd)
+            if doRaise:
+                raise RuntimeErr('cmdfail', cmdStr, errMsgStr)
 
-            return_value = p.stdout.read()
-            return return_value.decode()
-        finally:
-            p.stdout.close()
-            p.stderr.close()
+            fullErrMsg = f"{cmdStr} failed: {errMsgStr}"
+            warnings.warn(fullErrMsg)
+
+        return_value = p.stdout.read()
+        return return_value.decode()
 
 
-def xpaset(cmd, data=None, dataFunc=None, template=_DefTemplate,
-           doRaise=True):
-    """Executes a simple xpaset command:
-            xpaset -p <template> <cmd>
-    or else feeds data to:
-            xpaset <template> <cmd>
+def xpaset(cmd: str,
+           data=None,
+           dataFunc=None,
+           template: str = _DefTemplate,
+           doRaise: bool = True
+           ) -> None:
+    """Executes a simple xpaset command.
 
-    The command must not return any output for normal completion.
+    Parameters
+    ----------
+    cmd
+       The XPA command.
+    data
+       Extra data to send via stdout (a trailing new-line character is
+       added if needed).
+    dataFunc
+       Unused
+    template
+       The target of the XPA call. It can be the ds9 window title,
+       a string giving "host:port", or other supported forms.
+    doRaise
+       Should an error from xpaget raise an exception?
 
-    Inputs:
-    - cmd                command to execute
-    - data                data to write to xpaset's stdin; ignored if dataFunc specified.
-                            If data[-1] is not \n then a final \n is appended.
-    - dataFunc        a function that takes one argument, a file-like object,
-                            and writes data to that file. If specified, data is ignored.
-                            Warning: if a final \n is needed, dataFunc must supply it.
-    - template        xpa template; can be the ds9 window title
-                            (as specified in the -title command-line option)
-                            host:port, etc.
-    - doRaise        if True, raise RuntimeError if there is a communications error,
-                            else issue a UserWarning warning
-
-    Raises RuntimeError or issues a warning (depending on doRaise)
-    if anything is written to stdout or stderr.
     """
-    # Would be better to make a sequence rather than have to quote arguments
-    if data or dataFunc:
-        fullCmd = 'xpaset %s "%s"' % (template, cmd)
-    else:
-        fullCmd = 'xpaset -p %s "%s"' % (template, cmd)
 
+    fullCmd = ['xpaset']
+    if not data and not dataFunc:
+        fullCmd.append('-p')
+
+    fullCmd.extend([template, cmd])
     with _Popen(args=fullCmd,
-                shell=True,
+                shell=False,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT) as p:
+
         try:
-            try:
-                data = bytearray(data, "UTF-8")
-            except:
-                pass
+            data = bytearray(data, "UTF-8")
+        except:
+            pass
 
-            if data:
-                p.stdin.write(data)
-                if data[-1] != b'\n':
-                    p.stdin.write(b'\n')
-            p.stdin.close()
-            reply = p.stdout.read()
-            if reply:
-                errMsgStr = reply.strip().decode()
-                if doRaise:
-                    raise RuntimeErr('cmdfail', fullCmd, errMsgStr)
+        if data:
+            p.stdin.write(data)
+            if data[-1] != b'\n':
+                p.stdin.write(b'\n')
+        p.stdin.close()
+        reply = p.stdout.read()
+        if reply:
+            errMsgStr = reply.strip().decode()
+            cmdStr = shlex.join(fullCmd)
+            if doRaise:
+                raise RuntimeErr('cmdfail', cmdStr, errMsgStr)
 
-                fullErrMsg = f"{repr(fullCmd)} failed: {errMsgStr}"
-                warnings.warn(fullErrMsg)
-
-        finally:
-            p.stdin.close()  # redundant
-            p.stdout.close()
+            fullErrMsg = f"{cmdstr} failed: {errMsgStr}"
+            warnings.warn(fullErrMsg)
 
 
 def _computeCnvDict():
@@ -446,29 +342,29 @@ class DS9Win:
         if self.isOpen():
             return
 
-        # We want to fork ds9. This is possible with os.fork, but
-        # it doesn't work on Windows. At present Sherpa does not
-        # run on Windows, so it is not a serious problem, but it is
-        # not clear if it is an acceptable, or sensible, option.
-        #
-        p = _Popen(
-            args=('ds9', '-title', self.template, '-port', "0"),
-            cwd=None,
-            close_fds=True, stdin=None, stdout=None, stderr=None
-        )
+        fullCmd = ['ds9', '-title', self.template, '-port', '0']
+        with _Popen(
+                args=fullCmd,
+                shell=False,
+                cwd=None,
+                close_fds=True,
+                stdin=None,
+                stdout=None,
+                stderr=None) as p:
 
-        startTime = time.time()
-        while True:
-            time.sleep(_OpenCheckInterval)
-            if self.isOpen():
-                # Trick to stop a ResourceWarning warning to be created when
-                # running sherpa/tests/test_image.py
-                #
-                # Adapted from https://hg.python.org/cpython/rev/72946937536e
-                p.returncode = 0
-                return
-            if time.time() - startTime > _MaxOpenTime:
-                raise RuntimeErr('nowin', self.template)
+            startTime = time.time()
+            while True:
+                time.sleep(_OpenCheckInterval)
+                if self.isOpen():
+                    # Trick to stop a ResourceWarning warning to be created when
+                    # running sherpa/tests/test_image.py
+                    #
+                    # Adapted from https://hg.python.org/cpython/rev/72946937536e
+                    p.returncode = 0
+                    return
+
+                if time.time() - startTime > _MaxOpenTime:
+                    raise RuntimeErr('nowin', self.template)
 
     def isOpen(self):
         """Return True if this ds9 window is open
@@ -618,16 +514,21 @@ class DS9Win:
         for keyValue in kargs.items():
             self.xpaset(cmd=' '.join(keyValue))
 
-    def xpaget(self, cmd):
+    def xpaget(self,
+               cmd: str
+               ) -> str:
         """Execute a simple xpaget command and return the reply.
 
-        The command is of the form:
-                xpaset -p <template> <cmd>
+        Parameters
+        ----------
+        cmd
+           The XPA command.
 
-        Inputs:
-        - cmd                command to execute
+        Returns
+        -------
+        response
+           The response from DS9 to the query.
 
-        Raises RuntimeError if anything is written to stderr.
         """
         return xpaget(
             cmd=cmd,
@@ -635,23 +536,25 @@ class DS9Win:
             doRaise=self.doRaise,
         )
 
-    def xpaset(self, cmd, data=None, dataFunc=None):
-        """Executes a simple xpaset command:
-                xpaset -p <template> <cmd>
-        or else feeds data to:
-                xpaset <template> <cmd>
+    def xpaset(self,
+               cmd: str,
+               data=None,
+               dataFunc=None
+               ) -> None:
+        """Executes a simple xpaset command.
 
-        The command must not return any output for normal completion.
+        Parameters
+        ----------
+        cmd
+           The XPA command.
+        data
+           Extra data to send via stdout (a trailing new-line
+           character is added if needed).
+        dataFunc
+           Unused
 
-        Inputs:
-        - cmd                command to execute
-        - data                data to write to xpaset's stdin; ignored if dataFunc specified
-        - dataFunc        a function that takes one argument, a file-like object,
-                                and writes data to that file. If specified, data is ignored.
-
-        Raises RuntimeError if anything is written to stdout or stderr.
         """
-        return xpaset(
+        xpaset(
             cmd=cmd,
             data=data,
             dataFunc=dataFunc,

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -26,7 +26,10 @@ been simplified to only support the features that Sherpa needs.
 
 .. versionchanged:: 4.19.0
    XPA communication now defaults to the "local" method unless the
-   XPA_METHOD environment variable is set.
+   XPA_METHOD environment variable is set. Functionality not used by
+   Sherpa has been removed, including the setup process (supporting
+   multiple options), the showFITSFile method, and removing the unused
+   dataFunc argument to `xpaset`.
 
 """
 
@@ -36,7 +39,6 @@ import shlex
 import sys
 import time
 from typing import Any
-import warnings
 import subprocess
 
 import numpy as np
@@ -67,55 +69,22 @@ def _findUnixApp(appName: str) -> None:
         raise RuntimeErr('notonpath', appName)
 
 
-def setup() -> str | None:
-    """Search for xpa and ds9 and set globals accordingly.
-    Return None if all is well, else return an error string.
-    The return value is also saved in global variable _SetupError.
-
-    Sets globals:
-    - _SetupError        same value as returned
-    - _Popen                subprocess.Popen, if ds9 and xpa found,
-                                    else a variant that searches for ds9 and xpa
-                                    first and then runs subprocess.Popen if found
-                                    else raises an exception
-                                    This permits the user to install ds9 and xpa
-                                    and use this module without reloading it
-    """
-    global _SetupError, _Popen, _ex
-    _SetupError = None
-    try:
-        _findUnixApp("ds9")
-        _findUnixApp("xpaget")
-    except (SystemExit, KeyboardInterrupt):
-        raise
-    except Exception as e:
-        _ex = e
-        _SetupError = f"DS9Win unusable: {e}"
-
-    if _SetupError:
-        # Is this worth setting up?
-        class _Popen(subprocess.Popen):
-            def __init__(self, *args, **kargs):
-                setup()
-                super().__init__(*args, **kargs)
-
-        raise RuntimeErr('badwin', _ex)
-
-    else:
-        _Popen = subprocess.Popen
-
-    return _SetupError
+# If ds9 and the xpa tools are accessible (only xpaget is checked for)
+# then things are fine. If not, error out.
+#
+try:
+    _findUnixApp("ds9")
+    _findUnixApp("xpaget")
+except RuntimeErr as e:
+    raise RuntimeErr('badwin', e) from e
 
 
-errStr = setup()
-if errStr:
-    warnings.warn(errStr)
+_ArrayKeys: tuple[str, ...] = ("dim", "dims", "xdim", "ydim", "zdim",
+                               "bitpix", "skip", "arch")
+_DefTemplate: str = "sherpa"
 
-_ArrayKeys = ("dim", "dims", "xdim", "ydim", "zdim", "bitpix", "skip", "arch")
-_DefTemplate = "sherpa"
-
-_OpenCheckInterval = 0.2  # seconds
-_MaxOpenTime = 60.0  # seconds
+_OpenCheckInterval: float = 0.2  # seconds
+_MaxOpenTime: float = 60.0  # seconds
 
 
 def xpaget(cmd: str,
@@ -146,11 +115,11 @@ def xpaget(cmd: str,
         fullCmd.extend(['-m', method])
 
     fullCmd.extend([template, cmd])
-    with _Popen(args=fullCmd,
-                shell=False,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE) as p:
+    with subprocess.Popen(args=fullCmd,
+                          shell=False,
+                          stdin=subprocess.PIPE,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE) as p:
 
         p.stdin.close()
         errMsg = p.stderr.read()
@@ -193,12 +162,11 @@ def xpaset(cmd: str,
         fullCmd.append('-p')
 
     fullCmd.extend([template, cmd])
-    with _Popen(args=fullCmd,
-                shell=False,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT) as p:
-
+    with subprocess.Popen(args=fullCmd,
+                          shell=False,
+                          stdin=subprocess.PIPE,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT) as p:
         try:
             data = bytearray(data, "UTF-8")
         except TypeError:
@@ -321,7 +289,7 @@ class DS9Win:
         if self.xpa_method is not None:
             fullCmd.extend(['-xpa', self.xpa_method])
 
-        with _Popen(
+        with subprocess.Popen(
                 args=fullCmd,
                 shell=False,
                 cwd=None,

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -188,7 +188,6 @@ def xpaget(cmd: str,
 
 def xpaset(cmd: str,
            data: str | bytes | None = None,
-           dataFunc=None,
            template: str = _DefTemplate,
            doRaise: bool = True,
            method: str | None = None
@@ -202,8 +201,6 @@ def xpaset(cmd: str,
     data
        Extra data to send via stdout (a trailing new-line character is
        added if needed).
-    dataFunc
-       Unused
     template
        The target of the XPA call. It can be the ds9 window title,
        a string giving "host:port", or other supported forms.
@@ -218,7 +215,7 @@ def xpaset(cmd: str,
     if method is not None:
         fullCmd.extend(['-m', method])
 
-    if not data and not dataFunc:
+    if not data:
         fullCmd.append('-p')
 
     fullCmd.extend([template, cmd])
@@ -509,8 +506,7 @@ class DS9Win:
 
     def xpaset(self,
                cmd: str,
-               data: str | bytes | None = None,
-               dataFunc=None
+               data: str | bytes | None = None
                ) -> None:
         """Executes a simple xpaset command.
 
@@ -526,14 +522,11 @@ class DS9Win:
         data
            Extra data to send via stdout (a trailing new-line
            character is added if needed).
-        dataFunc
-           Unused
 
         """
         xpaset(
             cmd=cmd,
             data=data,
-            dataFunc=dataFunc,
             template=self.template,
             doRaise=self.doRaise,
             method=self.xpa_method

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -79,8 +79,6 @@ except RuntimeErr as e:
     raise RuntimeErr('badwin', e) from e
 
 
-_ArrayKeys: tuple[str, ...] = ("dim", "dims", "xdim", "ydim", "zdim",
-                               "bitpix", "skip", "arch")
 _DefTemplate: str = "sherpa"
 
 _OpenCheckInterval: float = 0.2  # seconds
@@ -220,22 +218,6 @@ def _formatOptions(kargs: Mapping[str, Any]) -> str:
     return ','.join(arglist)
 
 
-def _splitDict(inDict,
-               keys
-               ):
-    """Splits a dictionary into two parts:
-    - outDict contains any keys listed in "keys";
-      this is returned by the function
-    - inDict has those keys removed (this is the dictionary passed in;
-      it is modified by this call)
-    """
-    outDict = {}
-    for key in keys:
-        if key in inDict:
-            outDict[key] = inDict.pop(key)
-    return outDict
-
-
 class DS9Win:
     """An object that talks to a particular window on ds9
 
@@ -320,31 +302,26 @@ class DS9Win:
         except RuntimeErr:
             return False
 
-    def showArray(self,
-                  arr,
-                  **kargs) -> None:
+    def showArray(self, arr) -> None:
         """Display a 2-d or 3-d grayscale integer numarray arrays.
 
         3-d images are displayed as data cubes, meaning one can
         view a single z at a time or play through them as a movie,
         that sort of thing.
 
-        Inputs:
-        - arr: a numarray array; must be 2-d or 3-d:
-                2-d arrays have index order (y, x)
-                3-d arrays are loaded as a data cube index order (z, y, x)
-        kargs: see Extra Keyword Arguments in the module doc string for information.
-        Keywords that specify array info (see doc for showBinFile for the list)
-        are ignored, because array info is determined from the array itself.
+        Parameters
+        ----------
+        arr
+           An array (expected to be NumPy but need not be) that must
+           be 2-d (axis order is y,x) or 3-d (axis order is z,y,x).
 
-        Data types:
-        - UInt8, Int16, Int32 and floating point types sent unmodified.
-        - All other integer types are converted before transmission.
-        - Complex types are rejected.
+        Notes
+        -----
+        Complex data types cause an invalid. Other data types may be
+        modified before sending to DS9.
 
-        Raises ValueError if arr's elements are not some kind of integer.
-        Raises RuntimeError if ds9 is not running or returns an error message.
         """
+
         if not hasattr(arr, "dtype") or not hasattr(arr, "astype"):
             arr = np.array(arr)
 
@@ -369,14 +346,13 @@ class DS9Win:
         # If the byteorder is native, then use the system
         # endianness
         if arr.dtype.byteorder == '>':
-            isBigendian = True
+            arch = "bigendian"
         elif arr.dtype.byteorder == '<':
-            isBigendian = False
+            arch = "littleendian"
+        elif sys.byteorder == 'big':
+            arch = "bigendian"
         else:
-            if sys.byteorder == 'big':
-                isBigendian = True
-            else:
-                isBigendian = False
+            arch = "littleendian"
 
         # compute bits/pix; ds9 uses negative values for floating values
         bitsPerPix = arr.itemsize * 8
@@ -386,9 +362,6 @@ class DS9Win:
             # array is float; use negative value
             bitsPerPix = -bitsPerPix
 
-        # remove array info keywords from kargs; we compute all that
-        _splitDict(kargs, _ArrayKeys)
-
         # generate array info keywords; note that numarray
         # 2-d images are in order [y, x]
         # 3-d images are in order [z, y, x]
@@ -397,18 +370,12 @@ class DS9Win:
             arryDict[f"{axis}dim"] = size
 
         arryDict["bitpix"] = bitsPerPix
-        if isBigendian:
-            arryDict["arch"] = 'bigendian'
-        else:
-            arryDict["arch"] = 'littleendian'
+        arryDict["arch"] = arch
 
         self.xpaset(
             cmd=f'array [{_formatOptions(arryDict)}]',
             data=arr.tobytes(),
         )
-
-        for keyValue in kargs.items():
-            self.xpaset(cmd=' '.join(keyValue))
 
     def xpaget(self,
                cmd: str

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -29,7 +29,9 @@ been simplified to only support the features that Sherpa needs.
    XPA_METHOD environment variable is set. Functionality not used by
    Sherpa has been removed, including the setup process (supporting
    multiple options), the showFITSFile method, and removing the unused
-   dataFunc argument to `xpaset`.
+   dataFunc argument to `xpaset`. The code assumes that DS9 8.7 or
+   later is in use (if an older version is used then some image
+   displays may not be correct).
 
 """
 
@@ -183,31 +185,30 @@ def xpaset(cmd: str,
 
 
 
-def _computeCnvDict():
-    """Compute array type conversion dict.
-    Each item is: unsupported type: type to which to convert.
+# What data types need to be converted before sending to DS9?
+# DS9 8.7 supports
+#
+#     Integer types     Floating-point types
+#     -------------     --------------------
+#     unsigned 8-bit          32 bit
+#              16-bit         64-bit
+#     unsigned 16-bit
+#              32-bit
+#              64-bit
+#
+# There is no attempt to make this conversion match the capabilities
+# of the DS9 being used.
+#
+_CnvDict = {
+    np.int8: np.int16,
+    np.uint16: np.int32,
+    np.uint32: np.int64,
+}
 
-    ds9 supports UInt8, Int16, Int32, Float32 and Float64.
-    """
+if hasattr(np, "uint64"):
+    _CnvDict[np.uint64] = np.float64
 
-    cnvDict = {
-        np.int8: np.int16,
-        np.uint16: np.int32,
-        np.uint32: np.float32,  # ds9 can't handle 64 bit integer data
-        np.int64: np.float64,
-    }
-
-    # TODO: should this check for 'uint64' since 'uint64=' is not a
-    #       valid attribute name
-    if hasattr(np, "uint64="):
-        cnvDict[np.uint64] = np.float64
-
-    return cnvDict
-
-
-_CnvDict = _computeCnvDict()
 _FloatTypes = (np.float32, np.float64)
-_ComplexTypes = (np.complex64, np.complex128)
 
 
 def _formatOptions(kargs: Mapping[str, Any]) -> str:
@@ -309,6 +310,10 @@ class DS9Win:
         view a single z at a time or play through them as a movie,
         that sort of thing.
 
+        .. versionchanged:: 4.19.0
+           The datatype conversion used assumes that DS9 8.7 or later
+           is in use.
+
         Parameters
         ----------
         arr
@@ -332,12 +337,9 @@ class DS9Win:
         if ndim not in (2, 3):
             raise RuntimeErr('only2d3d')
 
-        dimNames = ["z", "y", "x"][3 - ndim:]
-
         # if necessary, convert array type
         cnvType = _CnvDict.get(arr.dtype.type)
         if cnvType:
-            # print "converting array from %s to %s" % (arr.type(), cnvType)
             arr = arr.astype(cnvType)
 
         # determine byte order of array
@@ -357,7 +359,6 @@ class DS9Win:
         # compute bits/pix; ds9 uses negative values for floating values
         bitsPerPix = arr.itemsize * 8
 
-        # if np.issubclass_(arr.dtype.type, float):
         if arr.dtype.type in _FloatTypes:
             # array is float; use negative value
             bitsPerPix = -bitsPerPix
@@ -366,6 +367,7 @@ class DS9Win:
         # 2-d images are in order [y, x]
         # 3-d images are in order [z, y, x]
         arryDict = {}
+        dimNames = ["z", "y", "x"][3 - ndim:]
         for axis, size in zip(dimNames, arr.shape):
             arryDict[f"{axis}dim"] = size
 

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -46,22 +46,6 @@ from sherpa.utils.err import RuntimeErr, TypeErr
 __all__ = ["setup", "xpaget", "xpaset", "DS9Win"]
 
 
-def _addToPATH(newPath: str) -> None:
-    """Add newPath to the PATH environment variable.
-    Do nothing if newPath already in PATH.
-    """
-    pathSep = ":"
-    pathStr = os.environ.get("PATH", "")
-    if newPath in pathStr:
-        return
-
-    if pathStr:
-        pathStr = pathStr + pathSep + newPath
-    else:
-        pathStr = newPath
-    os.environ["PATH"] = pathStr
-
-
 def _findUnixApp(appName: str) -> str:
     """Search PATH to find first directory that has the application.
     Return the path if found.
@@ -292,22 +276,6 @@ _FloatTypes = (np.float32, np.float64)
 _ComplexTypes = (np.complex64, np.complex128)
 
 
-def _expandPath(fname: str,
-                extraArgs: str = ""
-                ) -> str:
-    """Expand a file path and protect it such that spaces are allowed.
-    Inputs:
-    - fname                file path to expand
-    - extraArgs        extra arguments that are to be appended
-                            to the file path
-    """
-    filepath = os.path.abspath(os.path.expanduser(fname))
-    # if windows, change \ to / to work around a bug in ds9
-    filepath = filepath.replace("\\", "/")
-    # quote with "{...}" to allow ds9 to handle spaces in the file path
-    return f"{{{filepath}{extraArgs}}}"
-
-
 def _formatOptions(kargs: Mapping[str, Any]) -> str:
     """Returns a string: "key1=val1,key2=val2,..."
     (where keyx and valx are string representations)
@@ -507,59 +475,6 @@ class DS9Win:
             cmd=f'array [{_formatOptions(arryDict)}]',
             data=arr.tobytes(),
         )
-
-        for keyValue in kargs.items():
-            self.xpaset(cmd=' '.join(keyValue))
-
-# showBinFile is commented out because it is broken with ds9 3.0.3
-# (apparently due to a bug in ds9) and because it wasn't very useful
-#        def showBinFile(self, fname, **kargs):
-#                """Display a binary file in ds9.
-#
-#                The following keyword arguments are used to specify the array:
-#                - xdim                # of points along x
-#                - ydim                # of points along y
-#                - dim                # of points along x = along y (only use for a square array)
-#                - zdim                # of points along z
-#                - bitpix        number of bits/pixel; negative if floating
-#                - arch        one of bigendian or littleendian (intel)
-#
-#                The remaining keywords are extras treated as described
-#                in the module comment.
-#
-#                Note: integer data must be UInt8, Int16 or Int32
-#                (i.e. the formats supported by FITS).
-#                """
-#                arryDict = _splitDict(kargs, _ArrayKeys)
-#                if not arryDict:
-#                        raise RuntimeError("must specify dim (or xdim and ydim) and bitpix")
-#
-#                arrInfo = "[%s]" % (_formatOptions(arryDict),)
-#                filePathPlusInfo = _expandPath(fname, arrInfo)
-#
-#                self.xpaset(cmd='file array "%s"' % (filePathPlusInfo,))
-#
-#                for keyValue in kargs.iteritems():
-#                        self.xpaset(cmd=' '.join(keyValue))
-
-    def showFITSFile(self,
-                     fname,
-                     **kargs):
-        """Display a fits file in ds9.
-
-        Inputs:
-        - fname        name of file (including path information, if necessary)
-        kargs: see Extra Keyword Arguments in the module doc string for information.
-        Keywords that specify array info (see doc for showBinFile for the list)
-        must NOT be included.
-        """
-        filepath = _expandPath(fname)
-        self.xpaset(cmd=f'file "{filepath}"')
-
-        # remove array info keywords from kargs; we compute all that
-        arrKeys = _splitDict(kargs, _ArrayKeys)
-        if arrKeys:
-            raise RuntimeErr('badarr', arrKeys.keys())
 
         for keyValue in kargs.items():
             self.xpaset(cmd=' '.join(keyValue))

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -65,18 +65,14 @@ def _findUnixApp(appName):
     Return the path if found.
     Raise RuntimeError if not found.
     """
-    try:
-        appPath = ''
-        for path in os.environ['PATH'].split(':'):
-            if os.access(path + '/' + appName, os.X_OK):
-                appPath = path
-                break
+    appPath = ''
+    for path in os.environ['PATH'].split(':'):
+        if os.access(path + '/' + appName, os.X_OK):
+            appPath = path
+            break
 
-        if appPath == '' or not appPath.startswith("/"):
-            raise RuntimeErr('notonpath', appName)
-
-    except:
-        raise
+    if appPath == '' or not appPath.startswith("/"):
+        raise RuntimeErr('notonpath', appName)
 
     return appPath
 
@@ -97,7 +93,9 @@ def _findDS9AndXPA():
     return (ds9Dir, xpaDir)
 
 
-def setup(doRaise=True, debug=False):
+def setup(doRaise=True,
+          debug=False
+          ):
     """Search for xpa and ds9 and set globals accordingly.
     Return None if all is well, else return an error string.
     The return value is also saved in global variable _SetupError.
@@ -116,19 +114,19 @@ def setup(doRaise=True, debug=False):
     try:
         ds9Dir, xpaDir = _findDS9AndXPA()
         if debug:
-            print("ds9Dir=%r\npaDir=%r" % (ds9Dir, xpaDir))
+            print(f"ds9Dir={repr(ds9Dir)}\npaDir={repr(xpaDir)}")
     except (SystemExit, KeyboardInterrupt):
         raise
     except Exception as e:
         _ex = e
-        _SetupError = "DS9Win unusable: %s" % (e,)
+        _SetupError = f"DS9Win unusable: {e}"
         ds9Dir = xpaDir = None
 
     if _SetupError:
         class _Popen(subprocess.Popen):
             def __init__(self, *args, **kargs):
                 setup(doRaise=True)
-                subprocess.Popen.__init__(self, *args, **kargs)
+                super().__init__(*args, **kargs)
 
         if doRaise:
             raise RuntimeErr('badwin', _ex)
@@ -246,7 +244,7 @@ def xpaset(cmd: str,
 
         try:
             data = bytearray(data, "UTF-8")
-        except:
+        except TypeError:
             pass
 
         if data:
@@ -292,7 +290,9 @@ _FloatTypes = (np.float32, np.float64)
 _ComplexTypes = (np.complex64, np.complex128)
 
 
-def _expandPath(fname, extraArgs=""):
+def _expandPath(fname,
+                extraArgs=""
+                ):
     """Expand a file path and protect it such that spaces are allowed.
     Inputs:
     - fname                file path to expand
@@ -303,18 +303,20 @@ def _expandPath(fname, extraArgs=""):
     # if windows, change \ to / to work around a bug in ds9
     filepath = filepath.replace("\\", "/")
     # quote with "{...}" to allow ds9 to handle spaces in the file path
-    return "{%s%s}" % (filepath, extraArgs)
+    return f"{{{filepath}{extraArgs}}}"
 
 
 def _formatOptions(kargs):
     """Returns a string: "key1=val1,key2=val2,..."
     (where keyx and valx are string representations)
     """
-    arglist = ["%s=%s" % keyVal for keyVal in kargs.items()]
-    return '%s' % (','.join(arglist))
+    arglist = [f"{k}={str(v)}" for k,v in kargs.items()]
+    return ','.join(arglist)
 
 
-def _splitDict(inDict, keys):
+def _splitDict(inDict,
+               keys
+               ):
     """Splits a dictionary into two parts:
     - outDict contains any keys listed in "keys";
       this is returned by the function
@@ -418,7 +420,9 @@ class DS9Win:
         except RuntimeErr:
             return False
 
-    def showArray(self, arr, **kargs):
+    def showArray(self,
+                  arr,
+                  **kargs):
         """Display a 2-d or 3-d grayscale integer numarray arrays.
         3-d images are displayed as data cubes, meaning one can
         view a single z at a time or play through them as a movie,
@@ -489,7 +493,7 @@ class DS9Win:
         # 3-d images are in order [z, y, x]
         arryDict = {}
         for axis, size in zip(dimNames, arr.shape):
-            arryDict["%sdim" % axis] = size
+            arryDict[f"{axis}dim"] = size
 
         arryDict["bitpix"] = bitsPerPix
         if isBigendian:
@@ -498,7 +502,7 @@ class DS9Win:
             arryDict["arch"] = 'littleendian'
 
         self.xpaset(
-            cmd='array [%s]' % (_formatOptions(arryDict),),
+            cmd=f'array [{_formatOptions(arryDict)}]',
             data=arr.tobytes(),
         )
 
@@ -536,7 +540,9 @@ class DS9Win:
 #                for keyValue in kargs.iteritems():
 #                        self.xpaset(cmd=' '.join(keyValue))
 
-    def showFITSFile(self, fname, **kargs):
+    def showFITSFile(self,
+                     fname,
+                     **kargs):
         """Display a fits file in ds9.
 
         Inputs:
@@ -546,7 +552,7 @@ class DS9Win:
         must NOT be included.
         """
         filepath = _expandPath(fname)
-        self.xpaset(cmd='file "%s"' % filepath)
+        self.xpaset(cmd=f'file "{filepath}"')
 
         # remove array info keywords from kargs; we compute all that
         arrKeys = _splitDict(kargs, _ArrayKeys)

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -24,6 +24,10 @@ Loosely based on XPA, by Andrew Williams, with the original code by
 ROwen 2004-2005 and then the Sherpa team from 2006. This code has
 been simplified to only support the features that Sherpa needs.
 
+.. versionchanged:: 4.19.0
+   XPA communication now defaults to the "local" method unless the
+   XPA_METHOD environment variable is set.
+
 """
 
 import os
@@ -148,7 +152,8 @@ _MaxOpenTime = 60.0  # seconds
 
 def xpaget(cmd: str,
            template: str = _DefTemplate,
-           doRaise: bool = True
+           doRaise: bool = True,
+           method: str | None = None
            ) -> str:
     """Executes a simple xpaget command, returning the reply.
 
@@ -161,6 +166,8 @@ def xpaget(cmd: str,
        a string giving "host:port", or other supported forms.
     doRaise
        Should an error from xpaget raise an exception?
+    method
+       The XPA communication method (optional).
 
     Returns
     -------
@@ -169,7 +176,11 @@ def xpaget(cmd: str,
 
     """
 
-    fullCmd = ['xpaget', template, cmd]
+    fullCmd = ['xpaget']
+    if method is not None:
+        fullCmd.extend(['-m', method])
+
+    fullCmd.extend([template, cmd])
     with _Popen(args=fullCmd,
                 shell=False,
                 stdin=subprocess.PIPE,
@@ -195,7 +206,8 @@ def xpaset(cmd: str,
            data=None,
            dataFunc=None,
            template: str = _DefTemplate,
-           doRaise: bool = True
+           doRaise: bool = True,
+           method: str | None = None
            ) -> None:
     """Executes a simple xpaset command.
 
@@ -213,10 +225,15 @@ def xpaset(cmd: str,
        a string giving "host:port", or other supported forms.
     doRaise
        Should an error from xpaget raise an exception?
+    method
+       The XPA communication method (optional).
 
     """
 
     fullCmd = ['xpaset']
+    if method is not None:
+        fullCmd.extend(['-m', method])
+
     if not data and not dataFunc:
         fullCmd.append('-p')
 
@@ -314,35 +331,62 @@ def _splitDict(inDict, keys):
 class DS9Win:
     """An object that talks to a particular window on ds9
 
-    Inputs:
-    - template:        window name (see ds9 docs for talking to a remote ds9)
-    - doOpen: open ds9 using the desired template, if not already open;
-                    MacOS X warning: opening ds9 requires ds9 to be on your PATH;
-                    this may not be true by default;
-                    see the module documentation above for workarounds.
-    - doRaise        if True, raise RuntimeError if there is a communications error,
-                    else issue a UserWarning warning.
-                    Note: doOpen always raises RuntimeError on failure!
+    .. versionchanged:: 4.19.0
+       The XPA communication method now defaults to "local" unless the
+       XPA_METHOD environment variable is set when the class is
+       created.
+
+    Parameters
+    ----------
+    template
+       The window name (see ds9 docs for talking to a remote ds9).
+    doOpen
+       Open ds9 using the desired template, if not already open.
+    doRaise
+       Should an error from xpaget raise an exception?
+
     """
     def __init__(self,
-                 template=_DefTemplate,
-                 doOpen=True,
-                 doRaise=True):
+                 template: str = _DefTemplate,
+                 doOpen: bool = True,
+                 doRaise: bool = True
+                 ) -> None:
         self.template = str(template)
+
+        # What communication method to use? CIAO defaults to using the
+        # "local" method, so follow this (as there have been problems
+        # on macOS with the default method of "inet"). However, this
+        # is only done if the XPA_METHOD environment variable is not
+        # set (note there is no check whether the variable is set to
+        # anything sensible). The aim is to use the same method for
+        # each communication (as this should not change once DS9 has
+        # been started).
+        #
+        self.xpa_method = None if "XPA_METHOD" in os.environ else "local"
+
         self.doRaise = bool(doRaise)
         self.alreadyOpen = self.isOpen()
         if doOpen:
             self.doOpen()
 
-    def doOpen(self):
+    def doOpen(self) -> None:
         """Open the ds9 window (if necessary).
 
         Raise OSError or RuntimeError on failure, even if doRaise is False.
+
+        .. versionchanged:: 4.19.0
+           The communication method is set to "local" unless the
+           XPA_METHOD environment variable was set when the object was
+           created.
+
         """
         if self.isOpen():
             return
 
         fullCmd = ['ds9', '-title', self.template, '-port', '0']
+        if self.xpa_method is not None:
+            fullCmd.extend(['-xpa', self.xpa_method])
+
         with _Popen(
                 args=fullCmd,
                 shell=False,
@@ -366,12 +410,10 @@ class DS9Win:
                 if time.time() - startTime > _MaxOpenTime:
                     raise RuntimeErr('nowin', self.template)
 
-    def isOpen(self):
-        """Return True if this ds9 window is open
-        and available for communication, False otherwise.
-        """
+    def isOpen(self) -> bool:
+        """Is the DS9 window open and responding to XPA queries?"""
         try:
-            xpaget('mode', template=self.template, doRaise=True)
+            _ = self.xpaget('mode')  # the actual query is not relevant
             return True
         except RuntimeErr:
             return False
@@ -519,6 +561,11 @@ class DS9Win:
                ) -> str:
         """Execute a simple xpaget command and return the reply.
 
+        .. versionchanged:: 4.19.0
+           The communication method is set to "local" unless the
+           XPA_METHOD environment variable was set when the object was
+           created.
+
         Parameters
         ----------
         cmd
@@ -534,6 +581,7 @@ class DS9Win:
             cmd=cmd,
             template=self.template,
             doRaise=self.doRaise,
+            method=self.xpa_method
         )
 
     def xpaset(self,
@@ -542,6 +590,11 @@ class DS9Win:
                dataFunc=None
                ) -> None:
         """Executes a simple xpaset command.
+
+        .. versionchanged:: 4.19.0
+           The communication method is set to "local" unless the
+           XPA_METHOD environment variable was set when the object was
+           created.
 
         Parameters
         ----------
@@ -560,6 +613,7 @@ class DS9Win:
             dataFunc=dataFunc,
             template=self.template,
             doRaise=self.doRaise,
+            method=self.xpa_method
         )
 
 

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -79,8 +79,7 @@ def _findDS9AndXPA() -> tuple[str, str]:
     return (ds9Dir, xpaDir)
 
 
-def setup(doRaise: bool = True,
-          debug: bool = False
+def setup(debug: bool = False
           ) -> str | None:
     """Search for xpa and ds9 and set globals accordingly.
     Return None if all is well, else return an error string.
@@ -109,13 +108,13 @@ def setup(doRaise: bool = True,
         ds9Dir = xpaDir = None
 
     if _SetupError:
+        # Is this worth setting up?
         class _Popen(subprocess.Popen):
             def __init__(self, *args, **kargs):
-                setup(doRaise=True)
+                setup()
                 super().__init__(*args, **kargs)
 
-        if doRaise:
-            raise RuntimeErr('badwin', _ex)
+        raise RuntimeErr('badwin', _ex)
 
     else:
         _Popen = subprocess.Popen
@@ -123,7 +122,7 @@ def setup(doRaise: bool = True,
     return _SetupError
 
 
-errStr = setup(doRaise=True, debug=False)
+errStr = setup(debug=False)
 if errStr:
     warnings.warn(errStr)
 
@@ -136,7 +135,6 @@ _MaxOpenTime = 60.0  # seconds
 
 def xpaget(cmd: str,
            template: str = _DefTemplate,
-           doRaise: bool = True,
            method: str | None = None
            ) -> str:
     """Executes a simple xpaget command, returning the reply.
@@ -148,8 +146,6 @@ def xpaget(cmd: str,
     template
        The target of the XPA call. It can be the ds9 window title,
        a string giving "host:port", or other supported forms.
-    doRaise
-       Should an error from xpaget raise an exception?
     method
        The XPA communication method (optional).
 
@@ -176,11 +172,7 @@ def xpaget(cmd: str,
         if errMsg:
             errMsgStr = errMsg.decode()
             cmdStr = shlex.join(fullCmd)
-            if doRaise:
-                raise RuntimeErr('cmdfail', cmdStr, errMsgStr)
-
-            fullErrMsg = f"{cmdStr} failed: {errMsgStr}"
-            warnings.warn(fullErrMsg)
+            raise RuntimeErr('cmdfail', cmdStr, errMsgStr)
 
         return_value = p.stdout.read()
         return return_value.decode()
@@ -189,7 +181,6 @@ def xpaget(cmd: str,
 def xpaset(cmd: str,
            data: str | bytes | None = None,
            template: str = _DefTemplate,
-           doRaise: bool = True,
            method: str | None = None
            ) -> None:
     """Executes a simple xpaset command.
@@ -204,8 +195,6 @@ def xpaset(cmd: str,
     template
        The target of the XPA call. It can be the ds9 window title,
        a string giving "host:port", or other supported forms.
-    doRaise
-       Should an error from xpaget raise an exception?
     method
        The XPA communication method (optional).
 
@@ -239,11 +228,8 @@ def xpaset(cmd: str,
         if reply:
             errMsgStr = reply.strip().decode()
             cmdStr = shlex.join(fullCmd)
-            if doRaise:
-                raise RuntimeErr('cmdfail', cmdStr, errMsgStr)
+            raise RuntimeErr('cmdfail', cmdStr, errMsgStr)
 
-            fullErrMsg = f"{cmdstr} failed: {errMsgStr}"
-            warnings.warn(fullErrMsg)
 
 
 def _computeCnvDict():
@@ -311,14 +297,11 @@ class DS9Win:
        The window name (see ds9 docs for talking to a remote ds9).
     doOpen
        Open ds9 using the desired template, if not already open.
-    doRaise
-       Should an error from xpaget raise an exception?
 
     """
     def __init__(self,
                  template: str = _DefTemplate,
-                 doOpen: bool = True,
-                 doRaise: bool = True
+                 doOpen: bool = True
                  ) -> None:
         self.template = str(template)
 
@@ -333,15 +316,12 @@ class DS9Win:
         #
         self.xpa_method = None if "XPA_METHOD" in os.environ else "local"
 
-        self.doRaise = bool(doRaise)
         self.alreadyOpen = self.isOpen()
         if doOpen:
             self.doOpen()
 
     def doOpen(self) -> None:
         """Open the ds9 window (if necessary).
-
-        Raise OSError or RuntimeError on failure, even if doRaise is False.
 
         .. versionchanged:: 4.19.0
            The communication method is set to "local" unless the
@@ -391,6 +371,7 @@ class DS9Win:
                   arr,
                   **kargs) -> None:
         """Display a 2-d or 3-d grayscale integer numarray arrays.
+
         3-d images are displayed as data cubes, meaning one can
         view a single z at a time or play through them as a movie,
         that sort of thing.
@@ -500,7 +481,6 @@ class DS9Win:
         return xpaget(
             cmd=cmd,
             template=self.template,
-            doRaise=self.doRaise,
             method=self.xpa_method
         )
 
@@ -528,13 +508,12 @@ class DS9Win:
             cmd=cmd,
             data=data,
             template=self.template,
-            doRaise=self.doRaise,
             method=self.xpa_method
         )
 
 
 if __name__ == "__main__":
-    errStr = setup(doRaise=True, debug=True)
+    errStr = setup(debug=True)
     if errStr:
         print(errStr)
     else:

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -43,13 +43,19 @@ import numpy as np
 
 from sherpa.utils.err import RuntimeErr, TypeErr
 
-__all__ = ["setup", "xpaget", "xpaset", "DS9Win"]
+__all__ = ["xpaget", "xpaset", "DS9Win"]
 
 
-def _findUnixApp(appName: str) -> str:
+def _findUnixApp(appName: str) -> None:
     """Search PATH to find first directory that has the application.
-    Return the path if found.
-    Raise RuntimeError if not found.
+
+    The call will raise a RuntimeErr if appName can not be found.
+
+    Parameters
+    ----------
+    appName
+       The application name
+
     """
     appPath = ''
     for path in os.environ['PATH'].split(':'):
@@ -60,27 +66,8 @@ def _findUnixApp(appName: str) -> str:
     if appPath == '' or not appPath.startswith("/"):
         raise RuntimeErr('notonpath', appName)
 
-    return appPath
 
-
-def _findDS9AndXPA() -> tuple[str, str]:
-    """Locate ds9 and xpa, and add to PATH if not already there.
-
-    Returns:
-    - ds9Dir        directory containing ds9 executable
-    - xpaDir        directory containing xpaget and (presumably)
-                            the other xpa executables
-
-    Raise RuntimeError if ds9 or xpa are not found.
-    """
-    ds9Dir = _findUnixApp("ds9")
-    xpaDir = _findUnixApp("xpaget")
-
-    return (ds9Dir, xpaDir)
-
-
-def setup(debug: bool = False
-          ) -> str | None:
+def setup() -> str | None:
     """Search for xpa and ds9 and set globals accordingly.
     Return None if all is well, else return an error string.
     The return value is also saved in global variable _SetupError.
@@ -97,15 +84,13 @@ def setup(debug: bool = False
     global _SetupError, _Popen, _ex
     _SetupError = None
     try:
-        ds9Dir, xpaDir = _findDS9AndXPA()
-        if debug:
-            print(f"ds9Dir={repr(ds9Dir)}\npaDir={repr(xpaDir)}")
+        _findUnixApp("ds9")
+        _findUnixApp("xpaget")
     except (SystemExit, KeyboardInterrupt):
         raise
     except Exception as e:
         _ex = e
         _SetupError = f"DS9Win unusable: {e}"
-        ds9Dir = xpaDir = None
 
     if _SetupError:
         # Is this worth setting up?
@@ -122,7 +107,7 @@ def setup(debug: bool = False
     return _SetupError
 
 
-errStr = setup(debug=False)
+errStr = setup()
 if errStr:
     warnings.warn(errStr)
 
@@ -510,11 +495,3 @@ class DS9Win:
             template=self.template,
             method=self.xpa_method
         )
-
-
-if __name__ == "__main__":
-    errStr = setup(debug=True)
-    if errStr:
-        print(errStr)
-    else:
-        ds9Win = DS9Win("Test")

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -30,10 +30,12 @@ been simplified to only support the features that Sherpa needs.
 
 """
 
+from collections.abc import Mapping
 import os
 import shlex
 import sys
 import time
+from typing import Any
 import warnings
 import subprocess
 
@@ -44,7 +46,7 @@ from sherpa.utils.err import RuntimeErr, TypeErr
 __all__ = ["setup", "xpaget", "xpaset", "DS9Win"]
 
 
-def _addToPATH(newPath):
+def _addToPATH(newPath: str) -> None:
     """Add newPath to the PATH environment variable.
     Do nothing if newPath already in PATH.
     """
@@ -60,7 +62,7 @@ def _addToPATH(newPath):
     os.environ["PATH"] = pathStr
 
 
-def _findUnixApp(appName):
+def _findUnixApp(appName: str) -> str:
     """Search PATH to find first directory that has the application.
     Return the path if found.
     Raise RuntimeError if not found.
@@ -77,7 +79,7 @@ def _findUnixApp(appName):
     return appPath
 
 
-def _findDS9AndXPA():
+def _findDS9AndXPA() -> tuple[str, str]:
     """Locate ds9 and xpa, and add to PATH if not already there.
 
     Returns:
@@ -93,9 +95,9 @@ def _findDS9AndXPA():
     return (ds9Dir, xpaDir)
 
 
-def setup(doRaise=True,
-          debug=False
-          ):
+def setup(doRaise: bool = True,
+          debug: bool = False
+          ) -> str | None:
     """Search for xpa and ds9 and set globals accordingly.
     Return None if all is well, else return an error string.
     The return value is also saved in global variable _SetupError.
@@ -201,7 +203,7 @@ def xpaget(cmd: str,
 
 
 def xpaset(cmd: str,
-           data=None,
+           data: str | bytes | None = None,
            dataFunc=None,
            template: str = _DefTemplate,
            doRaise: bool = True,
@@ -290,9 +292,9 @@ _FloatTypes = (np.float32, np.float64)
 _ComplexTypes = (np.complex64, np.complex128)
 
 
-def _expandPath(fname,
-                extraArgs=""
-                ):
+def _expandPath(fname: str,
+                extraArgs: str = ""
+                ) -> str:
     """Expand a file path and protect it such that spaces are allowed.
     Inputs:
     - fname                file path to expand
@@ -306,7 +308,7 @@ def _expandPath(fname,
     return f"{{{filepath}{extraArgs}}}"
 
 
-def _formatOptions(kargs):
+def _formatOptions(kargs: Mapping[str, Any]) -> str:
     """Returns a string: "key1=val1,key2=val2,..."
     (where keyx and valx are string representations)
     """
@@ -422,7 +424,7 @@ class DS9Win:
 
     def showArray(self,
                   arr,
-                  **kargs):
+                  **kargs) -> None:
         """Display a 2-d or 3-d grayscale integer numarray arrays.
         3-d images are displayed as data cubes, meaning one can
         view a single z at a time or play through them as a movie,
@@ -592,7 +594,7 @@ class DS9Win:
 
     def xpaset(self,
                cmd: str,
-               data=None,
+               data: str | bytes | None = None,
                dataFunc=None
                ) -> None:
         """Executes a simple xpaset command.

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -198,10 +198,16 @@ class DataImage(Image):
         self.eqpos = getattr(data, 'eqpos', None)
         self.sky = getattr(data, 'sky', None)
         header = getattr(data, 'header', None)
-        if header is not None:
-            obj = header.get('OBJECT')
-            if obj is not None:
-                self.name = str(obj).replace(" ", "_")
+
+        # Clear out any previous version.
+        self.name = "Data"
+
+        if header is None:
+            return
+
+        obj = header.get('OBJECT')
+        if obj is not None:
+            self.name = str(obj).replace(" ", "_")
 
     def image(self, shape=None, newframe=False, tile=False):
         Image.image(self, self.y, shape, newframe, tile)

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -240,6 +240,15 @@ class DataImage(Image):
         Image.__init__(self)
 
     def prepare_image(self, data: Data2D) -> None:
+        """Create the data to display.
+
+        Parameters
+        ----------
+        data
+           The Sherpa data object to display.
+
+        """
+
         self.y = data.get_img()
         self.eqpos = getattr(data, 'eqpos', None)
         self.sky = getattr(data, 'sky', None)
@@ -260,6 +269,18 @@ class DataImage(Image):
               newframe: bool = False,
               tile: bool = False
               ) -> None:
+        """Send the data to the image viewer to display.
+
+        Parameters
+        ----------
+        shape
+           The shape of the data (optional).
+        newframe
+           Should the pixels be displayed in a new frame?
+        tile
+           Should the display be tiled?
+
+        """
         Image.image(self, self.y, shape, newframe, tile)
         Image.set_wcs((self.eqpos, self.sky, self.name))
 
@@ -282,6 +303,17 @@ class ModelImage(Image):
         Image.__init__(self)
 
     def prepare_image(self, data: Data2D, model: Model) -> None:
+        """Create the data to display.
+
+        Parameters
+        ----------
+        data
+           The Sherpa data object to display.
+        model
+           The model to evaluate on the data grid.
+
+        """
+
         self.y = data.get_img(model)
         self.y = self.y[1]
         self.eqpos = getattr(data, 'eqpos', None)
@@ -292,6 +324,18 @@ class ModelImage(Image):
               newframe: bool = False,
               tile: bool = False
               ) -> None:
+        """Send the data to the image viewer to display.
+
+        Parameters
+        ----------
+        shape
+           The shape of the data (optional).
+        newframe
+           Should the pixels be displayed in a new frame?
+        tile
+           Should the display be tiled?
+
+        """
         Image.image(self, self.y, shape, newframe, tile)
         Image.set_wcs((self.eqpos, self.sky, self.name))
 
@@ -304,8 +348,16 @@ class SourceImage(ModelImage):
         self.name = 'Source'
 
     def prepare_image(self, data: Data2D, model: Model) -> None:
-        # self.y = data.get_img(model)
-        # self.y = self.y[1]
+        """Create the data to display.
+
+        Parameters
+        ----------
+        data
+           The Sherpa data object to display.
+        model
+           The model to evaluate on the data grid.
+
+        """
 
         self.y = data.eval_model(model)
         data._check_shape()
@@ -316,7 +368,13 @@ class SourceImage(ModelImage):
 
 
 class RatioImage(Image):
-    """The data divide by the model."""
+    """The data divided by the model.
+
+    See Also
+    --------
+    ResidImage
+
+    """
 
     _fields: list[str] = ["name!", "y", "eqpos!", "sky!"]
     """The fields to include in the string output.
@@ -341,6 +399,17 @@ class RatioImage(Image):
         return (data / model)
 
     def prepare_image(self, data: Data2D, model: Model) -> None:
+        """Create the data to display.
+
+        Parameters
+        ----------
+        data
+           The Sherpa data object to display.
+        model
+           The model to evaluate on the data grid.
+
+        """
+
         self.y = data.get_img(model)
         self.y = self._calc_ratio(self.y)
         self.eqpos = getattr(data, 'eqpos', None)
@@ -351,12 +420,30 @@ class RatioImage(Image):
               newframe: bool = False,
               tile: bool = False
               ) -> None:
+        """Send the data to the image viewer to display.
+
+        Parameters
+        ----------
+        shape
+           The shape of the data (optional).
+        newframe
+           Should the pixels be displayed in a new frame?
+        tile
+           Should the display be tiled?
+
+        """
         Image.image(self, self.y, shape, newframe, tile)
         Image.set_wcs((self.eqpos, self.sky, self.name))
 
 
 class ResidImage(Image):
-    """The data - model image."""
+    """The data - model image.
+
+    See Also
+    --------
+    RatioImage
+
+    """
 
     _fields: list[str] = ["name!", "y", "eqpos!", "sky!"]
     """The fields to include in the string output.
@@ -376,6 +463,17 @@ class ResidImage(Image):
         return ylist[0] - ylist[1]
 
     def prepare_image(self, data: Data2D, model: Model) -> None:
+        """Create the data to display.
+
+        Parameters
+        ----------
+        data
+           The Sherpa data object to display.
+        model
+           The model to evaluate on the data grid.
+
+        """
+
         self.y = data.get_img(model)
         self.y = self._calc_resid(self.y)
         self.eqpos = getattr(data, 'eqpos', None)
@@ -386,12 +484,30 @@ class ResidImage(Image):
               newframe: bool = False,
               tile: bool = False
               ) -> None:
+        """Send the data to the image viewer to display.
+
+        Parameters
+        ----------
+        shape
+           The shape of the data (optional).
+        newframe
+           Should the pixels be displayed in a new frame?
+        tile
+           Should the display be tiled?
+
+        """
         Image.image(self, self.y, shape, newframe, tile)
         Image.set_wcs((self.eqpos, self.sky, self.name))
 
 
 class PSFImage(DataImage):
-    """The PSF image."""
+    """The PSF image.
+
+    See Also
+    --------
+    PSFKernelImage
+
+    """
 
     def prepare_image(self, psf, data=None) -> None:
         psfdata = psf.get_kernel(data, False)
@@ -400,7 +516,13 @@ class PSFImage(DataImage):
 
 
 class PSFKernelImage(DataImage):
-    """The PSF kernel image."""
+    """The PSF kernel image.
+
+    See Also
+    --------
+    PSFImage
+
+    """
 
     def prepare_image(self, psf, data=None) -> None:
         psfdata = psf.get_kernel(data)
@@ -412,6 +534,17 @@ class ComponentSourceImage(SourceImage):
     """The unconvolved source component."""
 
     def prepare_image(self, data: Data2D, model: Model) -> None:
+        """Create the data to display.
+
+        Parameters
+        ----------
+        data
+           The Sherpa data object to display.
+        model
+           The model to evaluate on the data grid.
+
+        """
+
         ModelImage.prepare_image(self, data, model)
         # self.name = "Source component '%s'" % model.name
         self.name = "Source_component"
@@ -421,6 +554,17 @@ class ComponentModelImage(ModelImage):
     """The model component."""
 
     def prepare_image(self, data: Data2D, model: Model) -> None:
+        """Create the data to display.
+
+        Parameters
+        ----------
+        data
+           The Sherpa data object to display.
+        model
+           The model to evaluate on the data grid.
+
+        """
+
         ModelImage.prepare_image(self, data, model)
         # self.name = "Model component '%s'" % model.name
         self.name = "Model_component"

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -36,6 +36,9 @@ import logging
 
 import numpy as np
 
+from sherpa.astro.io.wcs import WCS
+from sherpa.data import Data2D
+from sherpa.models.model import Model
 from sherpa.utils import NoNewAttributesAfterInit, bool_cast, display_fields
 
 warning = logging.getLogger(__name__).warning
@@ -79,17 +82,17 @@ class Image(NoNewAttributesAfterInit):
         return display_fields(self, self._fields)
 
     @staticmethod
-    def close():
+    def close() -> None:
         """Stop the image viewer."""
         backend.close()
 
     @staticmethod
-    def delete_frames():
+    def delete_frames() -> None:
         """Delete all the frames open in the image viewer."""
         backend.delete_frames()
 
     @staticmethod
-    def get_region(coord):
+    def get_region(coord: str) -> str:
         """Return the region defined in the image viewer.
 
         Parameters
@@ -108,11 +111,11 @@ class Image(NoNewAttributesAfterInit):
 
     # This version could be a staticmethod but derived classes can not be.
     def image(self,
-              array,
-              shape=None,
-              newframe=False,
-              tile=False
-              ):
+              array: np.ndarray,
+              shape: tuple[int, ...] | None = None,
+              newframe: bool = False,
+              tile: bool = False
+              ) -> None:
         """Send the data to the image viewer to display.
 
         Parameters
@@ -137,12 +140,12 @@ class Image(NoNewAttributesAfterInit):
         backend.image(vals, newframe, tile)
 
     @staticmethod
-    def open():
+    def open() -> None:
         """Start the image viewer."""
         backend.open()
 
     @staticmethod
-    def set_wcs(keys):
+    def set_wcs(keys: tuple[WCS | None, WCS | None, str]) -> None:
         """Send the WCS information to the image viewer.
 
         .. versionchanged:: 4.19.0
@@ -157,7 +160,7 @@ class Image(NoNewAttributesAfterInit):
         backend.wcs(keys)
 
     @staticmethod
-    def set_region(reg, coord):
+    def set_region(reg: str, coord: str) -> None:
         """Set the region to display in the image viewer.
 
         Parameters
@@ -172,7 +175,7 @@ class Image(NoNewAttributesAfterInit):
         backend.set_region(reg, coord)
 
     @staticmethod
-    def xpaget(arg):
+    def xpaget(arg: str) -> str:
         """Return the result of an XPA call to the image viewer.
 
         Send a query to the image viewer.
@@ -190,7 +193,7 @@ class Image(NoNewAttributesAfterInit):
         return backend.xpaget(arg)
 
     @staticmethod
-    def xpaset(arg, data=None):
+    def xpaset(arg: str, data: str | bytes | None = None) -> None:
         """Return the result of an XPA call to the image viewer.
 
         Send a command to the image viewer.
@@ -229,14 +232,14 @@ class DataImage(Image):
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.y = None
         self.eqpos = None
         self.sky = None
         self.name = 'Data'
         Image.__init__(self)
 
-    def prepare_image(self, data):
+    def prepare_image(self, data: Data2D) -> None:
         self.y = data.get_img()
         self.eqpos = getattr(data, 'eqpos', None)
         self.sky = getattr(data, 'sky', None)
@@ -252,7 +255,11 @@ class DataImage(Image):
         if obj is not None:
             self.name = str(obj).replace(" ", "_")
 
-    def image(self, shape=None, newframe=False, tile=False):
+    def image(self,
+              shape: tuple[int, ...] | None = None,
+              newframe: bool = False,
+              tile: bool = False
+              ) -> None:
         Image.image(self, self.y, shape, newframe, tile)
         Image.set_wcs((self.eqpos, self.sky, self.name))
 
@@ -267,20 +274,24 @@ class ModelImage(Image):
     passed through NumPy's array2string.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.name = 'Model'
         self.y = None
         self.eqpos = None
         self.sky = None
         Image.__init__(self)
 
-    def prepare_image(self, data, model):
+    def prepare_image(self, data: Data2D, model: Model) -> None:
         self.y = data.get_img(model)
         self.y = self.y[1]
         self.eqpos = getattr(data, 'eqpos', None)
         self.sky = getattr(data, 'sky', None)
 
-    def image(self, shape=None, newframe=False, tile=False):
+    def image(self,
+              shape: tuple[int, ...] | None = None,
+              newframe: bool = False,
+              tile: bool = False
+              ) -> None:
         Image.image(self, self.y, shape, newframe, tile)
         Image.set_wcs((self.eqpos, self.sky, self.name))
 
@@ -288,11 +299,11 @@ class ModelImage(Image):
 class SourceImage(ModelImage):
     """The source model (before convolution) data."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         ModelImage.__init__(self)
         self.name = 'Source'
 
-    def prepare_image(self, data, model):
+    def prepare_image(self, data: Data2D, model: Model) -> None:
         # self.y = data.get_img(model)
         # self.y = self.y[1]
 
@@ -314,7 +325,7 @@ class RatioImage(Image):
     passed through NumPy's array2string.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.name = 'Ratio'
         self.y = None
         self.eqpos = None
@@ -329,13 +340,17 @@ class RatioImage(Image):
         model[bad] = 1.0
         return (data / model)
 
-    def prepare_image(self, data, model):
+    def prepare_image(self, data: Data2D, model: Model) -> None:
         self.y = data.get_img(model)
         self.y = self._calc_ratio(self.y)
         self.eqpos = getattr(data, 'eqpos', None)
         self.sky = getattr(data, 'sky', None)
 
-    def image(self, shape=None, newframe=False, tile=False):
+    def image(self,
+              shape: tuple[int, ...] | None = None,
+              newframe: bool = False,
+              tile: bool = False
+              ) -> None:
         Image.image(self, self.y, shape, newframe, tile)
         Image.set_wcs((self.eqpos, self.sky, self.name))
 
@@ -350,7 +365,7 @@ class ResidImage(Image):
     passed through NumPy's array2string.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.name = 'Residual'
         self.y = None
         self.eqpos = None
@@ -360,13 +375,17 @@ class ResidImage(Image):
     def _calc_resid(self, ylist):
         return ylist[0] - ylist[1]
 
-    def prepare_image(self, data, model):
+    def prepare_image(self, data: Data2D, model: Model) -> None:
         self.y = data.get_img(model)
         self.y = self._calc_resid(self.y)
         self.eqpos = getattr(data, 'eqpos', None)
         self.sky = getattr(data, 'sky', None)
 
-    def image(self, shape=None, newframe=False, tile=False):
+    def image(self,
+              shape: tuple[int, ...] | None = None,
+              newframe: bool = False,
+              tile: bool = False
+              ) -> None:
         Image.image(self, self.y, shape, newframe, tile)
         Image.set_wcs((self.eqpos, self.sky, self.name))
 
@@ -374,7 +393,7 @@ class ResidImage(Image):
 class PSFImage(DataImage):
     """The PSF image."""
 
-    def prepare_image(self, psf, data=None):
+    def prepare_image(self, psf, data=None) -> None:
         psfdata = psf.get_kernel(data, False)
         DataImage.prepare_image(self, psfdata)
         self.name = psf.kernel.name
@@ -383,7 +402,7 @@ class PSFImage(DataImage):
 class PSFKernelImage(DataImage):
     """The PSF kernel image."""
 
-    def prepare_image(self, psf, data=None):
+    def prepare_image(self, psf, data=None) -> None:
         psfdata = psf.get_kernel(data)
         DataImage.prepare_image(self, psfdata)
         self.name = 'PSF_Kernel'
@@ -392,7 +411,7 @@ class PSFKernelImage(DataImage):
 class ComponentSourceImage(SourceImage):
     """The unconvolved source component."""
 
-    def prepare_image(self, data, model):
+    def prepare_image(self, data: Data2D, model: Model) -> None:
         ModelImage.prepare_image(self, data, model)
         # self.name = "Source component '%s'" % model.name
         self.name = "Source_component"
@@ -401,7 +420,7 @@ class ComponentSourceImage(SourceImage):
 class ComponentModelImage(ModelImage):
     """The model component."""
 
-    def prepare_image(self, data, model):
+    def prepare_image(self, data: Data2D, model: Model) -> None:
         ModelImage.prepare_image(self, data, model)
         # self.name = "Model component '%s'" % model.name
         self.name = "Model_component"

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -32,12 +32,13 @@ References
 
 """
 
-import numpy
+import logging
+
+import numpy as np
+
 from sherpa.utils import NoNewAttributesAfterInit, bool_cast, display_fields
 
-import logging
 warning = logging.getLogger(__name__).warning
-backend = None
 
 try:
     from . import ds9_backend as backend
@@ -45,9 +46,9 @@ try:
 except Exception as e:
     # if DS9 is not found for some reason, like inside gdb
     # give a useful warning and fall back on dummy_backend of noops
-    warning("imaging routines will not be available, \n" +
-            "failed to import sherpa.image.ds9_backend due to \n'%s: %s'" %
-            (type(e).__name__, str(e)))
+    warning("imaging routines will not be available, \n"
+            "failed to import sherpa.image.ds9_backend due to \n"
+            "'%s: %s'", type(e).__name__, str(e))
     from . import dummy_backend as backend
 
 
@@ -56,6 +57,14 @@ __all__ = ('Image', 'DataImage', 'ModelImage', 'RatioImage',
            'ComponentModelImage', 'ComponentSourceImage')
 
 
+# As with the Plot and Contour classes, the base Image class works
+# with explicit arrays but the derived classes work with Sherpa
+# objects (Data and Model), and extract the pixel values from
+# them. This means that the image method ends up causing issues for
+# type checkers, as the derived classes have a different
+# signature. There are also issues with the prepare_image call,
+# although this is not defined for the base Image class.
+#
 class Image(NoNewAttributesAfterInit):
     """Base class for sending image data to an external viewer."""
 
@@ -69,16 +78,17 @@ class Image(NoNewAttributesAfterInit):
     def __str__(self) -> str:
         return display_fields(self, self._fields)
 
+    @staticmethod
     def close():
         """Stop the image viewer."""
         backend.close()
-    close = staticmethod(close)
 
+    @staticmethod
     def delete_frames():
         """Delete all the frames open in the image viewer."""
         backend.delete_frames()
-    delete_frames = staticmethod(delete_frames)
 
+    @staticmethod
     def get_region(coord):
         """Return the region defined in the image viewer.
 
@@ -95,24 +105,53 @@ class Image(NoNewAttributesAfterInit):
 
         """
         return backend.get_region(coord)
-    get_region = staticmethod(get_region)
 
-    def image(self, array, shape=None, newframe=False, tile=False):
+    def image(self,
+              array,
+              shape=None,
+              newframe=False,
+              tile=False
+              ):
+        """Send the data to the image viewer to display.
+
+        Parameters
+        ----------
+        array
+           The pixel values
+        shape
+           The shape of the data (optional).
+        newframe
+           Should the pixels be displayed in a new frame?
+        tile
+           Should the display be tiled?
+
+        """
         newframe = bool_cast(newframe)
         tile = bool_cast(tile)
         if shape is None:
-            backend.image(array, newframe, tile)
+            vals = array
         else:
-            backend.image(array.reshape(shape), newframe, tile)
+            vals = array.reshape(shape)
 
+        backend.image(vals, newframe, tile)
+
+    @staticmethod
     def open():
         """Start the image viewer."""
         backend.open()
-    open = staticmethod(open)
 
     def set_wcs(self, keys):
+        """Send the WCS information to the image viewer.
+
+        Parameters
+        ----------
+        keys
+           The eqpos and sky transforms, and the name of the display.
+
+        """
         backend.wcs(keys)
 
+    @staticmethod
     def set_region(reg, coord):
         """Set the region to display in the image viewer.
 
@@ -126,8 +165,8 @@ class Image(NoNewAttributesAfterInit):
 
         """
         backend.set_region(reg, coord)
-    set_region = staticmethod(set_region)
 
+    @staticmethod
     def xpaget(arg):
         """Return the result of an XPA call to the image viewer.
 
@@ -144,8 +183,8 @@ class Image(NoNewAttributesAfterInit):
 
         """
         return backend.xpaget(arg)
-    xpaget = staticmethod(xpaget)
 
+    @staticmethod
     def xpaset(arg, data=None):
         """Return the result of an XPA call to the image viewer.
 
@@ -159,8 +198,7 @@ class Image(NoNewAttributesAfterInit):
            The data for the command.
 
         """
-        return backend.xpaset(arg, data=None)
-    xpaset = staticmethod(xpaset)
+        backend.xpaset(arg, data=None)
 
 
 class DataImage(Image):
@@ -215,6 +253,7 @@ class DataImage(Image):
 
 
 class ModelImage(Image):
+    """Model data."""
 
     _fields: list[str] = ["name!", "y", "eqpos!", "sky!"]
     """The fields to include in the string output.
@@ -242,6 +281,8 @@ class ModelImage(Image):
 
 
 class SourceImage(ModelImage):
+    """The source model (before convolution) data."""
+
     def __init__(self):
         ModelImage.__init__(self)
         self.name = 'Source'
@@ -259,6 +300,7 @@ class SourceImage(ModelImage):
 
 
 class RatioImage(Image):
+    """The data divide by the model."""
 
     _fields: list[str] = ["name!", "y", "eqpos!", "sky!"]
     """The fields to include in the string output.
@@ -275,9 +317,9 @@ class RatioImage(Image):
         Image.__init__(self)
 
     def _calc_ratio(self, ylist):
-        data = numpy.array(ylist[0])
-        model = numpy.asarray(ylist[1])
-        bad = numpy.where(model == 0.0)
+        data = np.array(ylist[0])
+        model = np.asarray(ylist[1])
+        bad = np.where(model == 0.0)
         data[bad] = 0.0
         model[bad] = 1.0
         return (data / model)
@@ -294,6 +336,7 @@ class RatioImage(Image):
 
 
 class ResidImage(Image):
+    """The data - model image."""
 
     _fields: list[str] = ["name!", "y", "eqpos!", "sky!"]
     """The fields to include in the string output.
@@ -324,6 +367,7 @@ class ResidImage(Image):
 
 
 class PSFImage(DataImage):
+    """The PSF image."""
 
     def prepare_image(self, psf, data=None):
         psfdata = psf.get_kernel(data, False)
@@ -332,6 +376,7 @@ class PSFImage(DataImage):
 
 
 class PSFKernelImage(DataImage):
+    """The PSF kernel image."""
 
     def prepare_image(self, psf, data=None):
         psfdata = psf.get_kernel(data)
@@ -340,6 +385,7 @@ class PSFKernelImage(DataImage):
 
 
 class ComponentSourceImage(ModelImage):
+    """The unconvolved source component."""
 
     def prepare_image(self, data, model):
         ModelImage.prepare_image(self, data, model)
@@ -348,6 +394,7 @@ class ComponentSourceImage(ModelImage):
 
 
 class ComponentModelImage(ModelImage):
+    """The model component."""
 
     def prepare_image(self, data, model):
         ModelImage.prepare_image(self, data, model)

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -106,6 +106,7 @@ class Image(NoNewAttributesAfterInit):
         """
         return backend.get_region(coord)
 
+    # This version could be a staticmethod but derived classes can not be.
     def image(self,
               array,
               shape=None,
@@ -140,8 +141,12 @@ class Image(NoNewAttributesAfterInit):
         """Start the image viewer."""
         backend.open()
 
-    def set_wcs(self, keys):
+    @staticmethod
+    def set_wcs(keys):
         """Send the WCS information to the image viewer.
+
+        .. versionchanged:: 4.19.0
+           This is now a static method.
 
         Parameters
         ----------
@@ -249,7 +254,7 @@ class DataImage(Image):
 
     def image(self, shape=None, newframe=False, tile=False):
         Image.image(self, self.y, shape, newframe, tile)
-        Image.set_wcs(self, (self.eqpos, self.sky, self.name))
+        Image.set_wcs((self.eqpos, self.sky, self.name))
 
 
 class ModelImage(Image):
@@ -277,7 +282,7 @@ class ModelImage(Image):
 
     def image(self, shape=None, newframe=False, tile=False):
         Image.image(self, self.y, shape, newframe, tile)
-        Image.set_wcs(self, (self.eqpos, self.sky, self.name))
+        Image.set_wcs((self.eqpos, self.sky, self.name))
 
 
 class SourceImage(ModelImage):
@@ -332,7 +337,7 @@ class RatioImage(Image):
 
     def image(self, shape=None, newframe=False, tile=False):
         Image.image(self, self.y, shape, newframe, tile)
-        Image.set_wcs(self, (self.eqpos, self.sky, self.name))
+        Image.set_wcs((self.eqpos, self.sky, self.name))
 
 
 class ResidImage(Image):
@@ -363,7 +368,7 @@ class ResidImage(Image):
 
     def image(self, shape=None, newframe=False, tile=False):
         Image.image(self, self.y, shape, newframe, tile)
-        Image.set_wcs(self, (self.eqpos, self.sky, self.name))
+        Image.set_wcs((self.eqpos, self.sky, self.name))
 
 
 class PSFImage(DataImage):
@@ -384,7 +389,7 @@ class PSFKernelImage(DataImage):
         self.name = 'PSF_Kernel'
 
 
-class ComponentSourceImage(ModelImage):
+class ComponentSourceImage(SourceImage):
     """The unconvolved source component."""
 
     def prepare_image(self, data, model):

--- a/sherpa/image/ds9_backend.py
+++ b/sherpa/image/ds9_backend.py
@@ -26,12 +26,19 @@ from sherpa.utils.err import DS9Err
 
 from . import DS9
 
-imager = DS9.DS9Win(DS9._DefTemplate, False)
+
+imager = DS9.DS9Win(template=DS9._DefTemplate, doOpen=False)
 
 
-# TODO: the except blocks would ideally catch explicit errors; the present
-#       catch-anything approach means that we lose potentially-useful
-#       information on the type of error.
+# The except blocks would ideally catch explicit errors; the present
+# catch-anything approach means that we lose potentially-useful
+# information on the type of error. To reduce the loss of information
+# the new exceptions are linked to the original exception.
+#
+# For now the try/except blocks have been made to catch BaseException
+# rather than Exception, since things like "ds9 being killed" is
+# probably something we either want to catch or users are already
+# relying on.
 #
 
 def close():
@@ -44,9 +51,9 @@ def delete_frames():
         raise DS9Err('open')
     try:
         imager.xpaset("frame delete all")
-        return imager.xpaset("frame new")
-    except:
-        raise DS9Err('delframe')
+        imager.xpaset("frame new")
+    except BaseException as exc:
+        raise DS9Err('delframe') from exc
 
 
 def get_region(coord):
@@ -60,39 +67,39 @@ def get_region(coord):
             else:
                 regionfmt = 'saoimage'
 
-            regionstr = "regions -format {} ".format(regionfmt) + \
-                        "-strip yes -system {}".format(coord)
+            regionstr = f"regions -format {regionfmt} " + \
+                        f"-strip yes -system {coord}"
 
-        regionstr = imager.xpaget(regionstr)
-        return regionstr
+        return imager.xpaget(regionstr)
 
-    except:
-        raise DS9Err('retreg')
+    except BaseException as exc:
+        raise DS9Err('retreg') from exc
 
 
 def image(arr, newframe=False, tile=False):
     if not imager.isOpen():
         imager.doOpen()
+
     # Create a new frame if the user requested it, *or* if
     # there happen to be no DS9 frames.
     if newframe or imager.xpaget("frame all") == "\n":
         try:
             imager.xpaset("frame new")
             imager.xpaset("frame last")
-        except:
-            raise DS9Err('newframe')
+        except BaseException as exc:
+            raise DS9Err('newframe') from exc
+
+    tileopt = "yes" if tile else "no"
     try:
-        if tile:
-            imager.xpaset("tile yes")
-        else:
-            imager.xpaset("tile no")
-    except:
-        raise DS9Err('settile')
+        imager.xpaset(f"tile {tileopt}")
+    except BaseException as exc:
+        raise DS9Err('settile') from exc
+
     time.sleep(1)
     try:
         imager.showArray(arr)
-    except:
-        raise DS9Err('noimage')
+    except BaseException as exc:
+        raise DS9Err('noimage') from exc
 
 
 def _set_wcs(keys: tuple[WCS | None, WCS | None, str]) -> str:
@@ -166,8 +173,8 @@ def wcs(keys: tuple[WCS | None, WCS | None, str]) -> None:
 
     try:
         imager.xpaset('wcs replace', info)
-    except:
-        raise DS9Err('setwcs')
+    except BaseException as exc:
+        raise DS9Err('setwcs') from exc
 
 
 def open():
@@ -180,7 +187,7 @@ def set_region(reg, coord):
     try:
         # Assume a region file defines everything correctly
         if access(reg, R_OK):
-            imager.xpaset("regions load " + "'" + reg + "'")
+            imager.xpaset(f"regions load '{reg}'")
         else:
             # Assume region string has to be in CIAO format
             regions = reg.split(";")
@@ -193,8 +200,8 @@ def set_region(reg, coord):
 
                     imager.xpaset("regions", data=data)
 
-    except:
-        raise DS9Err('badreg', str(reg))
+    except BaseException as exc:
+        raise DS9Err('badreg', str(reg)) from exc
 
 
 def xpaget(arg):
@@ -206,4 +213,4 @@ def xpaget(arg):
 def xpaset(arg, data=None):
     if not imager.isOpen():
         raise DS9Err('open')
-    return imager.xpaset(arg, data)
+    imager.xpaset(arg, data)

--- a/sherpa/image/ds9_backend.py
+++ b/sherpa/image/ds9_backend.py
@@ -42,11 +42,13 @@ imager = DS9.DS9Win(template=DS9._DefTemplate, doOpen=False)
 #
 
 def close():
+    """Stop the image viewer."""
     if imager.isOpen():
         imager.xpaset("quit")
 
 
 def delete_frames():
+    """Delete all the frames open in the image viewer."""
     if not imager.isOpen():
         raise DS9Err('open')
     try:
@@ -57,6 +59,20 @@ def delete_frames():
 
 
 def get_region(coord):
+    """Return the region defined in the image viewer.
+
+    Parameters
+    ----------
+    coord : str
+       The name of the coordinate system (the empty string means
+       to use the current system).
+
+    Returns
+    -------
+    region : str
+       The region, or regions, or the empty string.
+
+    """
     if not imager.isOpen():
         raise DS9Err('open')
     try:
@@ -76,7 +92,22 @@ def get_region(coord):
         raise DS9Err('retreg') from exc
 
 
-def image(arr, newframe=False, tile=False):
+def image(arr,
+          newframe=False,
+          tile=False
+          ):
+    """Send the data to the image viewer to display.
+
+    Parameters
+    ----------
+    array
+       The pixel values
+    newframe
+       Should the pixels be displayed in a new frame?
+    tile
+       Should the display be tiled?
+
+    """
     if not imager.isOpen():
         imager.doOpen()
 
@@ -102,10 +133,8 @@ def image(arr, newframe=False, tile=False):
         raise DS9Err('noimage') from exc
 
 
-def _set_wcs(keys: tuple[WCS | None, WCS | None, str]) -> str:
+def _set_wcs(eqpos: WCS | None, sky: WCS | None, name: str) -> str:
     """Convert the settings into a string to send via XPA"""
-
-    eqpos, sky, name = keys
 
     # DS9 can be very particular about the WCS settings, so attempt to
     # set everything to avoid problems with ds9 preference settings.
@@ -164,12 +193,20 @@ def _set_wcs(keys: tuple[WCS | None, WCS | None, str]) -> str:
     return '\n'.join(out)
 
 
-def wcs(keys: tuple[WCS | None, WCS | None, str]) -> None:
+def wcs(keys):
+    """Send the WCS information to the image viewer.
+
+    Parameters
+    ----------
+    keys
+       The eqpos and sky transforms, and the name of the display.
+
+    """
 
     if not imager.isOpen():
         raise DS9Err('open')
 
-    info = _set_wcs(keys)
+    info = _set_wcs(keys[0], keys[1], keys[2])
 
     try:
         imager.xpaset('wcs replace', info)
@@ -178,10 +215,22 @@ def wcs(keys: tuple[WCS | None, WCS | None, str]) -> None:
 
 
 def open():
+    """Start the image viewer."""
     imager.doOpen()
 
 
 def set_region(reg, coord):
+    """Set the region to display in the image viewer.
+
+    Parameters
+    ----------
+    reg : str
+       The region to display.
+    coord : str
+       The name of the coordinate system (the empty string means
+       to use the current system).
+
+    """
     if not imager.isOpen():
         raise DS9Err('open')
     try:
@@ -205,12 +254,38 @@ def set_region(reg, coord):
 
 
 def xpaget(arg):
+    """Query the image viewer via XPA.
+
+    Retrieve the results of a query to the image viewer.
+
+    Parameters
+    ----------
+    arg : str
+       A command to send to the image viewer via XPA.
+
+    Returns
+    -------
+    returnval : str
+
+    """
     if not imager.isOpen():
         raise DS9Err('open')
     return imager.xpaget(arg)
 
 
 def xpaset(arg, data=None):
+    """Send the image viewer a command via XPA.
+
+    Send a command to the image viewer.
+
+    Parameters
+    ----------
+    arg : str
+       A command to send to the image viewer via XPA.
+    data : optional
+       The data for the command.
+
+    """
     if not imager.isOpen():
         raise DS9Err('open')
     imager.xpaset(arg, data)

--- a/sherpa/image/ds9_backend.py
+++ b/sherpa/image/ds9_backend.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2016, 2017, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016-2017, 2021, 2026
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,9 +18,10 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import time
 from os import access, R_OK
+import time
 
+from sherpa.astro.io.wcs import WCS
 from sherpa.utils.err import DS9Err
 
 from . import DS9
@@ -93,54 +95,69 @@ def image(arr, newframe=False, tile=False):
         raise DS9Err('noimage')
 
 
-def _set_wcs(keys):
+def _set_wcs(keys: tuple[WCS | None, WCS | None, str]) -> str:
+    """Convert the settings into a string to send via XPA"""
+
     eqpos, sky, name = keys
 
-    phys = ''
-    wcs = "OBJECT = '%s'\n" % name
-
-    if eqpos is not None:
-        wcrpix = eqpos.crpix
-        wcrval = eqpos.crval
-        wcdelt = eqpos.cdelt
+    # DS9 can be very particular about the WCS settings, so attempt to
+    # set everything to avoid problems with ds9 preference settings.
+    #
+    out = [f"OBJECT = '{name}'"]
 
     if sky is not None:
         pcrpix = sky.crpix
         pcrval = sky.crval
         pcdelt = sky.cdelt
 
-        # join together all strings with a '\n' between each
-        phys = '\n'.join(["WCSNAMEP = 'PHYSICAL'",
-                          "CTYPE1P = 'x       '",
-                          'CRVAL1P = %.14E' % pcrval[0],
-                          'CRPIX1P = %.14E' % pcrpix[0],
-                          'CDELT1P = %.14E' % pcdelt[0],
-                          "CTYPE2P = 'y       '",
-                          'CRVAL2P = %.14E' % pcrval[1],
-                          'CRPIX2P = %.14E' % pcrpix[1],
-                          'CDELT2P = %.14E' % pcdelt[1]])
+        crval = [f'{pcrval[0]:.14E}', f'{pcrval[1]:.14E}']
+        crpix = [f'{pcrpix[0]:.14E}', f'{pcrpix[1]:.14E}']
+        cdelt = [f'{pcdelt[0]:.14E}', f'{pcdelt[1]:.14E}']
 
-        if eqpos is not None:
-            wcdelt = wcdelt * pcdelt
-            wcrpix = (wcrpix - pcrval) / pcdelt + pcrpix
+    else:
+        # Ensure we have the identity transform defined.
+        crval = ['1.0', '1.0']
+        crpix = ['1.0', '1.0']
+        cdelt = ['1.0', '1.0']
+
+    out.extend(['WCSAXESP = 2',
+                "WCSNAMEP = 'PHYSICAL'",
+                "CTYPE1P  = 'x       '",
+                "CTYPE2P  = 'y       '",
+                f'CRVAL1P  = {crval[0]}',
+                f'CRPIX1P  = {crpix[0]}',
+                f'CDELT1P  = {cdelt[0]}',
+                f'CRVAL2P  = {crval[1]}',
+                f'CRPIX2P  = {crpix[1]}',
+                f'CDELT2P  = {cdelt[1]}'])
 
     if eqpos is not None:
-        # join together all strings with a '\n' between each
-        wcs = wcs + '\n'.join(["RADECSYS = 'ICRS    '",
-                               "CTYPE1  = 'RA---TAN'",
-                               'CRVAL1  = %.14E' % wcrval[0],
-                               'CRPIX1  = %.14E' % wcrpix[0],
-                               'CDELT1  = %.14E' % wcdelt[0],
-                               "CTYPE2  = 'DEC--TAN'",
-                               'CRVAL2  = %.14E' % wcrval[1],
-                               'CRPIX2  = %.14E' % wcrpix[1],
-                               'CDELT2  = %.14E' % wcdelt[1]])
 
-    # join the wcs and physical with '\n' between them and at the end
-    return ('\n'.join([wcs, phys]) + '\n')
+        wcrval = eqpos.crval
+        if sky is not None:
+            wcdelt = eqpos.cdelt * sky.cdelt
+            wcrpix = (eqpos.crpix - sky.crval) / sky.cdelt + sky.crpix
+        else:
+            wcdelt = eqpos.cdelt
+            wcrpix = eqpos.crpix
+
+        out.extend(['WCSAXES = 2',
+                    "RADECSYS = 'ICRS    '",
+                    "CTYPE1  = 'RA---TAN'",
+                    "CTYPE2  = 'DEC--TAN'",
+                    f'CRVAL1  = {wcrval[0]:.14E}',
+                    f'CRPIX1  = {wcrpix[0]:.14E}',
+                    f'CDELT1  = {wcdelt[0]:.14E}',
+                    f'CRVAL2  = {wcrval[1]:.14E}',
+                    f'CRPIX2  = {wcrpix[1]:.14E}',
+                    f'CDELT2  = {wcdelt[1]:.14E}'])
+
+    # Ensure the string ends with a new-line
+    out.append('')
+    return '\n'.join(out)
 
 
-def wcs(keys):
+def wcs(keys: tuple[WCS | None, WCS | None, str]) -> None:
 
     if not imager.isOpen():
         raise DS9Err('open')
@@ -148,7 +165,6 @@ def wcs(keys):
     info = _set_wcs(keys)
 
     try:
-        # use stdin to pass the WCS info
         imager.xpaset('wcs replace', info)
     except:
         raise DS9Err('setwcs')

--- a/sherpa/image/ds9_backend.py
+++ b/sherpa/image/ds9_backend.py
@@ -21,6 +21,8 @@
 from os import access, R_OK
 import time
 
+import numpy as np
+
 from sherpa.astro.io.wcs import WCS
 from sherpa.utils.err import DS9Err
 
@@ -41,13 +43,13 @@ imager = DS9.DS9Win(template=DS9._DefTemplate, doOpen=False)
 # relying on.
 #
 
-def close():
+def close() -> None:
     """Stop the image viewer."""
     if imager.isOpen():
         imager.xpaset("quit")
 
 
-def delete_frames():
+def delete_frames() -> None:
     """Delete all the frames open in the image viewer."""
     if not imager.isOpen():
         raise DS9Err('open')
@@ -58,7 +60,7 @@ def delete_frames():
         raise DS9Err('delframe') from exc
 
 
-def get_region(coord):
+def get_region(coord: str) -> str:
     """Return the region defined in the image viewer.
 
     Parameters
@@ -92,10 +94,10 @@ def get_region(coord):
         raise DS9Err('retreg') from exc
 
 
-def image(arr,
-          newframe=False,
-          tile=False
-          ):
+def image(arr: np.ndarray,
+          newframe: bool = False,
+          tile: bool = False
+          ) -> None:
     """Send the data to the image viewer to display.
 
     Parameters
@@ -193,7 +195,7 @@ def _set_wcs(eqpos: WCS | None, sky: WCS | None, name: str) -> str:
     return '\n'.join(out)
 
 
-def wcs(keys):
+def wcs(keys: tuple[WCS | None, WCS | None, str]) -> None:
     """Send the WCS information to the image viewer.
 
     Parameters
@@ -214,12 +216,12 @@ def wcs(keys):
         raise DS9Err('setwcs') from exc
 
 
-def open():
+def open() -> None:
     """Start the image viewer."""
     imager.doOpen()
 
 
-def set_region(reg, coord):
+def set_region(reg: str, coord: str) -> None:
     """Set the region to display in the image viewer.
 
     Parameters
@@ -253,7 +255,7 @@ def set_region(reg, coord):
         raise DS9Err('badreg', str(reg)) from exc
 
 
-def xpaget(arg):
+def xpaget(arg: str) -> str:
     """Query the image viewer via XPA.
 
     Retrieve the results of a query to the image viewer.
@@ -273,7 +275,7 @@ def xpaget(arg):
     return imager.xpaget(arg)
 
 
-def xpaset(arg, data=None):
+def xpaset(arg: str, data: str | bytes | None = None) -> None:
     """Send the image viewer a command via XPA.
 
     Send a command to the image viewer.

--- a/sherpa/image/dummy_backend.py
+++ b/sherpa/image/dummy_backend.py
@@ -18,22 +18,26 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+import numpy as np
+
+from sherpa.astro.io.wcs import WCS
+
 
 imager = None
 """The DS9 window, or None"""
 
 
-def close():
+def close() -> None:
     """Stop the image viewer."""
     pass
 
 
-def delete_frames():
+def delete_frames() -> None:
     """Delete all the frames open in the image viewer."""
     pass
 
 
-def get_region(coord):
+def get_region(coord: str) -> str:
     """Return the region defined in the image viewer.
 
     Parameters
@@ -48,13 +52,13 @@ def get_region(coord):
        The region, or regions, or the empty string.
 
     """
-    pass
+    return ""
 
 
-def image(array,
-          newframe=False,
-          tile=False
-          ):
+def image(array: np.ndarray,
+          newframe: bool = False,
+          tile: bool = False
+          ) -> None:
     """Send the data to the image viewer to display.
 
     Parameters
@@ -70,7 +74,7 @@ def image(array,
     pass
 
 
-def wcs(keys):
+def wcs(keys: tuple[WCS | None, WCS | None, str]) -> None:
     """Send the WCS information to the image viewer.
 
     Parameters
@@ -82,12 +86,12 @@ def wcs(keys):
     pass
 
 
-def open():
+def open() -> None:
     """Start the image viewer."""
     pass
 
 
-def set_region(reg, coord):
+def set_region(reg: str, coord: str) -> None:
     """Set the region to display in the image viewer.
 
     Parameters
@@ -102,7 +106,7 @@ def set_region(reg, coord):
     pass
 
 
-def xpaget(arg):
+def xpaget(arg: str) -> str:
     """Query the image viewer via XPA.
 
     Retrieve the results of a query to the image viewer.
@@ -117,10 +121,10 @@ def xpaget(arg):
     returnval : str
 
     """
-    pass
+    return ""
 
 
-def xpaset(arg, data=None):
+def xpaset(arg: str, data: str | bytes | None = None) -> None:
     """Send the image viewer a command via XPA.
 
     Send a command to the image viewer.

--- a/sherpa/image/dummy_backend.py
+++ b/sherpa/image/dummy_backend.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2009,2010,2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2009, 2010, 2016, 2026
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,44 +18,119 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+
 imager = None
+"""The DS9 window, or None"""
 
 
-def close(*args, **kwargs):
+def close():
+    """Stop the image viewer."""
     pass
 
 
-def delete_frames(*args, **kwargs):
+def delete_frames():
+    """Delete all the frames open in the image viewer."""
     pass
 
 
-def get_region(*args, **kwargs):
+def get_region(coord):
+    """Return the region defined in the image viewer.
+
+    Parameters
+    ----------
+    coord : str
+       The name of the coordinate system (the empty string means
+       to use the current system).
+
+    Returns
+    -------
+    region : str
+       The region, or regions, or the empty string.
+
+    """
     pass
 
 
-def image(*args, **kwargs):
+def image(array,
+          newframe=False,
+          tile=False
+          ):
+    """Send the data to the image viewer to display.
+
+    Parameters
+    ----------
+    array
+       The pixel values
+    newframe
+       Should the pixels be displayed in a new frame?
+    tile
+       Should the display be tiled?
+
+    """
     pass
 
 
-def _set_wcs(*args, **kwargs):
+def wcs(keys):
+    """Send the WCS information to the image viewer.
+
+    Parameters
+    ----------
+    keys
+       The eqpos and sky transforms, and the name of the display.
+
+    """
     pass
 
 
-def wcs(*args, **kwargs):
+def open():
+    """Start the image viewer."""
     pass
 
 
-def open(*args, **kwargs):
+def set_region(reg, coord):
+    """Set the region to display in the image viewer.
+
+    Parameters
+    ----------
+    reg : str
+       The region to display.
+    coord : str
+       The name of the coordinate system (the empty string means
+       to use the current system).
+
+    """
     pass
 
 
-def set_region(*args, **kwargs):
+def xpaget(arg):
+    """Query the image viewer via XPA.
+
+    Retrieve the results of a query to the image viewer.
+
+    Parameters
+    ----------
+    arg : str
+       A command to send to the image viewer via XPA.
+
+    Returns
+    -------
+    returnval : str
+
+    """
     pass
 
 
-def xpaget(*args, **kwargs):
-    pass
+def xpaset(arg, data=None):
+    """Send the image viewer a command via XPA.
 
+    Send a command to the image viewer.
 
-def xpaset(*args, **kwargs):
+    Parameters
+    ----------
+    arg : str
+       A command to send to the image viewer via XPA.
+    data : optional
+       The data for the command.
+
+    """
     pass

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -251,7 +251,7 @@ def test_xpaget_error():
     im = Image()
     im.open()
     command = "not a command"
-    msg = rf"^'xpaget sherpa \"{command}\"' failed: XPA\$ERROR " + \
+    msg = rf"^\"xpaget sherpa '{command}'\" failed: XPA\$ERROR " + \
         "undefined command for this xpa "
     with pytest.raises(RuntimeErr, match=msg):
         _ = im.xpaget(command)
@@ -263,7 +263,7 @@ def test_xpaset_error():
     im = Image()
     im.open()
     command = "not a command"
-    msg = rf"^'xpaset -p sherpa \"{command}\"' failed: XPA\$ERROR " + \
+    msg = rf"^\"xpaset -p sherpa '{command}'\" failed: XPA\$ERROR " + \
         "undefined command for this xpa "
     with pytest.raises(RuntimeErr, match=msg):
         im.xpaset(command)

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -250,8 +250,11 @@ def test_xpaget_error():
     """Check the error is raised."""
     im = Image()
     im.open()
+
+    # The message may include "-m local"; do not worry about checking it.
+    #
     command = "not a command"
-    msg = rf"^\"xpaget sherpa '{command}'\" failed: XPA\$ERROR " + \
+    msg = rf"^\"xpaget .*sherpa '{command}'\" failed: XPA\$ERROR " + \
         "undefined command for this xpa "
     with pytest.raises(RuntimeErr, match=msg):
         _ = im.xpaget(command)
@@ -262,8 +265,11 @@ def test_xpaset_error():
     """Check the error is raised."""
     im = Image()
     im.open()
+
+    # The message may include "-m local"; do not worry about checking it.
+    #
     command = "not a command"
-    msg = rf"^\"xpaset -p sherpa '{command}'\" failed: XPA\$ERROR " + \
+    msg = rf"^\"xpaset .*-p sherpa '{command}'\" failed: XPA\$ERROR " + \
         "undefined command for this xpa "
     with pytest.raises(RuntimeErr, match=msg):
         im.xpaset(command)

--- a/sherpa/ui/tests/test_ui_image.py
+++ b/sherpa/ui/tests/test_ui_image.py
@@ -38,8 +38,6 @@ in serial.
 
 """
 
-import logging
-
 import numpy as np
 
 import pytest
@@ -50,9 +48,7 @@ from sherpa.astro.ui.utils import Session as AstroSession
 from sherpa.data import Data2D
 from sherpa.models import basic
 
-from sherpa.stats import Chi2Gehrels
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DS9Err, \
-    IdentifierErr
+from sherpa.utils.err import DS9Err
 from sherpa.utils.testing import requires_ds9
 
 
@@ -753,9 +749,7 @@ def test_image_kernel(session):
 @pytest.mark.parametrize("session",
                          [pytest.param(BaseSession, marks=pytest.mark.session),
                           AstroSession])
-@pytest.mark.parametrize("coord", ["", "image"])
-def test_image_getregion_starts_empty(session, coord):
-    from sherpa.image import backend
+def test_image_getregion_starts_empty(session):
 
     s = session()
     d = example_data()
@@ -770,7 +764,6 @@ def test_image_getregion_starts_empty(session, coord):
                          [pytest.param(BaseSession, marks=pytest.mark.session),
                           AstroSession])
 def test_image_setregion_invalid_string(session):
-    from sherpa.image import backend
 
     s = session()
     d = example_data()
@@ -780,7 +773,7 @@ def test_image_setregion_invalid_string(session):
     # "rect" is not part of https://ds9.si.edu/doc/ref/region.html
     reg = "rect(2,3,3,4)"
     with pytest.raises(DS9Err,
-                       match=rf"^Could not use rect\(2,3,3,4\) as a "
+                       match=r"^Could not use rect\(2,3,3,4\) as a "
                        "region or region file$"):
         s.image_setregion(reg)
 
@@ -791,7 +784,6 @@ def test_image_setregion_invalid_string(session):
                           AstroSession])
 @pytest.mark.parametrize("coord", ["", "image"])
 def test_image_setregion_string(session, coord):
-    from sherpa.image import backend
 
     s = session()
     d = example_data()
@@ -810,7 +802,6 @@ def test_image_setregion_string(session, coord):
                           AstroSession])
 @pytest.mark.parametrize("coord", ["", "image"])
 def test_image_setregions_string(session, coord):
-    from sherpa.image import backend
 
     s = session()
     d = example_data()
@@ -833,7 +824,6 @@ def test_image_setregions_string(session, coord):
                           AstroSession])
 @pytest.mark.parametrize("coord", ["", "image"])
 def test_image_setregion_file(session, coord, tmp_path):
-    from sherpa.image import backend
 
     s = session()
     d = example_data()

--- a/sherpa/ui/tests/test_ui_image.py
+++ b/sherpa/ui/tests/test_ui_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2023
+#  Copyright (C) 2021, 2023, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -51,7 +51,8 @@ from sherpa.data import Data2D
 from sherpa.models import basic
 
 from sherpa.stats import Chi2Gehrels
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, IdentifierErr
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DS9Err, \
+    IdentifierErr
 from sherpa.utils.testing import requires_ds9
 
 
@@ -97,7 +98,9 @@ def example_psf():
     return psf
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 @pytest.mark.parametrize("shape", [None, (9, 9)])
 def test_load_arrays2d(session, shape):
     """Does load_arrays work with 2D data?"""
@@ -126,7 +129,9 @@ def test_load_arrays2d(session, shape):
         assert got.shape == pytest.approx(shape)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_data_image(session):
     from sherpa.image import DataImage
 
@@ -165,7 +170,9 @@ def test_data_image_show(session, check_str):
                ])
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_model_image(session):
     from sherpa.image import ModelImage
 
@@ -188,7 +195,9 @@ def test_get_model_image(session):
     assert y[3, 3] == pytest.approx(102.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_model_component_image(session):
     from sherpa.image import ComponentModelImage
 
@@ -214,7 +223,9 @@ def test_get_model_component_image(session):
     assert y[3, 3] == pytest.approx(100.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_model_component_image_with_convolution(session):
     """What happens if there's a convolution component in play?"""
 
@@ -249,7 +260,9 @@ def test_get_model_component_image_with_convolution(session):
     assert y[3, 3] == pytest.approx(42.25302)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_source_image(session):
     """Note that here there's no difference of source and model"""
     from sherpa.image import SourceImage
@@ -273,7 +286,9 @@ def test_get_source_image(session):
     assert y[3, 3] == pytest.approx(102.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_source_component_image(session):
     """Note that here there's no difference of source and model"""
     from sherpa.image import ComponentSourceImage
@@ -297,7 +312,9 @@ def test_get_source_component_image(session):
     assert y[3, 3] == pytest.approx(100.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_source_component_image_with_convolution(session):
     """There is a difference thanks to the PSF"""
     from sherpa.image import ComponentSourceImage
@@ -325,7 +342,9 @@ def test_get_source_component_image_with_convolution(session):
     assert y[3, 3] == pytest.approx(100.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_resid_image(session):
     from sherpa.image import ResidImage
 
@@ -349,7 +368,9 @@ def test_get_resid_image(session):
     assert y[3, 3] == pytest.approx(-71.0983)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_ratio_image(session):
     from sherpa.image import RatioImage
 
@@ -373,7 +394,9 @@ def test_get_ratio_image(session):
     assert y[3, 3] == pytest.approx(0.302958)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_psf_image(session):
     from sherpa.image import PSFImage
 
@@ -397,7 +420,9 @@ def test_get_psf_image(session):
     assert obj.y == pytest.approx(y)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_kernel_image(session):
     from sherpa.image import PSFKernelImage
 
@@ -459,7 +484,9 @@ def check_xpa_resid(backend):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_data(session):
     from sherpa.image import backend
 
@@ -474,7 +501,9 @@ def test_image_data(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_model(session):
     from sherpa.image import backend
 
@@ -491,7 +520,9 @@ def test_image_model(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_model_component(session):
     from sherpa.image import backend
 
@@ -508,7 +539,9 @@ def test_image_model_component(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_model_component_with_convolution(session):
     """The convolution component changes the data."""
     from sherpa.image import backend
@@ -529,7 +562,9 @@ def test_image_model_component_with_convolution(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_source(session):
     from sherpa.image import backend
 
@@ -548,7 +583,9 @@ def test_image_source(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_source_component(session):
     from sherpa.image import backend
 
@@ -567,7 +604,9 @@ def test_image_source_component(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_source_component_with_convolution(session):
     """Unlike model, this does not change the component."""
     from sherpa.image import backend
@@ -588,7 +627,9 @@ def test_image_source_component_with_convolution(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_resid(session):
     from sherpa.image import backend
 
@@ -605,7 +646,9 @@ def test_image_resid(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_ratio(session):
     from sherpa.image import backend
 
@@ -624,7 +667,9 @@ def test_image_ratio(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_fit(session):
     from sherpa.image import backend
 
@@ -655,7 +700,9 @@ def test_image_fit(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_psf(session):
     from sherpa.image import backend
 
@@ -678,7 +725,9 @@ def test_image_psf(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_kernel(session):
     from sherpa.image import backend
 
@@ -698,3 +747,103 @@ def test_image_kernel(session):
     # Check the same reagion as test_image_psf
     grid = '0\n0.166667\n0\n0.166667\n0.166667\n0\n0\n0\n0.166667\n0.166667\n0\n0\n0.166667\n0\n0\n0\n'
     check_xpa(backend, 'data image 4 5 4 4 yes', grid)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+@pytest.mark.parametrize("coord", ["", "image"])
+def test_image_getregion_starts_empty(session, coord):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+    outreg = s.image_getregion()
+    assert outreg == ""
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+def test_image_setregion_invalid_string(session):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+
+    # "rect" is not part of https://ds9.si.edu/doc/ref/region.html
+    reg = "rect(2,3,3,4)"
+    with pytest.raises(DS9Err,
+                       match=rf"^Could not use rect\(2,3,3,4\) as a "
+                       "region or region file$"):
+        s.image_setregion(reg)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+@pytest.mark.parametrize("coord", ["", "image"])
+def test_image_setregion_string(session, coord):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+
+    inreg = "circle(2,3,3)"
+    s.image_setregion(inreg, coord)
+    outreg = s.image_getregion()
+    assert outreg == f"{inreg};"
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+@pytest.mark.parametrize("coord", ["", "image"])
+def test_image_setregions_string(session, coord):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+
+    # Add a "blank" region, and box gets changed by DS9 to
+    # include the rotation angle
+    inreg1 = "circle(2,3,3)"
+    inreg2 = "box(1,2,4,5)"
+    s.image_setregion(f"{inreg1};;{inreg2}", coord)
+
+    outreg = s.image_getregion()
+    assert outreg == f"{inreg1};box(1,2,4,5,0);"
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+@pytest.mark.parametrize("coord", ["", "image"])
+def test_image_setregion_file(session, coord, tmp_path):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+
+    inreg = "circle(2,3,3)"
+    regfile = tmp_path / "store.reg"
+    regfile.write_text(inreg)
+
+    s.image_setregion(str(regfile), coord)
+    outreg = s.image_getregion()
+    assert outreg == f"{inreg};"

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -19661,8 +19661,10 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        The XPA access point of the ds9 image viewer lets commands and
-        queries to be sent to the viewer.
+
+        The `XPA access point <https://ds9.si.edu/doc/ref/xpa.html>`_
+        of the ds9 image viewer lets commands and queries to be sent
+        to the viewer.
 
         Examples
         --------
@@ -19677,7 +19679,10 @@ class Session(NoNewAttributesAfterInit):
 
     # DOC-TODO: check the ds9 link when it is working
     # DOC-TODO: is there a link of ds9 commands we can link to?
-    def image_xpaset(self, arg: str, data=None) -> None:
+    def image_xpaset(self,
+                     arg: str,
+                     data: str | bytes | None = None
+                     ) -> None:
         """Return the result of an XPA call to the image viewer.
 
         Send a command to the image viewer.
@@ -19706,9 +19711,10 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        The XPA access point of the ds9 image viewer lets commands and
-        queries to be sent to the viewer.
 
+        The `XPA access point <https://ds9.si.edu/doc/ref/xpa.html>`_
+        of the ds9 image viewer lets commands and queries to be sent
+        to the viewer.
 
         Examples
         --------
@@ -19730,4 +19736,4 @@ class Session(NoNewAttributesAfterInit):
         >>> image_xpaset('saveimage png /tmp/img.png')
 
         """
-        return sherpa.image.Image.xpaset(arg, data)
+        sherpa.image.Image.xpaset(arg, data)


### PR DESCRIPTION
# Summary

Simplify the DS9 initialization code and make DS9 8.7 the minimum suggested version.

# Details

Requires
 - #2462 
 - #2465 
 - #2458 

The aim is to clean up the ds9-related code (extending the clean up from #2458) by dropping unused code and updating to the latest ds9 capabilities.

Changes include

- removing commented-out code
- removing methods unused by Sherpa (e.g. `sherpa.image.DS9.DS9Win.showFITSFile`)
- drop the unused `dataFunc` argument from the "xpa set" calls
- greatly simplify how the `sherpa.image.DS9` module sets things up; this is done in steps rather than all-at-once just to make it easier to follow
  - one of the main improvements is no-longer having to create a subclass of `subprocess.Popen` as there is no benefit for Sherpa to allow DS9 to be installed after a Sherpa session has started
- drop the unused extra arguments to `sherpa.image.DS9.DS9Win.showArray`
- fix a rarely-hit bug when sent uint64 data

One interesting change here is that ds9 8.7 properly supports unsigned int64 images and this commit makes several changes to the "what datatypes are supported" logic. Do we want to "enforce" a minimum ds9 version (in that it's up to the user to update if the display doesn't work, and not that we error out if the ds9 version is too old)? I have decided it is not worth the complexity of code and we just note that DS9 8.7 or later is suggested.n