### PR TITLE
DOCS: update sphinx requirements

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -472,7 +472,7 @@ Building the documentation requires a Sherpa installation, *including*
 the test data suite (either as a submodule or installed with the
 ``sherpa-test-data`` package), and several additional packages:
 
-* `Sphinx <https://sphinx.pocoo.org/>`_, version 1.8 or later
+* `Sphinx <https://sphinx.pocoo.org/>`_, version 5 or later
 * The ``sphinx_rtd_theme``
 * NumPy and `sphinx-astropy <https://github.com/astropy/sphinx-astropy/>`_
   (the latter can be installed with ``pip``)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ test = [
 # needs non-python packages such as pandoc and graphviz
 doc = [
   # code needed for the documentation
-  "sphinx>=5,<8",
+  "sphinx>=5",
   "sphinx_rtd_theme>=3.0.0",
   "sphinx-astropy",
   "nbsphinx",


### PR DESCRIPTION
# Summary

Update the documentation to correctly reflect the current Sphinx version requirement for building the documentation.

# Details

There was a time when we wanted to keep the Sphinx version below 8, but that was a long time ago, so we can update the pyproject doc optional requirement.

The install document still lists Sphinx as having a minimum version of < 2, so update this (version 5 of Sphinx was released a long time ago).