### PR TITLE
Tweak the error message when an xpaget or xpaset command fails

### DIFF
--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2006-2010, 2016-2021, 2025
+#  Copyright (C) 2006-2010, 2016-2021, 2025-2026
 #     Smithsonian Astrophysical Observatory
 #
 #
@@ -277,11 +277,13 @@ def xpaget(cmd, template=_DefTemplate, doRaise=True):
             p.stdin.close()
             errMsg = p.stderr.read()
             if errMsg:
-                fullErrMsg = "%r failed: %s" % (fullCmd, errMsg)
+                errMsgStr = errMsg.decode()
                 if doRaise:
-                    raise RuntimeErr('cmdfail', fullCmd, errMsg)
-                else:
-                    warnings.warn(fullErrMsg)
+                    raise RuntimeErr('cmdfail', fullCmd, errMsgStr)
+
+                fullErrMsg = f"{repr(fullCmd)} failed: {errMsgStr}"
+                warnings.warn(fullErrMsg)
+
             return_value = p.stdout.read()
             return return_value.decode()
         finally:
@@ -338,12 +340,13 @@ def xpaset(cmd, data=None, dataFunc=None, template=_DefTemplate,
             p.stdin.close()
             reply = p.stdout.read()
             if reply:
-                fullErrMsg = "%r failed: %s" % (fullCmd, reply.strip())
+                errMsgStr = reply.strip().decode()
                 if doRaise:
-                    raise RuntimeErr('cmdfail', fullCmd,
-                                     reply.strip())
-                else:
-                    warnings.warn(fullErrMsg)
+                    raise RuntimeErr('cmdfail', fullCmd, errMsgStr)
+
+                fullErrMsg = f"{repr(fullCmd)} failed: {errMsgStr}"
+                warnings.warn(fullErrMsg)
+
         finally:
             p.stdin.close()  # redundant
             p.stdout.close()

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -251,7 +251,7 @@ def test_xpaget_error():
     im = Image()
     im.open()
     command = "not a command"
-    msg = rf"^'xpaget sherpa \"{command}\"' failed: b'XPA\$ERROR " + \
+    msg = rf"^'xpaget sherpa \"{command}\"' failed: XPA\$ERROR " + \
         "undefined command for this xpa "
     with pytest.raises(RuntimeErr, match=msg):
         _ = im.xpaget(command)
@@ -263,7 +263,7 @@ def test_xpaset_error():
     im = Image()
     im.open()
     command = "not a command"
-    msg = rf"^'xpaset -p sherpa \"{command}\"' failed: b'XPA\$ERROR " + \
+    msg = rf"^'xpaset -p sherpa \"{command}\"' failed: XPA\$ERROR " + \
         "undefined command for this xpa "
     with pytest.raises(RuntimeErr, match=msg):
         im.xpaset(command)

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019, 2023
+#  Copyright (C) 2007, 2015-2016, 2017-2019, 2023, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -24,11 +24,13 @@ import pytest
 
 import tempfile
 import os
-import sherpa
+
 from sherpa.image import Image, DataImage, ModelImage, RatioImage, \
     ResidImage
 
+from sherpa.utils.err import DS9Err, RuntimeErr
 from sherpa.utils.testing import requires_ds9
+
 
 # Create a rectangular array for the tests just to ensure that
 # there are no issues with Fortran/C order.
@@ -100,8 +102,8 @@ def get_arr_from_imager(im, yexp):
 
 @requires_ds9
 def test_ds9():
-    ctor = sherpa.image.ds9_backend.DS9.DS9Win
-    im = ctor(sherpa.image.ds9_backend.DS9._DefTemplate, False)
+    from sherpa.image import DS9
+    im = DS9.DS9Win(DS9._DefTemplate, False)
     im.doOpen()
     im.showArray(data.y)
     data_out = get_arr_from_imager(im, data.y)
@@ -233,3 +235,35 @@ def test_image_getregion(coordsys):
     assert float(toks[0]) == pytest.approx(8.5)
     assert float(toks[1]) == pytest.approx(7.0)
     assert float(toks[2]) == pytest.approx(0.8)
+
+
+@requires_ds9
+def test_xpaget_error_not_open():
+    """Check the error is raised."""
+    im = Image()
+    with pytest.raises(DS9Err, match="^Imager not open$"):
+        _ = im.xpaget("not a command")
+
+
+@requires_ds9
+def test_xpaget_error():
+    """Check the error is raised."""
+    im = Image()
+    im.open()
+    command = "not a command"
+    msg = rf"^'xpaget sherpa \"{command}\"' failed: b'XPA\$ERROR " + \
+        "undefined command for this xpa "
+    with pytest.raises(RuntimeErr, match=msg):
+        _ = im.xpaget(command)
+
+
+@requires_ds9
+def test_xpaset_error():
+    """Check the error is raised."""
+    im = Image()
+    im.open()
+    command = "not a command"
+    msg = rf"^'xpaset -p sherpa \"{command}\"' failed: b'XPA\$ERROR " + \
+        "undefined command for this xpa "
+    with pytest.raises(RuntimeErr, match=msg):
+        im.xpaset(command)


### PR DESCRIPTION
# Summary

Tweak the error message created if an xpaget or xpaset call fails.

# Details

Originally from #2458 / #2413 but pulled out as small and self-contained.

We add tests of the error message that is created when a paste of xpaget command fails and then change the messages that we decode the error from the call before including it in the `RuntimeErr` message. This changes the message from

    ..... b'XPA$ERROR ...'

to

    ..... XPA$ERROR ...

It is not huge, but makes the text a bit cleaner to read.

If you look at the test coverage we can see that the `doRaise` is `False` case is not tested. We should remove the `doRaise` flag, as it's never changed by Sherpa (i.e. is always `True`), but that's for a later PR.