### PR TITLE
Reorder test information

### DIFF
--- a/.github/scripts/setup_ds9.sh
+++ b/.github/scripts/setup_ds9.sh
@@ -6,7 +6,10 @@
 # would need to identify x86 versus ARM, as well as update the OS).
 #
 
-ds9_base_url=https://ds9.si.edu/download/
+# The download/ version is the "latest" release whereas archive/ includes
+# older releases.
+# ds9_base_url=https://ds9.si.edu/download
+ds9_base_url=https://ds9.si.edu/archive
 
 if [[ "x${CONDA_PREFIX}" == "x" ]];
 then
@@ -15,7 +18,8 @@ then
 fi
 
 if [ "`uname -s`" == "Darwin" ] ; then
-    ds9_os=darwinbigsurx86
+    ds9_os=darwinbigsur
+    ds9_platform=x86
 else
     echo "* installing dev environment"
 
@@ -24,10 +28,14 @@ else
     sudo apt-get install -qq libx11-dev libsm-dev libxrender-dev
 
     # set os-specific variables
-    ds9_os=ubuntu20
+    ds9_os=ubuntu24
+    ds9_platform=x86
 fi
 
 echo "* ds9_os=$ds9_os"
+echo "* ds9_platform=$ds9_platform"
+
+ds9_label=${ds9_os}${ds9_platform}
 
 download () {
   echo "* downloading $1"
@@ -38,12 +46,12 @@ download () {
 }
 
 # Tarballs to fetch
-ds9_tar=ds9.${ds9_os}.8.6.tar.gz
-xpa_tar=xpa.${ds9_os}.2.1.20.tar.gz
+ds9_tar=ds9.${ds9_label}.8.7.tar.gz
+xpa_tar=xpa.${ds9_label}.2.1.20.tar.gz
 
 # Fetch them
-download $ds9_base_url/$ds9_os/$ds9_tar
-download $ds9_base_url/$ds9_os/$xpa_tar
+download $ds9_base_url/$ds9_label/$ds9_tar
+download $ds9_base_url/$ds9_label/$xpa_tar
 
 # untar them; assume $CONDA_PREFIX/bin is in the path
 echo "* unpacking ds9/XPA"

--- a/pytest.ini
+++ b/pytest.ini
@@ -60,28 +60,31 @@ doctest_norecursedirs =
     sherpa/ui
     sherpa/utils
 
+# Some pages need an I/O library, but there is no way to specify
+# "astropy or pycrates", so pick astropy as the more-generic version.
+#
 doctest_subpackage_requires =
+    # code (alphabetical)
+    sherpa/astro/data.py = astropy
     sherpa/astro/io/crates_backend.py = pycrates
     sherpa/astro/io/pyfits_backend.py = astropy
+    sherpa/optmethods/optscipy.py = scipy
+    sherpa/optmethods/optoptimagic.py = optimagic
     sherpa/plot/pylab_backend.py = matplotlib
     sherpa/plot/pylab_area_backend.py = matplotlib
     sherpa/plot/__init__.py = matplotlib
     sherpa/plot/bokeh_backend.py = bokeh
-    sherpa/optmethods/optscipy.py = scipy
-    sherpa/optmethods/optoptimagic.py = optimagic
-    docs/evaluation/simulate.rst = matplotlib astropy
-    docs/mcmc/index.rst = matplotlib
+    # documentation (alphabetical)
+    docs/evaluation/* = matplotlib
+    docs/evaluation/examples.rst = astropy group sherpa.astro.xspec._xspec
+    docs/evaluation/simulate.rst = astropy group
+    docs/fit/* = matplotlib
+    docs/fit/poisson.rst = group
+    docs/mcmc/index.rst = arviz matplotlib
+    docs/models/index.rst = matplotlib
     docs/model_classes/usermodel.rst = matplotlib
     docs/plots/* = matplotlib
-    docs/ui/index.rst = matplotlib
-    docs/models/index.rst = matplotlib
-    docs/quick.rst = matplotlib
-    docs/evaluation/* = matplotlib
-    docs/mcmc/index.rst = arviz
     docs/plots/backends.rst = matplotlib bokeh
     docs/plots/bokeh_backend.rst = bokeh
-    docs/evaluation/examples.rst = group sherpa.astro.xspec._xspec
-    # pycrates OR astropy would do, but the syntax does not allow to specify alternatives, so just pick one
-    docs/evaluation/examples.rst = astropy
-    docs/fit/poisson.rst = group
-    sherpa/astro/data.py = astropy
+    docs/quick.rst = matplotlib
+    docs/ui/index.rst = matplotlib


### PR DESCRIPTION
# Summary

An internal re-organization of testing code. There is no functional change.

# Details

This was first added in #2242 but it is independent of that work.

It requires #2453 just to make the tests pass.

Re-ordering and enforcing some structure makes it easier to see what is and isn't needed. It is, I admit, hardly the most exciting change!