### PR TITLE
TESTS: allow them to pass on aarch64 system

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2020-2025
+#  Copyright (C) 2016, 2018, 2020-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -4504,14 +4504,12 @@ def check_moncar(ncores, fr, g1, g2) -> None:
             # test for this (so we know if/when this assumption
             # changes).
             #
-            if platform.machine() == "x86_64":
+            if platform.machine() in ["x86_64", "aarch64"]:
                 nexp = 13788
                 gleft = g2
                 gright = g1
 
             else:
-                # This is known to work with Linux/aarch64 and
-                # Darwin/arm64.
                 nexp = 13785
                 gleft = g1
                 gright = g2

--- a/sherpa/astro/ui/tests/test_eqwidth_err.py
+++ b/sherpa/astro/ui/tests/test_eqwidth_err.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2018, 2021, 2023, 2025
+#  Copyright (C) 2018, 2021, 2023, 2025-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -397,7 +397,8 @@ def test_eqwidth_multi_id_poisson(clean_astro_ui):
 
     # A regression to check if the calculation changes.
     #
-    assert val1 == pytest.approx(0.0409343934694133)
+    tol = 1e-5
+    assert val1 == pytest.approx(0.0409343934694133, rel=tol)
 
     # Check the error results. This is calculated via get_draws,
     # which handles the multiple-id case.
@@ -425,9 +426,9 @@ def test_eqwidth_multi_id_poisson(clean_astro_ui):
     # be approximated by a "smaller" sigma limits range, and the
     # "a + b" and "b + a" give the same results.
     #
-    assert resa[0] == pytest.approx(0.04259715629705425)
-    assert resb[0] == pytest.approx(0.043209134605777154)
-    assert resab[0] == pytest.approx(0.04104216531226462)
+    assert resa[0] == pytest.approx(0.04259715629705425, rel=tol)
+    assert resb[0] == pytest.approx(0.043209134605777154, rel=tol)
+    assert resab[0] == pytest.approx(0.04104216531226462, rel=tol)
 
     # The resba results are identical to resab
     assert resba[4] == pytest.approx(resab[4])


### PR DESCRIPTION
# Summary

Update the tests to pass on a Linux/aarch64 system. There is no functional change here.

# Details

Tweak the tolerance for one test and the ordering/behaviour of another (to match with x86 rather than arm64) so that they pass on an aarch64 (emulated) system. Some of this is taken from #2341 and some from running a virtualized aarch64 machine (so there is a possibility that we may still need to tweak these in the future).