### PR TITLE
Fix links in sphinx documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,8 +126,8 @@ extensions = [
     # Use napoleon over numpydoc for now since it stops a large number
     # of warning messages (about missing links) that I don't have time
     # to investigate.
-    'sphinx.ext.napoleon',
-    # 'numpydoc.numpydoc',
+    # 'sphinx.ext.napoleon',
+    'numpydoc.numpydoc',
     'sphinx.ext.intersphinx',
     'sphinx_astropy.ext.intersphinx_toggle',
     'sphinx_astropy.ext.edit_on_github',
@@ -256,6 +256,7 @@ nbsphinx_prolog = r"""
 napoleon_google_docstring = False
 
 autosummary_generate = True
+numpydoc_class_members_toctree = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,10 +123,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.todo',
     'matplotlib.sphinxext.plot_directive',
-    # Use napoleon over numpydoc for now since it stops a large number
-    # of warning messages (about missing links) that I don't have time
-    # to investigate.
-    # 'sphinx.ext.napoleon',
     'numpydoc.numpydoc',
     'sphinx.ext.intersphinx',
     'sphinx_astropy.ext.intersphinx_toggle',

--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -58,7 +58,7 @@ counts, but it also has to act like an integrated data set
 The `DataIMG` class extends 2D support for "gridded" data, with
 multiple possible coordinate systems (e.g. ``logical``, ``physical``,
 and ``world``).  Along with this, spatial filters can be applied,
-using the CIAO region syntax [REGION]_.
+using the CIAO region syntax [2]_.
 
 Notes
 -----
@@ -76,24 +76,14 @@ Notebook support
 The Data objects support the rich display protocol of IPython, with
 HTML display of a table of information highlighting the relevant data
 and, for some classes, SVG images. Examples can be found at
-[AstroNoteBook]_.
+[1]_.
 
 References
 ----------
 
-.. [AstroNoteBook] https://sherpa.readthedocs.io/en/latest/NotebookSupport.html
+.. [1] https://sherpa.readthedocs.io/en/latest/NotebookSupport.html
 
-.. [OGIP_92_007] "The OGIP Spectral File Format", https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html
-
-.. [OGIP_92_007a] "The OGIP Spectral File Format Addendum: Changes log ", https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007a/ogip_92_007a.html
-
-.. [CAL_92_002] "The Calibration Requirements for Spectral Analysis (Definition of RMF and ARF file formats)", https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html
-
-.. [CAL_92_002a] "The Calibration Requirements for Spectral Analysis Addendum: Changes log", https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002a/cal_gen_92_002a.html
-
-.. [PRIVATE_KA] Private communication with Keith Arnaud
-
-.. [REGION] https://cxc.harvard.edu/ciao/ahelp/dmregions.html
+.. [2] https://cxc.harvard.edu/ciao/ahelp/dmregions.html
 
 Examples
 --------
@@ -908,8 +898,8 @@ class DataOgipResponse(Data1DInt):
 class DataARF(DataOgipResponse):
     """ARF data set.
 
-    The ARF format is described in OGIP documents [CAL_92_002]_ and
-    [CAL_92_002a]_.
+    The ARF format is described in OGIP documents [1]_ and
+    [2]_.
 
     .. versionchanged:: 4.18.0
        The bin_lo and bin_hi columns are now ignored.
@@ -944,6 +934,12 @@ class DataARF(DataOgipResponse):
     There is limited checking that the ARF matches the OGIP standard,
     but as there are cases of released data products that do not follow
     the standard, these checks can not cover all cases.
+
+    References
+    ----------
+    .. [1] "The Calibration Requirements for Spectral Analysis (Definition of RMF and ARF file formats)", https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html
+
+    .. [2] "The Calibration Requirements for Spectral Analysis Addendum: Changes log", https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002a/cal_gen_92_002a.html
 
     """
     _ui_name = "ARF"
@@ -1048,8 +1044,8 @@ class DataARF(DataOgipResponse):
 class DataRMF(DataOgipResponse):
     """RMF data set.
 
-    The RMF format is described in OGIP documents [CAL_92_002]_ and
-    [CAL_92_002a]_.
+    The RMF format is described in OGIP documents [1]_ and
+    [2]_.
 
     Parameters
     ----------
@@ -1078,6 +1074,12 @@ class DataRMF(DataOgipResponse):
     but as there are cases of released data products that do not follow
     the standard, these checks can not cover all cases. If a check fails
     then a warning message is logged.
+
+    References
+    ----------
+    .. [1] "The Calibration Requirements for Spectral Analysis (Definition of RMF and ARF file formats)", https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html
+
+    .. [2] "The Calibration Requirements for Spectral Analysis Addendum: Changes log", https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002a/cal_gen_92_002a.html
 
     """
     _ui_name = "RMF"
@@ -1491,8 +1493,8 @@ def replace_xspecvar_values(src_counts, bkg_counts,
 class DataPHA(Data1D):
     """PHA data set, including any associated instrument and background data.
 
-    The PHA format is described in an OGIP document [OGIP_92_007]_ and
-    [OGIP_92_007a]_.
+    The PHA format is described in an OGIP document [1]_ and
+    [2]_.
 
     .. versionchanged:: 4.18.0
        The bin_lo and bin_hi columns are now ignored. A diagonal RMF
@@ -1555,11 +1557,11 @@ class DataPHA(Data1D):
 
     The handling of the AREASCAl value - whether it is a scalar or
     array - is currently in flux. It is a value that is stored with
-    the PHA file, and the OGIP PHA standard ([OGIP_92_007]_,
-    [OGIP_92_007a]_) describes the observed counts being divided by
+    the PHA file, and the OGIP PHA standard ([1]_,
+    [2]_) describes the observed counts being divided by
     the area scaling before comparison to the model. However, this is
     not valid for Poisson-based statistics, and is also not how XSPEC
-    handles AREASCAL ([PRIVATE_KA]_); the AREASCAL values are used to
+    handles AREASCAL ([3]_); the AREASCAL values are used to
     scale the exposure times instead. The aim is to add this logic to
     the instrument models in `sherpa.astro.instrument`, such as
     `sherpa.astro.instrument.RMFModelPHA`. The area scaling still has
@@ -1568,6 +1570,13 @@ class DataPHA(Data1D):
     used for plots (following XSPEC so as to avoid sharp
     discontinuities where the area-scaling factor changes strongly).
 
+    References
+    ----------
+    .. [1] "The OGIP Spectral File Format", https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html
+
+    .. [2] "The OGIP Spectral File Format Addendum: Changes log ", https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007a/ogip_92_007a.html
+
+    .. [3] private communication with Keith Arnaud
     """
     _fields = ('name', 'channel', 'counts', 'staterror', 'syserror', 'grouping', 'quality')
     _extra_fields = ('exposure', 'backscal', 'areascal', 'grouped', 'subtracted', 'units', 'rate',
@@ -1971,7 +1980,7 @@ will be removed. The identifiers can be integers or strings.
 
         A group is indicated by a sequence of flag values starting
         with ``1`` and then ``-1`` for all the channels in the group,
-        following [OGIP_92_007]_.  The grouping array must match the
+        following [1]_.  The grouping array must match the
         number of channels and it will be converted to an integer type
         if necessary.
 
@@ -1988,6 +1997,10 @@ will be removed. The identifiers can be integers or strings.
         See Also
         --------
         group, grouped, quality
+
+        References
+        ----------
+        .. [1] "The OGIP Spectral File Format", https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html
 
         """
         return self._grouping
@@ -2040,7 +2053,7 @@ will be removed. The identifiers can be integers or strings.
 
         A quality value of 0 indicates a good channel, otherwise
         (values >=1) the channel is considered bad and can be excluded
-        using the `ignore_bad` method, as discussed in [OGIP_92_007]_. The
+        using the `ignore_bad` method, as discussed in [1]_. The
         quality array must match the number of channels and it will be
         converted to an integer type if necessary.
 
@@ -2052,6 +2065,9 @@ will be removed. The identifiers can be integers or strings.
         --------
         group, grouping
 
+        References
+        ----------
+        .. [1] "The OGIP Spectral File Format", https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html
         """
         return self._quality
 
@@ -3087,7 +3103,7 @@ It is an integer or string.
     def get_backscal(self, group=True, filter=False):
         """Return the background scaling of the PHA data set.
 
-        Return the BACKSCAL setting [OGIP_92_007]_ for the PHA data
+        Return the BACKSCAL setting [1]_ for the PHA data
         set.
 
         Parameters
@@ -3125,6 +3141,10 @@ It is an integer or string.
         >>> pha.get_backscal()
         2.5264364698914e-06
 
+        References
+        ----------
+        .. [1] "The OGIP Spectral File Format", https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html
+
         """
         if self.backscal is None:
             return None
@@ -3134,7 +3154,7 @@ It is an integer or string.
     def get_areascal(self, group=True, filter=False):
         """Return the fractional area factor of the PHA data set.
 
-        Return the AREASCAL setting [OGIP_92_007]_ for the PHA data
+        Return the AREASCAL setting [1]_ for the PHA data
         set.
 
         Parameters
@@ -3165,6 +3185,10 @@ It is an integer or string.
         >>> pha = read_pha(data_3c273 + '3c273.pi')
         >>> pha.get_areascal()
         1.0
+
+        References
+        ----------
+        .. [1] "The OGIP Spectral File Format", https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html
 
         """
         if self.areascal is None:
@@ -5234,8 +5258,8 @@ It is an integer or string.
         ylabel : str
             Label for the y axis that describes the current settings for the analysis
 
-        Example
-        -------
+        Examples
+        --------
         In this example, we first set up some data and a model, then we bin and filter
         as we would with a real dataset and retrieve the values.
         For this example, we load a datafile that is included in the Sherpa code. The

--- a/sherpa/astro/models/__init__.py
+++ b/sherpa/astro/models/__init__.py
@@ -632,7 +632,7 @@ class Voigt1D(RegriddableModel1D):
     """One dimensional Voigt profile.
 
     The Voigt profile is a convolution between a Gaussian distribution
-    a Cauchy-Lorentz distribution [Voigt_1912]_, [wiki_voigt]_. It is often used in
+    a Cauchy-Lorentz distribution [1]_, [2]_. It is often used in
     analyzing spectroscopy data.
 
     .. versionadded:: 4.12.2
@@ -654,11 +654,11 @@ class Voigt1D(RegriddableModel1D):
 
     Notes
     -----
-    Following [wiki_voigt]_, the Voigt profile can be written as::
+    Following [2]_, the Voigt profile can be written as::
 
         f(x) = ampl * Re[w(z)] / (sqrt(2 * PI) * sigma)
 
-    where Re[w(z)] is the real part of the Faddeeva function [wiki_faddeeva]_
+    where Re[w(z)] is the real part of the Faddeeva function [3]_
     and sigma and gamma are parameters of the Gaussian and
     Lorentzian model respectively::
 
@@ -672,7 +672,7 @@ class Voigt1D(RegriddableModel1D):
 
         fwhm_l = fwhm_g / sqrt(2 * log(2))
 
-    An approximation for the FWHM of the profile, taken from [wiki_voigt]_,
+    An approximation for the FWHM of the profile, taken from [2]_,
     is
 
         0.5346 fwhm_l + sqrt(0.2166 fwhm_l^2 + fwhm_g^2)
@@ -680,11 +680,11 @@ class Voigt1D(RegriddableModel1D):
     References
     ----------
 
-    .. [Voigt_1912] https://publikationen.badw.de/de/003395768
+    .. [1] https://publikationen.badw.de/de/003395768
 
-    .. [wiki_voigt] https://en.wikipedia.org/wiki/Voigt_profile
+    .. [2] https://en.wikipedia.org/wiki/Voigt_profile
 
-    .. [wiki_faddeeva] https://en.wikipedia.org/wiki/Faddeeva_function
+    .. [3] https://en.wikipedia.org/wiki/Faddeeva_function
 
     Examples
     --------

--- a/sherpa/astro/models/__init__.py
+++ b/sherpa/astro/models/__init__.py
@@ -583,9 +583,9 @@ class Lorentz1D(RegriddableModel1D):
     -----
     The functional form of the model for points is::
 
-        f(x) =              ampl * fwhm
-               --------------------------------------
-               2 * pi * (0.25 * fwhm^2 + (x - pos)^2)
+        f(x) = ampl * fwhm / denom(x)
+
+        denom(x) = 2 * pi * (0.25 * fwhm^2 + (x - pos)^2)
 
     and for an integrated grid it is the integral of this over
     the bin.
@@ -838,7 +838,7 @@ class PseudoVoigt1D(RegriddableModel1D):
 class NormBeta1D(RegriddableModel1D):
     """One-dimensional normalized beta model function.
 
-    This is the same model as the ``Beta1D`` model but with a
+    This is the same model as the `Beta1D` model but with a
     different slope parameter and normalisation.
 
     Attributes
@@ -989,9 +989,11 @@ class Beta2D(RegriddableModel2D):
 
         f(x0,x1) = ampl * (1 + r(x0,x1)^2)^(-alpha)
 
-        r(x0,x1)^2 = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
-                     -------------------------------------------
-                                  r0^2 * (1-ellip)^2
+        r(x0,x1)^2 = num(x0,x1) / denom(x0,x1)
+
+        num(x0,x1) = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
+
+        denom(x0,x1) = r0^2 * (1-ellip)^2
 
         xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
 
@@ -1054,7 +1056,7 @@ class DeVaucouleurs2D(RegriddableModel2D):
 
     A spatial de Vaucouleurs profile which is a formulation of the
     R^(1/4) law introduced by [1]_. It is a special case of the
-    ``Sersic2D`` model with ``n=4``, as described in [2]_, [3]_,
+    `Sersic2D` model with ``n=4``, as described in [2]_, [3]_,
     and [4]_.
 
     Attributes
@@ -1079,7 +1081,7 @@ class DeVaucouleurs2D(RegriddableModel2D):
 
     Notes
     -----
-    The model used is the same as the ``Sersic2D`` model with ``n=4``.
+    The model used is the same as the `Sersic2D` model with ``n=4``.
 
     References
     ----------
@@ -1161,9 +1163,11 @@ class HubbleReynolds(RegriddableModel2D):
 
         f(x0,x1) = ampl / (1 + r(x0,x1))^2
 
-        r(x0,x1)^2 = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
-                     -------------------------------------------
-                                  r0^2 * (1-ellip)^2
+        r(x0,x1)^2 = num(x0,x1) / denom(x0,x1)
+
+        num(x0,x1) = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
+
+        denom(x0,x1) = r0^2 * (1-ellip)^2
 
         xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
 
@@ -1248,9 +1252,11 @@ class Lorentz2D(RegriddableModel2D):
 
         f(x0,x1) = ampl / (1 + 4 * r(x0,x1)^2)
 
-        r(x0,x1)^2 = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
-                     -------------------------------------------
-                                 fwhm^2 * (1-ellip)^2
+        r(x0,x1)^2 = num(x0,x1) / denom(x0,x1)
+
+        num(x0,x1) = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
+
+        denom(x0,x1) = fwhm^2 * (1-ellip)^2
 
         xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
 
@@ -1410,7 +1416,7 @@ class JDPileup(RegriddableModel1D):
 class Sersic2D(RegriddableModel2D):
     """Two-dimensional Sersic model.
 
-    This is a generalization of the ``DeVaucouleurs2D`` model,
+    This is a generalization of the `DeVaucouleurs2D` model,
     in which the exponent ``n`` can vary ([1]_, [2]_, and [3]_).
 
     Attributes
@@ -1429,7 +1435,7 @@ class Sersic2D(RegriddableModel2D):
     ampl
         The amplitude refers to the maximum peak of the model.
     n
-        The Sersic index (n=4 replicates the ``DeVaucouleurs2D``
+        The Sersic index (n=4 replicates the `DeVaucouleurs2D`
         model).
 
     See Also
@@ -1445,13 +1451,15 @@ class Sersic2D(RegriddableModel2D):
 
             b(n) = 2 * n - 1 / 3 + 4 / (405 * n) + 46 / (25515 * n^2)
 
-        r(x0,x1)^2 = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
-                     -------------------------------------------
-                                  r0^2 * (1-ellip)^2
+        r(x0,x1)^2 = num(x0,x1) / denom(x0,x1)
 
-        xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
+        num(x0,x1) = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
 
-        yoff(x0,x1) = (x1 - ypos) * cos(theta) - (x0 - xpos) * sin(theta)
+        denom(x0,x1) = r0^2 * (1-ellip)^2
+
+         xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
+
+         yoff(x0,x1) = (x1 - ypos) * cos(theta) - (x0 - xpos) * sin(theta)
 
     The grid version is evaluated by adaptive multidimensional
     integration scheme on hypercubes using cubature rules, based

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -4372,7 +4372,7 @@ class Session(sherpa.ui.utils.Session):
         References
         ----------
 
-        `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
+        .. [1] `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
 
         Examples
         --------
@@ -4522,7 +4522,7 @@ class Session(sherpa.ui.utils.Session):
         References
         ----------
 
-        `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
+        .. [1] `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
 
 
         Examples
@@ -8539,7 +8539,7 @@ class Session(sherpa.ui.utils.Session):
         References
         ----------
 
-        `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
+        .. [1] `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
 
         Examples
         --------
@@ -8642,7 +8642,7 @@ class Session(sherpa.ui.utils.Session):
         References
         ----------
 
-        `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
+        .. [1] `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
 
         Examples
         --------
@@ -8721,7 +8721,7 @@ class Session(sherpa.ui.utils.Session):
         References
         ----------
 
-        `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
+        .. [1] `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
 
         Examples
         --------
@@ -8795,7 +8795,7 @@ class Session(sherpa.ui.utils.Session):
         References
         ----------
 
-        `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
+        .. [1] `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
 
         Examples
         --------
@@ -8882,7 +8882,7 @@ class Session(sherpa.ui.utils.Session):
         References
         ----------
 
-        `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
+        .. [1] `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
 
         Examples
         --------
@@ -8968,7 +8968,7 @@ class Session(sherpa.ui.utils.Session):
         References
         ----------
 
-        `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
+        .. [1] `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
 
         Examples
         --------
@@ -11111,8 +11111,8 @@ class Session(sherpa.ui.utils.Session):
                            etable=False) -> None:
         """Load a XSPEC table model.
 
-        Create an additive ('atable', [1]), multiplicative
-        ('mtable', [2]), or exponential ('etable', [3]) XSPEC
+        Create an additive ('atable', [1]_), multiplicative
+        ('mtable', [2]_), or exponential ('etable', [3]_) XSPEC
         table model component. These models may have multiple model
         parameters.
 
@@ -11131,7 +11131,7 @@ class Session(sherpa.ui.utils.Session):
            The identifier for this model component.
         filename : str
            The name of the FITS file containing the data, which should
-           match the XSPEC table model definition [4].
+           match the XSPEC table model definition [4]_.
         etable : bool, optional
            Set if this is an etable (as there's no way to determine this
            from the file itself). Defaults to False.
@@ -11165,13 +11165,13 @@ class Session(sherpa.ui.utils.Session):
         References
         ----------
 
-        1. https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelAtable.html
+        .. [1] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelAtable.html
 
-        2. https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelMtable.html
+        .. [2] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelMtable.html
 
-        3. https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelEtable.html
+        .. [3] https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmodelEtable.html
 
-        4. `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
+        .. [4] `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
 
         Examples
         --------
@@ -16945,7 +16945,7 @@ class Session(sherpa.ui.utils.Session):
                    bkg_id: IdType | None = None):
         """Calculate the K correction for a model.
 
-        The K correction ([1], [2], [3], [4]) is the numeric
+        The K correction ([1]_, [2]_, [3]_, [4]_) is the numeric
         factor applied to measured energy fluxes in an observed
         energy band to estimate the flux in a given rest-frame
         energy band. It accounts for the change in spectral energy
@@ -17009,16 +17009,16 @@ class Session(sherpa.ui.utils.Session):
         References
         ----------
 
-        1. `"The K correction", Hogg, D.W., et al. <https://arxiv.org/abs/astro-ph/0210394>`_
+        .. [1] `"The K correction", Hogg, D.W., et al. <https://arxiv.org/abs/astro-ph/0210394>`_
 
-        2. `Appendix B of Jones et al. 1998, ApJ, vol 495,
+        .. [2] `Appendix B of Jones et al. 1998, ApJ, vol 495,
            p. 100-114 <https://adsabs.harvard.edu/abs/1998ApJ...495..100J>`_
 
-        3. `"K and evolutionary corrections from UV to IR",
+        .. [3] `"K and evolutionary corrections from UV to IR",
            Poggianti, B.M., A&AS, 1997, vol 122, p. 399-407.
            <https://adsabs.harvard.edu/abs/1997A%26AS..122..399P>`_
 
-        4. `"Galactic evolution and cosmology - Probing the
+        .. [4] `"Galactic evolution and cosmology - Probing the
            cosmological deceleration parameter", Yoshii, Y. &
            Takahara, F., ApJ, 1988, vol 326, p. 1-18.
            <https://adsabs.harvard.edu/abs/1988ApJ...326....1Y>`_

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -4369,11 +4369,6 @@ class Session(sherpa.ui.utils.Session):
         only the ratio of source and background BACKSCAL values is
         used. It can be a scalar or be an array.
 
-        References
-        ----------
-
-        .. [1] `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
-
         Examples
         --------
 
@@ -4518,12 +4513,6 @@ class Session(sherpa.ui.utils.Session):
         -----
         The fractional area scale is normally set to 1, with the ARF used
         to scale the model.
-
-        References
-        ----------
-
-        .. [1] `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
-
 
         Examples
         --------
@@ -8536,11 +8525,6 @@ class Session(sherpa.ui.utils.Session):
         The ``grouped`` field of a PHA data set is set to ``True`` when
         the data is grouped.
 
-        References
-        ----------
-
-        .. [1] `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
-
         Examples
         --------
 
@@ -8635,9 +8619,10 @@ class Session(sherpa.ui.utils.Session):
         they are interpreted as the `id` and `val` parameters,
         respectively.
 
-        The meaning of the grouping column is taken from the OGIP standard, which says
-        that +1 indicates the start of a bin, -1 if the channel is part
-        of group, and 0 if the data grouping is undefined for all channels.
+        The meaning of the grouping column is taken from the OGIP
+        standard [1]_, which says that +1 indicates the start of a
+        bin, -1 if the channel is part of group, and 0 if the data
+        grouping is undefined for all channels.
 
         References
         ----------
@@ -8714,9 +8699,10 @@ class Session(sherpa.ui.utils.Session):
 
         Notes
         -----
-        The meaning of the grouping column is taken from the OGIP standard which says
-        that +1 indicates the start of a bin, -1 if the channel is part
-        of group, and 0 if the data grouping is undefined for all channels.
+        The meaning of the grouping column is taken from the OGIP
+        standard [1]_, which says that +1 indicates the start of a
+        bin, -1 if the channel is part of group, and 0 if the data
+        grouping is undefined for all channels.
 
         References
         ----------
@@ -8786,11 +8772,11 @@ class Session(sherpa.ui.utils.Session):
         they are interpreted as the `id` and `val` parameters,
         respectively.
 
-        The meaning of the quality column is taken from the OGIP standard, which says
-        that 0 indicates a "good" channel, 1 and 2 are for channels that
-        are identified as "bad" or "dubious" (respectively) by software,
-        5 indicates a "bad" channel set by the user, and values of 3 or 4
-        are not used.
+        The meaning of the quality column is taken from the OGIP
+        standard [1]_, which says that 0 indicates a "good" channel, 1
+        and 2 are for channels that are identified as "bad" or
+        "dubious" (respectively) by software, 5 indicates a "bad"
+        channel set by the user, and values of 3 or 4 are not used.
 
         References
         ----------
@@ -8873,11 +8859,11 @@ class Session(sherpa.ui.utils.Session):
 
         Notes
         -----
-        The meaning of the quality column is taken from the OGIP standard, which says
-        that 0 indicates a "good" channel, 1 and 2 are for channels that
-        are identified as "bad" or "dubious" (respectively) by software,
-        5 indicates a "bad" channel set by the user, and values of 3 or 4
-        are not used.
+        The meaning of the quality column is taken from the OGIP
+        standard [1]_, which says that 0 indicates a "good" channel, 1
+        and 2 are for channels that are identified as "bad" or
+        "dubious" (respectively) by software, 5 indicates a "bad"
+        channel set by the user, and values of 3 or 4 are not used.
 
         References
         ----------
@@ -8964,11 +8950,6 @@ class Session(sherpa.ui.utils.Session):
         If subtracting the background estimate from a data set, the
         grouping applied to the source data set is used for both
         source and background data sets.
-
-        References
-        ----------
-
-        .. [1] `K. A. Arnaud, I. M. George & A. F. Tennant, "The OGIP Spectral File Format" <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/ogip_92_007.html>`_
 
         Examples
         --------
@@ -9838,18 +9819,20 @@ class Session(sherpa.ui.utils.Session):
 
         The equation for the subtraction is::
 
-           src_counts - bg_counts * (src_exposure * src_backscal)
-                                    -----------------------------
-                                     (bg_exposure * bg_backscal)
+           src_counts - bkg_counts * src_scale / bkg_scale
 
-        where src_exposure and bg_exposure are the source and
-        background exposure times, and src_backscal and bg_backscal
+           src_scale = src_exposure * src_backscal
+
+           bkg_scale = bkg_exposure * bkg_backscal
+
+        where src_exposure and bkg_exposure are the source and
+        background exposure times, and src_backscal and bkg_backscal
         are the source and background backscales.  The backscale, read
         from the ``BACKSCAL`` header keyword of the `PHA file
         <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/node5.html>`_,
         is the ratio of data extraction area to total detector area.
 
-        The ``subtracted`` field of a dataset is set to ``True`` when
+        The ``subtracted`` field of a dataset is set to `True` when
         the background is subtracted.
 
         Examples

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -93,12 +93,12 @@ Notebook support
 
 The Data objects support the rich display protocol of IPython, with
 HTML display of a table of information highlighting the relevant data.
-Examples can be found at [NoteBook]_.
+Examples can be found at [1]_.
 
 References
 ----------
 
-.. [NoteBook] https://sherpa.readthedocs.io/en/latest/NotebookSupport.html
+.. [1] https://sherpa.readthedocs.io/en/latest/NotebookSupport.html
 
 Examples
 --------
@@ -1772,7 +1772,7 @@ class Data1D(Data):
         .. versionadded:: 4.17.0
 
         Parameters
-        -------
+        ----------
         label : str
            The new label.
 
@@ -2531,7 +2531,7 @@ class Data2D(Data):
         .. versionadded:: 4.17.0
 
         Parameters
-        -------
+        ----------
         label: str
 
         See Also
@@ -2547,7 +2547,7 @@ class Data2D(Data):
         .. versionadded:: 4.17.0
 
         Parameters
-        -------
+        ----------
         label: str
 
         See Also

--- a/sherpa/estmethods/__init__.py
+++ b/sherpa/estmethods/__init__.py
@@ -342,11 +342,10 @@ class Confidence(EstMethod):
         .. versionchanged:: 4.17.1
            All arguments other than statfunc and fitfunc are now
            keyword-only.
+
         Notes
         -----
         The statargs and statkwargs arguments are currently unused.
-
-
         """
 
         if statargs is not None or statkwargs is not None:

--- a/sherpa/image/__init__.py
+++ b/sherpa/image/__init__.py
@@ -20,15 +20,15 @@
 
 """Support image display with an external display tool.
 
-At present the only supported application is DS9 [DS9]_, which is
-connected to via XPA [XPA]_.
+At present the only supported application is DS9 [1]_, which is
+connected to via XPA [2]_.
 
 References
 ----------
 
-..  [DS9] SAOImageDS9, "An image display and visualization tool for astronomical data", https://ds9.si.edu/
+.. [1] SAOImageDS9, "An image display and visualization tool for astronomical data", https://ds9.si.edu/
 
-..  [XPA] "The XPA Messaging System", https://github.com/ericmandel/xpa
+.. [2] "The XPA Messaging System", https://github.com/ericmandel/xpa
 
 """
 

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2016, 2018-2025
+#  Copyright (C) 2010, 2016, 2018-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1516,7 +1516,7 @@ class Gauss2D(RegriddableModel2D):
 
     The grid version is evaluated by adaptive multidimensional
     integration scheme on hypercubes using cubature rules, based
-    on code from HIntLib ([1]_) and GSL ([2]_).
+    on code from HIntLib [1]_ and GSL [2]_.
 
     References
     ----------
@@ -1605,7 +1605,7 @@ class SigmaGauss2D(Gauss2D):
 
     The grid version is evaluated by adaptive multidimensional
     integration scheme on hypercubes using cubature rules, based
-    on code from HIntLib ([1]_) and GSL ([2]_).
+    on code from HIntLib [1]_ and GSL [2]_.
 
     References
     ----------
@@ -1692,7 +1692,7 @@ class NormGauss2D(RegriddableModel2D):
 
     The grid version is evaluated by adaptive multidimensional
     integration scheme on hypercubes using cubature rules, based
-    on code from HIntLib ([1]_) and GSL ([2]_).
+    on code from HIntLib [1]_ and GSL [2]_.
 
     References
     ----------

--- a/sherpa/models/basic.py
+++ b/sherpa/models/basic.py
@@ -752,9 +752,11 @@ class NormGauss1D(RegriddableModel1D):
     -----
     The functional form of the model for points is::
 
-        f(x) = ampl * exp(-4 * log(2) * (x - pos)^2 / fwhm^2)
-               ----------------------------------------------
-                       sqrt(pi / (4 * log(2))) * fwhm
+        f(x) = num(x) / denom(x)
+
+        num(x) = ampl * exp(-4 * log(2) * (x - pos)^2 / fwhm^2)
+
+        denom(x) = sqrt(pi / (4 * log(2))) * fwhm
 
     and for an integrated grid it is the integral of this over
     the bin.
@@ -1506,9 +1508,9 @@ class Gauss2D(RegriddableModel2D):
 
         f(x0,x1) = ampl * exp(-4 * log(2) * r(x0,x1)^2)
 
-        r(x0,x1)^2 = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
-                     -------------------------------------------
-                                fwhm^2 * (1-ellip)^2
+        r(x0,x1)^2 = num(x0,x1) / (fwhm^2 * (1-ellip)^2)
+
+        num(x0,x1) = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
 
         xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
 
@@ -1678,13 +1680,15 @@ class NormGauss2D(RegriddableModel2D):
     -----
     The functional form of the model for points is::
 
-        f(x0,x1) = 4 * log(2) * ampl * exp(-4 * log(2) * r(x0,x1)^2)
-                   -------------------------------------------------
-                       pi * fwhm * fwhm * sqrt(1 - ellip * ellip)
+        f(x0,x1) = num(x0,x1) / denom(x0,x1)
 
-        r(x0,x1)^2 = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
-                     -------------------------------------------
-                                 fwhm^2 * (1-ellip)^2
+        num(x0,x1) = 4 * log(2) * ampl * exp(-4 * log(2) * r(x0,x1)^2)
+
+        denom(x0,x1) = pi * fwhm * fwhm * sqrt(1 - ellip * ellip)
+
+        r(x0,x1)^2 = rnum(x0,x1) / (fwhm^2 * (1-ellip)^2)
+
+        rnum(x0,x1) = xoff(x0,x1)^2 * (1-ellip)^2 + yoff(x0,x1)^2
 
         xoff(x0,x1) = (x0 - xpos) * cos(theta) + (x1 - ypos) * sin(theta)
 

--- a/sherpa/optmethods/buildin.py
+++ b/sherpa/optmethods/buildin.py
@@ -115,8 +115,8 @@ class OptMethod(NoNewAttributesAfterInit):
                       str,             # message
                       dict[str, Any]]  # information to pass back
 
-    Example
-    -------
+    Examples
+    --------
     For this example, we first define an optimizer function. To demonstrate
     the interface, we use a function that is stupidly simple and should
     **not** be used for any real fitting problem: We will simply draw random

--- a/sherpa/optmethods/optoptimagic.py
+++ b/sherpa/optmethods/optoptimagic.py
@@ -246,8 +246,8 @@ try:
             the scaling, provide a dictionary or an instance of 
             `optimagic.parameters.scaling.ScalingOptions`.
         
-        Example
-        -------
+        Examples
+        --------
         In this example, we fit a Gaussian and a constant to some data:
 
         >>> import numpy as np

--- a/sherpa/optmethods/optscipy.py
+++ b/sherpa/optmethods/optscipy.py
@@ -214,8 +214,8 @@ try:
         callback : callable
             A callable called after each iteration.
 
-        Example
-        -------
+        Examples
+        --------
 
         We begin with a simple example of fitting a Gaussian and a constant
         to some data, using all the default options for the optimizer.

--- a/sherpa/plot/backends.py
+++ b/sherpa/plot/backends.py
@@ -295,8 +295,8 @@ class BaseBackend(metaclass=MetaBaseBackend):
             If True, clear entire plotting area before adding the new
             subplot.
 
-        Note
-        ----
+        Notes
+        -----
         This method is intended for grids of plots with the same number of
         plots in each row and each column. In some backends, more
         complex layouts (e.g. one wide plot on row 1 and two smaller plots

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -2503,14 +2503,14 @@ class Session(NoNewAttributesAfterInit):
            The Levenberg-Marquardt method is an interface to the
            MINPACK subroutine lmdif to find the local minimum of
            nonlinear least squares functions of several variables by a
-           modification of the Levenberg-Marquardt algorithm [1].
+           modification of the Levenberg-Marquardt algorithm [1]_.
 
         ``moncar``
-           The implementation of the moncar method is based on [2].
+           The implementation of the moncar method is based on [2]_.
 
         ``neldermead``
            The implementation of the Nelder Mead Simplex direct search
-           is based on [3].
+           is based on [3]_.
 
         ``simplex``
            This is another name for ``neldermead``.
@@ -2518,17 +2518,17 @@ class Session(NoNewAttributesAfterInit):
         References
         ----------
 
-        1. J.J. More, "The Levenberg Marquardt algorithm:
+        .. [1] J.J. More, "The Levenberg Marquardt algorithm:
            implementation and theory," in Lecture Notes in Mathematics
            630: Numerical Analysis, G.A. Watson (Ed.), Springer-Verlag:
            Berlin, 1978, pp.105-116.
 
-        2. Storn, R. and Price, K. "Differential Evolution: A
+        .. [2] Storn, R. and Price, K. "Differential Evolution: A
            Simple and Efficient Adaptive Scheme for Global Optimization
            over Continuous Spaces." J. Global Optimization 11, 341-359,
            1997.
 
-        3. Jeffrey C. Lagarias, James A. Reeds, Margaret H. Wright,
+        .. [3] Jeffrey C. Lagarias, James A. Reeds, Margaret H. Wright,
            Paul E. Wright "Convergence Properties of the Nelder-Mead
            Simplex Algorithm in Low Dimensions", SIAM Journal on
            Optimization,Vol. 9, No. 1 (1998), pages 112-147.
@@ -2796,7 +2796,7 @@ class Session(NoNewAttributesAfterInit):
 
         This is a chi-square statistic where the variance is computed
         from model amplitudes derived in the previous iteration of the
-        fit. This 'Iterative Weighting' ([1]) attempts to remove
+        fit. This 'Iterative Weighting' ([1]_) attempts to remove
         biased estimates of model parameters.
 
         The variance in bin i is estimated to be::
@@ -2827,7 +2827,7 @@ class Session(NoNewAttributesAfterInit):
         References
         ----------
 
-        1. `"Multiparameter linear least-squares fitting to Poisson
+        .. [1] `"Multiparameter linear least-squares fitting to Poisson
            data one count at a time", Wheaton et al. 1995, ApJ 438, 322
            <https://adsabs.harvard.edu/abs/1995ApJ...438..322W>`_
 
@@ -3085,7 +3085,7 @@ class Session(NoNewAttributesAfterInit):
         The available statistics include:
 
         cash
-           A maximum likelihood function [1].
+           A maximum likelihood function [1]_.
 
         chi2
            Chi-squared statistic using the supplied error values.
@@ -3099,7 +3099,7 @@ class Session(NoNewAttributesAfterInit):
            the error for that bin is 0.
 
         chi2gehrels
-           Chi-squared with gehrels method [2]. This is the default method.
+           Chi-squared with gehrels method [2]_. This is the default method.
 
         chi2modvar
            Chi-squared with model amplitude variance.
@@ -3115,7 +3115,7 @@ class Session(NoNewAttributesAfterInit):
 
         cstat
            A maximum likelihood function (the XSPEC implementation of
-           the Cash function) [3]. This does *not* include support
+           the Cash function) [3]_. This does *not* include support
            for including the background.
 
         cstatnegativepenalty
@@ -3129,7 +3129,7 @@ class Session(NoNewAttributesAfterInit):
            A maximum likelihood function which includes the background
            data as part of the fit (i.e. for when it is not being
            explicitly modelled) (the XSPEC implementation of the Cash
-           function) [3].
+           function) [3]_.
 
         leastsq
            The least-squares statisic (the error is not used in this
@@ -3138,16 +3138,16 @@ class Session(NoNewAttributesAfterInit):
         References
         ----------
 
-        1. `Cash, W. "Parameter estimation in astronomy through
+        .. [1] `Cash, W. "Parameter estimation in astronomy through
            application of the likelihood ratio", ApJ, vol 228,
            p. 939-947 (1979).
            <https://adsabs.harvard.edu/abs/1979ApJ...228..939C>`_
 
-        2. `Gehrels, N. "Confidence limits for small numbers of
+        .. [2] `Gehrels, N. "Confidence limits for small numbers of
            events in astrophysical data", ApJ, vol 303, p. 336-346 (1986).
            <https://adsabs.harvard.edu/abs/1986ApJ...303..336G>`_
 
-        3. https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html
+        .. [3] https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html
 
         Examples
         --------
@@ -11544,8 +11544,8 @@ class Session(NoNewAttributesAfterInit):
         near the minimum, the gradient of the function is zero or
         negligible, respectively. So the leading term of the expansion
         is quadratic.  The best root finding algorithm for a curve
-        which is approximately parabolic is Muller's method [1].
-        Muller's method is a generalization of the secant method [2]:
+        which is approximately parabolic is Muller's method [1]_.
+        Muller's method is a generalization of the secant method [2]_:
         the secant method is an iterative root finding method that
         approximates the function by a straight line through two
         points, whereas Muller's method is an iterative root finding
@@ -11581,12 +11581,12 @@ class Session(NoNewAttributesAfterInit):
         References
         ----------
 
-        1. Muller, David E., "A Method for Solving Algebraic
-           Equations Using an Automatic Computer," MTAC, 10
-           (1956), 208-215.
+        .. [1] Muller, David E., "A Method for Solving Algebraic
+               Equations Using an Automatic Computer," MTAC, 10
+               (1956), 208-215.
 
-        2. Numerical Recipes in Fortran, 2nd edition, 1986, Press
-           et al., p. 347
+        .. [2] Numerical Recipes in Fortran, 2nd edition, 1986, Press
+               et al., p. 347
 
         Examples
         --------
@@ -12173,10 +12173,10 @@ class Session(NoNewAttributesAfterInit):
         References
         ----------
 
-        `"Analysis of Energy Spectra with Low Photon Counts via
-        Bayesian Posterior Simulation", van Dyk, D.A., Connors, A.,
-        Kashyap, V.L., & Siemiginowska, A.  2001, Ap.J., 548, 224
-        <https://adsabs.harvard.edu/abs/2001ApJ...548..224V>`_
+        .. [1] `"Analysis of Energy Spectra with Low Photon Counts via
+               Bayesian Posterior Simulation", van Dyk, D.A., Connors, A.,
+               Kashyap, V.L., & Siemiginowska, A.  2001, Ap.J., 548, 224
+               <https://adsabs.harvard.edu/abs/2001ApJ...548..224V>`
 
         Examples
         --------
@@ -12951,7 +12951,7 @@ class Session(NoNewAttributesAfterInit):
 
         See Also
         --------
-        get_plot_prefs, plot_model, set_xlinearm set_xlog, set_ylinear,
+        get_plot_prefs, plot_model, set_xlinearm, set_xlog, set_ylinear,
         set_ylog
 
         Notes
@@ -14554,7 +14554,7 @@ class Session(NoNewAttributesAfterInit):
            The label is invalid.
 
         See Also
-        ---------
+        --------
         get_default_id, get_split_plot, set_xlinear, set_xlog,
         set_ylinear, set_ylog
 
@@ -16761,7 +16761,7 @@ class Session(NoNewAttributesAfterInit):
            The data set does not support the requested plot type.
 
         See Also
-        ---------
+        --------
         contour_data, contour_fit, contour_fit_resid, contour_kernel,
         contour_model, contour_psf, contour_ratio, contour_resid,
         contour_source, get_default_id, get_split_plot

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1299,8 +1299,8 @@ def get_keyword_defaults(func: Callable,
 
     See Also
     --------
-    get_keyword_names, get_num_args,
-    `sherpa.plot.backend_utils.get_keyword_defaults`
+    get_keyword_names, get_num_args
+    sherpa.plot.backend_utils.get_keyword_defaults
 
     """
 

--- a/sherpa/utils/akima.py
+++ b/sherpa/utils/akima.py
@@ -53,8 +53,8 @@ Requirements
 References
 ----------
 
-(1) A new method of interpolation and smooth curve fitting based
-    on local procedures. Hiroshi Akima, J. ACM, October 1970, 17(4), 589-602.
+.. [1] A new method of interpolation and smooth curve fitting based
+       on local procedures. Hiroshi Akima, J. ACM, October 1970, 17(4), 589-602.
 
 Examples
 --------


### PR DESCRIPTION
## Summary
Fix inconsistencies leading to briken markup in docstrings. Switch docstring provessing to numpydoc.

## Details
`numpydoc` is more strict that `napoleon`, so I'm using that here to root out inconsistencies in the documentation.

Technically, this could be done without switching to numpydoc, and the output is ver similar, however, we used to use numpydoc for a long time before we switched to napelon to avoid a bunch of warning, and numpydoc is mroe used in the ecosystem (e.g. numpy, scipy, astropy etc. all use numpydoc).

## Open questions
- in some moduels we give plaintext links ot references, in others we mark that up with the RST `name <URL>_` syntax. The latter form is easier to read in rendered docs and doesn't harm much in plain-text docstrings, so I have a slight preference. I don't think it's agood use of our time to go thourgh every single docstringin Sherpa right now, but I could at least turn the ones that I'm editing anyway into links.