### PR TITLE
ui: fix typing statement of internal routine

### DIFF
--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -12236,7 +12236,7 @@ class Session(NoNewAttributesAfterInit):
     #
 
     def _get_plot_objects(self,
-                          ids: IdType | IdTypes,
+                          ids: IdType | IdTypes | None,
                           getfunc: Callable[..., Plot | HistogramPlot],
                           *,
                           recalc: bool = True,


### PR DESCRIPTION
# Summary

Internal change to fix the typing of a routine. There is no functional change.

# Details

There is no functional change here but it avoids a number of type errors and better reflects the intent of the code - that is you can set ids=None here.

This was found when developing #2507 but is completely separate from that work.

Before this change pyright 1.1.411 reports 127 errors for sherpa/astro/ui/utils.py and after this change it drops to 109, with the errors removed being ones like

```
-  /Users/burked/code/sherpa/sherpa-3/sherpa/astro/ui/utils.py:14208:42 - error: Argument of type "IdType | IdTypes | None" cannot be assigned to parameter "ids" of type "IdType | IdTypes" in function "_get_plot_objects"
-    Type "IdType | IdTypes | None" is not assignable to type "IdType | IdTypes"
-      Type "None" is not assignable to type "IdType | IdTypes"
-        "None" is not assignable to "int"
-        "None" is not assignable to "str"
-        "None" is not assignable to "Sequence[IdType]" (reportArgumentType)
```