### PR TITLE
CI: drop manual download of macOS SDK

### DIFF
--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -13,14 +13,6 @@ if [ "`uname -s`" == "Darwin" ] ; then
     fi
     compilers="clang_osx-${sys} clangxx_osx-${sys} gfortran_osx-${sys}"
 
-    #Download the macOS 11.0 SDK to the CONDA_BUILD_SYSROOT location for the Conda Compilers to work
-    mkdir -p ${GITHUB_WORKSPACE}/../11.0SDK
-    wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.0.sdk.tar.xz -O MacOSX11.0.sdk.tar.xz
-    if [[ $? -ne 0 ]]; then
-      echo "macOS 11.0 SDK download failed"
-    fi
-    tar -C ${GITHUB_WORKSPACE}/../11.0SDK -xf MacOSX11.0.sdk.tar.xz
-
 else
     compilers="gcc_linux-64=14.2 gxx_linux-64=14.2 gfortran_linux-64"
 

--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -13,6 +13,14 @@ if [ "`uname -s`" == "Darwin" ] ; then
     fi
     compilers="clang_osx-${sys} clangxx_osx-${sys} gfortran_osx-${sys}"
 
+    #Download the macOS 11.0 SDK to the CONDA_BUILD_SYSROOT location for the Conda Compilers to work
+    mkdir -p ${GITHUB_WORKSPACE}/../11.0SDK
+    wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.0.sdk.tar.xz -O MacOSX11.0.sdk.tar.xz
+    if [[ $? -ne 0 ]]; then
+      echo "macOS 11.0 SDK download failed"
+    fi
+    tar -C ${GITHUB_WORKSPACE}/../11.0SDK -xf MacOSX11.0.sdk.tar.xz
+
     # What SDK is in use?
     #
     echo "*** SDK path: `xcrun --show-sdk-path`"

--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -13,6 +13,12 @@ if [ "`uname -s`" == "Darwin" ] ; then
     fi
     compilers="clang_osx-${sys} clangxx_osx-${sys} gfortran_osx-${sys}"
 
+    # What SDK is in use?
+    #
+    echo "*** SDK path: `xcrun --show-sdk-path`"
+    ls -l `xcrun --show-sdk-path`
+    echo "*** SDK version: `xcrun --show-sdk-version`"
+
 else
     compilers="gcc_linux-64=14.2 gxx_linux-64=14.2 gfortran_linux-64"
 

--- a/.github/scripts/setup_conda.sh
+++ b/.github/scripts/setup_conda.sh
@@ -52,6 +52,6 @@ echo "compilers:    ${compilers}"
 
 # Create and activate conda build environment
 # conda create --yes -n build python"=${PYTHONVER}.*=*cpython*" pip ${MATPLOTLIB} ${BOKEH} ${NUMPY} ${XSPEC} ${FITSBUILD} ${compilers}
-conda create --yes -n build python"=${PYTHONVER}.*" pip ${MATPLOTLIB} ${BOKEH} ${NUMPY} ${XSPEC} ${FITSBUILD} ${compilers}
+conda create --yes --quiet -n build python"=${PYTHONVER}.*" pip ${MATPLOTLIB} ${BOKEH} ${NUMPY} ${XSPEC} ${FITSBUILD} ${compilers}
 
 conda activate build

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -18,7 +18,6 @@ env:
   xspec_channel: "https://cxc.cfa.harvard.edu/conda/test"
   # ensure conda environment is built outside the repository (to
   # avoid errors from meson)
-  CONDA_BUILD_SYSROOT: ${{ github.workspace }}/../11.0SDK/MacOSX11.0.sdk
   conda_loc: ${{ github.workspace }}/../conda_loc
 
 jobs:

--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -39,7 +39,7 @@ jobs:
             test-data: submodule
             matplotlib-version: 3
             bokeh-version: 3
-            xspec-version: 12.14.0i
+            xspec-version: 12.14.0k
 
           - name: MacOS ARM Full Build (Python 3.12)
             os: macos-14
@@ -49,65 +49,7 @@ jobs:
             test-data: submodule
             matplotlib-version: 3
             bokeh-version: 3
-            xspec-version: 12.13.1e
-
-          - name: Linux Minimum Setup (Python 3.11)
-            os: ubuntu-latest
-            python-version: "3.11"
-            numpy-version: "2.3.2"
-            install-type: develop
-            test-data: none
-
-          - name: Linux Minimum Setup (Python 3.12)
-            os: ubuntu-latest
-            python-version: "3.12"
-            numpy-version: "2.3.2"
-            install-type: develop
-            test-data: none
-
-          - name: Linux Full Build (Python 3.13)
-            os: ubuntu-latest
-            python-version: "3.13"
-            install-type: develop
-            fits: astropy
-            test-data: submodule
-            matplotlib-version: 3
-            bokeh-version: 3
-            xspec-version: 12.14.0i
-
-          - name: Linux Full Build (Python 3.12)
-            os: ubuntu-latest
-            python-version: "3.12"
-            install-type: develop
-            fits: astropy
-            test-data: submodule
-            matplotlib-version: 3
-            bokeh-version: 3
-            xspec-version: 12.14.0i
-
-          - name: Linux Full Build (Python 3.11)
-            os: ubuntu-latest
-            python-version: "3.11"
-            install-type: develop
-            fits: astropy
-            test-data: submodule
-            matplotlib-version: 3
-            xspec-version: 12.13.1
-
-          - name: Linux Build (w/o Astropy or Xspec)
-            os: ubuntu-latest
-            python-version: "3.14"
-            install-type: install
-            test-data: package
-            matplotlib-version: 3
-
-          - name: Linux Build (w/o Matplotlib, Xspec, or test data)
-            os: ubuntu-latest
-            python-version: "3.13"
-            numpy-version: "2.3.2"
-            install-type: develop
-            fits: astropy
-            test-data: none
+            xspec-version: 12.14.0k
 
     steps:
     - name: Checkout Code
@@ -262,4 +204,3 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ${{ github.workspace }}/coverage.xml
         verbose: true
-

--- a/.github/workflows/ci-pip-workflow.yml
+++ b/.github/workflows/ci-pip-workflow.yml
@@ -32,44 +32,6 @@ jobs:
             install-type: develop
             test-data: none
 
-          - name: Linux Build (w/o Xspec; Python 3.12)
-            os: ubuntu-latest
-            python-version: "3.12"
-            numpy-pkg: 'numpy'
-            install-type: install
-            test-data: package
-            fits-pkg: 'astropy'
-            matplotlib-pkg: 'matplotlib>=3,<4'
-            bokeh-pkg: 'bokeh>=3,<4'
-            ncores: 1
-
-          - name: Linux Build (w/o Matplotlib, Astropy or Xspec)
-            os: ubuntu-latest
-            python-version: "3.12"
-            numpy-pkg: 'numpy'
-            install-type: install
-            test-data: package
-            optimagic-pkg: 'optimagic'
-
-          - name: Linux Build (w/o Matplotlib, Xspec, or test data)
-            os: ubuntu-latest
-            python-version: "3.11"
-            numpy-pkg: 'numpy'
-            install-type: develop
-            fits-pkg: 'astropy'
-            test-data: none
-
-          - name: Linux Build (submodule data without Xspec)
-            os: ubuntu-latest
-            python-version: "3.13"
-            numpy-pkg: 'numpy'
-            install-type: develop
-            matplotlib-pkg: 'matplotlib>=3,<4'
-            bokeh-pkg: 'bokeh>=3,<4'
-            arviz-pkg: 'arviz>=1.0.0'
-            fits-pkg: 'astropy'
-            test-data: submodule
-
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6


### PR DESCRIPTION
# Summary

Simplify the macOS testing on GitHub. There is no functional change.

# Details

The GitHub runners include a numnber of macOS SDKs, so do we need to download a much-older version for the test builds?

This seems to work. I have not made changes to `ci-conda-deployment.yml` as it's less obvious to me what this workflow is doing.

The macOS GitHub runners do include a number of macOS SDKs - e.g. for [macos-15](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#user-content-installed-sdks) - and we could set the `CONDA*blah*` environment variable to point to one of them, but at least for the test/development workflow I'm not sure it's worth it (at least whilst it doesn't seem to matter). I also note that the SDK previously used was much older than those provided in these runners.