### PR TITLE
Allow the sample flux routines to pass arguments to the error-estimation code (CSC)

### DIFF
--- a/sherpa/astro/flux.py
+++ b/sherpa/astro/flux.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2015-2016, 2019-2020, 2021, 2023, 2025
+#  Copyright (C) 2009, 2015-2016, 2019-2020, 2021, 2023, 2025-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -34,15 +34,18 @@ import numpy as np
 from sherpa.astro.utils import calc_energy_flux
 from sherpa.fit import Fit
 from sherpa.models.model import ArithmeticModel, SimulFitModel
-from sherpa.sim import NormalParameterSampleFromScaleMatrix, \
+from sherpa.sim import (
+    NormalParameterSampleFromScaleMatrix,
     NormalParameterSampleFromScaleVector
+)
 from sherpa.sim.sample import ClipValue
 from sherpa.utils import parallel_map, random
 from sherpa.utils.err import ArgumentErr, FitErr, ModelErr
+from sherpa.utils.types import PrefsType
 
 info = logging.getLogger(__name__).info
 
-__all__ = ['calc_flux', 'sample_flux', 'calc_sample_flux']
+__all__ = ['calc_flux', 'calc_sample_flux', 'sample_flux']
 
 
 class CalcFluxWorker:
@@ -159,9 +162,13 @@ def _sample_flux_get_samples_with_scales(fit: Fit,
                                          scales: np.ndarray,
                                          num: int,
                                          clip: ClipValue = 'hard',
-                                         rng: random.RandomType | None = None
+                                         rng: random.RandomType | None = None,
+                                         est_method_args: PrefsType | None = None
                                          ) -> tuple[np.ndarray, np.ndarray]:
     """Return the parameter samples given the parameter scales.
+
+    .. versionchanged:: 4.19.0
+       The routine now accepts the est_method_args parameter.
 
     Parameters
     ----------
@@ -197,6 +204,8 @@ def _sample_flux_get_samples_with_scales(fit: Fit,
         Determines how random numbers are created. If set to None then
         the routines from `numpy.random` are used, and so can be
         controlled by calling `numpy.random.seed`.
+    est_method_args
+        Any extra configuration for the error estimation class.
 
     Returns
     -------
@@ -281,10 +290,12 @@ def _sample_flux_get_samples_with_scales(fit: Fit,
 
     if correlated:
         sampler = NormalParameterSampleFromScaleMatrix()
-        samples = sampler.get_sample(fit, mycov=scales, num=num, rng=rng)
+        samples = sampler.get_sample(fit, mycov=scales, num=num, rng=rng,
+                                     est_method_args=est_method_args)
     else:
         sampler = NormalParameterSampleFromScaleVector()
-        samples = sampler.get_sample(fit, myscales=scales, num=num, rng=rng)
+        samples = sampler.get_sample(fit, myscales=scales, num=num, rng=rng,
+                                     est_method_args=est_method_args)
 
     clipped = sampler.clip(fit, samples, clip=clip)
     return samples, clipped
@@ -295,12 +306,16 @@ def _sample_flux_get_samples(fit: Fit,
                              correlated: bool,
                              num: int,
                              clip: ClipValue = 'hard',
-                             rng: random.RandomType | None = None
+                             rng: random.RandomType | None = None,
+                             est_method_args: PrefsType | None = None
                              ) -> tuple[np.ndarray, np.ndarray]:
     """Return the parameter samples, using fit to define the scales.
 
     The covariance method is used to estimate the errors for the
     parameter sampling.
+
+    .. versionchanged:: 4.19.0
+       The routine now accepts the est_method_args parameter.
 
     Parameters
     ----------
@@ -329,6 +344,8 @@ def _sample_flux_get_samples(fit: Fit,
         Determines how random numbers are created. If set to None then
         the routines from `numpy.random` are used, and so can be
         controlled by calling `numpy.random.seed`.
+    est_method_args
+        Any extra configuration for the error estimation class.
 
     Returns
     -------
@@ -355,7 +372,8 @@ def _sample_flux_get_samples(fit: Fit,
     else:
         sampler = NormalParameterSampleFromScaleVector()
 
-    samples = sampler.get_sample(fit, num=num, rng=rng)
+    samples = sampler.get_sample(fit, num=num, rng=rng,
+                                 est_method_args=est_method_args)
     clipped = sampler.clip(fit, samples, clip=clip)
     return samples, clipped
 
@@ -381,7 +399,7 @@ def decompose(mdl):
     # return the individual components, including sub-expressions,
     # so we just drop the sub-expressions.
     #
-    out = set([])
+    out = set()
 
     if isinstance(mdl, SimulFitModel):
         # This is messier than I'd like
@@ -414,7 +432,8 @@ def sample_flux(fit: Fit,
                 numcores: int | None = None,
                 samples: np.ndarray | None = None,
                 clip: ClipValue = 'hard',
-                rng: random.RandomType | None = None
+                rng: random.RandomType | None = None,
+                est_method_args: PrefsType | None = None
                 ) -> np.ndarray:
     """Calculate model fluxes from a sample of parameter values.
 
@@ -422,6 +441,9 @@ def sample_flux(fit: Fit,
     the model flux for each set of parameter values. The values are
     drawn from normal distributions, and the distributions can either
     be independent or have correlations between the parameters.
+
+    .. versionchanged:: 4.19.0
+       The routine now accepts the est_method_args parameter.
 
     .. versionchanged:: 4.16.0
        The rng parameter was added.
@@ -483,6 +505,8 @@ def sample_flux(fit: Fit,
         Determines how random numbers are created. If set to None then
         the routines from `numpy.random` are used, and so can be
         controlled by calling `numpy.random.seed`.
+    est_method_args
+        Any extra configuration for the error estimation class.
 
     Returns
     -------
@@ -543,11 +567,13 @@ def sample_flux(fit: Fit,
     scales = samples
     if scales is None:
         samples, clipped = _sample_flux_get_samples(fit, src, correlated,
-                                                    num, clip=clip, rng=rng)
+                                                    num, clip=clip, rng=rng,
+                                                    est_method_args=est_method_args)
     else:
         samples, clipped = _sample_flux_get_samples_with_scales(fit, src, correlated,
                                                                 scales, num, clip=clip,
-                                                                rng=rng)
+                                                                rng=rng,
+                                                                est_method_args=est_method_args)
 
     # When a subset of the full model is used we need to know how
     # to select which rows in the samples array refer to the
@@ -586,8 +612,8 @@ def calc_sample_flux(lo: float | None,
                      data,
                      samples,
                      modelcomponent,
-                     confidence: float | None
-                     ):
+                     confidence: float
+                     ) -> list[np.ndarray]:
     """Given a set of parameter samples, estimate the flux distribution.
 
     This is similar to sample_flux but returns values for both the full
@@ -635,7 +661,7 @@ def calc_sample_flux(lo: float | None,
         that is used for calculating the "unabsorbed" flux. This is
         not a SimulFitModel instance. If None then we just reuse the
         input flux values (first column of samples).
-    confidence : number, optional
+    confidence : number
        The confidence level for the upper and lower values, as a
        percentage (0 to 100). A value of 68.3 will return the
        one-sigma range.
@@ -713,10 +739,10 @@ def calc_sample_flux(lo: float | None,
     # but it would complicate the code for essentially no time saving.
     #
     hwidth = confidence / 2
-    result = []
+    result: list[np.ndarray] = []
     for flx in [oflx, iflx]:
         result.append(np.percentile(flx[valid],
-                                       [50, 50 + hwidth, 50 - hwidth]))
+                                    [50, 50 + hwidth, 50 - hwidth]))
 
     for lbl, arg in zip(['original model', 'model component'], result):
         med, usig, lsig = arg

--- a/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_fluxes.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020-2023, 2025
+#  Copyright (C) 2020-2023, 2025-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -2693,3 +2693,94 @@ def test_2337_linked_par_subset(setup, clean_astro_ui):
     assert res[:, 1] == pytest.approx([14.98264164, 18.13393656, 15.79721333, 15.80157972, 15.8858083 ])
     assert res[:, 2] == pytest.approx([5.99565486, 7.77280365, 4.44169833, 6.36608732, 6.36504029])
     assert res[:, 3] == pytest.approx([0] * 5)
+
+
+@requires_data
+@requires_fits
+@pytest.mark.parametrize("meth", [ui.sample_photon_flux,
+                                  ui.sample_energy_flux])
+def test_sample_xxx_flux_est_method_args(meth, make_data_path, clean_astro_ui):
+    """Check we can pass arguments via est_method_args."""
+
+    niter = 10
+    token = 723454645
+    scale = 2.0
+
+    # Pick a range where the model parameters are well defined.
+    # Ignore background subtraction.
+    #
+    with SherpaVerbosity('ERROR'):
+        ui.load_pha(1, make_data_path("3c273.pi"))
+
+        ui.get_data(1).delete_background(1)
+        ui.ignore(hi=1)
+        ui.ignore(lo=7)
+
+        ui.set_source(1, ui.powlaw1d.pl)
+        pl.gamma = 1.9
+        pl.ampl = 1e-4
+        ui.fit()
+
+    mdl = ui.get_source(1)
+    pvals = np.asarray(mdl.thawedpars)
+
+    ui.set_rng(np.random.RandomState(token))
+    vals1 = meth(id=1, num=niter)
+
+
+    ui.set_rng(np.random.RandomState(token))
+    vals2 = meth(id=1, num=niter, est_method_args={"sigma": scale})
+
+    # Are the samples related as expected?
+    #
+    d1 = vals1[:, 1:3] - pvals
+    d2 = vals2[:, 1:3] - pvals
+    ratio = d2 / d1
+
+    expected = np.full((niter, 2), scale)
+    assert ratio == pytest.approx(expected, rel=1e-4)
+
+
+@requires_data
+@requires_fits
+def test_sample_flux_est_method_args(make_data_path, clean_astro_ui):
+    """Check we can pass arguments via est_method_args."""
+
+    niter = 10
+    token = 723454645
+    scale = 2.0
+
+    # Pick a range where the model parameters are well defined.
+    # Ignore background subtraction.
+    #
+    with SherpaVerbosity('ERROR'):
+        ui.load_pha(1, make_data_path("3c273.pi"))
+
+        ui.get_data(1).delete_background(1)
+        ui.ignore(hi=1)
+        ui.ignore(lo=7)
+
+        ui.set_source(1, ui.powlaw1d.pl)
+        pl.gamma = 1.9
+        pl.ampl = 1e-4
+        ui.fit()
+
+    mdl = ui.get_source(1)
+    pvals = np.asarray(mdl.thawedpars)
+
+    ui.set_rng(np.random.RandomState(token))
+    _, _, vals1 = ui.sample_flux(id=1, num=niter)
+
+
+    ui.set_rng(np.random.RandomState(token))
+    _, _, vals2 = ui.sample_flux(id=1, num=niter,
+                                 est_method_args={"sigma": scale})
+
+    # Are the samples related as expected?
+    #
+    d1 = vals1[:, 1:3] - pvals
+    d2 = vals2[:, 1:3] - pvals
+    ratio = d2 / d1
+
+    expected = np.full((niter + 1, 2), scale)
+    assert ratio == pytest.approx(expected, rel=1e-4)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -63,6 +63,7 @@ from sherpa.models.model import Model
 import sherpa.plot
 from sherpa.sim import NormalParameterSampleFromScaleMatrix, \
     ReSampleData
+from sherpa.sim.sample import ClipValue
 from sherpa.stats import Cash, CStat, WStat
 
 import sherpa.ui.utils
@@ -74,7 +75,7 @@ from sherpa.utils import bool_cast, get_error_estimates, is_subclass, \
 from sherpa.utils.err import ArgumentErr, ArgumentTypeErr, DataErr, \
     IdentifierErr, ImportErr, IOErr, ModelErr
 from sherpa.utils.numeric_types import SherpaFloat
-from sherpa.utils.types import IdType, IdTypes
+from sherpa.utils.types import IdType, IdTypes, PrefsType
 
 warning = logging.getLogger(__name__).warning
 info = logging.getLogger(__name__).info
@@ -13125,7 +13126,7 @@ class Session(sherpa.ui.utils.Session):
                                   scales=None,
                                   model=None,
                                   otherids: IdTypes = (),
-                                  clip='hard'
+                                  clip: ClipValue = 'hard'
                                   ):
         """Run sample_energy_flux and convert to a plot.
         """
@@ -13149,7 +13150,7 @@ class Session(sherpa.ui.utils.Session):
                                   scales=None,
                                   model=None,
                                   otherids: IdTypes=(),
-                                  clip='hard'
+                                  clip: ClipValue = 'hard'
                                   ):
         """Run sample_photon_flux and convert to a plot.
         """
@@ -13161,21 +13162,21 @@ class Session(sherpa.ui.utils.Session):
         return plot
 
     def get_energy_flux_hist(self,
-                             lo=None,
-                             hi=None,
+                             lo: float | None = None,
+                             hi: float | None = None,
                              id: IdType | None = None,
-                             num=7500,
-                             bins=75,
+                             num: int = 7500,
+                             bins: int = 75,
                              correlated: bool = False,
                              numcores: int | None = None,
                              bkg_id: IdType | None = None,
-                             scales=None,
+                             scales: np.ndarray | None = None,
                              model=None,
                              otherids: IdTypes = (),
                              recalc: bool = True,
-                             clip='hard',
+                             clip: ClipValue = 'hard',
                              copy: bool = True
-                             ):
+                             ) -> sherpa.astro.plot.EnergyFluxHistogram:
         """Return the data displayed by plot_energy_flux.
 
         The get_energy_flux_hist() function calculates a histogram of
@@ -13316,21 +13317,21 @@ class Session(sherpa.ui.utils.Session):
         return cpy(plotobj, copy)
 
     def get_photon_flux_hist(self,
-                             lo=None,
-                             hi=None,
+                             lo: float | None = None,
+                             hi: float | None = None,
                              id: IdType | None = None,
-                             num=7500,
-                             bins=75,
+                             num: int = 7500,
+                             bins: int = 75,
                              correlated: bool = False,
                              numcores: int | None = None,
                              bkg_id: IdType | None = None,
-                             scales=None,
+                             scales: np.ndarray | None = None,
                              model=None,
                              otherids: IdTypes = (),
                              recalc: bool = True,
-                             clip='hard',
+                             clip: ClipValue = 'hard',
                              copy: bool = True
-                             ):
+                             ) -> sherpa.astro.plot.PhotonFluxHistogram:
         """Return the data displayed by plot_photon_flux.
 
         The get_photon_flux_hist() function calculates a histogram of
@@ -14424,7 +14425,7 @@ class Session(sherpa.ui.utils.Session):
                          model=None,
                          otherids: IdTypes = (),
                          recalc: bool = True,
-                         clip='hard',
+                         clip: ClipValue = 'hard',
                          overplot: bool = False,
                          clearwindow: bool = True,
                          **kwargs) -> None:
@@ -14588,7 +14589,7 @@ class Session(sherpa.ui.utils.Session):
                          model=None,
                          otherids: IdTypes = (),
                          recalc: bool = True,
-                         clip='hard',
+                         clip: ClipValue = 'hard',
                          overplot: bool = False,
                          clearwindow: bool = True,
                          **kwargs) -> None:
@@ -15123,18 +15124,19 @@ class Session(sherpa.ui.utils.Session):
                             rng=self.get_rng())
 
     def sample_photon_flux(self,
-                           lo=None,
-                           hi=None,
+                           lo: float | None = None,
+                           hi: float | None = None,
                            id: IdType | None = None,
-                           num=1,
-                           scales=None,
+                           num: int = 1,
+                           scales: np.ndarray | None = None,
                            correlated: bool = False,
                            numcores: int | None = None,
                            bkg_id: IdType | None = None,
                            model=None,
                            otherids: IdTypes = (),
-                           clip='hard'
-                           ):
+                           clip: ClipValue = 'hard',
+                           est_method_args: PrefsType | None = None
+                           ) -> np.ndarray:
         """Return the photon flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -15142,6 +15144,9 @@ class Session(sherpa.ui.utils.Session):
         model over the given range (the flux). The return array
         contains the flux and parameter values for each iteration.
         The units for the flux are as returned by `calc_photon_flux`.
+
+        .. versionchanged:: 4.19.0
+           The routine now accepts the est_method_args parameter.
 
         .. versionchanged:: 4.16.0
            The random number generation is now controlled by the
@@ -15209,6 +15214,8 @@ class Session(sherpa.ui.utils.Session):
             clipping. The last column in the returned arrays indicates
             if the row had any clipped parameters (even when clip is
             set to 'none').
+        est_method_args
+           Any extra configuration for the error estimation class.
 
         Returns
         -------
@@ -15358,21 +15365,23 @@ class Session(sherpa.ui.utils.Session):
                                              num=num, lo=lo, hi=hi,
                                              numcores=numcores,
                                              samples=scales, clip=clip,
-                                             rng=self.get_rng())
+                                             rng=self.get_rng(),
+                                             est_method_args=est_method_args)
 
     def sample_energy_flux(self,
-                           lo=None,
-                           hi=None,
+                           lo: float | None = None,
+                           hi: float | None = None,
                            id: IdType | None = None,
-                           num=1,
-                           scales=None,
-                           correlated=False,
-                           numcores=None,
+                           num: int = 1,
+                           scales: np.ndarray | None = None,
+                           correlated: bool = False,
+                           numcores: int | None = None,
                            bkg_id: IdType | None = None,
                            model=None,
                            otherids: IdTypes = (),
-                           clip='hard'
-                           ):
+                           clip: ClipValue = 'hard',
+                           est_method_args: PrefsType | None = None
+                           ) -> np.ndarray:
         """Return the energy flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -15380,6 +15389,9 @@ class Session(sherpa.ui.utils.Session):
         model over the given range (the flux). The return array
         contains the flux and parameter values for each iteration.
         The units for the flux are as returned by `calc_energy_flux`.
+
+        .. versionchanged:: 4.19.0
+           The routine now accepts the est_method_args parameter.
 
         .. versionchanged:: 4.16.0
            The random number generation is now controlled by the
@@ -15447,6 +15459,8 @@ class Session(sherpa.ui.utils.Session):
             clipping. The last column in the returned arrays indicates
             if the row had any clipped parameters (even when clip is
             set to 'none').
+        est_method_args
+           Any extra configuration for the error estimation class.
 
         Returns
         -------
@@ -15596,20 +15610,22 @@ class Session(sherpa.ui.utils.Session):
                                              num=num, lo=lo, hi=hi,
                                              numcores=numcores,
                                              samples=scales, clip=clip,
-                                             rng=self.get_rng())
+                                             rng=self.get_rng(),
+                                             est_method_args=est_method_args)
 
     def sample_flux(self,
                     modelcomponent=None,
-                    lo=None,
-                    hi=None,
+                    lo: float | None = None,
+                    hi: float | None = None,
                     id: IdType | None = None,
-                    num=1,
-                    scales=None,
-                    correlated=False,
-                    numcores=None,
+                    num: int = 1,
+                    scales: np.ndarray | None = None,
+                    correlated: bool = False,
+                    numcores: int | None = None,
                     bkg_id: IdType | None = None,
-                    Xrays=True,
-                    confidence=68
+                    Xrays: bool = True,
+                    confidence: float = 68,
+                    est_method_args: PrefsType | None = None
                     ):
         """Return the flux distribution of a model.
 
@@ -15619,6 +15635,9 @@ class Session(sherpa.ui.utils.Session):
         and sum the model over the given range (the flux). Return the
         parameter values used, together with the median, upper, and
         lower quantiles of the flux distribution.
+
+        .. versionchanged:: 4.19.0
+           The routine now accepts the est_method_args parameter.
 
         .. versionchanged:: 4.16.0
            The random number generation is now controlled by the
@@ -15681,6 +15700,8 @@ class Session(sherpa.ui.utils.Session):
            The confidence level for the upper and lower values, as a
            percentage (0 to 100). The default is 68, so as to return
            the one-sigma range.
+        est_method_args
+           Any extra configuration for the error estimation class.
 
         Returns
         -------
@@ -15823,7 +15844,8 @@ class Session(sherpa.ui.utils.Session):
                                               scales=scales, clip='soft',
                                               correlated=correlated,
                                               numcores=numcores,
-                                              bkg_id=bkg_id)
+                                              bkg_id=bkg_id,
+                                              est_method_args=est_method_args)
 
         return sherpa.astro.flux.calc_sample_flux(lo=lo, hi=hi,
                                                   fit=fit, data=data, samples=samples,

--- a/sherpa/sim/__init__.py
+++ b/sherpa/sim/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015-2016, 2018-2021, 2023-2025
+#  Copyright (C) 2011, 2015-2016, 2018-2021, 2023-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -193,7 +193,6 @@ parameter::
 """
 from datetime import datetime
 import logging
-from typing import Optional
 
 import numpy as np
 
@@ -842,8 +841,8 @@ class ReSampleData(NoNewAttributesAfterInit):
 
     def __call__(self, niter=1000, seed=None, rng=None,
                  *,
-                 stat: Optional[Stat] = None,
-                 method: Optional[OptMethod] = None
+                 stat: Stat | None = None,
+                 method: OptMethod | None = None
                  ) -> dict[str, np.ndarray]:
         return self.call(niter, seed=seed, rng=rng, stat=stat,
                          method=method)
@@ -854,8 +853,8 @@ class ReSampleData(NoNewAttributesAfterInit):
              # interface and the interface is complicated enough it
              # is worth marking them keyword only.
              #
-             stat: Optional[Stat] = None,
-             method: Optional[OptMethod] = None
+             stat: Stat | None = None,
+             method: OptMethod | None = None
              ) -> dict[str, np.ndarray]:
         """Resample the data and fit the model to each iteration.
 

--- a/sherpa/sim/sample.py
+++ b/sherpa/sim/sample.py
@@ -29,7 +29,7 @@ from sherpa.fit import Fit
 from sherpa.utils import NoNewAttributesAfterInit, random
 from sherpa.utils.err import EstErr
 from sherpa.utils.parallel import parallel_map
-from sherpa.utils.types import ArrayType
+from sherpa.utils.types import ArrayType, PrefsType
 
 warning = logging.getLogger("sherpa").warning
 
@@ -137,9 +137,13 @@ class ParameterScale(NoNewAttributesAfterInit):
 
     def get_scales(self,
                    fit: Fit,
-                   myscales: np.ndarray | None = None
+                   myscales: np.ndarray | None = None,
+                   est_method_args: PrefsType | None = None
                    ) -> np.ndarray:
         """Return the samples.
+
+        .. versionchanged:: 4.19.0
+           The routine now accepts the est_method_args parameter.
 
         Parameters
         ----------
@@ -150,6 +154,8 @@ class ParameterScale(NoNewAttributesAfterInit):
         myscales : numpy array or None, optional
             The scales to use. If None then they are
             calculated from the fit.
+        est_method_args
+            Any extra configuration for the error estimation class.
 
         Returns
         -------
@@ -168,9 +174,13 @@ class ParameterScaleVector(ParameterScale):
 
     def get_scales(self,
                    fit: Fit,
-                   myscales: np.ndarray | None = None
+                   myscales: np.ndarray | None = None,
+                   est_method_args: PrefsType | None = None
                    ) -> np.ndarray:
         """Return the samples.
+
+        .. versionchanged:: 4.19.0
+           The routine now accepts the est_method_args parameter.
 
         Parameters
         ----------
@@ -184,6 +194,8 @@ class ParameterScaleVector(ParameterScale):
             between the parameters). If None then they are calculated
             from the fit, using the object's sigma attribute to scale
             the results.
+        est_method_args
+            Any extra configuration for the error estimation class.
 
         Returns
         -------
@@ -206,6 +218,9 @@ class ParameterScaleVector(ParameterScale):
 
             covar = Covariance()
             covar.config['sigma'] = self.sigma
+            if est_method_args is not None:
+                covar.config.update(est_method_args)
+
             fit.estmethod = covar
 
             try:
@@ -223,6 +238,9 @@ class ParameterScaleVector(ParameterScale):
 
                     conf = Confidence()
                     conf.config['sigma'] = self.sigma
+                    if est_method_args is not None:
+                        conf.config.update(est_method_args)
+
                     fit.estmethod = conf
                     try:
                         t = fit.est_errors(parlist=(par,))
@@ -280,9 +298,13 @@ class ParameterScaleMatrix(ParameterScale):
 
     def get_scales(self,
                    fit: Fit,
-                   myscales: np.ndarray | None = None
+                   myscales: np.ndarray | None = None,
+                   est_method_args: PrefsType | None = None
                    ) -> np.ndarray:
         """Return the samples.
+
+        .. versionchanged:: 4.19.0
+           The routine now accepts the est_method_args parameter.
 
         Parameters
         ----------
@@ -295,6 +317,8 @@ class ParameterScaleMatrix(ParameterScale):
             for the parameters.  If None then they are calculated from
             the fit, using the object's sigma attribute to scale the
             results.
+        est_method_args
+            Any extra configuration for the error estimation class.
 
         Returns
         -------
@@ -311,6 +335,9 @@ class ParameterScaleMatrix(ParameterScale):
             oldestmethod = fit.estmethod
             covar = Covariance()
             covar.config['sigma'] = self.sigma
+            if est_method_args is not None:
+                covar.config.update(est_method_args)
+
             fit.estmethod = covar
 
             try:
@@ -326,7 +353,8 @@ class ParameterScaleMatrix(ParameterScale):
             # sigma value (which is expected to be 1, although it
             # can be changed).
             #
-            cov = self.sigma**2 * cov
+            sigma = covar.config['sigma']
+            cov = sigma**2 * cov
 
         else:
             # NOTE: the self.sigma value is not used when the scales

--- a/sherpa/sim/sample.py
+++ b/sherpa/sim/sample.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2019-2021, 2023, 2025
+#  Copyright (C) 2011, 2015, 2016, 2019-2021, 2023, 2025-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -355,7 +355,7 @@ class ParameterScaleMatrix(ParameterScale):
         return cov
 
 
-ClipValue = Literal["none"] | Literal["hard"] | Literal["soft"]
+ClipValue = Literal["none", "hard", "soft"]
 
 
 class ParameterSample(NoNewAttributesAfterInit):

--- a/sherpa/sim/sample.py
+++ b/sherpa/sim/sample.py
@@ -367,9 +367,13 @@ class ParameterSample(NoNewAttributesAfterInit):
                    fit: Fit,
                    *,
                    num: int = 1,
-                   rng: random.RandomType | None = None
+                   rng: random.RandomType | None = None,
+                   **kwargs
                    ) -> np.ndarray:
         """Return the samples.
+
+        .. versionchanged:: 4.19.0
+           The routine now accepts a kwargs argument.
 
         .. versionchanged:: 4.16.0
            All arguments but the first one must be passed as a keyword
@@ -486,9 +490,13 @@ class UniformParameterSampleFromScaleVector(ParameterSampleFromScaleVector):
                    *,
                    factor: float = 4,
                    num: int = 1,
-                   rng: random.RandomType | None = None
+                   rng: random.RandomType | None = None,
+                   **kwargs
                    ) -> np.ndarray:
         """Return the parameter samples.
+
+        .. versionchanged:: 4.19.0
+           The routine now accepts a kwargs argument.
 
         .. versionchanged:: 4.16.0
            All arguments but the first one must be passed as a keyword
@@ -542,9 +550,13 @@ class NormalParameterSampleFromScaleVector(ParameterSampleFromScaleVector):
                    *,
                    myscales: np.ndarray | None = None,
                    num: int = 1,
-                   rng: random.RandomType | None = None
+                   rng: random.RandomType | None = None,
+                   **kwargs
                    ) -> np.ndarray:
         """Return the parameter samples.
+
+        .. versionchanged:: 4.19.0
+           The routine now accepts a kwargs argument.
 
         .. versionchanged:: 4.16.0
            All arguments but the first one must be passed as a keyword
@@ -597,9 +609,13 @@ class NormalParameterSampleFromScaleMatrix(ParameterSampleFromScaleMatrix):
                    *,
                    mycov: np.ndarray | None = None,
                    num: int = 1,
-                   rng: random.RandomType | None = None
+                   rng: random.RandomType | None = None,
+                   **kwargs
                    ) -> np.ndarray:
         """Return the parameter samples.
+
+        .. versionchanged:: 4.19.0
+           The routine now accepts a kwargs argument.
 
         .. versionchanged:: 4.16.0
            All arguments but the first one must be passed as a keyword
@@ -650,8 +666,12 @@ class StudentTParameterSampleFromScaleMatrix(ParameterSampleFromScaleMatrix):
                    dof: int,
                    num: int = 1,
                    rng: random.RandomType | None = None,
+                   **kwargs
                    ) -> np.ndarray:
         """Return the parameter samples.
+
+        .. versionchanged:: 4.19.0
+           The routine now accepts a kwargs argument.
 
         .. versionchanged:: 4.16.0
            All arguments but the first one must be passed as a keyword
@@ -778,9 +798,13 @@ class NormalSampleFromScaleMatrix(NormalParameterSampleFromScaleMatrix):
                    num: int = 1,
                    numcores: int | None = None,
                    rng: random.RandomType | None = None,
-                   clip: ClipValue = "none"
+                   clip: ClipValue = "none",
+                   **kwargs
                    ) -> np.ndarray:
         """Return the statistic and parameter samples.
+
+        .. versionchanged:: 4.19.0
+           The routine now accepts a kwargs argument.
 
         .. versionchanged:: 4.18.0
            The clip argument has been added, and the return value now
@@ -823,7 +847,7 @@ class NormalSampleFromScaleMatrix(NormalParameterSampleFromScaleMatrix):
         """
 
         # Knowledge of whether a row has been clipped is dropped
-        samples = super().get_sample(fit, num=num, rng=rng)
+        samples = super().get_sample(fit, num=num, rng=rng, **kwargs)
         clipped = self.clip(fit, samples, clip=clip)
         return _sample_stat(fit, samples, clipped, numcores=numcores)
 
@@ -844,9 +868,13 @@ class NormalSampleFromScaleVector(NormalParameterSampleFromScaleVector):
                    num: int = 1,
                    numcores: int | None = None,
                    rng: random.RandomType | None = None,
-                   clip: ClipValue = "none"
+                   clip: ClipValue = "none",
+                   **kwargs
                    ) -> np.ndarray:
         """Return the statistic and parameter samples.
+
+        .. versionchanged:: 4.19.0
+           The routine now accepts a kwargs argument.
 
         .. versionchanged:: 4.18.0
            The clip argument has been added, and the return value now
@@ -889,7 +917,7 @@ class NormalSampleFromScaleVector(NormalParameterSampleFromScaleVector):
         """
 
         # Knowledge of whether a row has been clipped is dropped
-        samples = super().get_sample(fit, num=num, rng=rng)
+        samples = super().get_sample(fit, num=num, rng=rng, **kwargs)
         clipped = self.clip(fit, samples, clip=clip)
         return _sample_stat(fit, samples, clipped, numcores=numcores)
 
@@ -909,9 +937,13 @@ class UniformSampleFromScaleVector(UniformParameterSampleFromScaleVector):
                    factor: float = 4,
                    numcores: int | None = None,
                    rng: random.RandomType | None = None,
-                   clip: ClipValue = "none"
+                   clip: ClipValue = "none",
+                   **kwargs
                    ) -> np.ndarray:
         """Return the statistic and parameter samples.
+
+        .. versionchanged:: 4.19.0
+           The routine now accepts a kwargs argument.
 
         .. versionchanged:: 4.18.0
            The clip argument has been added, and the return value now
@@ -956,7 +988,7 @@ class UniformSampleFromScaleVector(UniformParameterSampleFromScaleVector):
 
         """
         samples = super().get_sample(fit, factor=factor, num=num,
-                                     rng=rng)
+                                     rng=rng, **kwargs)
         clipped = self.clip(fit, samples, clip=clip)
         return _sample_stat(fit, samples, clipped, numcores=numcores)
 
@@ -978,9 +1010,13 @@ class StudentTSampleFromScaleMatrix(StudentTParameterSampleFromScaleMatrix):
                    dof: int = 2,
                    numcores: int | None = None,
                    rng: random.RandomType | None = None,
-                   clip: ClipValue = "none"
+                   clip: ClipValue = "none",
+                   **kwargs
                    ) -> np.ndarray:
         """Return the statistic and parameter samples.
+
+        .. versionchanged:: 4.19.0
+           The routine now accepts a kwargs argument.
 
         .. versionchanged:: 4.18.0
            The clip argument has been added, and the return value now
@@ -1023,7 +1059,8 @@ class StudentTSampleFromScaleMatrix(StudentTParameterSampleFromScaleMatrix):
            indicates whether any parameters were clipped.
 
         """
-        samples = super().get_sample(fit, dof=dof, num=num, rng=rng)
+        samples = super().get_sample(fit, dof=dof, num=num, rng=rng,
+                                     **kwargs)
         clipped = self.clip(fit, samples, clip=clip)
         return _sample_stat(fit, samples, clipped, numcores=numcores)
 

--- a/sherpa/sim/sample.py
+++ b/sherpa/sim/sample.py
@@ -397,12 +397,13 @@ class ParameterSample(NoNewAttributesAfterInit):
                    *,
                    num: int = 1,
                    rng: random.RandomType | None = None,
+                   est_method_args: PrefsType | None = None,
                    **kwargs
                    ) -> np.ndarray:
         """Return the samples.
 
         .. versionchanged:: 4.19.0
-           The routine now accepts a kwargs argument.
+           The routine now accepts est_method_args and kwargs.
 
         .. versionchanged:: 4.16.0
            All arguments but the first one must be passed as a keyword
@@ -419,6 +420,8 @@ class ParameterSample(NoNewAttributesAfterInit):
            Determines how random numbers are created. If set to None
            then the routines from `numpy.random` are used, and so can
            be controlled by calling `numpy.random.seed`.
+        est_method_args
+            Any extra configuration for the error estimation class.
 
         Returns
         -------
@@ -520,12 +523,13 @@ class UniformParameterSampleFromScaleVector(ParameterSampleFromScaleVector):
                    factor: float = 4,
                    num: int = 1,
                    rng: random.RandomType | None = None,
+                   est_method_args: PrefsType | None = None,
                    **kwargs
                    ) -> np.ndarray:
         """Return the parameter samples.
 
         .. versionchanged:: 4.19.0
-           The routine now accepts a kwargs argument.
+           The routine now accepts est_method_args and kwargs.
 
         .. versionchanged:: 4.16.0
            All arguments but the first one must be passed as a keyword
@@ -545,6 +549,8 @@ class UniformParameterSampleFromScaleVector(ParameterSampleFromScaleVector):
            Determines how random numbers are created. If set to None
            then the routines from `numpy.random` are used, and so can
            be controlled by calling `numpy.random.seed`.
+        est_method_args
+            Any extra configuration for the error estimation class.
 
         Returns
         -------
@@ -554,7 +560,7 @@ class UniformParameterSampleFromScaleVector(ParameterSampleFromScaleVector):
 
         """
         vals = np.array(fit.model.thawedpars)
-        scales = self.scale.get_scales(fit)
+        scales = self.scale.get_scales(fit, est_method_args=est_method_args)
         size = int(num)
         samples = [random.uniform(rng,
                                   val - factor * abs(scale),
@@ -580,12 +586,13 @@ class NormalParameterSampleFromScaleVector(ParameterSampleFromScaleVector):
                    myscales: np.ndarray | None = None,
                    num: int = 1,
                    rng: random.RandomType | None = None,
+                   est_method_args: PrefsType | None = None,
                    **kwargs
                    ) -> np.ndarray:
         """Return the parameter samples.
 
         .. versionchanged:: 4.19.0
-           The routine now accepts a kwargs argument.
+           The routine now accepts est_method_args and kwargs.
 
         .. versionchanged:: 4.16.0
            All arguments but the first one must be passed as a keyword
@@ -606,6 +613,8 @@ class NormalParameterSampleFromScaleVector(ParameterSampleFromScaleVector):
            Determines how random numbers are created. If set to None
            then the routines from `numpy.random` are used, and so can
            be controlled by calling `numpy.random.seed`.
+        est_method_args
+            Any extra configuration for the error estimation class.
 
         Returns
         -------
@@ -615,7 +624,8 @@ class NormalParameterSampleFromScaleVector(ParameterSampleFromScaleVector):
 
         """
         vals = np.array(fit.model.thawedpars)
-        scales = self.scale.get_scales(fit, myscales=myscales)
+        scales = self.scale.get_scales(fit, myscales=myscales,
+                                       est_method_args=est_method_args)
         size = int(num)
 
         samples = [random.normal(rng, loc=val, scale=scale, size=size)
@@ -639,12 +649,13 @@ class NormalParameterSampleFromScaleMatrix(ParameterSampleFromScaleMatrix):
                    mycov: np.ndarray | None = None,
                    num: int = 1,
                    rng: random.RandomType | None = None,
+                   est_method_args: PrefsType | None = None,
                    **kwargs
                    ) -> np.ndarray:
         """Return the parameter samples.
 
         .. versionchanged:: 4.19.0
-           The routine now accepts a kwargs argument.
+           The routine now accepts est_method_args and kwargs.
 
         .. versionchanged:: 4.16.0
            All arguments but the first one must be passed as a keyword
@@ -674,7 +685,8 @@ class NormalParameterSampleFromScaleMatrix(ParameterSampleFromScaleMatrix):
 
         """
         vals = np.array(fit.model.thawedpars)
-        cov = self.scale.get_scales(fit, myscales=mycov)
+        cov = self.scale.get_scales(fit, myscales=mycov,
+                                    est_method_args=est_method_args)
         return random.multivariate_normal(rng, mean=vals, cov=cov,
                                           size=int(num))
 
@@ -695,12 +707,13 @@ class StudentTParameterSampleFromScaleMatrix(ParameterSampleFromScaleMatrix):
                    dof: int,
                    num: int = 1,
                    rng: random.RandomType | None = None,
+                   est_method_args: PrefsType | None = None,
                    **kwargs
                    ) -> np.ndarray:
         """Return the parameter samples.
 
         .. versionchanged:: 4.19.0
-           The routine now accepts a kwargs argument.
+           The routine now accepts est_method_args and kwargs.
 
         .. versionchanged:: 4.16.0
            All arguments but the first one must be passed as a keyword
@@ -728,7 +741,7 @@ class StudentTParameterSampleFromScaleMatrix(ParameterSampleFromScaleMatrix):
 
         """
         vals = np.array(fit.model.thawedpars)
-        cov = self.scale.get_scales(fit)
+        cov = self.scale.get_scales(fit, est_method_args=est_method_args)
         return multivariate_t(vals, cov=cov, df=dof, size=int(num),
                               rng=rng)
 
@@ -827,13 +840,14 @@ class NormalSampleFromScaleMatrix(NormalParameterSampleFromScaleMatrix):
                    num: int = 1,
                    numcores: int | None = None,
                    rng: random.RandomType | None = None,
+                   est_method_args: PrefsType | None = None,
                    clip: ClipValue = "none",
                    **kwargs
                    ) -> np.ndarray:
         """Return the statistic and parameter samples.
 
         .. versionchanged:: 4.19.0
-           The routine now accepts a kwargs argument.
+           The routine now accepts est_method_args and kwargs.
 
         .. versionchanged:: 4.18.0
            The clip argument has been added, and the return value now
@@ -858,6 +872,8 @@ class NormalSampleFromScaleMatrix(NormalParameterSampleFromScaleMatrix):
            Determines how random numbers are created. If set to None
            then the routines from `numpy.random` are used, and so can
            be controlled by calling `numpy.random.seed`.
+        est_method_args
+            Any extra configuration for the error estimation class.
         clip : {'hard', 'soft', 'none'}, optional
            What clipping strategy should be applied to the sampled
            parameters. The default ('none') applies no clipping,
@@ -876,7 +892,9 @@ class NormalSampleFromScaleMatrix(NormalParameterSampleFromScaleMatrix):
         """
 
         # Knowledge of whether a row has been clipped is dropped
-        samples = super().get_sample(fit, num=num, rng=rng, **kwargs)
+        samples = super().get_sample(fit, num=num, rng=rng,
+                                     est_method_args=est_method_args,
+                                     **kwargs)
         clipped = self.clip(fit, samples, clip=clip)
         return _sample_stat(fit, samples, clipped, numcores=numcores)
 
@@ -897,13 +915,14 @@ class NormalSampleFromScaleVector(NormalParameterSampleFromScaleVector):
                    num: int = 1,
                    numcores: int | None = None,
                    rng: random.RandomType | None = None,
+                   est_method_args: PrefsType | None = None,
                    clip: ClipValue = "none",
                    **kwargs
                    ) -> np.ndarray:
         """Return the statistic and parameter samples.
 
         .. versionchanged:: 4.19.0
-           The routine now accepts a kwargs argument.
+           The routine now accepts est_method_args and kwargs.
 
         .. versionchanged:: 4.18.0
            The clip argument has been added, and the return value now
@@ -928,6 +947,8 @@ class NormalSampleFromScaleVector(NormalParameterSampleFromScaleVector):
            Determines how random numbers are created. If set to None
            then the routines from `numpy.random` are used, and so can
            be controlled by calling `numpy.random.seed`.
+        est_method_args
+            Any extra configuration for the error estimation class.
         clip : {'hard', 'soft', 'none'}, optional
            What clipping strategy should be applied to the sampled
            parameters. The default ('none') applies no clipping,
@@ -946,7 +967,9 @@ class NormalSampleFromScaleVector(NormalParameterSampleFromScaleVector):
         """
 
         # Knowledge of whether a row has been clipped is dropped
-        samples = super().get_sample(fit, num=num, rng=rng, **kwargs)
+        samples = super().get_sample(fit, num=num, rng=rng,
+                                     est_method_args=est_method_args,
+                                     **kwargs)
         clipped = self.clip(fit, samples, clip=clip)
         return _sample_stat(fit, samples, clipped, numcores=numcores)
 
@@ -966,13 +989,14 @@ class UniformSampleFromScaleVector(UniformParameterSampleFromScaleVector):
                    factor: float = 4,
                    numcores: int | None = None,
                    rng: random.RandomType | None = None,
+                   est_method_args: PrefsType | None = None,
                    clip: ClipValue = "none",
                    **kwargs
                    ) -> np.ndarray:
         """Return the statistic and parameter samples.
 
         .. versionchanged:: 4.19.0
-           The routine now accepts a kwargs argument.
+           The routine now accepts est_method_args and kwargs.
 
         .. versionchanged:: 4.18.0
            The clip argument has been added, and the return value now
@@ -1000,6 +1024,8 @@ class UniformSampleFromScaleVector(UniformParameterSampleFromScaleVector):
            Determines how random numbers are created. If set to None
            then the routines from `numpy.random` are used, and so can
            be controlled by calling `numpy.random.seed`.
+        est_method_args
+            Any extra configuration for the error estimation class.
         clip : {'hard', 'soft', 'none'}, optional
            What clipping strategy should be applied to the sampled
            parameters. The default ('none') applies no clipping,
@@ -1017,7 +1043,9 @@ class UniformSampleFromScaleVector(UniformParameterSampleFromScaleVector):
 
         """
         samples = super().get_sample(fit, factor=factor, num=num,
-                                     rng=rng, **kwargs)
+                                     rng=rng,
+                                     est_method_args=est_method_args,
+                                     **kwargs)
         clipped = self.clip(fit, samples, clip=clip)
         return _sample_stat(fit, samples, clipped, numcores=numcores)
 
@@ -1039,13 +1067,14 @@ class StudentTSampleFromScaleMatrix(StudentTParameterSampleFromScaleMatrix):
                    dof: int = 2,
                    numcores: int | None = None,
                    rng: random.RandomType | None = None,
+                   est_method_args: PrefsType | None = None,
                    clip: ClipValue = "none",
                    **kwargs
                    ) -> np.ndarray:
         """Return the statistic and parameter samples.
 
         .. versionchanged:: 4.19.0
-           The routine now accepts a kwargs argument.
+           The routine now accepts est_method_args and kwargs.
 
         .. versionchanged:: 4.18.0
            The clip argument has been added, and the return value now
@@ -1072,6 +1101,8 @@ class StudentTSampleFromScaleMatrix(StudentTParameterSampleFromScaleMatrix):
            Determines how random numbers are created. If set to None
            then the routines from `numpy.random` are used, and so can
            be controlled by calling `numpy.random.seed`.
+        est_method_args
+            Any extra configuration for the error estimation class.
         clip : {'hard', 'soft', 'none'}, optional
            What clipping strategy should be applied to the sampled
            parameters. The default ('none') applies no clipping,
@@ -1089,6 +1120,7 @@ class StudentTSampleFromScaleMatrix(StudentTParameterSampleFromScaleMatrix):
 
         """
         samples = super().get_sample(fit, dof=dof, num=num, rng=rng,
+                                     est_method_args=est_method_args,
                                      **kwargs)
         clipped = self.clip(fit, samples, clip=clip)
         return _sample_stat(fit, samples, clipped, numcores=numcores)
@@ -1101,7 +1133,8 @@ def normal_sample(fit: Fit,
                   correlate: bool = True,
                   numcores: int | None = None,
                   rng: random.RandomType | None = None,
-                  clip: ClipValue = "none"
+                  clip: ClipValue = "none",
+                  est_method_args: PrefsType | None = None
                   ) -> np.ndarray:
     """Sample the fit statistic by taking the parameter values
     from a normal distribution.
@@ -1109,6 +1142,9 @@ def normal_sample(fit: Fit,
     For each iteration (sample), change the thawed parameters by
     drawing values from a uni- or multi-variate normal (Gaussian)
     distribution, and calculate the fit statistic.
+
+    .. versionchanged:: 4.19.0
+        The routine now accepts the est_method_args optional argument.
 
     .. versionchanged:: 4.18.0
        The sigma parameter has been renamed to scale, and the code has
@@ -1144,6 +1180,8 @@ def normal_sample(fit: Fit,
        What clipping strategy should be applied to the sampled
        parameters. The default ('none') applies no clipping, 'hard'
        uses the hard parameter limits, and 'soft' the soft limits.
+    est_method_args
+       Any extra configuration for the error estimation class.
 
     Returns
     -------
@@ -1178,7 +1216,8 @@ def normal_sample(fit: Fit,
 
     sampler.scale.sigma = scale
     return sampler.get_sample(fit, num=num, numcores=numcores,
-                              rng=rng, clip=clip)
+                              rng=rng, clip=clip,
+                              est_method_args=est_method_args)
 
 
 def uniform_sample(fit: Fit,
@@ -1186,7 +1225,8 @@ def uniform_sample(fit: Fit,
                    factor: float = 4,
                    numcores: int | None = None,
                    rng: random.RandomType | None = None,
-                   clip: ClipValue = "none"
+                   clip: ClipValue = "none",
+                   est_method_args: PrefsType | None = None
                    ) -> np.ndarray:
     """Sample the fit statistic by taking the parameter values
     from an uniform distribution.
@@ -1194,6 +1234,9 @@ def uniform_sample(fit: Fit,
     For each iteration (sample), change the thawed parameters by
     drawing values from a uniform distribution, and calculate the
     fit statistic.
+
+    .. versionchanged:: 4.19.0
+        The routine now accepts the est_method_args optional argument.
 
     .. versionchanged:: 4.18.0
        The sigma parameter has been renamed to scale, and the code has
@@ -1224,6 +1267,8 @@ def uniform_sample(fit: Fit,
        What clipping strategy should be applied to the sampled
        parameters. The default ('none') applies no clipping, 'hard'
        uses the hard parameter limits, and 'soft' the soft limits.
+    est_method_args
+       Any extra configuration for the error estimation class.
 
     Returns
     -------
@@ -1244,6 +1289,7 @@ def uniform_sample(fit: Fit,
     sampler.scale.sigma = 1
     return sampler.get_sample(fit, num=num, factor=factor,
                               numcores=numcores, rng=rng,
+                              est_method_args=est_method_args,
                               clip=clip)
 
 
@@ -1252,7 +1298,8 @@ def t_sample(fit: Fit,
              dof: int = 2,
              numcores: int | None = None,
              rng: random.RandomType | None = None,
-             clip: ClipValue = "none"
+             clip: ClipValue = "none",
+             est_method_args: PrefsType | None = None
              ) -> np.ndarray:
     """Sample the fit statistic by taking the parameter values from
     a Student's t-distribution.
@@ -1260,6 +1307,9 @@ def t_sample(fit: Fit,
     For each iteration (sample), change the thawed parameters
     by drawing values from a Student's t-distribution, and
     calculate the fit statistic.
+
+    .. versionchanged:: 4.19.0
+        The routine now accepts the est_method_args optional argument.
 
     .. versionchanged:: 4.18.0
        The sigma parameter has been renamed to scale, and the code has
@@ -1291,10 +1341,12 @@ def t_sample(fit: Fit,
        What clipping strategy should be applied to the sampled
        parameters. The default ('none') applies no clipping, 'hard'
        uses the hard parameter limits, and 'soft' the soft limits.
+    est_method_args
+       Any extra configuration for the error estimation class.
 
     Returns
     -------
-    samples :
+    samples
        A NumPy array table with the first column representing the
        statistic, the later columns the parameters used, and the last
        column indicating whether any parameter in the row was clipped.
@@ -1307,4 +1359,5 @@ def t_sample(fit: Fit,
     """
     sampler = StudentTSampleFromScaleMatrix()
     return sampler.get_sample(fit, num=num, dof=dof,
+                              est_method_args=est_method_args,
                               numcores=numcores, rng=rng, clip=clip)

--- a/sherpa/sim/sample.py
+++ b/sherpa/sim/sample.py
@@ -18,8 +18,9 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from collections.abc import Sequence
 import logging
-from typing import Literal
+from typing import Literal, SupportsIndex
 
 import numpy as np
 
@@ -48,7 +49,7 @@ __all__ = ('multivariate_t', 'multivariate_cauchy',
 def multivariate_t(mean: ArrayType,
                    cov: np.ndarray,
                    df: int,
-                   size: tuple[int, ...] | None = None,
+                   size: SupportsIndex | Sequence[SupportsIndex] | None = None,
                    rng: random.RandomType | None = None
                    ) -> np.ndarray:
     """Draw random deviates from a multivariate Student's T distribution.
@@ -110,7 +111,7 @@ def multivariate_t(mean: ArrayType,
 #
 def multivariate_cauchy(mean: ArrayType,
                         cov: np.ndarray,
-                        size: tuple[int, ...] | None = None,
+                        size: SupportsIndex | Sequence[SupportsIndex] | None = None,
                         rng: random.RandomType | None = None
                         ) -> np.ndarray:
     """

--- a/sherpa/sim/tests/test_sim.py
+++ b/sherpa/sim/tests/test_sim.py
@@ -359,6 +359,46 @@ def test_uniform_sample2(setup):
     assert out == pytest.approx(EXPECTED_UNIFORM)
 
 
+def check_ratio(setup,
+                expected: np.ndarray,
+                got: np.ndarray,
+                scale: float
+                ) -> None:
+    """Check that the got value is scale * expected after parvals."""
+
+    # Calculate the offset from the expected value, dropping the
+    # statistic column (which is first, and the clipped column,
+    # which is last).
+    #
+    pvals = np.asarray(setup.results.parvals)
+    delta1 = expected[:, 1:-1] - pvals
+    delta2 = got[:, 1:-1] - pvals
+    ratio = delta2 / delta1
+
+    ncols = len(pvals)
+    expected = np.full((setup.num, pvals.size), scale)
+    assert ratio == pytest.approx(expected, rel=1e-4)
+
+
+def test_uniform_sample_factor(setup):
+    """Scale with the factor argument"""
+    scale = 2.0
+    out = sim.uniform_sample(setup.fit, num=setup.num, factor=scale * 4,
+                             rng=setup.rng)
+
+    check_ratio(setup, EXPECTED_UNIFORM, out, scale)
+
+
+def test_uniform_sample_via_est_methods(setup):
+    """Scale sigma via the est_method_args argument"""
+    scale = 2.0
+    out = sim.uniform_sample(setup.fit, num=setup.num,
+                             est_method_args={"sigma": scale},
+                             rng=setup.rng)
+
+    check_ratio(setup, EXPECTED_UNIFORM, out, scale)
+
+
 def test_normal_sample_vector(setup):
     ps = sim.NormalSampleFromScaleVector()
     out = ps.get_sample(setup.fit, num=setup.num, rng=setup.rng)
@@ -394,33 +434,27 @@ def test_normal_sample_sigma(setup):
     The sigma parameter has been renamed scale in 4.18.0.
     """
 
-    # Run with scale=1 and 2 and then check the output differs
-    # as expected. The return value is a 2D array where the first
-    # column is the statistic value and the remaining columns are
-    # the simulated parameter values. So the check is to compare
-    # the offset of the parameter values to the "truth", and
-    # see if it varies with scale.
-    #
-    # The scale=1 values have been tested in test_normal_sample,
-    # so there is no need to recalculate them here. Note they were
-    # calculated with the same RNG.
-    #
-    out1 = EXPECTED_NORMAL
-    out2 = sim.normal_sample(setup.fit, num=setup.num, scale=2,
-                             correlate=False, rng=setup.rng)
+    scale = 2.0
+    out = sim.normal_sample(setup.fit, num=setup.num, scale=scale,
+                            correlate=False, rng=setup.rng)
 
-    # Calculate the offset from the expected value, dropping the
-    # statistic column (which is first, and the clipped column,
-    # which is last).
-    #
-    pvals = np.asarray(setup.results.parvals)
-    delta1 = out1[:, 1:-1] - pvals
-    delta2 = out2[:, 1:-1] - pvals
-    ratio = delta2 / delta1
+    check_ratio(setup, EXPECTED_NORMAL, out, scale)
 
-    ncols = len(pvals)
-    expected = np.full((setup.num, ncols), 2.0)
-    assert ratio == pytest.approx(expected, rel=1e-4)
+
+def test_normal_sample_sigma_via_est_methods(setup):
+    """Test normal_sample with different sigma values.
+
+    The est_method_args allows various settings to be changed, but
+    the easiest test is to use it to replicate the sample setting.
+
+    """
+
+    scale = 2.0
+    out = sim.normal_sample(setup.fit, num=setup.num,
+                            est_method_args={"sigma": scale},
+                            correlate=False, rng=setup.rng)
+
+    check_ratio(setup, EXPECTED_NORMAL, out, scale)
 
 
 def test_normal_sample_correlated(setup):
@@ -437,39 +471,44 @@ def test_normal_sample_correlated_sigma(setup):
 
     """
 
-    # Run with scale=1 and 2 and then check the output differs
-    # as expected. The return value is a 2D array where the first
-    # column is the statistic value and the remaining columns are
-    # the simulated parameter values. So the check is to compare
-    # the offset of the parameter values to the "truth", and
-    # see if it varies with sigma.
-    #
-    # The scale=1 values have been tested in test_normal_sample_correlated,
-    # so there is no need to recalculate them here. Note they were
-    # calculated with the same RNG.
-    #
-    out1 = EXPECTED_NORMAL2
-    out2 = sim.normal_sample(setup.fit, num=setup.num, scale=2,
-                             correlate=True, rng=setup.rng)
+    scale = 2.0
+    out = sim.normal_sample(setup.fit, num=setup.num, scale=scale,
+                            correlate=True, rng=setup.rng)
 
-    # Calculate the offset from the expected value, dropping the
-    # statistic column (which is first, and the clipped column,
-    # which is last).
-    #
-    pvals = np.asarray(setup.results.parvals)
-    delta1 = out1[:, 1:-1] - pvals
-    delta2 = out2[:, 1:-1] - pvals
-    ratio = delta2 / delta1
+    check_ratio(setup, EXPECTED_NORMAL2, out, scale)
 
-    ncols = len(pvals)
-    expected = np.full((setup.num, ncols), 2.0)
-    assert ratio == pytest.approx(expected, rel=1e-4)
+
+def test_normal_sample_correlated_sigma_via_est_methods(setup):
+    """Test normal_sample with different sigma values + correlation.
+
+    The est_method_args allows various settings to be changed, but
+    the easiest test is to use it to replicate the sample setting.
+
+    """
+
+    scale = 2.0
+    out = sim.normal_sample(setup.fit, num=setup.num,
+                            est_method_args={"sigma": scale},
+                            correlate=True, rng=setup.rng)
+
+    check_ratio(setup, EXPECTED_NORMAL2, out, scale)
 
 
 def test_t_sample(setup):
     out = sim.t_sample(setup.fit, setup.num, setup.dof, rng=setup.rng)
 
     assert out == pytest.approx(EXPECTED_T)
+
+
+def test_t_sample_sigma_via_est_methods(setup):
+    """Does changing the sigma change the result?"""
+
+    scale = 2.0
+    out = sim.t_sample(setup.fit, setup.num, setup.dof,
+                       est_method_args={"sigma": scale},
+                       rng=setup.rng)
+
+    check_ratio(setup, EXPECTED_T, out, scale)
 
 
 RATIOS_ONE = np.asarray([2.43733721, 3.52628288, 4.18396336, 1.73659659, 3.70862308, 2.19009678,

--- a/sherpa/sim/tests/test_sim.py
+++ b/sherpa/sim/tests/test_sim.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2016, 2018, 2020-2021, 2023-2025
+#  Copyright (C) 2011, 2016, 2018, 2020-2021, 2023-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -259,6 +259,23 @@ def test_parameter_scale_vector_sigma2(setup):
     assert out == pytest.approx(2.0 * EXPECTED_VECTOR_ERR)
 
 
+def test_parameter_scale_vector_sigma_overload(setup):
+    """Test est_method_args setting.
+
+    THe way the code is currently structured is that the
+    sigma attribute is applied *before* the est_method_args
+    values are applied, so we can over-ride the setting. This
+    is not the intended use case for est_method_args but is
+    technically valid.
+
+    """
+    ps = sim.ParameterScaleVector()
+    ps.sigma = 2
+    out = ps.get_scales(setup.fit, est_method_args={"sigma": 1.0})
+
+    assert out == pytest.approx(EXPECTED_VECTOR_ERR)
+
+
 def test_parameter_scale_matrix(setup):
     ps = sim.ParameterScaleMatrix()
     out = ps.get_scales(setup.fit)
@@ -275,6 +292,16 @@ def test_parameter_scale_matrix_sigma2(setup):
     # code has never been clear about sigma/variance.
     #
     assert out == pytest.approx(2 * 2 * EXPECTED_MATRIX_ERR)
+
+
+def test_parameter_scale_matrix_sigma_overload(setup):
+    """See test_parameter_scale_vector_sigma_overload."""
+
+    ps = sim.ParameterScaleMatrix()
+    ps.sigma = 2
+    out = ps.get_scales(setup.fit, est_method_args={"sigma": 1})
+
+    assert out == pytest.approx(EXPECTED_MATRIX_ERR)
 
 
 def test_parameter_sample_checks_clip_argument(setup):


### PR DESCRIPTION
# Summary

Add the est_method_args parameter to the sample_flux routine at the UI layer (and related routines that it calls) so that the error estimation configuration can be over-ridden by the caller. This is to support the Chandra Source Catalog.

# Details

This is a rework of #2186 concentrating on just the `est_method_args` changes, since the other changes in that PR have already been merged into Sherpa.

The code starts with a number of code-clean up changes, including

- typing changes
  - replace Optional[x] by x | None and Literal[x] | Literal[y] by Literal[x, y]
  - better typing of arguments to match the actual code (e.g. allowing a value to be a scalar as well as a sequence, or allowing a variable to be None, or removing None from the type of a variable)
- changes to the sherpa.sim.sample classes to improve the typing results by
  - making the sub-classes not overload super-class routines in a manner that causes type checkers to complain
    (mainly by allowing **kwargs) 
  - allow passing through of est_method_args to allow the error estimator (e.g. Covar or Conf) to have its settings updated beyond just changing the sigma value
- allow the user-facing code to send around the est_method_args value

I spend some time trying to see if we could avoid an "ugly" approach like just passing around a dict all the way down to where it is needed. I eventually decided that 

- this could be useful for some users
- there wasn't really a good way to do this with the current code base

so went with the long parameter name, as the expectation is that it is unlikely to be used.

I was also able to write some tests that actually exercise this functionality.