### PR TITLE
BUILD: update xspec version to 12.14.0k for all cases

### DIFF
--- a/.github/workflows/ci-conda-workflow.yml
+++ b/.github/workflows/ci-conda-workflow.yml
@@ -40,7 +40,7 @@ jobs:
             test-data: submodule
             matplotlib-version: 3
             bokeh-version: 3
-            xspec-version: 12.14.0i
+            xspec-version: 12.14.0k
 
           - name: MacOS ARM Full Build (Python 3.12)
             os: macos-14
@@ -50,7 +50,7 @@ jobs:
             test-data: submodule
             matplotlib-version: 3
             bokeh-version: 3
-            xspec-version: 12.13.1e
+            xspec-version: 12.14.0k
 
           - name: Linux Minimum Setup (Python 3.11)
             os: ubuntu-latest
@@ -74,7 +74,7 @@ jobs:
             test-data: submodule
             matplotlib-version: 3
             bokeh-version: 3
-            xspec-version: 12.14.0i
+            xspec-version: 12.14.0k
 
           - name: Linux Full Build (Python 3.12)
             os: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
             test-data: submodule
             matplotlib-version: 3
             bokeh-version: 3
-            xspec-version: 12.14.0i
+            xspec-version: 12.14.0k
 
           - name: Linux Full Build (Python 3.11)
             os: ubuntu-latest
@@ -93,7 +93,7 @@ jobs:
             fits: astropy
             test-data: submodule
             matplotlib-version: 3
-            xspec-version: 12.13.1
+            xspec-version: 12.14.0k
 
           - name: Linux Build (w/o Astropy or Xspec)
             os: ubuntu-latest


### PR DESCRIPTION
# Summary

Bump up the XSPEC version used in the conda workflow. There is no functional change.

# Details

At present there is little benefit in testing with a really-old XSPEC version such as 12.13.1, so update to the last available build in the conda test channel.