### PR TITLE
PKG: Fix conda recipe for Meson build update

### DIFF
--- a/.github/workflows/ci-conda-deployment.yml
+++ b/.github/workflows/ci-conda-deployment.yml
@@ -262,24 +262,24 @@ jobs:
         source ${conda_loc}/etc/profile.d/conda.sh
         curl -LO -k https://github.com/sherpa/sherpa-test-data/archive/main.zip
         #
-        echo "conda create -n test311 --yes -q -c file://$(pwd)/packages python=3.11 astropy sherpa matplotlib"
-        conda create -n test311 --yes -q -c file://$(pwd)/packages python=3.11 astropy sherpa matplotlib
+        echo "conda create -n test311 --yes -q -c file://$(pwd)/packages python=3.11 astropy sherpa=4.* matplotlib"
+        conda create -n test311 --yes -q -c file://$(pwd)/packages python=3.11 astropy sherpa=4.* matplotlib
         conda activate test311
         pip install main.zip
         sherpa_smoke -f astropy
         sherpa_test
         conda deactivate
         #
-        echo "conda create -n test312 --yes -q -c file://$(pwd)/packages python=3.12 astropy sherpa matplotlib"
-        conda create -n test312 --yes -q -c file://$(pwd)/packages python=3.12 astropy sherpa matplotlib
+        echo "conda create -n test312 --yes -q -c file://$(pwd)/packages python=3.12 astropy sherpa=4.* matplotlib"
+        conda create -n test312 --yes -q -c file://$(pwd)/packages python=3.12 astropy sherpa=4.* matplotlib
         conda activate test312
         pip install main.zip
         sherpa_smoke -f astropy
         sherpa_test
         conda deactivate
         #
-        echo "conda create -n test313 --yes -q -c file://$(pwd)/packages python=3.13 astropy sherpa matplotlib"
-        conda create -n test313 --yes -q -c file://$(pwd)/packages python=3.13 astropy sherpa matplotlib
+        echo "conda create -n test313 --yes -q -c file://$(pwd)/packages python=3.13 astropy sherpa=4.* matplotlib"
+        conda create -n test313 --yes -q -c file://$(pwd)/packages python=3.13 astropy sherpa=4.* matplotlib
         conda activate test313
         pip install main.zip
         sherpa_smoke -f astropy

--- a/recipes/conda/meta.yaml
+++ b/recipes/conda/meta.yaml
@@ -22,13 +22,16 @@ requirements:
   - numpy 1.24.* # [py<312]
   - numpy 1.26.* # [py==312]
   - numpy 2.*    # [py>312]
+  - meson
+  - meson-python
   - setuptools
+  - pkg-config
   - six
+  - fftw
 
  run:
   - python
   - {{ pin_compatible('numpy') }}
-  - setuptools
   - pytest
   - six
 


### PR DESCRIPTION
Update the conda packaging recipe to use Meson. Adds meson and meson-python to the host build dep.