### PR TITLE
Build the extension modules with the limited API

### DIFF
--- a/helpers/extensions/__init__.py
+++ b/helpers/extensions/__init__.py
@@ -22,8 +22,12 @@
 from setuptools.extension import Extension
 import numpy
 
-# Allow the caller to easily change this setting
-LIMITED_API = True
+# This can be changed, before setup() is called, with something like
+#
+#   from helpers.extensions import LIMITED_API
+#   LIMITED_API = False
+#
+LIMITED_API: bool = True
 
 numpy_incdir = numpy.get_include()
 
@@ -169,155 +173,162 @@ def build_ext(command, name, *args, **kwargs):
 # Static Extensions
 ###
 
-estmethods = Extension('sherpa.estmethods._est_funcs',
-              ['sherpa/estmethods/src/estutils.cc',
-               'sherpa/estmethods/src/info_matrix.cc',
-               'sherpa/estmethods/src/projection.cc',
-               'sherpa/estmethods/src/estwrappers.cc'],
-              (sherpa_inc + ['sherpa/utils/src/gsl']),
-              depends=(get_deps(['extension', 'utils']) +
-                       ['sherpa/estmethods/src/estutils.hh',
-                        'sherpa/estmethods/src/info_matrix.hh',
-                        'sherpa/estmethods/src/projection.hh',
-                        'sherpa/utils/src/gsl/fcmp.h']),
-              py_limited_api=LIMITED_API)
+def static_ext_modules():
+    """Create the list of extension modules.
+
+    This is a function to allow deciding on whether to build with the
+    limited API or not.
+
+    """
+
+    print(f"** building extension modules with limited_api={LIMITED_API}")
+    estmethods = Extension('sherpa.estmethods._est_funcs',
+                  ['sherpa/estmethods/src/estutils.cc',
+                   'sherpa/estmethods/src/info_matrix.cc',
+                   'sherpa/estmethods/src/projection.cc',
+                   'sherpa/estmethods/src/estwrappers.cc'],
+                  (sherpa_inc + ['sherpa/utils/src/gsl']),
+                  depends=(get_deps(['extension', 'utils']) +
+                           ['sherpa/estmethods/src/estutils.hh',
+                            'sherpa/estmethods/src/info_matrix.hh',
+                            'sherpa/estmethods/src/projection.hh',
+                            'sherpa/utils/src/gsl/fcmp.h']),
+                  py_limited_api=LIMITED_API)
 
 
-utils = Extension('sherpa.utils._utils',
-              ['sherpa/utils/src/cephes/const.c',
-               'sherpa/utils/src/cephes/fabs.c',
-               'sherpa/utils/src/cephes/isnan.c',
-               'sherpa/utils/src/cephes/mtherr.c',
-               'sherpa/utils/src/cephes/polevl.c',
-               'sherpa/utils/src/cephes/ndtri.c',
-               'sherpa/utils/src/cephes/gamma.c',
-               'sherpa/utils/src/cephes/igam.c',
-               'sherpa/utils/src/cephes/igami.c',
-               'sherpa/utils/src/cephes/incbet.c',
-               'sherpa/utils/src/cephes/incbi.c',
-               'sherpa/utils/src/sjohnson/Faddeeva.cc',
-               'sherpa/utils/src/_utils.cc'],
-              sherpa_inc + ['sherpa/utils/src/cephes',
-                            'sherpa/utils/src/gsl',
-                            'sherpa/utils/src/sjohnson'],
-              depends=(get_deps(['extension', 'utils'])+
-                       ['sherpa/utils/src/gsl/fcmp.h',
-                        'sherpa/utils/src/cephes/cephes.h',
-                        'sherpa/utils/src/cephes/mconf.h',
-                        'sherpa/utils/src/cephes/protos.h',
-                        'sherpa/utils/src/sjohnson/Faddeeva.hh']),
-              py_limited_api=LIMITED_API)
+    utils = Extension('sherpa.utils._utils',
+                  ['sherpa/utils/src/cephes/const.c',
+                   'sherpa/utils/src/cephes/fabs.c',
+                   'sherpa/utils/src/cephes/isnan.c',
+                   'sherpa/utils/src/cephes/mtherr.c',
+                   'sherpa/utils/src/cephes/polevl.c',
+                   'sherpa/utils/src/cephes/ndtri.c',
+                   'sherpa/utils/src/cephes/gamma.c',
+                   'sherpa/utils/src/cephes/igam.c',
+                   'sherpa/utils/src/cephes/igami.c',
+                   'sherpa/utils/src/cephes/incbet.c',
+                   'sherpa/utils/src/cephes/incbi.c',
+                   'sherpa/utils/src/sjohnson/Faddeeva.cc',
+                   'sherpa/utils/src/_utils.cc'],
+                  sherpa_inc + ['sherpa/utils/src/cephes',
+                                'sherpa/utils/src/gsl',
+                                'sherpa/utils/src/sjohnson'],
+                  depends=(get_deps(['extension', 'utils'])+
+                           ['sherpa/utils/src/gsl/fcmp.h',
+                            'sherpa/utils/src/cephes/cephes.h',
+                            'sherpa/utils/src/cephes/mconf.h',
+                            'sherpa/utils/src/cephes/protos.h',
+                            'sherpa/utils/src/sjohnson/Faddeeva.hh']),
+                  py_limited_api=LIMITED_API)
 
 
-modelfcts = Extension('sherpa.models._modelfcts',
-                      ['sherpa/models/src/_modelfcts.cc'],
-                      sherpa_inc,
-                      depends=get_deps(['model_extension', 'models']),
-                      py_limited_api=LIMITED_API)
+    modelfcts = Extension('sherpa.models._modelfcts',
+                          ['sherpa/models/src/_modelfcts.cc'],
+                          sherpa_inc,
+                          depends=get_deps(['model_extension', 'models']),
+                          py_limited_api=LIMITED_API)
 
-saoopt = Extension('sherpa.optmethods._saoopt',
-              ['sherpa/optmethods/src/_saoopt.cc',
-               'sherpa/optmethods/src/Simplex.cc'],
-              sherpa_inc + ['sherpa/utils/src/gsl'],
-              depends=(get_deps(['myArray', 'extension']) +
-                       ['sherpa/include/sherpa/fcmp.hh',
-                        'sherpa/include/sherpa/MersenneTwister.h',
-                        'sherpa/include/sherpa/functor.hh',
-                        'sherpa/optmethods/src/DifEvo.hh',
-                        'sherpa/optmethods/src/DifEvo.cc',
-                        'sherpa/optmethods/src/NelderMead.hh',
-                        'sherpa/optmethods/src/NelderMead.cc',
-                        'sherpa/optmethods/src/Opt.hh',
-                        'sherpa/optmethods/src/PyWrapper.hh',
-                        'sherpa/optmethods/src/RanOpt.hh',
-                        'sherpa/optmethods/src/Simplex.hh',
-                        'sherpa/optmethods/src/Simplex.cc',
-                        'sherpa/optmethods/src/minpack/LevMar.hh',
-                        'sherpa/optmethods/src/minpack/LevMar.cc',
-                        'sherpa/optmethods/src/minim.hh']),
-              py_limited_api=LIMITED_API)
+    saoopt = Extension('sherpa.optmethods._saoopt',
+                  ['sherpa/optmethods/src/_saoopt.cc',
+                   'sherpa/optmethods/src/Simplex.cc'],
+                  sherpa_inc + ['sherpa/utils/src/gsl'],
+                  depends=(get_deps(['myArray', 'extension']) +
+                           ['sherpa/include/sherpa/fcmp.hh',
+                            'sherpa/include/sherpa/MersenneTwister.h',
+                            'sherpa/include/sherpa/functor.hh',
+                            'sherpa/optmethods/src/DifEvo.hh',
+                            'sherpa/optmethods/src/DifEvo.cc',
+                            'sherpa/optmethods/src/NelderMead.hh',
+                            'sherpa/optmethods/src/NelderMead.cc',
+                            'sherpa/optmethods/src/Opt.hh',
+                            'sherpa/optmethods/src/PyWrapper.hh',
+                            'sherpa/optmethods/src/RanOpt.hh',
+                            'sherpa/optmethods/src/Simplex.hh',
+                            'sherpa/optmethods/src/Simplex.cc',
+                            'sherpa/optmethods/src/minpack/LevMar.hh',
+                            'sherpa/optmethods/src/minpack/LevMar.cc',
+                            'sherpa/optmethods/src/minim.hh']),
+                  py_limited_api=LIMITED_API)
 
-tstoptfct = Extension('sherpa.optmethods._tstoptfct',
-              ['sherpa/optmethods/tests/_tstoptfct.cc'],
-              sherpa_inc,
-              depends=(get_deps(['extension']) +
-                       ['sherpa/include/sherpa/fcmp.hh',
-                        'sherpa/include/sherpa/MersenneTwister.h',
-                        'sherpa/include/sherpa/functor.hh',
-                        'sherpa/optmethods/tests/tstopt.hh',
-                        'sherpa/optmethods/tests/tstoptfct.hh',
-                        'sherpa/optmethods/src/DifEvo.hh',
-                        'sherpa/optmethods/src/DifEvo.cc',
-                        'sherpa/optmethods/src/NelderMead.hh',
-                        'sherpa/optmethods/src/NelderMead.cc',
-                        'sherpa/optmethods/src/Opt.hh',
-                        'sherpa/optmethods/src/PyWrapper.hh',
-                        'sherpa/optmethods/src/RanOpt.hh',
-                        'sherpa/optmethods/src/Simplex.hh',
-                        'sherpa/optmethods/src/Simplex.cc',
-                        'sherpa/optmethods/src/minpack/LevMar.hh',
-                        'sherpa/optmethods/src/minpack/LevMar.cc']),
-              py_limited_api=LIMITED_API)
+    tstoptfct = Extension('sherpa.optmethods._tstoptfct',
+                  ['sherpa/optmethods/tests/_tstoptfct.cc'],
+                  sherpa_inc,
+                  depends=(get_deps(['extension']) +
+                           ['sherpa/include/sherpa/fcmp.hh',
+                            'sherpa/include/sherpa/MersenneTwister.h',
+                            'sherpa/include/sherpa/functor.hh',
+                            'sherpa/optmethods/tests/tstopt.hh',
+                            'sherpa/optmethods/tests/tstoptfct.hh',
+                            'sherpa/optmethods/src/DifEvo.hh',
+                            'sherpa/optmethods/src/DifEvo.cc',
+                            'sherpa/optmethods/src/NelderMead.hh',
+                            'sherpa/optmethods/src/NelderMead.cc',
+                            'sherpa/optmethods/src/Opt.hh',
+                            'sherpa/optmethods/src/PyWrapper.hh',
+                            'sherpa/optmethods/src/RanOpt.hh',
+                            'sherpa/optmethods/src/Simplex.hh',
+                            'sherpa/optmethods/src/Simplex.cc',
+                            'sherpa/optmethods/src/minpack/LevMar.hh',
+                            'sherpa/optmethods/src/minpack/LevMar.cc']),
+                  py_limited_api=LIMITED_API)
 
-statfcts = Extension('sherpa.stats._statfcts',
-              ['sherpa/stats/src/_statfcts.cc'],
-              sherpa_inc,
-              depends=get_deps(['stat_extension', 'stats']),
-              py_limited_api=LIMITED_API)
+    statfcts = Extension('sherpa.stats._statfcts',
+                  ['sherpa/stats/src/_statfcts.cc'],
+                  sherpa_inc,
+                  depends=get_deps(['stat_extension', 'stats']),
+                  py_limited_api=LIMITED_API)
 
-integration = Extension('sherpa.utils.integration',
-              ['sherpa/utils/src/gsl/err.c',
-               'sherpa/utils/src/gsl/error.c',
-               'sherpa/utils/src/gsl/stream.c',
-               'sherpa/utils/src/gsl/strerror.c',
-               'sherpa/utils/src/gsl/message.c',
-               'sherpa/utils/src/gsl/qng.c',
-               'sherpa/utils/src/sjohnson/adapt_integrate.c',
-               'sherpa/utils/src/integration.cc'],
-              sherpa_inc +[ 'sherpa/utils/src',
-                            'sherpa/utils/src/sjohnson',
-                            'sherpa/utils/src/gsl'],
-              depends=(get_deps(['integration'])+
-                       ['sherpa/utils/src/sjohnson/adapt_integrate.h',
-                        'sherpa/utils/src/gsl/gsl_integration.h']),
-              py_limited_api=LIMITED_API)
+    integration = Extension('sherpa.utils.integration',
+                  ['sherpa/utils/src/gsl/err.c',
+                   'sherpa/utils/src/gsl/error.c',
+                   'sherpa/utils/src/gsl/stream.c',
+                   'sherpa/utils/src/gsl/strerror.c',
+                   'sherpa/utils/src/gsl/message.c',
+                   'sherpa/utils/src/gsl/qng.c',
+                   'sherpa/utils/src/sjohnson/adapt_integrate.c',
+                   'sherpa/utils/src/integration.cc'],
+                  sherpa_inc +[ 'sherpa/utils/src',
+                                'sherpa/utils/src/sjohnson',
+                                'sherpa/utils/src/gsl'],
+                  depends=(get_deps(['integration'])+
+                           ['sherpa/utils/src/sjohnson/adapt_integrate.h',
+                            'sherpa/utils/src/gsl/gsl_integration.h']),
+                  py_limited_api=LIMITED_API)
 
-astro_modelfcts = Extension('sherpa.astro.models._modelfcts',
-                            ['sherpa/astro/models/src/_modelfcts.cc',
-                             'sherpa/utils/src/sjohnson/Faddeeva.cc'],
-                            sherpa_inc + ['sherpa/utils/src/sjohnson'],
-                            depends=get_deps(['model_extension', 'astro/models']) + \
-                                    ['sherpa/utils/src/sjohnson/Faddeeva.hh'],
-                            py_limited_api=LIMITED_API)
+    astro_modelfcts = Extension('sherpa.astro.models._modelfcts',
+                                ['sherpa/astro/models/src/_modelfcts.cc',
+                                 'sherpa/utils/src/sjohnson/Faddeeva.cc'],
+                                sherpa_inc + ['sherpa/utils/src/sjohnson'],
+                                depends=get_deps(['model_extension', 'astro/models']) + \
+                                        ['sherpa/utils/src/sjohnson/Faddeeva.hh'],
+                                py_limited_api=LIMITED_API)
 
-pileup = Extension('sherpa.astro.utils._pileup',
-              ['sherpa/astro/utils/src/fftn.c',
-               'sherpa/astro/utils/src/_pileup.cc',
-               'sherpa/astro/utils/src/pileup.cc'],
-              sherpa_inc + ['sherpa/astro/utils/src'],
-              depends=(get_deps(['extension']) +
-                       ['sherpa/astro/utils/src/pileup.hh',
-                        'sherpa/astro/utils/src/PyWrapper.hh',
-                        'sherpa/astro/utils/src/fftn.inc']),
-              py_limited_api=LIMITED_API)
+    pileup = Extension('sherpa.astro.utils._pileup',
+                  ['sherpa/astro/utils/src/fftn.c',
+                   'sherpa/astro/utils/src/_pileup.cc',
+                   'sherpa/astro/utils/src/pileup.cc'],
+                  sherpa_inc + ['sherpa/astro/utils/src'],
+                  depends=(get_deps(['extension']) +
+                           ['sherpa/astro/utils/src/pileup.hh',
+                            'sherpa/astro/utils/src/PyWrapper.hh',
+                            'sherpa/astro/utils/src/fftn.inc']),
+                  py_limited_api=LIMITED_API)
 
-astro_utils = Extension('sherpa.astro.utils._utils',
-              ['sherpa/astro/utils/src/_utils.cc'],
-              (sherpa_inc + ['sherpa/utils/src/gsl']),
-              depends=(get_deps(['extension', 'utils', 'astro/utils'])+
-                       ['sherpa/utils/src/gsl/fcmp.h']),
-              py_limited_api=LIMITED_API)
+    astro_utils = Extension('sherpa.astro.utils._utils',
+                  ['sherpa/astro/utils/src/_utils.cc'],
+                  (sherpa_inc + ['sherpa/utils/src/gsl']),
+                  depends=(get_deps(['extension', 'utils', 'astro/utils'])+
+                           ['sherpa/utils/src/gsl/fcmp.h']),
+                  py_limited_api=LIMITED_API)
 
-
-static_ext_modules = [
-                   estmethods,
-                   utils,
-                   modelfcts,
-                   saoopt,
-                   tstoptfct,
-                   statfcts,
-                   integration,
-                   astro_modelfcts,
-                   pileup,
-                   astro_utils,
-                ]
+    return [estmethods,
+            utils,
+            modelfcts,
+            saoopt,
+            tstoptfct,
+            statfcts,
+            integration,
+            astro_modelfcts,
+            pileup,
+            astro_utils,
+            ]

--- a/helpers/extensions/__init__.py
+++ b/helpers/extensions/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014, 2016 - 2018, 2020, 2022, 2024
+#  Copyright (C) 2014, 2016-2018, 2020, 2022, 2024, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -21,6 +21,9 @@
 
 from setuptools.extension import Extension
 import numpy
+
+# Allow the caller to easily change this setting
+LIMITED_API = True
 
 numpy_incdir = numpy.get_include()
 
@@ -74,7 +77,8 @@ def build_psf_ext(library_dirs, include_dirs, libraries):
              library_dirs=library_dirs,
              libraries=libraries,
              depends=(get_deps(['extension', 'utils'])+
-                      ['sherpa/utils/src/tcd/tcd.h',]))
+                      ['sherpa/utils/src/tcd/tcd.h',]),
+             py_limited_api=LIMITED_API)
 
 def build_wcs_ext(library_dirs, include_dirs, libraries):
     return Extension('sherpa.astro.utils._wcs',
@@ -82,7 +86,8 @@ def build_wcs_ext(library_dirs, include_dirs, libraries):
                  sherpa_inc + include_dirs,
                  library_dirs=library_dirs,
                  libraries=libraries,
-                 depends=get_deps(['extension']))
+                 depends=get_deps(['extension']),
+                 py_limited_api=LIMITED_API)
 
 def build_region_ext(library_dirs, include_dirs, libraries, define_macros=None):
     return Extension('sherpa.astro.utils._region',
@@ -91,7 +96,8 @@ def build_region_ext(library_dirs, include_dirs, libraries, define_macros=None):
                  library_dirs=library_dirs,
                  libraries=(libraries),
                  define_macros=define_macros,
-                 depends=get_deps(['extension']))
+                 depends=get_deps(['extension']),
+                 py_limited_api=LIMITED_API)
 
 def build_xspec_ext(library_dirs, include_dirs, libraries, define_macros=None):
     return Extension('sherpa.astro.xspec._xspec',
@@ -101,7 +107,8 @@ def build_xspec_ext(library_dirs, include_dirs, libraries, define_macros=None):
                   runtime_library_dirs=library_dirs,
                   libraries=libraries,
                   define_macros=define_macros,
-                  depends=(get_deps(['astro/xspec_extension'])))
+                  depends=(get_deps(['astro/xspec_extension'])),
+                  py_limited_api=LIMITED_API)
 
 
 def build_lib_arrays(command, libname):
@@ -172,7 +179,8 @@ estmethods = Extension('sherpa.estmethods._est_funcs',
                        ['sherpa/estmethods/src/estutils.hh',
                         'sherpa/estmethods/src/info_matrix.hh',
                         'sherpa/estmethods/src/projection.hh',
-                        'sherpa/utils/src/gsl/fcmp.h']))
+                        'sherpa/utils/src/gsl/fcmp.h']),
+              py_limited_api=LIMITED_API)
 
 
 utils = Extension('sherpa.utils._utils',
@@ -197,12 +205,15 @@ utils = Extension('sherpa.utils._utils',
                         'sherpa/utils/src/cephes/cephes.h',
                         'sherpa/utils/src/cephes/mconf.h',
                         'sherpa/utils/src/cephes/protos.h',
-                        'sherpa/utils/src/sjohnson/Faddeeva.hh']))
+                        'sherpa/utils/src/sjohnson/Faddeeva.hh']),
+              py_limited_api=LIMITED_API)
+
 
 modelfcts = Extension('sherpa.models._modelfcts',
                       ['sherpa/models/src/_modelfcts.cc'],
                       sherpa_inc,
-                      depends=get_deps(['model_extension', 'models']))
+                      depends=get_deps(['model_extension', 'models']),
+                      py_limited_api=LIMITED_API)
 
 saoopt = Extension('sherpa.optmethods._saoopt',
               ['sherpa/optmethods/src/_saoopt.cc',
@@ -223,7 +234,8 @@ saoopt = Extension('sherpa.optmethods._saoopt',
                         'sherpa/optmethods/src/Simplex.cc',
                         'sherpa/optmethods/src/minpack/LevMar.hh',
                         'sherpa/optmethods/src/minpack/LevMar.cc',
-                        'sherpa/optmethods/src/minim.hh']))
+                        'sherpa/optmethods/src/minim.hh']),
+              py_limited_api=LIMITED_API)
 
 tstoptfct = Extension('sherpa.optmethods._tstoptfct',
               ['sherpa/optmethods/tests/_tstoptfct.cc'],
@@ -244,12 +256,14 @@ tstoptfct = Extension('sherpa.optmethods._tstoptfct',
                         'sherpa/optmethods/src/Simplex.hh',
                         'sherpa/optmethods/src/Simplex.cc',
                         'sherpa/optmethods/src/minpack/LevMar.hh',
-                        'sherpa/optmethods/src/minpack/LevMar.cc']))
+                        'sherpa/optmethods/src/minpack/LevMar.cc']),
+              py_limited_api=LIMITED_API)
 
 statfcts = Extension('sherpa.stats._statfcts',
               ['sherpa/stats/src/_statfcts.cc'],
               sherpa_inc,
-              depends=get_deps(['stat_extension', 'stats']))
+              depends=get_deps(['stat_extension', 'stats']),
+              py_limited_api=LIMITED_API)
 
 integration = Extension('sherpa.utils.integration',
               ['sherpa/utils/src/gsl/err.c',
@@ -265,14 +279,16 @@ integration = Extension('sherpa.utils.integration',
                             'sherpa/utils/src/gsl'],
               depends=(get_deps(['integration'])+
                        ['sherpa/utils/src/sjohnson/adapt_integrate.h',
-                        'sherpa/utils/src/gsl/gsl_integration.h']))
+                        'sherpa/utils/src/gsl/gsl_integration.h']),
+              py_limited_api=LIMITED_API)
 
 astro_modelfcts = Extension('sherpa.astro.models._modelfcts',
                             ['sherpa/astro/models/src/_modelfcts.cc',
                              'sherpa/utils/src/sjohnson/Faddeeva.cc'],
                             sherpa_inc + ['sherpa/utils/src/sjohnson'],
                             depends=get_deps(['model_extension', 'astro/models']) + \
-                                    ['sherpa/utils/src/sjohnson/Faddeeva.hh'])
+                                    ['sherpa/utils/src/sjohnson/Faddeeva.hh'],
+                            py_limited_api=LIMITED_API)
 
 pileup = Extension('sherpa.astro.utils._pileup',
               ['sherpa/astro/utils/src/fftn.c',
@@ -282,13 +298,15 @@ pileup = Extension('sherpa.astro.utils._pileup',
               depends=(get_deps(['extension']) +
                        ['sherpa/astro/utils/src/pileup.hh',
                         'sherpa/astro/utils/src/PyWrapper.hh',
-                        'sherpa/astro/utils/src/fftn.inc']))
+                        'sherpa/astro/utils/src/fftn.inc']),
+              py_limited_api=LIMITED_API)
 
 astro_utils = Extension('sherpa.astro.utils._utils',
               ['sherpa/astro/utils/src/_utils.cc'],
               (sherpa_inc + ['sherpa/utils/src/gsl']),
               depends=(get_deps(['extension', 'utils', 'astro/utils'])+
-                       ['sherpa/utils/src/gsl/fcmp.h']))
+                       ['sherpa/utils/src/gsl/fcmp.h']),
+              py_limited_api=LIMITED_API)
 
 
 static_ext_modules = [

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014, 2017 - 2024
+# Copyright (C) 2014, 2017-2024, 2026
 # Smithsonian Astrophysical Observatory
 #
 #
@@ -91,4 +91,4 @@ for opt, help in HELP.items():
 
 setup(version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(sherpa_commands),
-      ext_modules=static_ext_modules)
+      ext_modules=static_ext_modules())

--- a/sherpa/astro/utils/src/_region.cc
+++ b/sherpa/astro/utils/src/_region.cc
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2009, 2016, 2020-2022, 2025
+//  Copyright (C) 2009, 2016, 2020-2022, 2025-2026
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -78,9 +78,10 @@ static regRegion* parse_string( std::string input, int fileflag ) {
 
 static PyObject* pyRegion_build(PyTypeObject *type, regRegion *reg) {
   PyRegion *ret = NULL;
-  ret = (PyRegion*)type->tp_alloc( type, 0 );
-  if( ret )
-  ret->region = reg;
+  ret = (PyRegion*) PyType_GenericAlloc(type, 0);
+  if( ret ) {
+    ret->region = reg;
+  }
 
   return (PyObject*)ret;
 }
@@ -205,55 +206,28 @@ static PyMethodDef pyRegion_methods[] = {
 };
 
 
-// Unfortunately we can not use C99-style designated initializers here
-// so we need to keep all the "null" values.
-//
-static PyTypeObject pyRegion_Type = {
-  // Note that there is no semicolon after the PyObject_HEAD_INIT macro;
-  // one is included in the macro definition.
-  PyVarObject_HEAD_INIT(NULL, 0)    // ob_size
-  (char*)"PyRegion",             // tp_name
-  sizeof(PyRegion),              // tp_basicsize
-  0, 		                 // tp_itemsize
-  (destructor)pyRegion_dealloc,  // tp_dealloc
-  0,                             // tp_print
-  0,                             // tp_getattr
-  0,                             // tp_setattr
-  0,                             // tp_compare
-  (reprfunc)pyRegion_str,        // tp_repr
-  0,                             // tp_as_number
-  0,                             // tp_as_sequence
-  0,                             // tp_as_mapping
-  0,                             // tp_hash
-  0,                             // tp_call
-  (reprfunc)pyRegion_str,        // tp_str
-  0,                             // tp_getattro
-  0,                             // tp_setattro
-  0,                             // tp_as_buffer
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, //tp_flags  DO NOT REMOVE
-  (char*)"PyRegion reg = Region(region, fileflag=False)",      // tp_doc, __doc__
-  0,		                 // tp_traverse
-  0,		                 // tp_clear
-  0,		                 // tp_richcompare
-  0,		                 // tp_weaklistoffset
-  0,		                 // tp_iter, __iter__
-  0,		                 // tp_iternext
-  pyRegion_methods,              // tp_methods
-  0,                             // tp_members
-  0,                             // tp_getset
-  0,                             // tp_base
-  0,                             // tp_dict, __dict__
-  0,                             // tp_descr_get
-  0,                             // tp_descr_set
-  0,                             // tp_dictoffset
-  0,                             // tp_init, __init__
-  0,                             // tp_alloc
-  pyRegion_new,                  // tp_new
+static PyType_Slot pyRegion_Slots[] =
+  {
+    {Py_tp_doc, (void *) "PyRegion reg = Region(region, fileflag=False)"},
+    {Py_tp_dealloc, (void *) pyRegion_dealloc},
+    {Py_tp_repr, (void *) pyRegion_str},
+    {Py_tp_str, (void *) pyRegion_str},
+    {Py_tp_methods, (void *) pyRegion_methods},
+    {Py_tp_new, (void *) pyRegion_new},
+    {0, 0}
+  };
+
+static PyType_Spec pyRegion_Spec = {
+  "_reg.PyRegion",
+  sizeof(PyRegion),
+  0,
+  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  pyRegion_Slots
 };
 
+static PyTypeObject *pyRegion_Type = NULL;
 
-// Needs to be defined after pyRegion_type is defined.
-//
+
 // Take the union of the the argument with the object.
 //
 static PyObject* region_union( PyRegion* self, PyObject* args, PyObject *kwargs )
@@ -264,7 +238,8 @@ static PyObject* region_union( PyRegion* self, PyObject* args, PyObject *kwargs 
   static const char *kwlist[] = {"region", NULL};
   if ( !PyArg_ParseTupleAndKeywords( args, kwargs, "O!",
                                      const_cast<char**>(kwlist),
-				     &pyRegion_Type, &reg_obj2))
+				     (PyObject *) pyRegion_Type,
+				     &reg_obj2))
     return NULL;
 
   PyRegion *reg2 = (PyRegion*)(reg_obj2);
@@ -285,7 +260,7 @@ static PyObject* region_union( PyRegion* self, PyObject* args, PyObject *kwargs 
   // increase the reference count (and if "O" is used it
   // leaks memory...)
   //
-  PyRegion *out = (PyRegion*) pyRegion_build( &pyRegion_Type, combined );
+  PyRegion *out = (PyRegion*) pyRegion_build( pyRegion_Type, combined );
   return Py_BuildValue((char*)"N", out);
 
 }
@@ -300,7 +275,8 @@ static PyObject* region_subtract( PyRegion* self, PyObject* args, PyObject *kwar
   static const char *kwlist[] = {"region", NULL};
   if ( !PyArg_ParseTupleAndKeywords( args, kwargs, "O!",
                                      const_cast<char**>(kwlist),
-				     &pyRegion_Type, &reg_obj2))
+				     (PyObject *)pyRegion_Type,
+				     &reg_obj2))
     return NULL;
 
   PyRegion *reg2 = (PyRegion*)(reg_obj2);
@@ -323,7 +299,7 @@ static PyObject* region_subtract( PyRegion* self, PyObject* args, PyObject *kwar
   // increase the reference count (and if "O" is used it
   // leaks memory...)
   //
-  PyRegion *out = (PyRegion*) pyRegion_build( &pyRegion_Type, combined );
+  PyRegion *out = (PyRegion*) pyRegion_build( pyRegion_Type, combined );
   return Py_BuildValue((char*)"N", out);
 
 }
@@ -363,21 +339,16 @@ PyMODINIT_FUNC
 PyInit__region(void)
 {
 
-  PyObject *m;
-
-  if (PyType_Ready(&pyRegion_Type) < 0)
-    return NULL;
-
   import_array();
 
-  m = PyModule_Create(&module_region);
+  PyObject *m = PyModule_Create(&module_region);
   if (m == NULL)
     return NULL;
 
-  Py_INCREF(&pyRegion_Type);
-  if (PyModule_AddObject(m, (char*)"Region", (PyObject *)&pyRegion_Type) < 0) {
-    Py_DECREF(&pyRegion_Type);
+  pyRegion_Type = (PyTypeObject *) PyType_FromSpec(&pyRegion_Spec);
+  if (PyModule_AddObject(m, (char*)"Region", (PyObject*)pyRegion_Type) < 0) {
     Py_DECREF(m);
+    return NULL;
   }
 
   // Add a symbol to indicate whether the module was built with the

--- a/sherpa/astro/utils/src/_wcs.cc
+++ b/sherpa/astro/utils/src/_wcs.cc
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2009, 2025
+//  Copyright (C) 2009, 2025-2026
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -22,6 +22,7 @@
 #include "sherpa/extension.hh"
 #include <sstream>
 #include <iostream>
+#include <cstring>
 
 extern "C" {
 #include "wcs.h"

--- a/sherpa/include/sherpa/array.hh
+++ b/sherpa/include/sherpa/array.hh
@@ -23,8 +23,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
-#define Py_LIMITED_API 0x030B0000
-#include <Python.h>
+#include <sherpa/python.hh>
 
 #include <numpy/arrayobject.h>
 

--- a/sherpa/include/sherpa/array.hh
+++ b/sherpa/include/sherpa/array.hh
@@ -1,5 +1,6 @@
 // 
-//  Copyright (C) 2007, 2015  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2015, 2026
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -22,7 +23,9 @@
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
+#define Py_LIMITED_API 0x030B0000
 #include <Python.h>
+
 #include <numpy/arrayobject.h>
 
 

--- a/sherpa/include/sherpa/python.hh
+++ b/sherpa/include/sherpa/python.hh
@@ -1,0 +1,41 @@
+//
+//  Copyright (C) 2026
+//  Smithsonian Astrophysical Observatory
+//
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along
+//  with this program; if not, write to the Free Software Foundation, Inc.,
+//  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+
+#ifndef __sherpa_python_hh__
+#define __sherpa_python_hh__
+
+// Use the same setup for extension modules
+
+// The current (mid 2026) free-threaded build does not support the
+// limited API, so only set if not using such a build (although the
+// current Sherpa build does not officially support the free-threaded
+// build).
+//
+// This code is from
+// https://github.com/python/cpython/blob/main/Modules/xxlimited_35.c
+//
+#include <pyconfig.h>   // Py_GIL_DISABLED
+#ifndef Py_GIL_DISABLED
+#  define Py_LIMITED_API 0x030B0000
+#endif
+
+#include <Python.h>
+
+#endif /* __sherpa_python_hh__ */

--- a/sherpa/optmethods/tests/_tstoptfct.cc
+++ b/sherpa/optmethods/tests/_tstoptfct.cc
@@ -30,6 +30,8 @@
 #include <sherpa/extension.hh>
 #include "tstoptfct.hh"
 
+#include <cstring>
+
 static PyObject *Ackley( PyObject *self, PyObject *args ) {
   DoubleArray xpar, fvec;
   if ( !PyArg_ParseTuple( args, "O&", CONVERTME(DoubleArray), &xpar ) )

--- a/sherpa/optmethods/tests/_tstoptfct.cc
+++ b/sherpa/optmethods/tests/_tstoptfct.cc
@@ -1,5 +1,6 @@
 //
-//  Copyright (C) 2007, 2020, 2021  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2020-2021, 2026
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -18,9 +19,12 @@
 //
 
 // This define is needed for "#i" argument to PyArg_ParseTuple in init_optfcn
-// and must be made before including Python.h
+// and must be made before including Python.h (at least while still supporting
+// Python 3.12 and earlier).
+//
 #define PY_SSIZE_T_CLEAN
 
+#define Py_LIMITED_API 0x030B0000
 #include <Python.h>
 
 #include <sherpa/extension.hh>

--- a/sherpa/optmethods/tests/_tstoptfct.cc
+++ b/sherpa/optmethods/tests/_tstoptfct.cc
@@ -24,9 +24,6 @@
 //
 #define PY_SSIZE_T_CLEAN
 
-#define Py_LIMITED_API 0x030B0000
-#include <Python.h>
-
 #include <sherpa/extension.hh>
 #include "tstoptfct.hh"
 

--- a/sherpa/utils/src/_psf.cc
+++ b/sherpa/utils/src/_psf.cc
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2007, 2016, 2018, 2020-2021, 2025
+//  Copyright (C) 2007, 2016, 2018, 2020-2021, 2025-2026
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -76,8 +76,7 @@ static PyObject *tcdPyData_new(PyTypeObject *type, PyObject *args,
 {
 
   tcdPyData *self = NULL;
-  self = (tcdPyData*)type->tp_alloc(type, 0);
-  return (PyObject*)self;
+  return PyType_GenericAlloc(type, 0);
 
 }
 
@@ -464,49 +463,27 @@ static PyMethodDef tcdPyData_methods[] = {
   {NULL, NULL, 0, NULL}  // Sentinel
 };
 
+static PyType_Slot tcdPyData_Slots[] =
+  {
+    {Py_tp_doc, (void *) "tcdPyData object"},
+    {Py_tp_dealloc, (void *) tcdPyData_dealloc},
+    {Py_tp_methods, (void *) tcdPyData_methods},
+    {Py_tp_members, (void *) tcdPyData_members},
+    {Py_tp_init, (void *) tcdPyData_init},
+    {Py_tp_new, (void *) tcdPyData_new},
+    {0, 0}
+  };
 
-// New datatype initialization
-static PyTypeObject tcdPyData_Type = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-//  0,                                // ob_size
-  (char*)"tcdData",                 // tp_name
-  sizeof(tcdPyData),                // tp_basicsize
-  0, 		                    // tp_itemsize
-  (destructor)tcdPyData_dealloc,    // tp_dealloc
-  0,                                // tp_print
-  0,                                // tp_getattr, __getattr__
-  0,                                // tp_setattr, __setattr__
-  0,                                // tp_compare
-  0, //(reprfunc)tcdPyData_repr,       // tp_repr, __repr__
-  0,                                // tp_as_number
-  0,                                // tp_as_sequence
-  0,                                // tp_as_mapping
-  0,                                // tp_hash
-  0,                                // tp_call, __call__
-  0, //(reprfunc)tcdPyData_repr,       // tp_str, __str__
-  0,                                // tp_getattro
-  0,                                // tp_setattro
-  0,                                // tp_as_buffer
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, //tp_flags
-  (char*)"tcdPyData object",        // tp_doc, __doc__
-  0,		                    // tp_traverse
-  0,		                    // tp_clear
-  0,		                    // tp_richcompare
-  0,		                    // tp_weaklistoffset
-  0,		                    // tp_iter, __iter__
-  0,		                    // tp_iternext
-  tcdPyData_methods,              // tp_methods
-  tcdPyData_members,              // tp_members
-  0,                                // tp_getset
-  0,                                // tp_base
-  0,                                // tp_dict, __dict__
-  0,                                // tp_descr_get
-  0,                                // tp_descr_set
-  0,                                // tp_dictoffset
-  (initproc)tcdPyData_init,         // tp_init, __init__
-  0,                                // tp_alloc
-  tcdPyData_new,                    // tp_new
+static PyType_Spec tcdPyData_Spec = {
+  "_tcd.tcdData",
+  sizeof(tcdPyData),
+  0,
+  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  tcdPyData_Slots
 };
+
+static PyTypeObject *tcdPyData_Type = NULL;
+
 
 static void _normalize_kernel( double* res, long len ) {
 
@@ -999,21 +976,20 @@ static struct PyModuleDef psf = {
     PsfFcts
 };
 
-PyMODINIT_FUNC PyInit__psf(void) {
-  if( PyType_Ready(&tcdPyData_Type) < 0 )
+PyMODINIT_FUNC
+PyInit__psf(void) {
+
+  import_array();
+
+  PyObject* m = PyModule_Create(&psf);
+  if (m == NULL)
     return NULL;
 
-   import_array();
-
-   PyObject* m;
-   m = PyModule_Create(&psf);
-
-  if( m == NULL )
+  tcdPyData_Type = (PyTypeObject *) PyType_FromSpec(&tcdPyData_Spec);
+  if (PyModule_AddObject(m, (char*)"tcdData", (PyObject*)tcdPyData_Type) < 0) {
+    Py_DECREF(m);
     return NULL;
-
-  Py_INCREF(&tcdPyData_Type);
-
-  PyModule_AddObject(m, (char*)"tcdData", (PyObject*)&tcdPyData_Type);
+  }
 
   return m;
 }

--- a/sherpa/utils/src/integration.cc
+++ b/sherpa/utils/src/integration.cc
@@ -20,8 +20,7 @@
 
 #define _INTEGRATIONMODULE
 
-#define Py_LIMITED_API 0x030B0000
-#include <Python.h>
+#include <sherpa/python.hh>
 
 #include "sherpa/integration.hh"
 #include <iostream>

--- a/sherpa/utils/src/integration.cc
+++ b/sherpa/utils/src/integration.cc
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2007, 2016, 2020, 2025
+//  Copyright (C) 2007, 2016, 2020, 2025-2026
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -19,7 +19,10 @@
 //
 
 #define _INTEGRATIONMODULE
+
+#define Py_LIMITED_API 0x030B0000
 #include <Python.h>
+
 #include "sherpa/integration.hh"
 #include <iostream>
 #include <limits>


### PR DESCRIPTION
# Summary

Update the extension models to use the Python limited API. There is no functional changes.

# Details

This picks Python 3.11.0 as the "version" of the limited API (since this is the minimum Python version we support).

There is no attempt (at present) to update the stack and group modules from the extern/ directory (although it looks like they should be able to be easily updated to support the limited API). It is not clear if this helps when building Sherpa for distribution (I'm guessing not).

The changes are primarily

- change how the `_region` and  `_psf` modules create their Python class; they remain created as heap objects but are now created using "modern" Python code (setting up a specification and using slots) rather than the older API which requires direct accress to the `PyhTypeObject` struct (since access to this is limited when using the limited API)
  - a useful example for this is from the Python code base: https://github.com/python/cpython/blob/main/Modules/xxlimited_35.c (there's a version for python 3.13 and for 3.15+ but as we need to support 3.11 and 3.12 we stick with this file)
- set the `Py_LIMITED_API` macro value to `0x030B0000` (3.11.0) which tells the code to only allow the extension code to use the limited API but does not do anything to take advantage of it when actually building the modules
  - this requires setting things in several places, which is not ideal and is addressed in a later commit 
- over time the include files automatically included with `Python.h` has changed, which means on some builds we need to now include `cstring` (the official recommendation is that we should include the files so we don't rely on what `Python.h` includes, I think) 
- add an `sherpa/python.h` file to rationalize the python setup
  - as part of this support only setting the limited API if the GIL is not disabled because (before python 3.15 I think), the free-threaded build does not support the limited API; this is based in part on https://github.com/python/cpython/blob/main/Modules/xxlimited_35.c
    - we currently do not support the free-threaded build but I want to allow experimentation 
- allow setuptools to set the "yes, I want the limited API" option when building (this appears to mainly change the names of the modules from `<name>.cpython-<version>-<system info>.so` to `<name>.abi3.so`
  - this does not hold for the `stk` and `group` modules from extern, which remain as `<name>.so`