### PR TITLE
Fix matplotlib 3.11 subplots compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,9 +127,3 @@ docs/*.ipynb
 
 # emacs related files
 flycheck*py
-
-# OpenClaw runtime files (agent profiles, memory, sessions)
-MEMORY.md
-main/
-mara/
-agents/

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,9 @@ docs/*.ipynb
 
 # emacs related files
 flycheck*py
+
+# OpenClaw runtime files (agent profiles, memory, sessions)
+MEMORY.md
+main/
+mara/
+agents/

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -32,6 +32,7 @@ correct data; it is more a check that the routines can be called.
 
 import copy
 import logging
+import matplotlib.colors as mcolors
 
 import numpy as np
 
@@ -2080,7 +2081,7 @@ def test_pha1_plot_fit_options(clean_astro_ui, requires_pylab, basic_pha1):
     assert pts.get_color() != 'green'  # option over-ridden
     assert pts.get_linestyle() == '-'
     assert pts.get_marker() == 'None'
-    assert pts.get_markerfacecolor() == '#1f77b4'  # line.get_color()  # option over-ridden
+    assert mcolors.to_hex(pts.get_markerfacecolor()) == '#1f77b4'  # line.get_color()  # option over-ridden
     assert pts.get_markersize() == pytest.approx(6.0)
     assert pts.get_alpha() == pytest.approx(0.7)
 

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -32,7 +32,6 @@ correct data; it is more a check that the routines can be called.
 
 import copy
 import logging
-import matplotlib.colors as mcolors
 
 import numpy as np
 
@@ -2081,7 +2080,10 @@ def test_pha1_plot_fit_options(clean_astro_ui, requires_pylab, basic_pha1):
     assert pts.get_color() != 'green'  # option over-ridden
     assert pts.get_linestyle() == '-'
     assert pts.get_marker() == 'None'
-    assert mcolors.to_hex(pts.get_markerfacecolor()) == '#1f77b4'  # line.get_color()  # option over-ridden
+    # matplotlib 3.11 changed get_markerfacecolor() to return an RGB tuple
+    # instead of a hex string; accept either form for backward compatibility
+    fcolor = pts.get_markerfacecolor()
+    assert fcolor == '#1f77b4' or fcolor == pytest.approx((0.1216, 0.4667, 0.7059), abs=0.01)  # line.get_color()  # option over-ridden
     assert pts.get_markersize() == pytest.approx(6.0)
     assert pts.get_alpha() == pytest.approx(0.7)
 

--- a/sherpa/plot/pylab_backend.py
+++ b/sherpa/plot/pylab_backend.py
@@ -712,7 +712,7 @@ class PylabBackend(BasicBackend):
             ratios[top] = ratio
             gs = {'height_ratios': ratios}
             fig, axes = plt.subplots(nrows, ncols, sharex=True, num=1,
-                                     gridspec_kw=gs)
+                                     gridspec_kw=gs, clear=True)
             fig.subplots_adjust(hspace=0.05)
 
             # Change all but the bottom row. By setting sharex


### PR DESCRIPTION
Closes #2471

matplotlib 3.11 added _raise_if_figure_exists() which throws when
plt.subplots(num=1) is called on an existing figure. The fix is
adding clear=True to destroy and recreate the figure.

There is only one plt.subplots(num=...) call in the codebase
(sherpa/plot/pylab_backend.py:714). The other subplot calls use
plt.subplot (singular) which is unaffected.