### PR TITLE
Image string serialization

### DIFF
--- a/sherpa/astro/io/wcs.py
+++ b/sherpa/astro/io/wcs.py
@@ -189,7 +189,7 @@ class WCS(NoNewAttributesAfterInit):
                x0: float | ArrayType,
                x1: float | ArrayType
                ) -> tuple[np.float64 | np.ndarray, np.float64 | np.ndarray]:
-        """Convert the output coordinates to the inpyt system.
+        """Convert the output coordinates to the input system.
 
         Parameters
         ----------

--- a/sherpa/astro/io/wcs.py
+++ b/sherpa/astro/io/wcs.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2020, 2021, 2024
+#  Copyright (C) 2008, 2020-2021, 2024, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -25,10 +25,13 @@ This only supports a limited number of 2D transformations.
 """
 
 import logging
+from typing import overload
 
 import numpy as np
 
-from sherpa.utils import NoNewAttributesAfterInit
+from sherpa.utils import NoNewAttributesAfterInit, arr2str
+from sherpa.utils.types import ArrayType
+
 
 warning = logging.getLogger(__name__).warning
 
@@ -38,16 +41,55 @@ except ImportError:
     warning('WCS support is not available')
 
     def pix2world(*args, **kwargs):
+        "Pixel to World Coordinates"
         raise RuntimeError("No WCS support")
 
     def world2pix(*args, **kwargs):
+        "World to Pixel Coordinates"
         raise RuntimeError("No WCS support")
 
 
 class WCS(NoNewAttributesAfterInit):
+    """Represent a World Coordinate System transformation.
 
-    def __init__(self, name, type, crval, crpix, cdelt,
-                 crota=0.0, epoch=2000.0, equinox=2000.0):
+    This does not support all possible astronomical transforms.
+
+    Parameters
+    ----------
+    name
+       The name of the transformation (expected to be "world" or
+       "physical").
+    type
+       The transform type (expected to be one of "LINEAR", "WCS",
+       or "TAN-P").
+    crval
+       The reference point in the output coordinate system (a
+       two-element sequence).
+    crpix
+       The reference point in the input coordinate system (a
+       two-element sequence).
+    cdelt
+       The width and height of a pixel in the output coordinate
+       system (a two-element sequence).
+    crota
+       The rotation of the transformation.
+    epoch
+       The epoch of the transformation (not always used).
+    equinox
+       The equinox of the transformation (not always used).
+
+    """
+
+    def __init__(self,
+                 name: str,
+                 type: str,
+                 crval: ArrayType,
+                 crpix: ArrayType,
+                 cdelt: ArrayType,
+                 crota: float = 0.0,
+                 epoch: float = 2000.0,
+                 equinox: float = 2000.0
+                 ) -> None:
         self.name = name
         self.type = type
         self.crval = np.asarray(crval, dtype=float)
@@ -62,14 +104,10 @@ class WCS(NoNewAttributesAfterInit):
         return f"<{type(self).__name__} Coordinate instance '{self.name}'>"
 
     def __str__(self):
-        def tostr(vals):
-            return np.array2string(vals, separator=',', precision=4,
-                                   suppress_small=False)
-
         val = [self.name,
-               f' crval    = {tostr(self.crval)}',
-               f' crpix    = {tostr(self.crpix)}',
-               f' cdelt    = {tostr(self.cdelt)}']
+               f' crval    = {arr2str(self.crval)}',
+               f' crpix    = {arr2str(self.crpix)}',
+               f' cdelt    = {arr2str(self.cdelt)}']
 
         if self.type == 'WCS':
             val.append(f' crota    = {self.crota:g}')
@@ -78,14 +116,112 @@ class WCS(NoNewAttributesAfterInit):
 
         return '\n'.join(val)
 
-    def apply(self, x0, x1):
-        x0, x1 = pix2world(self.type, x0, x1,
-                           self.crpix, self.crval, self.cdelt,
-                           self.crota, self.equinox, self.epoch)
-        return (x0, x1)
+    @overload
+    def apply(self,
+              x0: float,
+              x1: float
+              ) -> tuple[np.float64, np.float64]:
+        ...
 
-    def invert(self, x0, x1):
-        x0, x1 = world2pix(self.type, x0, x1,
-                           self.crpix, self.crval, self.cdelt,
-                           self.crota, self.equinox, self.epoch)
-        return (x0, x1)
+    @overload
+    def apply(self,
+              x0: ArrayType,
+              x1: ArrayType
+              ) -> tuple[np.ndarray, np.ndarray]:
+        ...
+
+    def apply(self,
+              x0: float | ArrayType,
+              x1: float | ArrayType
+              ) -> tuple[np.float64 | np.ndarray, np.float64 | np.ndarray]:
+        """Convert the input coordinates to the output system.
+
+        Parameters
+        ----------
+        x0
+          Coordinate or coordinates of the first axis.
+        x1
+          Coordinate or coordinates of the second axis (must match the
+          size of x0).
+
+        Returns
+        -------
+        retval
+           The coordinate (or coordinates) of the points in the output
+           system as the two-element tuple (c0, c1). If x0 and x1 are
+           scalars then c0 and c1 will be scalars otherwise they will
+           be arrays.
+
+        Examples
+        --------
+
+        >>> crval = [200, -100]
+        >>> crpix = [5, 10]
+        >>> cdelt = [2, 4]
+        >>> c1 = WCS("physical", "LINEAR", crval, crpix, cdelt)
+        >>> x, y = c1.apply(5, 10)
+        >>> float(x), float(y)
+        (200.0, -100.0)
+        >>> c1.apply([5, 10], [10, 2])
+        (array([200., 210.]), array([-100., -132.]))
+
+        """
+
+        return pix2world(self.type, x0, x1,
+                         self.crpix, self.crval, self.cdelt,
+                         self.crota, self.equinox, self.epoch)
+
+    @overload
+    def invert(self,
+               x0: float,
+               x1: float
+               ) -> tuple[np.float64, np.float64]:
+        ...
+
+    @overload
+    def invert(self,
+               x0: ArrayType,
+               x1: ArrayType
+               ) -> tuple[np.ndarray, np.ndarray]:
+        ...
+
+    def invert(self,
+               x0: float | ArrayType,
+               x1: float | ArrayType
+               ) -> tuple[np.float64 | np.ndarray, np.float64 | np.ndarray]:
+        """Convert the output coordinates to the inpyt system.
+
+        Parameters
+        ----------
+        x0
+          Coordinate or coordinates of the first axis.
+        x1
+          Coordinate or coordinates of the second axis (must match the
+          size of x0).
+
+        Returns
+        -------
+        retval
+           The coordinate (or coordinates) of the points in the input
+           system as the two-element tuple (c0, c1). If x0 and x1 are
+           scalars then c0 and c1 will be scalars otherwise they will
+           be arrays.
+
+        Examples
+        --------
+
+        >>> crval = [200, -100]
+        >>> crpix = [5, 10]
+        >>> cdelt = [2, 4]
+        >>> c1 = WCS("physical", "LINEAR", crval, crpix, cdelt)
+        >>> x, y = c1.invert(200, -100)
+        >>> float(x), float(y)
+        (5.0, 10.0)
+        >>> c1.invert([200, 210], [-100, -132])
+        (array([ 5., 10.]), array([10.,  2.]))
+
+        """
+
+        return world2pix(self.type, x0, x1,
+                         self.crpix, self.crval, self.cdelt,
+                         self.crota, self.equinox, self.epoch)

--- a/sherpa/image/DS9.py
+++ b/sherpa/image/DS9.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2006-2010, 2016-2021, 2025
+#  Copyright (C) 2006-2010, 2016-2021, 2025-2026
 #     Smithsonian Astrophysical Observatory
 #
 #
@@ -277,11 +277,13 @@ def xpaget(cmd, template=_DefTemplate, doRaise=True):
             p.stdin.close()
             errMsg = p.stderr.read()
             if errMsg:
-                fullErrMsg = "%r failed: %s" % (fullCmd, errMsg)
+                errMsgStr = errMsg.decode()
                 if doRaise:
-                    raise RuntimeErr('cmdfail', fullCmd, errMsg)
-                else:
-                    warnings.warn(fullErrMsg)
+                    raise RuntimeErr('cmdfail', fullCmd, errMsgStr)
+
+                fullErrMsg = f"{repr(fullCmd)} failed: {errMsgStr}"
+                warnings.warn(fullErrMsg)
+
             return_value = p.stdout.read()
             return return_value.decode()
         finally:
@@ -338,12 +340,13 @@ def xpaset(cmd, data=None, dataFunc=None, template=_DefTemplate,
             p.stdin.close()
             reply = p.stdout.read()
             if reply:
-                fullErrMsg = "%r failed: %s" % (fullCmd, reply.strip())
+                errMsgStr = reply.strip().decode()
                 if doRaise:
-                    raise RuntimeErr('cmdfail', fullCmd,
-                                     reply.strip())
-                else:
-                    warnings.warn(fullErrMsg)
+                    raise RuntimeErr('cmdfail', fullCmd, errMsgStr)
+
+                fullErrMsg = f"{repr(fullCmd)} failed: {errMsgStr}"
+                warnings.warn(fullErrMsg)
+
         finally:
             p.stdin.close()  # redundant
             p.stdout.close()

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -213,7 +213,7 @@ class ModelImage(Image):
     _fields: list[str] = ["name!", "y", "eqpos!", "sky!"]
     """The fields to include in the string output.
 
-    Names that end in ! are displayed diretly, otherwise they are
+    Names that end in ! are displayed directly, otherwise they are
     passed through NumPy's array2string.
     """
 
@@ -257,7 +257,7 @@ class RatioImage(Image):
     _fields: list[str] = ["name!", "y", "eqpos!", "sky!"]
     """The fields to include in the string output.
 
-    Names that end in ! are displayed diretly, otherwise they are
+    Names that end in ! are displayed directly, otherwise they are
     passed through NumPy's array2string.
     """
 
@@ -292,7 +292,7 @@ class ResidImage(Image):
     _fields: list[str] = ["name!", "y", "eqpos!", "sky!"]
     """The fields to include in the string output.
 
-    Names that end in ! are displayed diretly, otherwise they are
+    Names that end in ! are displayed directly, otherwise they are
     passed through NumPy's array2string.
     """
 

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2016, 2021, 2024
+#  Copyright (C) 2007, 2016, 2021, 2024, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -33,7 +33,7 @@ References
 """
 
 import numpy
-from sherpa.utils import NoNewAttributesAfterInit, bool_cast
+from sherpa.utils import NoNewAttributesAfterInit, bool_cast, display_fields
 
 import logging
 warning = logging.getLogger(__name__).warning
@@ -59,8 +59,15 @@ __all__ = ('Image', 'DataImage', 'ModelImage', 'RatioImage',
 class Image(NoNewAttributesAfterInit):
     """Base class for sending image data to an external viewer."""
 
-    def __init__(self):
-        NoNewAttributesAfterInit.__init__(self)
+    _fields: list[str] = []
+    """The fields to include in the string output.
+
+    Names that end in ! are treated as scalars, otherwise they are
+    passed through NumPy's array2string.
+    """
+
+    def __str__(self) -> str:
+        return display_fields(self, self._fields)
 
     def close():
         """Stop the image viewer."""
@@ -171,22 +178,20 @@ class DataImage(Image):
 
     """
 
+    _fields: list[str] = ["name!", "y", "eqpos!", "sky!"]
+    """The fields to include in the string output.
+
+    Names that end in ! are displayed directly, otherwise they are
+    passed through NumPy's array2string.
+
+    """
+
     def __init__(self):
         self.y = None
         self.eqpos = None
         self.sky = None
         self.name = 'Data'
         Image.__init__(self)
-
-    def __str__(self):
-        y = self.y
-        if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4,
-                                   suppress_small=False)
-        return (('name   = %s\n' % self.name) +
-                ('y      = %s\n' % y) +
-                ('eqpos  = %s\n' % self.eqpos) +
-                ('sky    = %s\n' % self.sky))
 
     def prepare_image(self, data):
         self.y = data.get_img()
@@ -205,22 +210,19 @@ class DataImage(Image):
 
 class ModelImage(Image):
 
+    _fields: list[str] = ["name!", "y", "eqpos!", "sky!"]
+    """The fields to include in the string output.
+
+    Names that end in ! are displayed diretly, otherwise they are
+    passed through NumPy's array2string.
+    """
+
     def __init__(self):
         self.name = 'Model'
         self.y = None
         self.eqpos = None
         self.sky = None
         Image.__init__(self)
-
-    def __str__(self):
-        y = self.y
-        if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4,
-                                   suppress_small=False)
-        return (('name   = %s\n' % self.name) +
-                ('y      = %s\n' % y) +
-                ('eqpos  = %s\n' % self.eqpos) +
-                ('sky    = %s\n' % self.sky))
 
     def prepare_image(self, data, model):
         self.y = data.get_img(model)
@@ -252,22 +254,19 @@ class SourceImage(ModelImage):
 
 class RatioImage(Image):
 
+    _fields: list[str] = ["name!", "y", "eqpos!", "sky!"]
+    """The fields to include in the string output.
+
+    Names that end in ! are displayed diretly, otherwise they are
+    passed through NumPy's array2string.
+    """
+
     def __init__(self):
         self.name = 'Ratio'
         self.y = None
         self.eqpos = None
         self.sky = None
         Image.__init__(self)
-
-    def __str__(self):
-        y = self.y
-        if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4,
-                                   suppress_small=False)
-        return (('name   = %s\n' % self.name) +
-                ('y      = %s\n' % y) +
-                ('eqpos  = %s\n' % self.eqpos) +
-                ('sky    = %s\n' % self.sky))
 
     def _calc_ratio(self, ylist):
         data = numpy.array(ylist[0])
@@ -290,22 +289,19 @@ class RatioImage(Image):
 
 class ResidImage(Image):
 
+    _fields: list[str] = ["name!", "y", "eqpos!", "sky!"]
+    """The fields to include in the string output.
+
+    Names that end in ! are displayed diretly, otherwise they are
+    passed through NumPy's array2string.
+    """
+
     def __init__(self):
         self.name = 'Residual'
         self.y = None
         self.eqpos = None
         self.sky = None
         Image.__init__(self)
-
-    def __str__(self):
-        y = self.y
-        if self.y is not None:
-            y = numpy.array2string(self.y, separator=',', precision=4,
-                                   suppress_small=False)
-        return (('name   = %s\n' % self.name) +
-                ('y      = %s\n' % y) +
-                ('eqpos  = %s\n' % self.eqpos) +
-                ('sky    = %s\n' % self.sky))
 
     def _calc_resid(self, ylist):
         return ylist[0] - ylist[1]

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -251,7 +251,7 @@ def test_xpaget_error():
     im = Image()
     im.open()
     command = "not a command"
-    msg = rf"^'xpaget sherpa \"{command}\"' failed: b'XPA\$ERROR " + \
+    msg = rf"^'xpaget sherpa \"{command}\"' failed: XPA\$ERROR " + \
         "undefined command for this xpa "
     with pytest.raises(RuntimeErr, match=msg):
         _ = im.xpaget(command)
@@ -263,7 +263,7 @@ def test_xpaset_error():
     im = Image()
     im.open()
     command = "not a command"
-    msg = rf"^'xpaset -p sherpa \"{command}\"' failed: b'XPA\$ERROR " + \
+    msg = rf"^'xpaset -p sherpa \"{command}\"' failed: XPA\$ERROR " + \
         "undefined command for this xpa "
     with pytest.raises(RuntimeErr, match=msg):
         im.xpaset(command)

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2017, 2018, 2019, 2023
+#  Copyright (C) 2007, 2015-2016, 2017-2019, 2023, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -24,11 +24,13 @@ import pytest
 
 import tempfile
 import os
-import sherpa
+
 from sherpa.image import Image, DataImage, ModelImage, RatioImage, \
     ResidImage
 
+from sherpa.utils.err import DS9Err, RuntimeErr
 from sherpa.utils.testing import requires_ds9
+
 
 # Create a rectangular array for the tests just to ensure that
 # there are no issues with Fortran/C order.
@@ -100,8 +102,8 @@ def get_arr_from_imager(im, yexp):
 
 @requires_ds9
 def test_ds9():
-    ctor = sherpa.image.ds9_backend.DS9.DS9Win
-    im = ctor(sherpa.image.ds9_backend.DS9._DefTemplate, False)
+    from sherpa.image import DS9
+    im = DS9.DS9Win(DS9._DefTemplate, False)
     im.doOpen()
     im.showArray(data.y)
     data_out = get_arr_from_imager(im, data.y)
@@ -233,3 +235,35 @@ def test_image_getregion(coordsys):
     assert float(toks[0]) == pytest.approx(8.5)
     assert float(toks[1]) == pytest.approx(7.0)
     assert float(toks[2]) == pytest.approx(0.8)
+
+
+@requires_ds9
+def test_xpaget_error_not_open():
+    """Check the error is raised."""
+    im = Image()
+    with pytest.raises(DS9Err, match="^Imager not open$"):
+        _ = im.xpaget("not a command")
+
+
+@requires_ds9
+def test_xpaget_error():
+    """Check the error is raised."""
+    im = Image()
+    im.open()
+    command = "not a command"
+    msg = rf"^'xpaget sherpa \"{command}\"' failed: b'XPA\$ERROR " + \
+        "undefined command for this xpa "
+    with pytest.raises(RuntimeErr, match=msg):
+        _ = im.xpaget(command)
+
+
+@requires_ds9
+def test_xpaset_error():
+    """Check the error is raised."""
+    im = Image()
+    im.open()
+    command = "not a command"
+    msg = rf"^'xpaset -p sherpa \"{command}\"' failed: b'XPA\$ERROR " + \
+        "undefined command for this xpa "
+    with pytest.raises(RuntimeErr, match=msg):
+        im.xpaset(command)

--- a/sherpa/image/tests/test_image.py
+++ b/sherpa/image/tests/test_image.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015-2016, 2017-2019, 2023, 2026
+#  Copyright (C) 2007, 2015-2019, 2023, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #

--- a/sherpa/plot/__init__.py
+++ b/sherpa/plot/__init__.py
@@ -73,7 +73,7 @@ import contextlib
 import copy
 import logging
 import importlib
-from typing import Any, Literal, overload
+from typing import Any, Literal
 
 import numpy as np
 
@@ -85,11 +85,12 @@ from sherpa.optmethods import LevMar, NelderMead
 from sherpa.plot.backends import BaseBackend, BasicBackend, PLOT_BACKENDS
 from sherpa.stats import Stat, Likelihood, LeastSq, Chi2XspecVar
 from sherpa.utils import NoNewAttributesAfterInit, erf, \
-    bool_cast, parallel_map, dataspace1d, histogram1d, get_error_estimates
+    bool_cast, parallel_map, dataspace1d, histogram1d, \
+    get_error_estimates, display_fields
 from sherpa.utils.err import ArgumentTypeErr, ConfidenceErr, \
     IdentifierErr, PlotErr, StatErr
 from sherpa.utils.numeric_types import SherpaFloat
-from sherpa.utils.types import ArrayType, PrefsType
+from sherpa.utils.types import PrefsType
 
 # PLOT_BACKENDS only contains backends in modules that are imported successfully
 # but modules are not discovered by itself. Entrypoints would solve this problem
@@ -400,91 +401,6 @@ def calculate_errors(data: Data,
             warning("%s\nzeros or negative values found", msg)
 
         return None
-
-
-@overload
-def arr2str(x: None) -> None:
-    ...
-
-@overload
-def arr2str(x: ArrayType) -> str:
-    ...
-
-def arr2str(x: ArrayType | None) -> str | None:
-    """Convert an array to a string for __str__ calls
-
-    Parameters
-    ----------
-    x : sequence or None
-
-    Returns
-    -------
-    arrstr : str
-
-    """
-
-    if x is None:
-        return x
-
-    return np.array2string(np.asarray(x), separator=',',
-                           precision=4, suppress_small=False)
-
-
-# This is used in a similar manner to the way that sherpa.data._fields
-# is used to control the string output of the Data objects. We extend
-# that version to allow a decision of whether to display as an array -
-# via arr2str - or as is. Given how our classes are arranged it is not
-# worth trying to share infrastructure between the plot classes and
-# the data classes to handle the similar __str__ handling.
-#
-def display_fields(obj,  # hard to provide an accurate type
-                   fields: Sequence[str]) -> str:
-    """Create the __str__ output for the object.
-
-    Parameters
-    ----------
-    obj
-       The object to convert to a string. It is expected to be
-       derived from one of the plot classes.
-    fields
-       The fields to diplay. A field name ending in ! means display
-       directly, otherwise the value is passed through arr2str.
-
-    Returns
-    -------
-    strval
-       The string representation (one field per line)
-
-    Notes
-    -----
-
-    The default length for the labels is 6 but we check the labels so
-    that a larger value is used if need be (except for any xxx_prefs
-    label, just to better match the original output). This is wasted
-    logic, in that it could be calculated at object creation, but it
-    is not that much work to do here.
-
-    """
-
-    out = []
-    size = 6
-    for lbl in fields:
-        if lbl.endswith('!'):
-            lbl = lbl[:-1]
-            scalar = True
-        else:
-            scalar = False
-
-        val = getattr(obj, lbl)
-        if not scalar:
-            val = arr2str(val)
-
-        out.append((lbl, val))
-        if not lbl.endswith("_prefs"):
-            size = max(size, len(lbl))
-
-    fmt = f"{{:{size}s}} = {{}}"
-    return "\n".join(fmt.format(*vals) for vals in out)
 
 
 class Plot(NoNewAttributesAfterInit):

--- a/sherpa/sim/simulate.py
+++ b/sherpa/sim/simulate.py
@@ -33,9 +33,8 @@ from sherpa.stats import Cash, CStat, WStat
 from sherpa.optmethods import NelderMead
 from sherpa.estmethods import Covariance
 from sherpa.fit import Fit
-from sherpa.plot import arr2str
 from sherpa.sim.sample import NormalParameterSampleFromScaleMatrix
-from sherpa.utils import NoNewAttributesAfterInit
+from sherpa.utils import NoNewAttributesAfterInit, arr2str
 from sherpa.utils.parallel import parallel_map_rng
 from sherpa.utils.random import poisson_noise
 from sherpa.utils.types import ArrayType

--- a/sherpa/ui/tests/test_ui_image.py
+++ b/sherpa/ui/tests/test_ui_image.py
@@ -147,6 +147,24 @@ def test_get_data_image(session):
     assert y[2, 5] == pytest.approx(100.0)
 
 
+@pytest.mark.parametrize("session",
+                         [pytest.param(BaseSession, marks=pytest.mark.session),
+                          AstroSession])
+def test_data_image_show(session, check_str):
+
+    s = session()
+    s.set_data(Data2D('example', [1, 1, 1], [-5, -4, -3], [2, 3, 4],
+                      shape=(1, 3)))
+
+    obj = s.get_data_image()
+    check_str(str(obj),
+              ["name   = Data",
+               "y      = [[2,3,4]]",
+               "eqpos  = None",
+               "sky    = None",
+               ])
+
+
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
 def test_get_model_image(session):
     from sherpa.image import ModelImage

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -34,7 +34,7 @@ import pydoc
 import string
 import sys
 from types import FunctionType, MethodType
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, overload
 import warnings
 
 import numpy as np
@@ -57,6 +57,7 @@ from .guess import _guess_ampl_scale, get_midpoint, get_peak, \
 from .parallel import multi as _multi, ncpus as _ncpus, \
     parallel_map, parallel_map_funcs, run_tasks
 from .random import poisson_noise
+from .types import ArrayType
 
 
 warning = logging.getLogger("sherpa").warning
@@ -1414,6 +1415,87 @@ def print_fields(names: Sequence[str],
             v = str(v)
         lines.append(fmt % (n, v))
     return '\n'.join(lines)
+
+
+@overload
+def arr2str(x: None) -> None:
+    ...
+
+@overload
+def arr2str(x: ArrayType) -> str:
+    ...
+
+def arr2str(x: ArrayType | None) -> str | None:
+    """Convert an array to a string for __str__ calls
+
+    Parameters
+    ----------
+    x : sequence or None
+
+    Returns
+    -------
+    arrstr : str
+
+    """
+
+    if x is None:
+        return x
+
+    return np.array2string(np.asarray(x), separator=',',
+                           precision=4, suppress_small=False)
+
+
+# This is similar to print_fields, but used for plot and image
+# objects.
+#
+def display_fields(obj,  # hard to provide an accurate type
+                   fields: Sequence[str]) -> str:
+    """Create the __str__ output for the object.
+
+    Parameters
+    ----------
+    obj
+       The object to convert to a string. It is expected to be
+       derived from one of the plot classes.
+    fields
+       The fields to diplay. A field name ending in ! means display
+       directly, otherwise the value is passed through arr2str.
+
+    Returns
+    -------
+    strval
+       The string representation (one field per line)
+
+    Notes
+    -----
+
+    The default length for the labels is 6 but we check the labels so
+    that a larger value is used if need be (except for any xxx_prefs
+    label, just to better match the original output). This is wasted
+    logic, in that it could be calculated at object creation, but it
+    is not that much work to do here.
+
+    """
+
+    out = []
+    size = 6
+    for lbl in fields:
+        if lbl.endswith('!'):
+            lbl = lbl[:-1]
+            scalar = True
+        else:
+            scalar = False
+
+        val = getattr(obj, lbl)
+        if not scalar:
+            val = arr2str(val)
+
+        out.append((lbl, val))
+        if not lbl.endswith("_prefs"):
+            size = max(size, len(lbl))
+
+    fmt = f"{{:{size}s}} = {{}}"
+    return "\n".join(fmt.format(*vals) for vals in out)
 
 
 def create_expr(vals, mask=None, format='%s', delim='-'):


### PR DESCRIPTION
# Summary

Rework the image string code to use the same routine as the plot code. Documentation has been added to the WCS class.

# Details

Requires #2461 (not really for this but for follow-on PRs that depend on both).

As the `display_fields` routine is now used in multiple places it, along with `arr2str` are moved to `sherpa.utils`. This requires a little-bit of code shuffling. This code doesn't quite match that used for a number of the UI code structures (`print_fields`) and I do not believe it is worth combining the two as I try to avoid changing the string representation wherever possible (because I know some people/code can rely on a particular layout).

The WCS code is also converted to use this routine, and as part of it some basic documentation and typing is added to the module (it is not directly related to this PR but I have a lot of related PRs and I don't want to break things up too much). This code could be moved into a separate PR if needed.