### PR TITLE
Reset the title field for new image displays

### DIFF
--- a/sherpa/astro/io/wcs.py
+++ b/sherpa/astro/io/wcs.py
@@ -49,6 +49,11 @@ except ImportError:
         raise RuntimeError("No WCS support")
 
 
+__doctest_requires__ = {
+    '*': ['sherpa.astro.utils._wcs']
+}
+
+
 class WCS(NoNewAttributesAfterInit):
     """Represent a World Coordinate System transformation.
 

--- a/sherpa/astro/ui/tests/test_astro_session_image.py
+++ b/sherpa/astro/ui/tests/test_astro_session_image.py
@@ -243,7 +243,7 @@ def test_get_data_image_dataimg_repeated():
 
     # What is the name field now?
     obj = s.get_data_image()
-    assert obj.name == 'A_big_blob'  # ideally this would be "Data"
+    assert obj.name == 'Data'
 
 
 @requires_ds9

--- a/sherpa/astro/ui/tests/test_astro_session_image.py
+++ b/sherpa/astro/ui/tests/test_astro_session_image.py
@@ -340,7 +340,18 @@ def test_wcs_with_no_wcs(make_data_path, tmp_path, check_str):
 
     cts = wcsfile.read_text()
 
-    lines = []
+    lines = [
+        "WCSAXES =                    2 / Number of WCS axes",
+        "WCSNAME = 'PHYSICAL'           / Reference name for the coord. frame",
+        "CRPIX1  =                  1.0 / Reference pixel on axis 1",
+        "CRPIX2  =                  1.0 / Reference pixel on axis 2",
+        "CRVAL1  =                  1.0 / Value at ref. pixel on axis 1",
+        "CRVAL2  =                  1.0 / Value at ref. pixel on axis 2",
+        "CTYPE1  = 'x       '           / Type of co-ordinate on axis 1",
+        "CTYPE2  = 'y       '           / Type of co-ordinate on axis 2",
+        "CDELT1  =                  1.0 / Pixel size on axis 1",
+        "CDELT2  =                  1.0 / Pixel size on axis 2",
+    ]
 
     expected = [f"{l:80s}" for l in lines] + ["", ""]
     check_str(cts, expected)
@@ -423,7 +434,7 @@ def test_wcs_with_wcs(make_data_path, tmp_path):
 
 @requires_wcs
 @requires_ds9
-def test_read_image_only_sky(tmp_path):
+def test_read_image_only_sky(tmp_path, check_str):
     """Read in an image with "only" physical/sky transform image.
 
     The split between "physical" and "world" coordinate systems is
@@ -457,14 +468,25 @@ def test_read_image_only_sky(tmp_path):
 
     cts = wcsfile.read_text()
 
-    # For now this is easy to check.
+    # This is not as hard to check as test_wcs_with_wcs as we can use
+    # check_str.
     #
     ctslines = cts.split("\n")
-    assert len(ctslines) == 2
 
-    # Ends in two blank lines
-    assert ctslines[-2] == ctslines[-1]
-    assert ctslines[-1] == ""
+    lines = ["WCSAXES =                    2 / Number of WCS axes",
+             "WCSNAME = 'PHYSICAL'           / Reference name for the coord. frame",
+             "CRPIX1  =                  1.0 / Reference pixel on axis 1",
+             "CRPIX2  =                  1.0 / Reference pixel on axis 2",
+             "CRVAL1  =                101.0 / Value at ref. pixel on axis 1",
+             "CRVAL2  =                198.0 / Value at ref. pixel on axis 2",
+             "CTYPE1  = 'x       '           / Type of co-ordinate on axis 1",
+             "CTYPE2  = 'y       '           / Type of co-ordinate on axis 2",
+             "CDELT1  =                  2.0 / Pixel size on axis 1",
+             "CDELT2  =                  4.0 / Pixel size on axis 2"
+             ]
+
+    expected = [f"{l:80s}" for l in lines] + ["", ""]
+    check_str(cts, expected)
 
 
 @requires_wcs
@@ -517,7 +539,17 @@ def test_read_image_only_eqpos(tmp_path, check_str):
              "CTYPE2  = 'DEC--TAN'           / Type of co-ordinate on axis 2",
              "CDELT1  =                 -0.5 / Pixel size on axis 1",
              "CDELT2  =                 0.05 / Pixel size on axis 2",
-             "RADESYS = 'ICRS    '           / Reference frame for RA/DEC values"
+             "RADESYS = 'ICRS    '           / Reference frame for RA/DEC values",
+             "WCSAXESP=                    2 / Number of WCS axes",
+             "WCSNAMEP= 'PHYSICAL'           / Reference name for the coord. frame",
+             "CRPIX1P =                  1.0 / Reference pixel on axis 1",
+             "CRPIX2P =                  1.0 / Reference pixel on axis 2",
+             "CRVAL1P =                  1.0 / Value at ref. pixel on axis 1",
+             "CRVAL2P =                  1.0 / Value at ref. pixel on axis 2",
+             "CTYPE1P = 'x       '           / Type of co-ordinate on axis 1",
+             "CTYPE2P = 'y       '           / Type of co-ordinate on axis 2",
+             "CDELT1P =                  1.0 / Pixel size on axis 1",
+             "CDELT2P =                  1.0 / Pixel size on axis 2"
              ]
 
     expected = [f"{l:80s}" for l in lines] + ["", ""]

--- a/sherpa/astro/ui/tests/test_astro_session_image.py
+++ b/sherpa/astro/ui/tests/test_astro_session_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2022, 2025
+#  Copyright (C) 2022, 2025-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -44,7 +44,8 @@ from sherpa.astro.ui.utils import Session as AstroSession
 from sherpa.astro.data import DataIMG
 
 from sherpa.utils.err import ArgumentTypeErr
-from sherpa.utils.testing import requires_ds9, requires_region
+from sherpa.utils.testing import requires_data, requires_ds9, \
+    requires_region, requires_wcs
 
 
 def example_data():
@@ -197,3 +198,327 @@ def test_ignore2d_image():
     # 47 is from test_notice2d_image
     assert len(d.mask) == FILTER_NTOT
     assert d.mask.sum() == (FILTER_NTOT - FILTER_NSET)
+
+
+@requires_ds9
+def test_get_data_image_dataimg():
+    """Check that the OBJECT keyword is used"""
+
+    from sherpa.image import DataImage
+
+    s = AstroSession()
+    d = example_data()
+    d.header = {"OBJECT": "A big blob", "NOT_OBJ": "foo"}
+    s.set_data(d)
+
+    obj = s.get_data_image()
+    assert isinstance(obj, DataImage)
+    assert obj.name == 'A_big_blob'
+    assert obj.eqpos is None
+    assert obj.sky is None
+
+    assert d.y.ndim == 1
+    y = d.y.reshape((9, 9))
+    assert obj.y == pytest.approx(y)
+
+    # sanity check
+    assert y[2, 5] == pytest.approx(100.0)
+
+
+@requires_ds9
+def test_get_data_image_dataimg_repeated():
+    """If OBJECT is set and then not set, what happens?"""
+
+    s = AstroSession()
+    d = example_data()
+    d.header = {"OBJECT": "A big blob", "NOT_OBJ": "foo"}
+    s.set_data(d)
+
+    # This changes the name field (see test_get_data_image_dataimg)
+    _ = s.get_data_image()
+
+    d = example_data()
+    d.header = {"NOT_OBJ": "foo"}
+    s.set_data(d)
+
+    # What is the name field now?
+    obj = s.get_data_image()
+    assert obj.name == 'A_big_blob'  # ideally this would be "Data"
+
+
+@requires_ds9
+@requires_wcs
+def test_send_wcs(tmp_path, check_str):
+    """Check we can send WCS information to DS9.
+
+    Validating this is awkward and it has revealed some subtle issues
+    with how DS9 interacts with its preference settings (e.g. ICRS vs
+    FK5) that can result in subtle changes. Hence the need to be
+    explicit about the SKY WCS.
+
+    """
+
+    from sherpa.astro.io.wcs import WCS
+
+    s = AstroSession()
+    s.dataspace2d([4, 3])
+
+    # Set the WCS to something that is easy to check when returned
+    # from DS9.
+    #
+    d = s.get_data()
+    d.sky = WCS(type="LINEAR", name="physical", crval=[2000.0, 3000.0],
+                crpix=[0.5, 0.5], cdelt=[2.0, 2.0])
+
+    d.eqpos = WCS(type="WCS", name="world", crval=[50.5, -23.4],
+                  crpix=[2000.0, 3000.0], cdelt=[-0.036, 0.036],
+                  crota=0.0, epoch=2000.0, equinox=2000.0)
+
+    # This needs to call the image method, not just prepare_image
+    s.image_data()
+
+    resp = s.image_xpaget("wcs")
+    assert resp == "wcs\n"
+
+    # Is this the best way to check the WCS info that DS9 has?
+    # Ensure we use ICRS, since the results are slightly different
+    # if the FK5 system is in use.
+    #
+    s.image_xpaset("wcs sky icrs")
+    wcsfile = tmp_path / "test.wcs"
+    s.image_xpaset(f"wcs save {wcsfile}")
+
+    # How much does the output here depend on system info (e.g
+    # numerical precision) and is the order fixed across versions of
+    # DS9?
+    #
+    cts = wcsfile.read_text()
+
+    lines = ["WCSAXES =                    2 / Number of WCS axes",
+             "CRPIX1  =                  0.5 / Reference pixel on axis 1",
+             "CRPIX2  =                  0.5 / Reference pixel on axis 2",
+             "CRVAL1  =                 50.5 / Value at ref. pixel on axis 1",
+             "CRVAL2  =                -23.4 / Value at ref. pixel on axis 2",
+             "CTYPE1  = 'RA---TAN'           / Type of co-ordinate on axis 1",
+             "CTYPE2  = 'DEC--TAN'           / Type of co-ordinate on axis 2",
+             "CDELT1  =               -0.072 / Pixel size on axis 1",
+             "CDELT2  =                0.072 / Pixel size on axis 2",
+             "RADESYS = 'ICRS    '           / Reference frame for RA/DEC values",
+             "WCSAXESP=                    2 / Number of WCS axes",
+             "WCSNAMEP= 'PHYSICAL'           / Reference name for the coord. frame",
+             "CRPIX1P =                  1.0 / Reference pixel on axis 1",
+             "CRPIX2P =                  1.0 / Reference pixel on axis 2",
+             "CRVAL1P =               2001.0 / Value at ref. pixel on axis 1",
+             "CRVAL2P =               3001.0 / Value at ref. pixel on axis 2",
+             "CTYPE1P = 'x       '           / Type of co-ordinate on axis 1",
+             "CTYPE2P = 'y       '           / Type of co-ordinate on axis 2",
+             "CDELT1P =                  2.0 / Pixel size on axis 1",
+             "CDELT2P =                  2.0 / Pixel size on axis 2"
+             ]
+
+    # No idea why the two blank/empty lines
+    expected = [f"{l:80s}" for l in lines] + ["", ""]
+    check_str(cts, expected)
+
+
+# This test should not require the WCS library
+@requires_data
+@requires_ds9
+def test_wcs_with_no_wcs(make_data_path, tmp_path, check_str):
+    """What happens if the image has no WCS?
+
+    """
+
+    infile = make_data_path("img.fits")
+
+    s = AstroSession()
+    s.load_image(infile)
+    s.image_data()
+
+    wcsfile = tmp_path / "img.wcs"
+    s.image_xpaset(f"wcs save {wcsfile}")
+
+    cts = wcsfile.read_text()
+
+    lines = []
+
+    expected = [f"{l:80s}" for l in lines] + ["", ""]
+    check_str(cts, expected)
+
+
+@requires_data
+@requires_wcs
+@requires_ds9
+def test_wcs_with_wcs(make_data_path, tmp_path):
+    """What happens if the image has WCS?
+
+    """
+
+    infile = make_data_path("acisf07999_000N001_r0035_regevt3_srcimg.fits")
+
+    s = AstroSession()
+    s.load_image(infile)
+    s.image_data()
+
+    wcsfile = tmp_path / "img.wcs"
+    s.image_xpaset(f"wcs save {wcsfile}")
+
+    cts = wcsfile.read_text()
+
+    # The output is hard to check because of potential numerical
+    # differences. However, we do not care too much about the actual
+    # contents, so just check we approximately match. This is a
+    # specialized version of the check_str fixture.
+    #
+    lines = [
+        ("WCSAXES", int, 2),
+        ("CRPIX1", float, pytest.approx(1035.189941)),
+        ("CRPIX2", float, pytest.approx(-235.629883)),
+        ("CRVAL1", float, pytest.approx(149.88534733444996)),
+        ("CRVAL2", float, pytest.approx(2.6079504903528972)),
+        ("CTYPE1", str, "'RA---TAN'"),
+        ("CTYPE2", str, "'DEC--TAN'"),
+        ("CDELT1", float, pytest.approx(-1.36666666666671E-4)),
+        ("CDELT2", float, pytest.approx(0.00013666666666667)),
+        ("RADESYS", str, "'ICRS    '"),
+        ("WCSAXESP", int, 2),
+        ("WCSNAMEP", str, "'PHYSICAL'"),
+        ("CRPIX1P", float, pytest.approx(1.0)),
+        ("CRPIX2P", float, pytest.approx(1.0)),
+        ("CRVAL1P", float, pytest.approx(3062.3100585938)),
+        ("CRVAL2P", float, pytest.approx(4333.1298828125)),
+        ("CTYPE1P", str, "'x       '"),
+        ("CTYPE2P", str, "'y       '"),
+        ("CDELT1P", float, pytest.approx(1.0)),
+        ("CDELT2P", float, pytest.approx(1.0))
+    ]
+
+    ctslines = cts.split("\n")
+
+    # Check values then the number of lines
+    for gotval, expval in zip(ctslines, lines):
+        name, typeval, value = expval
+
+        assert gotval[8] == "=", gotval
+        assert gotval[:8].rstrip() == name, gotval
+
+        if typeval == str:
+            assert gotval[10:].startswith(value), (gotval, value)
+        else:
+            # We want to check the first non-string value
+            stripped = gotval[10:].lstrip()
+            idx = stripped.find(" ")
+            strippedval = typeval(stripped[:idx])
+
+            assert strippedval == value, (gotval, value)
+
+    ngot = len(ctslines)
+    nexp = len(lines) + 2
+    assert ngot == nexp
+
+    # Ends in two blank lines
+    assert ctslines[-2] == ctslines[-1]
+    assert ctslines[-1] == ""
+
+
+@requires_wcs
+@requires_ds9
+def test_read_image_only_sky(tmp_path):
+    """Read in an image with "only" physical/sky transform image.
+
+    The split between "physical" and "world" coordinate systems is
+    CIAO specific, so it's awkward to come up with a useful
+    example.
+
+    """
+
+    from sherpa.astro.io.wcs import WCS
+
+    y = np.arange(12)
+    x1, x0 = np.mgrid[1:4, 1:5]
+    img = DataIMG("phyx", x0.flatten(), x1.flatten(), y, shape=(3, 4))
+
+    # Add an OBJECT keyword
+    img.header["OBJECT"] = "x 23"
+
+    # Add a physical transform
+    crval = [100, 196]
+    crpix = [0.5, 0.5]
+    cdelt = [2, 4]
+    sky = WCS("physical", "LINEAR", crval, crpix, cdelt)
+    img.sky = sky
+
+    s = AstroSession()
+    s.set_data(img)
+    s.image_data()
+
+    wcsfile = tmp_path / "img.wcs"
+    s.image_xpaset(f"wcs save {wcsfile}")
+
+    cts = wcsfile.read_text()
+
+    # For now this is easy to check.
+    #
+    ctslines = cts.split("\n")
+    assert len(ctslines) == 2
+
+    # Ends in two blank lines
+    assert ctslines[-2] == ctslines[-1]
+    assert ctslines[-1] == ""
+
+
+@requires_wcs
+@requires_ds9
+def test_read_image_only_eqpos(tmp_path, check_str):
+    """Read in an image with "only" WCS transform image.
+
+    The split between "physical" and "world" coordinate systems is
+    CIAO specific, so it's awkward to come up with a useful
+    example.
+
+    """
+
+    from sherpa.astro.io.wcs import WCS
+
+    y = np.arange(12)
+    x1, x0 = np.mgrid[1:4, 1:5]
+    img = DataIMG("phyx", x0.flatten(), x1.flatten(), y, shape=(3, 4))
+
+    # Add an OBJECT keyword
+    img.header["OBJECT"] = "yy 23-4"
+
+    # Add a world transform
+    crval = [100, -5]
+    crpix = [0.5, 0.5]
+    cdelt = [-0.5, 0.05]
+    eqpos = WCS("world", "WCS", crval, crpix, cdelt)
+    img.eqpos = eqpos
+
+    s = AstroSession()
+    s.set_data(img)
+    s.image_data()
+
+    wcsfile = tmp_path / "img.wcs"
+    s.image_xpaset(f"wcs save {wcsfile}")
+
+    cts = wcsfile.read_text()
+
+    # This is not as hard to check as test_wcs_with_wcs as we can use
+    # check_str.
+    #
+    ctslines = cts.split("\n")
+
+    lines = ["WCSAXES =                    2 / Number of WCS axes",
+             "CRPIX1  =                  0.5 / Reference pixel on axis 1",
+             "CRPIX2  =                  0.5 / Reference pixel on axis 2",
+             "CRVAL1  =                100.0 / Value at ref. pixel on axis 1",
+             "CRVAL2  =                 -5.0 / Value at ref. pixel on axis 2",
+             "CTYPE1  = 'RA---TAN'           / Type of co-ordinate on axis 1",
+             "CTYPE2  = 'DEC--TAN'           / Type of co-ordinate on axis 2",
+             "CDELT1  =                 -0.5 / Pixel size on axis 1",
+             "CDELT2  =                 0.05 / Pixel size on axis 2",
+             "RADESYS = 'ICRS    '           / Reference frame for RA/DEC values"
+             ]
+
+    expected = [f"{l:80s}" for l in lines] + ["", ""]
+    check_str(cts, expected)

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -198,10 +198,16 @@ class DataImage(Image):
         self.eqpos = getattr(data, 'eqpos', None)
         self.sky = getattr(data, 'sky', None)
         header = getattr(data, 'header', None)
-        if header is not None:
-            obj = header.get('OBJECT')
-            if obj is not None:
-                self.name = str(obj).replace(" ", "_")
+
+        # Clear out any previous version.
+        self.name = "Data"
+
+        if header is None:
+            return
+
+        obj = header.get('OBJECT')
+        if obj is not None:
+            self.name = str(obj).replace(" ", "_")
 
     def image(self, shape=None, newframe=False, tile=False):
         Image.image(self, self.y, shape, newframe, tile)

--- a/sherpa/image/ds9_backend.py
+++ b/sherpa/image/ds9_backend.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2016, 2017, 2021  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2016-2017, 2021, 2026
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -17,9 +18,10 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import time
 from os import access, R_OK
+import time
 
+from sherpa.astro.io.wcs import WCS
 from sherpa.utils.err import DS9Err
 
 from . import DS9
@@ -93,54 +95,69 @@ def image(arr, newframe=False, tile=False):
         raise DS9Err('noimage')
 
 
-def _set_wcs(keys):
+def _set_wcs(keys: tuple[WCS | None, WCS | None, str]) -> str:
+    """Convert the settings into a string to send via XPA"""
+
     eqpos, sky, name = keys
 
-    phys = ''
-    wcs = "OBJECT = '%s'\n" % name
-
-    if eqpos is not None:
-        wcrpix = eqpos.crpix
-        wcrval = eqpos.crval
-        wcdelt = eqpos.cdelt
+    # DS9 can be very particular about the WCS settings, so attempt to
+    # set everything to avoid problems with ds9 preference settings.
+    #
+    out = [f"OBJECT = '{name}'"]
 
     if sky is not None:
         pcrpix = sky.crpix
         pcrval = sky.crval
         pcdelt = sky.cdelt
 
-        # join together all strings with a '\n' between each
-        phys = '\n'.join(["WCSNAMEP = 'PHYSICAL'",
-                          "CTYPE1P = 'x       '",
-                          'CRVAL1P = %.14E' % pcrval[0],
-                          'CRPIX1P = %.14E' % pcrpix[0],
-                          'CDELT1P = %.14E' % pcdelt[0],
-                          "CTYPE2P = 'y       '",
-                          'CRVAL2P = %.14E' % pcrval[1],
-                          'CRPIX2P = %.14E' % pcrpix[1],
-                          'CDELT2P = %.14E' % pcdelt[1]])
+        crval = [f'{pcrval[0]:.14E}', f'{pcrval[1]:.14E}']
+        crpix = [f'{pcrpix[0]:.14E}', f'{pcrpix[1]:.14E}']
+        cdelt = [f'{pcdelt[0]:.14E}', f'{pcdelt[1]:.14E}']
 
-        if eqpos is not None:
-            wcdelt = wcdelt * pcdelt
-            wcrpix = (wcrpix - pcrval) / pcdelt + pcrpix
+    else:
+        # Ensure we have the identity transform defined.
+        crval = ['1.0', '1.0']
+        crpix = ['1.0', '1.0']
+        cdelt = ['1.0', '1.0']
+
+    out.extend(['WCSAXESP = 2',
+                "WCSNAMEP = 'PHYSICAL'",
+                "CTYPE1P  = 'x       '",
+                "CTYPE2P  = 'y       '",
+                f'CRVAL1P  = {crval[0]}',
+                f'CRPIX1P  = {crpix[0]}',
+                f'CDELT1P  = {cdelt[0]}',
+                f'CRVAL2P  = {crval[1]}',
+                f'CRPIX2P  = {crpix[1]}',
+                f'CDELT2P  = {cdelt[1]}'])
 
     if eqpos is not None:
-        # join together all strings with a '\n' between each
-        wcs = wcs + '\n'.join(["RADECSYS = 'ICRS    '",
-                               "CTYPE1  = 'RA---TAN'",
-                               'CRVAL1  = %.14E' % wcrval[0],
-                               'CRPIX1  = %.14E' % wcrpix[0],
-                               'CDELT1  = %.14E' % wcdelt[0],
-                               "CTYPE2  = 'DEC--TAN'",
-                               'CRVAL2  = %.14E' % wcrval[1],
-                               'CRPIX2  = %.14E' % wcrpix[1],
-                               'CDELT2  = %.14E' % wcdelt[1]])
 
-    # join the wcs and physical with '\n' between them and at the end
-    return ('\n'.join([wcs, phys]) + '\n')
+        wcrval = eqpos.crval
+        if sky is not None:
+            wcdelt = eqpos.cdelt * sky.cdelt
+            wcrpix = (eqpos.crpix - sky.crval) / sky.cdelt + sky.crpix
+        else:
+            wcdelt = eqpos.cdelt
+            wcrpix = eqpos.crpix
+
+        out.extend(['WCSAXES = 2',
+                    "RADECSYS = 'ICRS    '",
+                    "CTYPE1  = 'RA---TAN'",
+                    "CTYPE2  = 'DEC--TAN'",
+                    f'CRVAL1  = {wcrval[0]:.14E}',
+                    f'CRPIX1  = {wcrpix[0]:.14E}',
+                    f'CDELT1  = {wcdelt[0]:.14E}',
+                    f'CRVAL2  = {wcrval[1]:.14E}',
+                    f'CRPIX2  = {wcrpix[1]:.14E}',
+                    f'CDELT2  = {wcdelt[1]:.14E}'])
+
+    # Ensure the string ends with a new-line
+    out.append('')
+    return '\n'.join(out)
 
 
-def wcs(keys):
+def wcs(keys: tuple[WCS | None, WCS | None, str]) -> None:
 
     if not imager.isOpen():
         raise DS9Err('open')
@@ -148,7 +165,6 @@ def wcs(keys):
     info = _set_wcs(keys)
 
     try:
-        # use stdin to pass the WCS info
         imager.xpaset('wcs replace', info)
     except:
         raise DS9Err('setwcs')

--- a/sherpa/ui/tests/test_ui_image.py
+++ b/sherpa/ui/tests/test_ui_image.py
@@ -38,8 +38,6 @@ in serial.
 
 """
 
-import logging
-
 import numpy as np
 
 import pytest
@@ -50,9 +48,7 @@ from sherpa.astro.ui.utils import Session as AstroSession
 from sherpa.data import Data2D
 from sherpa.models import basic
 
-from sherpa.stats import Chi2Gehrels
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DS9Err, \
-    IdentifierErr
+from sherpa.utils.err import DS9Err
 from sherpa.utils.testing import requires_ds9
 
 
@@ -753,9 +749,7 @@ def test_image_kernel(session):
 @pytest.mark.parametrize("session",
                          [pytest.param(BaseSession, marks=pytest.mark.session),
                           AstroSession])
-@pytest.mark.parametrize("coord", ["", "image"])
-def test_image_getregion_starts_empty(session, coord):
-    from sherpa.image import backend
+def test_image_getregion_starts_empty(session):
 
     s = session()
     d = example_data()
@@ -770,7 +764,6 @@ def test_image_getregion_starts_empty(session, coord):
                          [pytest.param(BaseSession, marks=pytest.mark.session),
                           AstroSession])
 def test_image_setregion_invalid_string(session):
-    from sherpa.image import backend
 
     s = session()
     d = example_data()
@@ -780,7 +773,7 @@ def test_image_setregion_invalid_string(session):
     # "rect" is not part of https://ds9.si.edu/doc/ref/region.html
     reg = "rect(2,3,3,4)"
     with pytest.raises(DS9Err,
-                       match=rf"^Could not use rect\(2,3,3,4\) as a "
+                       match=r"^Could not use rect\(2,3,3,4\) as a "
                        "region or region file$"):
         s.image_setregion(reg)
 
@@ -791,7 +784,6 @@ def test_image_setregion_invalid_string(session):
                           AstroSession])
 @pytest.mark.parametrize("coord", ["", "image"])
 def test_image_setregion_string(session, coord):
-    from sherpa.image import backend
 
     s = session()
     d = example_data()
@@ -810,7 +802,6 @@ def test_image_setregion_string(session, coord):
                           AstroSession])
 @pytest.mark.parametrize("coord", ["", "image"])
 def test_image_setregions_string(session, coord):
-    from sherpa.image import backend
 
     s = session()
     d = example_data()
@@ -833,7 +824,6 @@ def test_image_setregions_string(session, coord):
                           AstroSession])
 @pytest.mark.parametrize("coord", ["", "image"])
 def test_image_setregion_file(session, coord, tmp_path):
-    from sherpa.image import backend
 
     s = session()
     d = example_data()

--- a/sherpa/ui/tests/test_ui_image.py
+++ b/sherpa/ui/tests/test_ui_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2021, 2023
+#  Copyright (C) 2021, 2023, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -51,7 +51,8 @@ from sherpa.data import Data2D
 from sherpa.models import basic
 
 from sherpa.stats import Chi2Gehrels
-from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, IdentifierErr
+from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DS9Err, \
+    IdentifierErr
 from sherpa.utils.testing import requires_ds9
 
 
@@ -97,7 +98,9 @@ def example_psf():
     return psf
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 @pytest.mark.parametrize("shape", [None, (9, 9)])
 def test_load_arrays2d(session, shape):
     """Does load_arrays work with 2D data?"""
@@ -126,7 +129,9 @@ def test_load_arrays2d(session, shape):
         assert got.shape == pytest.approx(shape)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_data_image(session):
     from sherpa.image import DataImage
 
@@ -165,7 +170,9 @@ def test_data_image_show(session, check_str):
                ])
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_model_image(session):
     from sherpa.image import ModelImage
 
@@ -188,7 +195,9 @@ def test_get_model_image(session):
     assert y[3, 3] == pytest.approx(102.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_model_component_image(session):
     from sherpa.image import ComponentModelImage
 
@@ -214,7 +223,9 @@ def test_get_model_component_image(session):
     assert y[3, 3] == pytest.approx(100.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_model_component_image_with_convolution(session):
     """What happens if there's a convolution component in play?"""
 
@@ -249,7 +260,9 @@ def test_get_model_component_image_with_convolution(session):
     assert y[3, 3] == pytest.approx(42.25302)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_source_image(session):
     """Note that here there's no difference of source and model"""
     from sherpa.image import SourceImage
@@ -273,7 +286,9 @@ def test_get_source_image(session):
     assert y[3, 3] == pytest.approx(102.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_source_component_image(session):
     """Note that here there's no difference of source and model"""
     from sherpa.image import ComponentSourceImage
@@ -297,7 +312,9 @@ def test_get_source_component_image(session):
     assert y[3, 3] == pytest.approx(100.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_source_component_image_with_convolution(session):
     """There is a difference thanks to the PSF"""
     from sherpa.image import ComponentSourceImage
@@ -325,7 +342,9 @@ def test_get_source_component_image_with_convolution(session):
     assert y[3, 3] == pytest.approx(100.0)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_resid_image(session):
     from sherpa.image import ResidImage
 
@@ -349,7 +368,9 @@ def test_get_resid_image(session):
     assert y[3, 3] == pytest.approx(-71.0983)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_ratio_image(session):
     from sherpa.image import RatioImage
 
@@ -373,7 +394,9 @@ def test_get_ratio_image(session):
     assert y[3, 3] == pytest.approx(0.302958)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_psf_image(session):
     from sherpa.image import PSFImage
 
@@ -397,7 +420,9 @@ def test_get_psf_image(session):
     assert obj.y == pytest.approx(y)
 
 
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_get_kernel_image(session):
     from sherpa.image import PSFKernelImage
 
@@ -459,7 +484,9 @@ def check_xpa_resid(backend):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_data(session):
     from sherpa.image import backend
 
@@ -474,7 +501,9 @@ def test_image_data(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_model(session):
     from sherpa.image import backend
 
@@ -491,7 +520,9 @@ def test_image_model(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_model_component(session):
     from sherpa.image import backend
 
@@ -508,7 +539,9 @@ def test_image_model_component(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_model_component_with_convolution(session):
     """The convolution component changes the data."""
     from sherpa.image import backend
@@ -529,7 +562,9 @@ def test_image_model_component_with_convolution(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_source(session):
     from sherpa.image import backend
 
@@ -548,7 +583,9 @@ def test_image_source(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_source_component(session):
     from sherpa.image import backend
 
@@ -567,7 +604,9 @@ def test_image_source_component(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_source_component_with_convolution(session):
     """Unlike model, this does not change the component."""
     from sherpa.image import backend
@@ -588,7 +627,9 @@ def test_image_source_component_with_convolution(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_resid(session):
     from sherpa.image import backend
 
@@ -605,7 +646,9 @@ def test_image_resid(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_ratio(session):
     from sherpa.image import backend
 
@@ -624,7 +667,9 @@ def test_image_ratio(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_fit(session):
     from sherpa.image import backend
 
@@ -655,7 +700,9 @@ def test_image_fit(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_psf(session):
     from sherpa.image import backend
 
@@ -678,7 +725,9 @@ def test_image_psf(session):
 
 
 @requires_ds9
-@pytest.mark.parametrize("session", [BaseSession, AstroSession])
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
 def test_image_kernel(session):
     from sherpa.image import backend
 
@@ -698,3 +747,103 @@ def test_image_kernel(session):
     # Check the same reagion as test_image_psf
     grid = '0\n0.166667\n0\n0.166667\n0.166667\n0\n0\n0\n0.166667\n0.166667\n0\n0\n0.166667\n0\n0\n0\n'
     check_xpa(backend, 'data image 4 5 4 4 yes', grid)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+@pytest.mark.parametrize("coord", ["", "image"])
+def test_image_getregion_starts_empty(session, coord):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+    outreg = s.image_getregion()
+    assert outreg == ""
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+def test_image_setregion_invalid_string(session):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+
+    # "rect" is not part of https://ds9.si.edu/doc/ref/region.html
+    reg = "rect(2,3,3,4)"
+    with pytest.raises(DS9Err,
+                       match=rf"^Could not use rect\(2,3,3,4\) as a "
+                       "region or region file$"):
+        s.image_setregion(reg)
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+@pytest.mark.parametrize("coord", ["", "image"])
+def test_image_setregion_string(session, coord):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+
+    inreg = "circle(2,3,3)"
+    s.image_setregion(inreg, coord)
+    outreg = s.image_getregion()
+    assert outreg == f"{inreg};"
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+@pytest.mark.parametrize("coord", ["", "image"])
+def test_image_setregions_string(session, coord):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+
+    # Add a "blank" region, and box gets changed by DS9 to
+    # include the rotation angle
+    inreg1 = "circle(2,3,3)"
+    inreg2 = "box(1,2,4,5)"
+    s.image_setregion(f"{inreg1};;{inreg2}", coord)
+
+    outreg = s.image_getregion()
+    assert outreg == f"{inreg1};box(1,2,4,5,0);"
+
+
+@requires_ds9
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+@pytest.mark.parametrize("coord", ["", "image"])
+def test_image_setregion_file(session, coord, tmp_path):
+    from sherpa.image import backend
+
+    s = session()
+    d = example_data()
+    s.set_data(d)
+    s.image_data()
+
+    inreg = "circle(2,3,3)"
+    regfile = tmp_path / "store.reg"
+    regfile.write_text(inreg)
+
+    s.image_setregion(str(regfile), coord)
+    outreg = s.image_getregion()
+    assert outreg == f"{inreg};"


### PR DESCRIPTION
# Summary

Ensure that the name/title of a DS9 image is reset in case subsequent displayed images do not have the OBJECT field set in their header. Ensure that images with no WCS have an identity transform added when displayed in DS9 to fix #2468.

# Details

This is another PR taken from #2458 / #2413.

First we add some tests. The main one for this PR is in `sherpa/astro/ui/tests/test_astro_session.py::test_get_data_image_dataimg_repeated` but there are also some other tests that were added to improve test coverage when developing the larger-scale changes.

The actual bug fix is that we were taking the `name` field for `DataImage` objects from the header, but not clearing it when a new dataset was loaded. The fix is pretty easy.

We then clean up the code used to send the `WCS` information to DS9 (which includes the OBJECT field) to avoid confusing the type checkers. If there is no WCS data then add in an identity transform for the PHYSICAL system. This is to stop DS9 from creating warning messages from the AST library (these can also be seen if the DS9 session is saved and then restored, and are "not a problem" to Sherpa itself). This is to address #2468. Note that since writing this the latest development build of DS9 has been updated to not print the warning message if the `wcs replace` command is just sent the `OBJECT` keyword but I believe this is still a worthwhile clean up.

I have had discussions with the DS9 maintainer about whether there could be an XPA command to just set the OBJECT keyword but

- that would require a minimum ds9 version for CIAO
- it turns out not to be easy and so is not going to be done