### PR TITLE
TESTS: change to importlib for importing modules in pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 minversion = 8.0
 testpaths = docs sherpa
-addopts = -rs --doctest-rst --strict-config --doctest-plus
+addopts = -rs --doctest-rst --strict-config --doctest-plus --import-mode=importlib
 
 
 norecursedirs = .git build dist tmp* .eggs

--- a/sherpa/__init__.py
+++ b/sherpa/__init__.py
@@ -1043,7 +1043,8 @@ def clitest() -> None:
     import pytest
 
     # Add in command-line arguments to allow configuring the Sherpa tests
-    args = [os.path.dirname(__file__), '-rs'] + sys.argv[1:]
+    args = [os.path.dirname(__file__), '-rs',
+            '--import-mode=importlib'] + sys.argv[1:]
 
     # passing the plugins that have been installed "now".
     errno = pytest.main(args, plugins=plugins)

--- a/sherpa/astro/datastack/tests/test_datastack.py
+++ b/sherpa/astro/datastack/tests/test_datastack.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014-2016, 2018-2021, 2025
+#  Copyright (C) 2014-2016, 2018-2021, 2025-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -30,7 +30,7 @@ from sherpa.utils.testing import requires_fits, requires_group, requires_stk
 from sherpa.astro import ui
 from sherpa.astro import datastack
 from sherpa.astro.datastack import DataStack
-from acis_bkg_model import acis_bkg_model
+from .acis_bkg_model import acis_bkg_model
 
 logger = logging.getLogger('sherpa')
 

--- a/sherpa/astro/ui/__init__.py
+++ b/sherpa/astro/ui/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2018, 2020, 2021, 2024
+#  Copyright (C) 2007, 2018, 2020-2021, 2024, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -20,7 +20,7 @@
 
 import sherpa.all
 import sherpa.astro.all
-import sherpa.astro.ui.utils
+from sherpa.astro.ui import utils
 from sherpa.utils import calc_mlr, calc_ftest, rebin, histogram1d, \
     histogram2d, gamma, lgam, igamc, igam, incbet, multinormal_pdf, \
     multit_pdf

--- a/sherpa/ui/__init__.py
+++ b/sherpa/ui/__init__.py
@@ -1,5 +1,6 @@
 #
-#  Copyright (C) 2007, 2018  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2007, 2018, 2026
+#  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,7 +19,7 @@
 #
 
 import sherpa.all
-import sherpa.ui.utils
+from sherpa.ui import utils
 from sherpa.utils import calc_mlr, calc_ftest, rebin, histogram1d, \
     histogram2d, gamma, lgam, igamc, igam, incbet, multinormal_pdf, \
     multit_pdf


### PR DESCRIPTION
# Summary

Switch the pytest machinery to use the recommended "importlib" approach for the import mode. Fix #2485.

# Details

This is primarily to "improve" the test code, as this approach is now the recommended method for pytest users:
https://docs.pytest.org/en/stable/explanation/goodpractices.html#choosing-an-import-mode

In doing this we need to

a) tell pytest that this is the seleted option

    - pytest.ini is changed for pytest users (editable installs)
    - sherpa_test is changed for normal installs

b) some code has had to be changed to account for this

    - the sherpa[astro].ui utils change has long been in the back of my mind, but I have never felt it worth the change