### PR TITLE
DOCS: point out we can also use bokeh for visualization

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,6 +6,7 @@ channels:
   - nodefaults
 
 dependencies:
+  - gxx=14.2
   - bison
   - python=3.13
   - numpy

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -42,16 +42,13 @@ if installed:
 
 * :term:`Astropy`: for reading and writing files in
   :term:`FITS` format.
-* :term:`matplotlib`: for visualisation of
+* :term:`matplotlib` or :term:`bokeh`: for visualisation of
   one-dimensional data or models, one- or two- dimensional
   error analysis, and the results of Monte-Carlo Markov Chain
-  runs. There are no known incompatibilities with matplotlib, but there
-  has only been limited testing. Please
-  `report any problems <https://github.com/sherpa/sherpa/issues/>`_
-  you find.
+  runs.
 * `scipy <https://www.scipy.org>`_ for the `sherpa.optmethods.optscipy`
   module, which provides an interface to several optimizers from Scipy.
-* `optimagic <https://optimagic.readthedocs.io>`_ for the 
+* `optimagic <https://optimagic.readthedocs.io>`_ for the
   `sherpa.optmethods.optoptimagic` module which provides an interface to `optimagic.minimize`.
   Optimagic provides a single interface to dozens of optimizers, many of which
   rely on other external packages that need to be `installed separately


### PR DESCRIPTION
# Summary

Update the Read-The-Docs installation page to mention bokeh as well as matplotlib.

# Details

As well as pointing out bokeh remove the "not-well tested" message for matplotlib as that statement has been outdated for many years. Although it's amusing that I wrote this and then matplotlib 3.11 came along and broke things ...

This was found working on #2432 but is completely separate from that work.

There is also a change needed to allow the RTD code to build (by forcing a gcc version older than 15.0 - as noted in #2223). There are alternative fixes that could be made, but this is by far the simplest.