### PR TITLE
Improve the typing of the utils module

### DIFF
--- a/sherpa/astro/data.py
+++ b/sherpa/astro/data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2015-2025
+#  Copyright (C) 2008, 2015-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1212,7 +1212,7 @@ class DataRMF(DataOgipResponse):
                         self.detchans, self.offset)
 
     @overload
-    def notice(self, noticed_chans: None) -> None:
+    def notice(self, noticed_chans: None = None) -> None:
         ...
 
     @overload
@@ -1220,7 +1220,9 @@ class DataRMF(DataOgipResponse):
         ...
 
     # Note that noticed_chans is not a mask, but the channel values.
-    def notice(self, noticed_chans=None):
+    def notice(self,
+               noticed_chans: np.ndarray | None = None
+               ) -> np.ndarray | None:
         """Filter the response to match the requested channels."""
 
         self._fch = self.f_chan
@@ -1830,7 +1832,7 @@ will be removed. The identifiers can be integers or strings.
                      attr: str,
                      val: ArrayType | None,
                      check_mask: bool = True,
-                     allow_scalar: object = Literal[False],
+                     allow_scalar: Literal[False] = False,
                      **kwargs
                      ) -> None:
         ...
@@ -1840,7 +1842,7 @@ will be removed. The identifiers can be integers or strings.
                      attr: str,
                      val: float,
                      check_mask: bool = True,
-                     allow_scalar: object = Literal[True],
+                     allow_scalar: Literal[True] = True,
                      **kwargs
                      ) -> None:
         ...
@@ -3184,7 +3186,10 @@ It is an integer or string.
                      groupfunc: Callable) -> np.ndarray:
         ...
 
-    def apply_filter(self, data, groupfunc=np.sum):
+    def apply_filter(self,
+                     data: ArrayType | None,
+                     groupfunc: Callable = np.sum
+                     ) -> np.ndarray | None:
         """Group and filter the supplied data to match the data set.
 
         Parameters
@@ -3341,7 +3346,10 @@ It is an integer or string.
                        groupfunc: Callable) -> np.ndarray:
         ...
 
-    def apply_grouping(self, data, groupfunc=np.sum):
+    def apply_grouping(self,
+                       data: ArrayType | None,
+                       groupfunc: Callable = np.sum
+                       ) -> np.ndarray | None:
         """Apply the grouping scheme of the data set to the supplied data.
 
         Parameters

--- a/sherpa/astro/xspec/__init__.py
+++ b/sherpa/astro/xspec/__init__.py
@@ -153,11 +153,7 @@ xsstate: dict[str, Any] = {
 # documentation run).
 #
 @overload
-def get_xsabund() -> str:
-    ...
-
-@overload
-def get_xsabund(element: None) -> str:
+def get_xsabund(element: None = None) -> str:
     ...
 
 @overload
@@ -782,11 +778,7 @@ def clear_xsxset() -> None:
 
 
 @overload
-def get_xsxset() -> dict[str, str]:
-    ...
-
-@overload
-def get_xsxset(name: None) -> dict[str, str]:
+def get_xsxset(name: None = None) -> dict[str, str]:
     ...
 
 @overload

--- a/sherpa/data.py
+++ b/sherpa/data.py
@@ -186,7 +186,7 @@ def _check_nomask(array: None) -> None:
 def _check_nomask(array: ArrayType) -> np.ndarray:
     ...
 
-def _check_nomask(array):
+def _check_nomask(array: ArrayType | None) -> np.ndarray | None:
     if hasattr(array, 'mask'):
         warnings.warn(f'Input array {array} has a mask attribute. Because masks are supported for dependent variables only the mask attribute of the independent array is ignored and values `behind the mask` are used.')
 
@@ -204,7 +204,8 @@ def _check_dep(array: None) -> tuple[None, Literal[True]]:
 def _check_dep(array: ArrayType) -> tuple[np.ndarray, bool]:
     ...
 
-def _check_dep(array):
+def _check_dep(array: ArrayType | None
+               ) -> tuple[None, Literal[True]] | tuple[np.ndarray, bool]:
     if not hasattr(array, 'mask'):
         return _check(array), True
 
@@ -648,7 +649,9 @@ class Filter:
     def apply(self, array: ArrayType) -> np.ndarray:
         ...
 
-    def apply(self, array):
+    def apply(self,
+              array: ArrayType | None
+              ) -> np.ndarray | None:
         """Apply this filter to an array
 
         Parameters
@@ -1461,7 +1464,9 @@ class Data(NoNewAttributesAfterInit, BaseData):
     def apply_filter(self, data: ArrayType) -> np.ndarray:
         ...
 
-    def apply_filter(self, data):
+    def apply_filter(self,
+                     data: ArrayType | None
+                     ) -> np.ndarray | None:
         if data is None:
             return None
 
@@ -1837,15 +1842,8 @@ class Data1D(Data):
         model_evaluation = yfunc(*self.get_evaluation_indep(filter, yfunc, use_evaluation_space))
         return (y, model_evaluation)
 
-    @overload
-    def get_bounding_mask(self) -> tuple[bool, None]:
-        ...
-
-    @overload
-    def get_bounding_mask(self) -> tuple[np.ndarray, tuple[int]]:
-        ...
-
-    def get_bounding_mask(self):
+    def get_bounding_mask(self
+                          ) -> tuple[np.ndarray, tuple[int]] | tuple[bool, None]:
         mask = self.mask
         size = None
         if np.iterable(self.mask):

--- a/sherpa/utils/__init__.py
+++ b/sherpa/utils/__init__.py
@@ -1822,7 +1822,25 @@ def parse_expr(expr: str) -> list[tuple[float | None, float | None]]:
     return res
 
 
-def calc_total_error(staterror=None, syserror=None):
+@overload
+def calc_total_error(staterror: None = None, syserror: None = None) -> None:
+    ...
+
+@overload
+def calc_total_error(staterror: ArrayType, syserror: None = None) -> np.ndarray:
+    ...
+
+@overload
+def calc_total_error(staterror: None, syserror: ArrayType) -> np.ndarray:
+    ...
+
+@overload
+def calc_total_error(staterror: ArrayType, syserror: ArrayType) -> np.ndarray:
+    ...
+
+def calc_total_error(staterror: ArrayType | None = None,
+                     syserror: ArrayType | None = None
+                     ) -> np.ndarray | None:
     """Add statistical and systematic errors in quadrature.
 
     Parameters
@@ -1840,15 +1858,17 @@ def calc_total_error(staterror=None, syserror=None):
 
     """
 
-    if (staterror is None) and (syserror is None):
-        error = None
-    elif (staterror is not None) and (syserror is None):
-        error = staterror
-    elif (staterror is None) and (syserror is not None):
-        error = syserror
-    else:
-        error = np.sqrt(staterror * staterror + syserror * syserror)
-    return error
+    if staterror is not None:
+        s1 = np.asarray(staterror)
+        if syserror is None:
+            return s1
+
+        return np.sqrt(s1**2 + np.asarray(syserror)**2)
+
+    if syserror is not None:
+        return np.asarray(syserror)
+
+    return None
 
 
 def quantile(sorted_array, f):

--- a/sherpa/utils/guess.py
+++ b/sherpa/utils/guess.py
@@ -488,8 +488,8 @@ def guess_amplitude_at_ref(r: float,
 def guess_amplitude2d(y: np.ndarray,
                       x0lo: np.ndarray,
                       x1lo: np.ndarray,
-                      x0hi: Literal[None],
-                      x1hi: Literal[None]
+                      x0hi: None = None,
+                      x1hi: None = None
                       ) -> ValueAndRange:
     ...
 
@@ -502,7 +502,12 @@ def guess_amplitude2d(y: np.ndarray,
                       ) -> ValueAndRange:
     ...
 
-def guess_amplitude2d(y, x0lo, x1lo, x0hi=None, x1hi=None):
+def guess_amplitude2d(y: np.ndarray,
+                      x0lo: np.ndarray,
+                      x1lo: np.ndarray,
+                      x0hi: np.ndarray | None = None,
+                      x1hi: np.ndarray | None = None
+                      ) -> ValueAndRange:
     """
     Guess 2D model parameter amplitude (val, min, max)
 
@@ -576,8 +581,8 @@ def get_position(y: np.ndarray,
 def guess_position(y: np.ndarray,
                    x0lo: np.ndarray,
                    x1lo: np.ndarray,
-                   x0hi: Literal[None],
-                   x1hi: Literal[None]
+                   x0hi: None = None,
+                   x1hi: None = None
                    ) -> tuple[ValueAndRange, ValueAndRange]:
     ...
 
@@ -590,7 +595,12 @@ def guess_position(y: np.ndarray,
                    ) -> tuple[ValueAndRange, ValueAndRange]:
     ...
 
-def guess_position(y, x0lo, x1lo, x0hi=None, x1hi=None):
+def guess_position(y: np.ndarray,
+                   x0lo: np.ndarray,
+                   x1lo: np.ndarray,
+                   x0hi: np.ndarray | None = None,
+                   x1hi: np.ndarray | None = None
+                   ) -> tuple[ValueAndRange, ValueAndRange]:
     """
     Guess 2D model parameter positions xpos, ypos ({val0, min0, max0},
                                                    {val1, min1, max1})
@@ -620,7 +630,7 @@ def guess_position(y, x0lo, x1lo, x0hi=None, x1hi=None):
 
 @overload
 def guess_bounds(x: np.ndarray,
-                 xhi: Literal[True]
+                 xhi: Literal[True] = True
                  ) -> tuple[ValueAndRange, ValueAndRange]:
     ...
 
@@ -630,7 +640,9 @@ def guess_bounds(x: np.ndarray,
                  ) -> ValueAndRange:
     ...
 
-def guess_bounds(x, xhi=True):
+def guess_bounds(x: np.ndarray,
+                 xhi: bool = True
+                 ) -> ValueAndRange | tuple[ValueAndRange, ValueAndRange]:
     """Guess the bounds of a parameter from the independent axis.
 
     Parameters
@@ -672,8 +684,8 @@ def guess_bounds(x, xhi=True):
 @overload
 def guess_radius(x0lo: np.ndarray,
                  x1lo: np.ndarray,
-                 x0hi: Literal[None],
-                 x1hi: Literal[None]
+                 x0hi: None = None,
+                 x1hi: None = None
                  ) -> ValueAndRange:
     ...
 
@@ -685,7 +697,11 @@ def guess_radius(x0lo: np.ndarray,
                  ) -> ValueAndRange:
     ...
 
-def guess_radius(x0lo, x1lo, x0hi=None, x1hi=None):
+def guess_radius(x0lo: np.ndarray,
+                 x1lo: np.ndarray,
+                 x0hi: np.ndarray | None = None,
+                 x1hi: np.ndarray | None = None
+                 ) -> ValueAndRange:
     """Guess the radius parameter of a 2D model.
 
     Parameters

--- a/sherpa/utils/guess.py
+++ b/sherpa/utils/guess.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2007, 2015, 2016, 2018 - 2024
+#  Copyright (C) 2007, 2015, 2016, 2018-2024, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -26,7 +26,7 @@ Routines related to estimating initial parameter values and limits.
 
 """
 
-from typing import Any, Optional, Literal, TypedDict, cast, overload
+from typing import Any, Literal, TypedDict, cast, overload
 
 import numpy as np
 
@@ -45,8 +45,8 @@ __all__ = ("_guess_ampl_scale", "get_midpoint", "get_peak",
 class ValueAndRange(TypedDict):
     """Represent a value and range as a dict."""
     val: float
-    min: Optional[float]
-    max: Optional[float]
+    min: float | None
+    max: float | None
 
 
 _guess_ampl_scale: float = 1.e+3
@@ -94,7 +94,7 @@ def get_midpoint(a: np.ndarray) -> float:
 #
 def get_peak(y: np.ndarray,
              x: np.ndarray,
-             xhi: Optional[np.ndarray] = None) -> float:
+             xhi: np.ndarray | None = None) -> float:
     """Estimate the peak position of the data.
 
     Parameters
@@ -125,7 +125,7 @@ def get_peak(y: np.ndarray,
 
 def get_valley(y: np.ndarray,
                x: np.ndarray,
-               xhi: Optional[np.ndarray] = None) -> float:
+               xhi: np.ndarray | None = None) -> float:
     """Estimate the position of the minimum of the data.
 
     Parameters
@@ -155,7 +155,7 @@ def get_valley(y: np.ndarray,
 
 def get_fwhm(y: np.ndarray,
              x: np.ndarray,
-             xhi: Optional[np.ndarray] = None) -> float:
+             xhi: np.ndarray | None = None) -> float:
     """Estimate the width of the data.
 
     This is only valid for positive data values (``y``).
@@ -252,7 +252,7 @@ def get_fwhm(y: np.ndarray,
 
 def guess_fwhm(y: np.ndarray,
                x: np.ndarray,
-               xhi: Optional[np.ndarray] = None,
+               xhi: np.ndarray | None = None,
                scale: float = 1000) -> ValueAndRange:
     """Estimate the value and valid range for the FWHM of the data.
 
@@ -414,7 +414,7 @@ def get_amplitude_position(arr: np.ndarray,
 
 def guess_amplitude(y: np.ndarray,
                     x: np.ndarray,
-                    xhi: Optional[np.ndarray] = None
+                    xhi: np.ndarray | None = None
                     ) -> ValueAndRange:
     """
     Guess model parameter amplitude (val, min, max)
@@ -445,7 +445,7 @@ def guess_amplitude(y: np.ndarray,
 def guess_amplitude_at_ref(r: float,
                            y: np.ndarray,
                            x: np.ndarray,
-                           xhi: Optional[np.ndarray] = None
+                           xhi: np.ndarray | None = None
                            ) -> ValueAndRange:
     """
     Guess model parameter amplitude (val, min, max)
@@ -524,7 +524,7 @@ def guess_amplitude2d(y, x0lo, x1lo, x0hi=None, x1hi=None):
 def guess_reference(pmin: float,
                     pmax: float,
                     x: np.ndarray,
-                    xhi: Optional[np.ndarray] = None
+                    xhi: np.ndarray | None = None
                     ) -> ValueAndRange:
     """
     Guess model parameter reference (val, min, max)
@@ -553,7 +553,7 @@ def guess_reference(pmin: float,
 
 def get_position(y: np.ndarray,
                  x: np.ndarray,
-                 xhi: Optional[np.ndarray] = None
+                 xhi: np.ndarray | None = None
                  ) -> ValueAndRange:
     """
     Get 1D model parameter positions pos (val, min, max)

--- a/sherpa/utils/random.py
+++ b/sherpa/utils/random.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2023 - 2025
+#  Copyright (C) 2023-2025, 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -28,7 +28,7 @@ allows both the legacy (pre 1.17) NumPy random API to be used
 """
 
 from collections.abc import Sequence
-from typing import Literal, SupportsFloat, overload
+from typing import SupportsFloat, overload
 
 import numpy as np
 
@@ -156,7 +156,7 @@ SizeType = int | Sequence[int] | np.ndarray
 def uniform(rng: RandomType | None,
             low: float,
             high: float,
-            size: Literal[None] = None
+            size: None = None
             ) -> float:
     ...
 
@@ -174,7 +174,7 @@ def uniform(rng: RandomType | None,
 def uniform(rng: RandomType | None,
             low: ArrayType,
             high: ArrayType,
-            size: Literal[None] = None
+            size: None = None
             ) -> np.ndarray:
     ...
 
@@ -243,7 +243,7 @@ def integers(rng: RandomType | None,
 def normal(rng: RandomType | None,
            loc: float,
            scale: float,
-           size: Literal[None]
+           size: None = None
            ) -> float:
     ...
 
@@ -288,7 +288,7 @@ def normal(rng: RandomType | None,
 
 @overload
 def standard_normal(rng: RandomType | None,
-                    size: Literal[None]
+                    size: None = None
                     ) -> float:
     ...
 

--- a/sherpa/utils/random.py
+++ b/sherpa/utils/random.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2023-2025, 2026
+#  Copyright (C) 2023-2026
 #  Smithsonian Astrophysical Observatory
 #
 #


### PR DESCRIPTION
# Summary

Improve the typing of a number of routines, primarily from the sherpa.utiils module. There is no functional change.

# Details

This is a subset of #2417, focussing on improving our use of the [`overload`](https://typing.python.org/en/latest/spec/overload.html) symbol (the documentation has improved over time), particularly the handling of optional arguments.

It is still not clear to me whether we have to type the actual routine with the combined rules from the `overload` statement, but I am going to assume that this is so (even if it feels wasteful with the repetition).

The typing errors don't always decrease after these changes but

- we drop a number of ones that say "error: Overloaded implementation is not consistent with signature of overload 1" (this is a `pyright` example)
- the extra warnings/errors from the typing code is normally because it can now better type things (and we have a number of cases where array-like vs numpy array like typing statements appear problematic)