### PR TITLE
Address get plot data access issues

### DIFF
--- a/sherpa/astro/ui/tests/test_astro_session.py
+++ b/sherpa/astro/ui/tests/test_astro_session.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016, 2018, 2020-2025
+#  Copyright (C) 2016, 2018, 2020-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -4646,10 +4646,10 @@ def test_plot_fit_resid_get_labels(session):
 
     s.plot_fit_resid()
 
-    fplot = s.get_fit_plot(recalc=False)
-    dplot = s.get_data_plot(recalc=False)
-    mplot = s.get_model_plot(recalc=False)
-    rplot = s.get_resid_plot(recalc=False)
+    fplot = s.get_fit_plot(recalc=False, copy=False)
+    dplot = s.get_data_plot(recalc=False, copy=False)
+    mplot = s.get_model_plot(recalc=False, copy=False)
+    rplot = s.get_resid_plot(recalc=False, copy=False)
 
     # Do these objects respect the changes that the plot_fit_resid
     # call to handle labels?
@@ -4662,10 +4662,10 @@ def test_plot_fit_resid_get_labels(session):
 
     # Check whether they have changed.
     #
-    fplot2 = s.get_fit_plot(recalc=False)
-    dplot2 = s.get_data_plot(recalc=True)
-    mplot2 = s.get_model_plot(recalc=True)
-    rplot2 = s.get_resid_plot(recalc=True)
+    fplot2 = s.get_fit_plot(recalc=False, copy=False)
+    dplot2 = s.get_data_plot(recalc=True, copy=False)
+    mplot2 = s.get_model_plot(recalc=True, copy=False)
+    rplot2 = s.get_resid_plot(recalc=True, copy=False)
     assert fplot2.dataplot.xlabel == 'x'
     assert fplot2.modelplot.xlabel == 'x'
     assert dplot2.xlabel == 'x'

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019-2025
+#  Copyright (C) 2019-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -1061,8 +1061,8 @@ def check_bkg_fit(plotfunc, idval, isfit=True):
     (e.g. the pixel display/PNG output).
     """
 
-    dplot = ui.get_bkg_plot(idval, recalc=False)
-    mplot = ui.get_bkg_model_plot(idval, recalc=False)
+    dplot = ui.get_bkg_plot(idval, recalc=False, copy=False)
+    mplot = ui.get_bkg_model_plot(idval, recalc=False, copy=False)
     assert isinstance(dplot, sherpa.astro.plot.BkgDataPlot)
 
     # The model for a PHA fit uses a specialized class that ignores
@@ -1089,7 +1089,7 @@ def check_bkg_fit(plotfunc, idval, isfit=True):
 
     # grab the model plot from the get_bkg_fit_plot call.
     #
-    fplot = ui.get_bkg_fit_plot(idval, recalc=False)
+    fplot = ui.get_bkg_fit_plot(idval, recalc=False, copy=False)
     assert fplot.dataplot is dplot
     mplot = fplot.modelplot
     assert isinstance(mplot, sherpa.astro.plot.BkgModelPHAHistogram)
@@ -1098,7 +1098,7 @@ def check_bkg_fit(plotfunc, idval, isfit=True):
 
     # check plot basics
     for plot in [dplot, mplot]:
-        assert plot.xlabel == xlabel
+        # assert plot.xlabel == xlabel  WAT
         assert plot.ylabel == 'Counts/sec/channel'
 
     assert dplot.xlo == pytest.approx(_data_chan)
@@ -3611,7 +3611,7 @@ def test_datapha_plot_after_clean():
     s = sherpa.astro.ui.utils.Session()
     s.set_data(d)
 
-    d1 = s.get_data_plot()
+    d1 = s.get_data_plot(copy=False)
 
     # Change the yerrorbars setting. It depends whether we
     # have a plot backend or not.
@@ -3630,7 +3630,7 @@ def test_datapha_plot_after_clean():
 
     # Check the yerrorbars setting is back to True
     #
-    d2 = s.get_data_plot()
+    d2 = s.get_data_plot(copy=False)
     assert isinstance(d2, sherpa.astro.plot.DataPHAPlot)
 
     prefs = s.get_data_plot_prefs()
@@ -3698,7 +3698,6 @@ def test_set_plot_opt_x(cls, datafunc, plotfunc, all_plot_backends):
     s.set_xlinear()
     plot()
 
-    # Technically not needed as p1 is the same as p2
     p2 = pdata()
     if plotfunc == 'fit':
         if is_int:
@@ -3770,7 +3769,6 @@ def test_set_plot_opt_y(cls, datafunc, plotfunc, answer):
     s.set_ylinear()
     plot()
 
-    # Technically not needed as p1 is the same as p2
     p2 = pdata()
     if plotfunc == 'fit':
         if is_int:
@@ -3851,7 +3849,6 @@ def test_set_plot_opt_x_astro(cls, datafunc, plotfunc):
     s.set_xlinear()
     plot()
 
-    # Technically not needed as p1 is the same as p2
     p2 = pdata()
     if plotfunc in ['fit', 'bkg_fit']:
         assert not p2.dataplot.histo_prefs['xlog']
@@ -3914,7 +3911,6 @@ def test_set_plot_opt_y_astro(cls, datafunc, plotfunc, answer):
     s.set_ylinear()
     plot()
 
-    # Technically not needed as p1 is the same as p2
     p2 = pdata()
     if plotfunc in ['fit', 'bkg_fit']:
         assert not p2.dataplot.histo_prefs['ylog']
@@ -4173,8 +4169,8 @@ def test_set_plot_opt_changes_fields(cls, name, extraargs):
     s.set_source(2, mdl)
 
     getfunc = getattr(s, f"get_{name}_plot")
-    p1 = getfunc(1, *extraargs, recalc=False)
-    p2 = getfunc(2, *extraargs, recalc=False)
+    p1 = getfunc(1, *extraargs, recalc=False, copy=False)
+    p2 = getfunc(2, *extraargs, recalc=False, copy=False)
 
     assert not p1.plot_prefs["xlog"]
     assert not p1.plot_prefs["ylog"]
@@ -4422,7 +4418,7 @@ def test_set_ylog_foo_component_data1d(plot, get, clean_astro_ui):
     ui.set_source(ui.const1d.mdl)
     mdl.c0 = 6
 
-    plotobj = get(mdl, recalc=False)
+    plotobj = get(mdl, recalc=False, copy=False)
 
     assert not plotobj.plot_prefs["xlog"]
     assert not plotobj.plot_prefs["ylog"]
@@ -4446,7 +4442,7 @@ def test_set_ylog_foo_component_data1dint(plot, get, clean_astro_ui):
     ui.set_source(ui.const1d.mdl)
     mdl.c0 = 6
 
-    plotobj = get(mdl, recalc=False)
+    plotobj = get(mdl, recalc=False, copy=False)
 
     assert not plotobj.histo_prefs["xlog"]
     assert not plotobj.histo_prefs["ylog"]
@@ -4470,7 +4466,7 @@ def test_set_ylog_foo_component_datapha(plot, get, clean_astro_ui):
     ui.set_source(ui.const1d.mdl)
     mdl.c0 = 6
 
-    plotobj = get(mdl, recalc=False)
+    plotobj = get(mdl, recalc=False, copy=False)
 
     assert not plotobj.histo_prefs["xlog"]
     assert not plotobj.histo_prefs["ylog"]

--- a/sherpa/astro/ui/tests/test_astro_ui_plot.py
+++ b/sherpa/astro/ui/tests/test_astro_ui_plot.py
@@ -1098,7 +1098,7 @@ def check_bkg_fit(plotfunc, idval, isfit=True):
 
     # check plot basics
     for plot in [dplot, mplot]:
-        # assert plot.xlabel == xlabel  WAT
+        assert plot.xlabel == xlabel
         assert plot.ylabel == 'Counts/sec/channel'
 
     assert dplot.xlo == pytest.approx(_data_chan)

--- a/sherpa/astro/ui/utils.py
+++ b/sherpa/astro/ui/utils.py
@@ -66,7 +66,7 @@ from sherpa.sim import NormalParameterSampleFromScaleMatrix, \
 from sherpa.stats import Cash, CStat, WStat
 
 import sherpa.ui.utils
-from sherpa.ui.utils import _check_type, _check_str_type, _is_str
+from sherpa.ui.utils import _check_type, _check_str_type, _is_str, cpy
 
 import sherpa.utils
 from sherpa.utils import bool_cast, get_error_estimates, is_subclass, \
@@ -11826,7 +11826,9 @@ class Session(sherpa.ui.utils.Session):
 
     def get_data_plot(self,
                       id: IdType | None = None,
-                      recalc: bool = True):
+                      recalc: bool = True,
+                      copy: bool = True
+                      ):
         if recalc:
             data = self.get_data(id)
         else:
@@ -11837,16 +11839,18 @@ class Session(sherpa.ui.utils.Session):
             if recalc:
                 plotobj.prepare(data, self.get_stat())
 
-            return plotobj
+            return cpy(plotobj, copy)
 
-        return super().get_data_plot(id, recalc=recalc)
+        return super().get_data_plot(id, recalc=recalc, copy=copy)
 
     get_data_plot.__doc__ = sherpa.ui.utils.Session.get_data_plot.__doc__
     get_data_plot.__annotations__ = sherpa.ui.utils.Session.get_data_plot.__annotations__
 
     def get_model_plot(self,
                        id: IdType | None = None,
-                       recalc: bool = True):
+                       recalc: bool = True,
+                       copy: bool = True
+                       ):
         if recalc:
             data = self.get_data(id)
         else:
@@ -11857,9 +11861,9 @@ class Session(sherpa.ui.utils.Session):
             if recalc:
                 plotobj.prepare(data, self.get_model(id), self.get_stat())
 
-            return plotobj
+            return cpy(plotobj, copy)
 
-        return super().get_model_plot(id, recalc=recalc)
+        return super().get_model_plot(id, recalc=recalc, copy=copy)
 
     get_model_plot.__doc__ = sherpa.ui.utils.Session.get_model_plot.__doc__
     get_model_plot.__annotations__ = sherpa.ui.utils.Session.get_model_plot.__annotations__
@@ -11869,8 +11873,14 @@ class Session(sherpa.ui.utils.Session):
                         id: IdType | None = None,
                         lo: float | None = None,
                         hi: float | None = None,
-                        recalc: bool = True):
+                        recalc: bool = True,
+                        copy: bool = True
+                        ):
         """Return the data used by plot_source.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -11885,6 +11895,10 @@ class Session(sherpa.ui.utils.Session):
            If ``False`` then the results from the last call to
            `plot_source` (or `get_source_plot`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -11954,17 +11968,19 @@ class Session(sherpa.ui.utils.Session):
             if recalc:
                 plotobj.prepare(data, self.get_source(id), lo=lo, hi=hi)
 
-            return plotobj
+            return cpy(plotobj, copy)
 
-        return super().get_source_plot(id, recalc=recalc)
+        return super().get_source_plot(id, recalc=recalc, copy=copy)
 
     def get_fit_plot(self,
                      id: IdType | None = None,
-                     recalc: bool = True):
+                     recalc: bool = True,
+                     copy: bool = True
+                     ):
 
         plotobj = self._plot_types["fit"][0]
         if not recalc:
-            return plotobj
+            return cpy(plotobj, copy)
 
         data = self.get_data(id)
         if isinstance(data, DataPHA):
@@ -11984,18 +12000,27 @@ class Session(sherpa.ui.utils.Session):
                              self.get_stat())
 
             plotobj.prepare(dataobj, modelobj)
-            return plotobj
+            return cpy(plotobj, copy)
 
-        return super().get_fit_plot(id, recalc=recalc)
+        return super().get_fit_plot(id, recalc=recalc, copy=copy)
 
     get_fit_plot.__doc__ = sherpa.ui.utils.Session.get_fit_plot.__doc__
     get_fit_plot.__annotations__ = sherpa.ui.utils.Session.get_fit_plot.__annotations__
 
-    def get_model_component_plot(self, id, model=None, recalc: bool = True):
+    def get_model_component_plot(self,
+                                 id,
+                                 model=None,
+                                 recalc: bool = True,
+                                 copy: bool = True
+                                 ):
         """Return the data used to create the model-component plot.
 
         For PHA data, the response model is automatically added by the
         routine unless the model contains a response.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12008,6 +12033,10 @@ class Session(sherpa.ui.utils.Session):
            If ``False`` then the results from the last call to
            `plot_model_component` (or `get_model_component_plot`)
            are returned, otherwise the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12081,12 +12110,18 @@ class Session(sherpa.ui.utils.Session):
 
                 plotobj.prepare(data, model, self.get_stat())
 
-            return plotobj
+            return cpy(plotobj, copy)
 
-        return super().get_model_component_plot(id, model=model, recalc=recalc)
+        return super().get_model_component_plot(id, model=model,
+                                                recalc=recalc, copy=copy)
 
     # copy doc string from sherpa.utils
-    def get_source_component_plot(self, id, model=None, recalc: bool = True):
+    def get_source_component_plot(self,
+                                  id,
+                                  model=None,
+                                  recalc: bool = True,
+                                  copy: bool = True
+                                  ):
         if model is None:
             id, model = model, id
         model = self._check_model(model)
@@ -12101,16 +12136,19 @@ class Session(sherpa.ui.utils.Session):
             if recalc:
                 plotobj.prepare(data, model, self.get_stat())
 
-            return plotobj
+            return cpy(plotobj, copy)
 
-        return super().get_source_component_plot(id, model=model, recalc=recalc)
+        return super().get_source_component_plot(id, model=model,
+                                                 recalc=recalc, copy=copy)
 
     get_source_component_plot.__doc__ = sherpa.ui.utils.Session.get_source_component_plot.__doc__
     get_source_component_plot.__annotations__ = sherpa.ui.utils.Session.get_source_component_plot.__annotations__
 
     def get_ratio_plot(self,
                        id: IdType | None = None,
-                       recalc: bool = True):
+                       recalc: bool = True,
+                       copy: bool = True
+                       ):
         if recalc:
             data = self.get_data(id)
         else:
@@ -12121,16 +12159,18 @@ class Session(sherpa.ui.utils.Session):
             if recalc:
                 plotobj.prepare(data, self.get_model(id), self.get_stat())
 
-            return plotobj
+            return cpy(plotobj, copy)
 
-        return super().get_ratio_plot(id, recalc=recalc)
+        return super().get_ratio_plot(id, recalc=recalc, copy=copy)
 
     get_ratio_plot.__doc__ = sherpa.ui.utils.Session.get_ratio_plot.__doc__
     get_ratio_plot.__annotations__ = sherpa.ui.utils.Session.get_ratio_plot.__annotations__
 
     def get_resid_plot(self,
                        id: IdType | None = None,
-                       recalc: bool = True):
+                       recalc: bool = True,
+                       copy: bool = True
+                       ):
         if recalc:
             data = self.get_data(id)
         else:
@@ -12141,16 +12181,18 @@ class Session(sherpa.ui.utils.Session):
             if recalc:
                 plotobj.prepare(data, self.get_model(id), self.get_stat())
 
-            return plotobj
+            return cpy(plotobj, copy)
 
-        return super().get_resid_plot(id, recalc=recalc)
+        return super().get_resid_plot(id, recalc=recalc, copy=copy)
 
     get_resid_plot.__doc__ = sherpa.ui.utils.Session.get_resid_plot.__doc__
     get_resid_plot.__annotations__ = sherpa.ui.utils.Session.get_resid_plot.__annotations__
 
     def get_delchi_plot(self,
                         id: IdType | None = None,
-                        recalc: bool = True):
+                        recalc: bool = True,
+                        copy: bool = True
+                        ):
         if recalc:
             data = self.get_data(id)
         else:
@@ -12161,16 +12203,18 @@ class Session(sherpa.ui.utils.Session):
             if recalc:
                 plotobj.prepare(data, self.get_model(id), self.get_stat())
 
-            return plotobj
+            return cpy(plotobj, copy)
 
-        return super().get_delchi_plot(id, recalc=recalc)
+        return super().get_delchi_plot(id, recalc=recalc, copy=copy)
 
     get_delchi_plot.__doc__ = sherpa.ui.utils.Session.get_delchi_plot.__doc__
     get_delchi_plot.__annotations__ = sherpa.ui.utils.Session.get_delchi_plot.__annotations__
 
     def get_chisqr_plot(self,
                         id: IdType | None = None,
-                        recalc: bool = True):
+                        recalc: bool = True,
+                        copy: bool = True
+                        ):
         if recalc:
             data = self.get_data(id)
         else:
@@ -12181,9 +12225,9 @@ class Session(sherpa.ui.utils.Session):
             if recalc:
                 plotobj.prepare(data, self.get_model(id), self.get_stat())
 
-            return plotobj
+            return cpy(plotobj, copy)
 
-        return super().get_chisqr_plot(id, recalc=recalc)
+        return super().get_chisqr_plot(id, recalc=recalc, copy=copy)
 
     get_chisqr_plot.__doc__ = sherpa.ui.utils.Session.get_chisqr_plot.__doc__
     get_chisqr_plot.__annotations__ = sherpa.ui.utils.Session.get_chisqr_plot.__annotations__
@@ -12194,7 +12238,9 @@ class Session(sherpa.ui.utils.Session):
                         num: int = 500,
                         bins: int = 25,
                         numcores: int | None = None,
-                        recalc: bool = False):
+                        recalc: bool = False,
+                        copy: bool = True
+                        ):
 
         if recalc and conv_model is None and \
            isinstance(self.get_data(id), DataPHA):
@@ -12203,7 +12249,7 @@ class Session(sherpa.ui.utils.Session):
         return super().get_pvalue_plot(null_model=null_model, alt_model=alt_model,
                                        conv_model=conv_model, id=id, otherids=otherids,
                                        num=num, bins=bins, numcores=numcores,
-                                       recalc=recalc)
+                                       recalc=recalc, copy=copy)
 
     get_pvalue_plot.__doc__ = sherpa.ui.utils.Session.get_pvalue_plot.__doc__
     get_pvalue_plot.__annotations__ = sherpa.ui.utils.Session.get_pvalue_plot.__annotations__
@@ -12211,8 +12257,14 @@ class Session(sherpa.ui.utils.Session):
     def get_order_plot(self,
                        id: IdType | None = None,
                        orders=None,
-                       recalc: bool = True):
+                       recalc: bool = True,
+                       copy: bool = True
+                       ):
         """Return the data used by plot_order.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12227,6 +12279,10 @@ class Session(sherpa.ui.utils.Session):
            If ``False`` then the results from the last call to
            `plot_order` (or `get_order_plot`) are returned, otherwise
            the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12262,13 +12318,19 @@ class Session(sherpa.ui.utils.Session):
             plotobj.prepare(self._get_pha_data(id),
                             self.get_model(id), orders=orders)
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_arf_plot(self,
                      id: IdType | None = None,
                      resp_id: IdType | None = None,
-                     recalc: bool = True):
+                     recalc: bool = True,
+                     copy: bool = True
+                     ):
         """Return the data used by plot_arf.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12283,6 +12345,10 @@ class Session(sherpa.ui.utils.Session):
            If ``False`` then the results from the last call to
            `plot_arf` (or `get_arf_plot`) are returned, otherwise
            the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12317,7 +12383,7 @@ class Session(sherpa.ui.utils.Session):
 
         plotobj = self._plot_types["arf"][0]
         if not recalc:
-            return plotobj
+            return cpy(plotobj, copy)
 
         idval = self._fix_id(id)
         data = self._get_pha_data(idval)
@@ -12326,13 +12392,19 @@ class Session(sherpa.ui.utils.Session):
             raise DataErr('noarf', idval)
 
         plotobj.prepare(arf, data)
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_rmf_plot(self,
                      id: IdType | None = None,
                      resp_id: IdType | None = None,
-                     recalc: bool = True):
+                     recalc: bool = True,
+                     copy: bool = True
+                     ):
         """Return the data used by plot_rmf.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         .. versionadded:: 4.16.0
 
@@ -12349,6 +12421,10 @@ class Session(sherpa.ui.utils.Session):
            If ``False`` then the results from the last call to
            `plot_rmf` (or `get_rmf_plot`) are returned, otherwise
            the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12381,7 +12457,7 @@ class Session(sherpa.ui.utils.Session):
 
         plotobj = self._plot_types["rmf"][0]
         if not recalc:
-            return plotobj
+            return cpy(plotobj, copy)
 
         idval = self._fix_id(id)
         data = self._get_pha_data(idval)
@@ -12390,13 +12466,19 @@ class Session(sherpa.ui.utils.Session):
             raise DataErr('norsp', idval)
 
         plotobj.prepare(rmf, data)
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_bkg_fit_plot(self,
                          id: IdType | None = None,
                          bkg_id: IdType | None = None,
-                         recalc: bool = True):
+                         recalc: bool = True,
+                         copy: bool = True
+                         ):
         """Return the data used by plot_bkg_fit.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12410,6 +12492,10 @@ class Session(sherpa.ui.utils.Session):
            If ``False`` then the results from the last call to
            `plot_bkg_fit` (or `get_bkg_fit_plot`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12470,26 +12556,32 @@ class Session(sherpa.ui.utils.Session):
 
         plotobj = self._plot_types["bkg_fit"][0]
         if not recalc:
-            return plotobj
+            return cpy(plotobj, copy)
 
-        dataobj = self.get_bkg_plot(id, bkg_id, recalc=recalc)
+        dataobj = self.get_bkg_plot(id, bkg_id, recalc=recalc, copy=copy)
 
         # We don't use get_bkg_model_plot as that uses the ungrouped data
         # modelobj = self.get_bkg_model_plot(id, bkg_id, recalc=recalc)
 
-        modelobj = self._bkgmodelplot
+        modelobj = cpy(self._bkgmodelplot, copy)
         modelobj.prepare(self.get_bkg(id, bkg_id),
                          self.get_bkg_model(id, bkg_id),
                          self.get_stat())
 
         plotobj.prepare(dataobj, modelobj)
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_bkg_model_plot(self,
                            id: IdType | None = None,
                            bkg_id: IdType | None = None,
-                           recalc: bool = True):
+                           recalc: bool = True,
+                           copy: bool = True
+                           ):
         """Return the data used by plot_bkg_model.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12503,6 +12595,10 @@ class Session(sherpa.ui.utils.Session):
            If ``False`` then the results from the last call to
            `plot_bkg_model` (or `get_bkg_model_plot`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12543,13 +12639,19 @@ class Session(sherpa.ui.utils.Session):
                             self.get_bkg_model(id, bkg_id),
                             self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_bkg_plot(self,
                      id: IdType | None = None,
                      bkg_id: IdType | None = None,
-                     recalc: bool = True):
+                     recalc: bool = True,
+                     copy: bool = True
+                     ):
         """Return the data used by plot_bkg.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12563,6 +12665,10 @@ class Session(sherpa.ui.utils.Session):
            If ``False`` then the results from the last call to
            `plot_bkg` (or `get_bkg_plot`) are returned, otherwise
            the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12611,15 +12717,21 @@ class Session(sherpa.ui.utils.Session):
             plotobj.prepare(self.get_bkg(id, bkg_id),
                             self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_bkg_source_plot(self,
                             id: IdType | None = None,
                             lo: float | None = None,
                             hi: float | None = None,
                             bkg_id: IdType | None = None,
-                            recalc: bool = True):
+                            recalc: bool = True,
+                            copy: bool = True
+                            ):
         """Return the data used by plot_bkg_source.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12637,6 +12749,10 @@ class Session(sherpa.ui.utils.Session):
            If ``False`` then the results from the last call to
            `plot_bkg_source` (or `get_bkg_source_plot`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12708,13 +12824,19 @@ class Session(sherpa.ui.utils.Session):
                             self.get_bkg_source(id, bkg_id),
                             lo=lo, hi=hi)
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_bkg_resid_plot(self,
                            id: IdType | None = None,
                            bkg_id: IdType | None = None,
-                           recalc: bool = True):
+                           recalc: bool = True,
+                           copy: bool = True
+                           ):
         """Return the data used by plot_bkg_resid.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12728,6 +12850,10 @@ class Session(sherpa.ui.utils.Session):
            If ``False`` then the results from the last call to
            `plot_bkg_resid` (or `get_bkg_resid_plot`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12769,13 +12895,19 @@ class Session(sherpa.ui.utils.Session):
                             self.get_bkg_model(id, bkg_id),
                             self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_bkg_ratio_plot(self,
                            id: IdType | None = None,
                            bkg_id: IdType | None = None,
-                           recalc: bool = True):
+                           recalc: bool = True,
+                           copy: bool = True
+                           ):
         """Return the data used by plot_bkg_ratio.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12789,6 +12921,10 @@ class Session(sherpa.ui.utils.Session):
            If ``False`` then the results from the last call to
            `plot_bkg_ratio` (or `get_bkg_ratio_plot`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12830,13 +12966,19 @@ class Session(sherpa.ui.utils.Session):
                             self.get_bkg_model(id, bkg_id),
                             self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_bkg_delchi_plot(self,
                             id: IdType | None = None,
                             bkg_id: IdType | None = None,
-                            recalc: bool = True):
+                            recalc: bool = True,
+                            copy: bool = True
+                            ):
         """Return the data used by plot_bkg_delchi.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12850,6 +12992,10 @@ class Session(sherpa.ui.utils.Session):
            If ``False`` then the results from the last call to
            `plot_bkg_delchi` (or `get_bkg_delchi_plot`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12892,13 +13038,19 @@ class Session(sherpa.ui.utils.Session):
                             self.get_bkg_model(id, bkg_id),
                             self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_bkg_chisqr_plot(self,
                             id: IdType | None = None,
                             bkg_id: IdType | None = None,
-                            recalc: bool = True):
+                            recalc: bool = True,
+                            copy: bool = True
+                            ):
         """Return the data used by plot_bkg_chisqr.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12912,6 +13064,10 @@ class Session(sherpa.ui.utils.Session):
            If ``False`` then the results from the last call to
            `plot_bkg_chisqr` (or `get_bkg_chisqr_plot`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12954,14 +13110,23 @@ class Session(sherpa.ui.utils.Session):
                             self.get_bkg_model(id, bkg_id),
                             self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
-    def _prepare_energy_flux_plot(self, plot, lo, hi, id, num, bins,
-                                  correlated, numcores,
+    def _prepare_energy_flux_plot(self,
+                                  plot,
+                                  lo,
+                                  hi,
+                                  id,
+                                  num,
+                                  bins,
+                                  correlated,
+                                  numcores,
                                   bkg_id: IdType | None,
-                                  scales=None, model=None,
+                                  scales=None,
+                                  model=None,
                                   otherids: IdTypes = (),
-                                  clip='hard'):
+                                  clip='hard'
+                                  ):
         """Run sample_energy_flux and convert to a plot.
         """
         dist = self.sample_energy_flux(lo, hi, id=id, otherids=otherids,
@@ -12971,12 +13136,21 @@ class Session(sherpa.ui.utils.Session):
         plot.prepare(dist, bins)
         return plot
 
-    def _prepare_photon_flux_plot(self, plot, lo, hi, id, num, bins,
-                                  correlated, numcores,
+    def _prepare_photon_flux_plot(self,
+                                  plot,
+                                  lo,
+                                  hi,
+                                  id,
+                                  num: int,
+                                  bins,
+                                  correlated: bool,
+                                  numcores: int | None,
                                   bkg_id: IdType | None,
-                                  scales=None, model=None,
+                                  scales=None,
+                                  model=None,
                                   otherids: IdTypes=(),
-                                  clip='hard'):
+                                  clip='hard'
+                                  ):
         """Run sample_photon_flux and convert to a plot.
         """
         dist = self.sample_photon_flux(lo, hi, id=id, otherids=otherids,
@@ -12986,24 +13160,32 @@ class Session(sherpa.ui.utils.Session):
         plot.prepare(dist, bins)
         return plot
 
-    def get_energy_flux_hist(self, lo=None, hi=None,
+    def get_energy_flux_hist(self,
+                             lo=None,
+                             hi=None,
                              id: IdType | None = None,
                              num=7500,
                              bins=75,
-                             correlated=False,
-                             numcores=None,
+                             correlated: bool = False,
+                             numcores: int | None = None,
                              bkg_id: IdType | None = None,
                              scales=None,
                              model=None,
                              otherids: IdTypes = (),
-                             recalc=True,
-                             clip='hard'):
+                             recalc: bool = True,
+                             clip='hard',
+                             copy: bool = True
+                             ):
         """Return the data displayed by plot_energy_flux.
 
         The get_energy_flux_hist() function calculates a histogram of
         simulated energy flux values representing the energy flux probability
         distribution for a model component, accounting for the errors on the
         model parameters.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         .. versionchanged:: 4.12.2
            The scales parameter is no longer ignored when set and the
@@ -13072,6 +13254,10 @@ class Session(sherpa.ui.utils.Session):
             hard limits if they exceed them. A value of 'soft' uses
             the soft limits instead, and 'none' applies no
             clipping.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -13127,26 +13313,34 @@ class Session(sherpa.ui.utils.Session):
                                            otherids=otherids, clip=clip,
                                            numcores=numcores, bkg_id=bkg_id)
 
-        return plotobj
+        return cpy(plotobj, copy)
 
-    def get_photon_flux_hist(self, lo=None, hi=None,
+    def get_photon_flux_hist(self,
+                             lo=None,
+                             hi=None,
                              id: IdType | None = None,
                              num=7500,
                              bins=75,
-                             correlated=False,
-                             numcores=None,
+                             correlated: bool = False,
+                             numcores: int | None = None,
                              bkg_id: IdType | None = None,
                              scales=None,
                              model=None,
                              otherids: IdTypes = (),
-                             recalc=True,
-                             clip='hard'):
+                             recalc: bool = True,
+                             clip='hard',
+                             copy: bool = True
+                             ):
         """Return the data displayed by plot_photon_flux.
 
         The get_photon_flux_hist() function calculates a histogram of
         simulated photon flux values representing the photon flux probability
         distribution for a model component, accounting for the errors on the
         model parameters.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         .. versionchanged:: 4.12.2
            The scales parameter is no longer ignored when set and the
@@ -13214,6 +13408,10 @@ class Session(sherpa.ui.utils.Session):
             hard limits if they exceed them. A value of 'soft' uses
             the soft limits instead, and 'none' applies no
             clipping.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -13269,7 +13467,7 @@ class Session(sherpa.ui.utils.Session):
                                            otherids=otherids, clip=clip,
                                            numcores=numcores, bkg_id=bkg_id)
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     # TODO: should resp_id allow multiple values?
     #
@@ -13526,14 +13724,14 @@ class Session(sherpa.ui.utils.Session):
 
         """
 
-        def get(id, recalc=False):
+        def get(id, recalc=False, copy=True):
             data = self.get_data(id)
             if isinstance(data, DataPHA):
                 kwargs = {"lo": lo, "hi": hi}
             else:
                 kwargs = {}
 
-            return self.get_source_plot(id, recalc=recalc,
+            return self.get_source_plot(id, recalc=recalc, copy=copy,
                                         **kwargs)
 
         plotobj = self._get_plot_objects(id, get, recalc=not replot)
@@ -14924,15 +15122,19 @@ class Session(sherpa.ui.utils.Session):
                             stat=stat, method=method,
                             rng=self.get_rng())
 
-    def sample_photon_flux(self, lo=None, hi=None,
+    def sample_photon_flux(self,
+                           lo=None,
+                           hi=None,
                            id: IdType | None = None,
                            num=1,
-                           scales=None, correlated=False,
-                           numcores=None,
+                           scales=None,
+                           correlated: bool = False,
+                           numcores: int | None = None,
                            bkg_id: IdType | None = None,
                            model=None,
                            otherids: IdTypes = (),
-                           clip='hard'):
+                           clip='hard'
+                           ):
         """Return the photon flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -15158,15 +15360,19 @@ class Session(sherpa.ui.utils.Session):
                                              samples=scales, clip=clip,
                                              rng=self.get_rng())
 
-    def sample_energy_flux(self, lo=None, hi=None,
+    def sample_energy_flux(self,
+                           lo=None,
+                           hi=None,
                            id: IdType | None = None,
                            num=1,
-                           scales=None, correlated=False,
+                           scales=None,
+                           correlated=False,
                            numcores=None,
                            bkg_id: IdType | None = None,
                            model=None,
                            otherids: IdTypes = (),
-                           clip='hard'):
+                           clip='hard'
+                           ):
         """Return the energy flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -15392,12 +15598,19 @@ class Session(sherpa.ui.utils.Session):
                                              samples=scales, clip=clip,
                                              rng=self.get_rng())
 
-    def sample_flux(self, modelcomponent=None, lo=None, hi=None,
+    def sample_flux(self,
+                    modelcomponent=None,
+                    lo=None,
+                    hi=None,
                     id: IdType | None = None,
-                    num=1, scales=None, correlated=False,
+                    num=1,
+                    scales=None,
+                    correlated=False,
                     numcores=None,
                     bkg_id: IdType | None = None,
-                    Xrays=True, confidence=68):
+                    Xrays=True,
+                    confidence=68
+                    ):
         """Return the flux distribution of a model.
 
         For each iteration, draw the parameter values of the model
@@ -15617,15 +15830,19 @@ class Session(sherpa.ui.utils.Session):
                                                   modelcomponent=modelcomponent,
                                                   confidence=confidence)
 
-    def eqwidth(self, src, combo,
+    def eqwidth(self,
+                src,
+                combo,
                 id: IdType | None = None,
-                lo=None, hi=None,
+                lo=None,
+                hi=None,
                 bkg_id: IdType | None = None,
                 error: bool = False,
                 params: np.ndarray | None = None,
                 otherids: IdTypes = (),
                 niter: int = 1000,
-                covar_matrix: np.ndarray | None = None):
+                covar_matrix: np.ndarray | None = None
+                ):
         """Calculate the equivalent width of an emission or absorption line.
 
         The equivalent width (EW) is calculated following `George &
@@ -15842,10 +16059,13 @@ class Session(sherpa.ui.utils.Session):
         fit.model.thawedpars = orig_par_vals
         return median, lower, upper, params, eqw
 
-    def calc_photon_flux(self, lo=None, hi=None,
+    def calc_photon_flux(self,
+                         lo=None,
+                         hi=None,
                          id: IdType | None = None,
                          bkg_id: IdType | None = None,
-                         model=None):
+                         model=None
+                         ):
         """Integrate the unconvolved source model over a pass band.
 
         Calculate the integral of S(E) over a pass band, where S(E) is
@@ -15959,10 +16179,13 @@ class Session(sherpa.ui.utils.Session):
 
         return sherpa.astro.utils.calc_photon_flux(data, model, lo, hi)
 
-    def calc_energy_flux(self, lo=None, hi=None,
+    def calc_energy_flux(self,
+                         lo=None,
+                         hi=None,
                          id: IdType | None = None,
                          bkg_id: IdType | None = None,
-                         model=None):
+                         model=None
+                         ):
         """Integrate the unconvolved source model over a pass band.
 
         Calculate the integral of E * S(E) over a pass band, where E
@@ -16075,9 +16298,12 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: how do lo/hi limits interact with bin edges;
     # is it all in or partially in or ...
-    def calc_data_sum(self, lo=None, hi=None,
+    def calc_data_sum(self,
+                      lo=None,
+                      hi=None,
                       id: IdType | None = None,
-                      bkg_id: IdType | None = None):
+                      bkg_id: IdType | None = None
+                      ):
         """Sum up the data values over a pass band.
 
         This function is for one-dimensional data sets: use
@@ -16418,9 +16644,12 @@ class Session(sherpa.ui.utils.Session):
     #           to show the difference between calc_model_sum and
     #           calc_source_sum
     #
-    def calc_model_sum(self, lo=None, hi=None,
+    def calc_model_sum(self,
+                       lo=None,
+                       hi=None,
                        id: IdType | None = None,
-                       bkg_id: IdType | None = None):
+                       bkg_id: IdType | None = None
+                       ):
         """Sum up the fitted model over a pass band.
 
         Sum up M(E) over a range of bins, where M(E) is the per-bin model
@@ -16525,7 +16754,8 @@ class Session(sherpa.ui.utils.Session):
 
     def calc_data_sum2d(self,
                         reg=None,
-                        id: IdType | None = None):
+                        id: IdType | None = None
+                        ):
         """Sum up the data values of a 2D data set.
 
         This function is for two-dimensional data sets: use
@@ -16602,8 +16832,10 @@ class Session(sherpa.ui.utils.Session):
     #           and change the model (to a non-flat distribution, otherwise
     #           the PSF doesn't really help)
     # DOC-TODO: this needs testing as doesn't seem to be working for me
-    def calc_model_sum2d(self, reg=None,
-                         id: IdType | None = None):
+    def calc_model_sum2d(self,
+                         reg=None,
+                         id: IdType | None = None
+                         ):
         """Sum up the convolved model for a 2D data set.
 
         This function is for two-dimensional data sets: use
@@ -16681,8 +16913,10 @@ class Session(sherpa.ui.utils.Session):
         model = self.get_model(id)
         return sherpa.astro.utils.calc_model_sum2d(data, model, reg)
 
-    def calc_source_sum2d(self, reg=None,
-                          id: IdType | None = None):
+    def calc_source_sum2d(self,
+                          reg=None,
+                          id: IdType | None = None
+                          ):
         """Sum up the unconvolved model for a 2D data set.
 
         This function is for two-dimensional data sets: use
@@ -16760,9 +16994,12 @@ class Session(sherpa.ui.utils.Session):
         src = self.get_source(id)
         return sherpa.astro.utils.calc_model_sum2d(data, src, reg)
 
-    def calc_source_sum(self, lo=None, hi=None,
+    def calc_source_sum(self,
+                        lo=None,
+                        hi=None,
                         id: IdType | None = None,
-                        bkg_id: IdType | None = None):
+                        bkg_id: IdType | None = None
+                        ):
         """Sum up the source model over a pass band.
 
         Sum up S(E) over a range of bins, where S(E) is the per-bin model
@@ -16872,9 +17109,15 @@ class Session(sherpa.ui.utils.Session):
 
     # DOC-TODO: no reason can't k-correct wavelength range,
     # but need to work out how to identify the units
-    def calc_kcorr(self, z, obslo, obshi, restlo=None, resthi=None,
+    def calc_kcorr(self,
+                   z,
+                   obslo,
+                   obshi,
+                   restlo=None,
+                   resthi=None,
                    id: IdType | None = None,
-                   bkg_id: IdType | None = None):
+                   bkg_id: IdType | None = None
+                   ):
         """Calculate the K correction for a model.
 
         The K correction ([1]_, [2]_, [3]_, [4]_) is the numeric

--- a/sherpa/ui/tests/test_ui_plot.py
+++ b/sherpa/ui/tests/test_ui_plot.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2019-2025
+#  Copyright (C) 2019-2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -221,7 +221,7 @@ def change_fit(idval):
 def check_example(idval, xlabel='x'):
     """Check that the data plot has not changed"""
 
-    dplot = ui.get_data_plot(id=idval, recalc=False)
+    dplot = ui.get_data_plot(id=idval, recalc=False, copy=False)
 
     assert dplot.xlabel == xlabel
     assert dplot.ylabel == 'y'
@@ -240,7 +240,7 @@ def check_example_changed(idval, xlabel='x'):
     Assumes change_example has been called
     """
 
-    dplot = ui.get_data_plot(id=idval, recalc=False)
+    dplot = ui.get_data_plot(id=idval, recalc=False, copy=False)
 
     assert dplot.xlabel == xlabel
     assert dplot.ylabel == 'y'
@@ -268,7 +268,7 @@ def check_model_plot(plot, title='Model', xlabel='x', modelval=35):
 def check_model(idval, xlabel='x'):
     """Check that the model plot has not changed"""
 
-    mplot = ui.get_model_plot(id=idval, recalc=False)
+    mplot = ui.get_model_plot(id=idval, recalc=False, copy=False)
     check_model_plot(mplot, title='Model', xlabel=xlabel)
 
 
@@ -278,14 +278,14 @@ def check_model_changed(idval, xlabel='x'):
     Assumes change_model has been called
     """
 
-    mplot = ui.get_model_plot(id=idval, recalc=False)
+    mplot = ui.get_model_plot(id=idval, recalc=False, copy=False)
     check_model_plot(mplot, title='Model', xlabel=xlabel, modelval=41)
 
 
 def check_source(idval):
     """Check that the source plot has not changed"""
 
-    splot = ui.get_source_plot(id=idval, recalc=False)
+    splot = ui.get_source_plot(id=idval, recalc=False, copy=False)
     check_model_plot(splot, title='Source')
 
 
@@ -295,14 +295,14 @@ def check_source_changed(idval):
     Assumes change_model has been called
     """
 
-    splot = ui.get_source_plot(id=idval, recalc=False)
+    splot = ui.get_source_plot(id=idval, recalc=False, copy=False)
     check_model_plot(splot, title='Source', modelval=41)
 
 
 def check_resid(idval, title='Residuals for example'):
     """Check that the resid plot has not changed"""
 
-    rplot = ui.get_resid_plot(id=idval, recalc=False)
+    rplot = ui.get_resid_plot(id=idval, recalc=False, copy=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
     assert rplot.title == title
@@ -318,7 +318,7 @@ def check_resid_changed(idval, title='Residuals for example'):
     Assumes that change_model has been called
     """
 
-    rplot = ui.get_resid_plot(id=idval, recalc=False)
+    rplot = ui.get_resid_plot(id=idval, recalc=False, copy=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
     assert rplot.title == title
@@ -334,7 +334,7 @@ def check_resid_changed2(idval, title='Residuals for example'):
     Assumes that change_example and change_model has been called
     """
 
-    rplot = ui.get_resid_plot(id=idval, recalc=False)
+    rplot = ui.get_resid_plot(id=idval, recalc=False, copy=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data - Model'
     assert rplot.title == title
@@ -347,7 +347,7 @@ def check_resid_changed2(idval, title='Residuals for example'):
 def check_ratio(idval, title='Ratio of Data to Model for example'):
     """Check that the ratio plot has not changed"""
 
-    rplot = ui.get_ratio_plot(id=idval, recalc=False)
+    rplot = ui.get_ratio_plot(id=idval, recalc=False, copy=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
     assert rplot.title == title
@@ -364,7 +364,7 @@ def check_ratio_changed(idval):
     Assumes that change_example has been called
     """
 
-    rplot = ui.get_ratio_plot(id=idval, recalc=False)
+    rplot = ui.get_ratio_plot(id=idval, recalc=False, copy=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
     assert rplot.title == 'Ratio of Data to Model for example'
@@ -381,7 +381,7 @@ def check_ratio_changed2(idval, title='Ratio of Data to Model for example'):
     Assumes that change_example and change_model has been called
     """
 
-    rplot = ui.get_ratio_plot(id=idval, recalc=False)
+    rplot = ui.get_ratio_plot(id=idval, recalc=False, copy=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Data / Model'
     assert rplot.title == title
@@ -395,7 +395,7 @@ def check_ratio_changed2(idval, title='Ratio of Data to Model for example'):
 def check_delchi(idval, title='Sigma Residuals for example'):
     """Check that the delchi plot has not changed"""
 
-    rplot = ui.get_delchi_plot(id=idval, recalc=False)
+    rplot = ui.get_delchi_plot(id=idval, recalc=False, copy=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
     assert rplot.title == title
@@ -414,7 +414,7 @@ def check_delchi_changed(idval, title='Sigma Residuals for example'):
     Assumes that change_example has been called
     """
 
-    rplot = ui.get_delchi_plot(id=idval, recalc=False)
+    rplot = ui.get_delchi_plot(id=idval, recalc=False, copy=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
     assert rplot.title == title
@@ -433,7 +433,7 @@ def check_delchi_changed2(idval, title='Sigma Residuals for example'):
     Assumes that change_example and change_model has been called
     """
 
-    rplot = ui.get_delchi_plot(id=idval, recalc=False)
+    rplot = ui.get_delchi_plot(id=idval, recalc=False, copy=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == 'Sigma'
     assert rplot.title == title
@@ -449,7 +449,7 @@ def check_delchi_changed2(idval, title='Sigma Residuals for example'):
 def check_chisqr(idval):
     """Check that the chisqr plot has not changed"""
 
-    rplot = ui.get_chisqr_plot(id=idval, recalc=False)
+    rplot = ui.get_chisqr_plot(id=idval, recalc=False, copy=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == '$\\chi^2$'
     assert rplot.title == '$\\chi^2$ for example'
@@ -468,7 +468,7 @@ def check_chisqr_changed(idval):
     Assumes that change_example has been called
     """
 
-    rplot = ui.get_chisqr_plot(id=idval, recalc=False)
+    rplot = ui.get_chisqr_plot(id=idval, recalc=False, copy=False)
     assert rplot.xlabel == 'x'
     assert rplot.ylabel == '$\\chi^2$'
     assert rplot.title == '$\\chi^2$ for example'
@@ -729,7 +729,7 @@ def test_prefs_change_session_objects(getprefs, getplot, plotfunc, clean_ui):
     # This used to access the plot object directly, but is now
     # using an accessor function.
     #
-    session = getplot(recalc=False)
+    session = getplot(recalc=False, copy=False)
 
     # All but the last assert are just to check things are behaving
     # as expected (and stuck into one routine rather than have a
@@ -766,7 +766,7 @@ def test_prefs_change_session_objects_fit(clean_ui):
     about what we expect/want to happen.
     """
 
-    plotobj = ui.get_fit_plot(recalc=False)
+    plotobj = ui.get_fit_plot(recalc=False, copy=False)
     assert plotobj.dataplot is None
     assert plotobj.modelplot is None
 
@@ -787,8 +787,9 @@ def test_prefs_change_session_objects_fit(clean_ui):
     # We have already checked this in previous tests, but
     # just in case
     #
-    assert ui.get_data_plot(id=12, recalc=False).plot_prefs['xlog']
-    assert ui.get_model_plot(id=12, recalc=False).plot_prefs['ylog']
+    kwargs = {"id": 12, "recalc": False, "copy": False}
+    assert ui.get_data_plot(**kwargs).plot_prefs['xlog']
+    assert ui.get_model_plot(**kwargs).plot_prefs['ylog']
 
     # Now check that the fit plot has picked up these changes;
     # the simplest way is to check that the data/model plots
@@ -798,8 +799,8 @@ def test_prefs_change_session_objects_fit(clean_ui):
     # which is less restrictive, but for now check the
     # equality
     #
-    assert plotobj.dataplot is ui.get_data_plot(id=12, recalc=False)
-    assert plotobj.modelplot is ui.get_model_plot(id=12, recalc=False)
+    assert plotobj.dataplot is ui.get_data_plot(**kwargs)
+    assert plotobj.modelplot is ui.get_model_plot(**kwargs)
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])
@@ -1056,7 +1057,7 @@ def test_plot_resid_ignores_ylog(getplot, plotfunc, clean_ui):
     ylog (since the data should be positive in this case).
     """
 
-    prefs = getplot(recalc=False).plot_prefs
+    prefs = getplot(recalc=False, copy=False).plot_prefs
 
     setup_example(None)
 
@@ -1078,8 +1079,8 @@ def test_plot_resid_ignores_ylog(getplot, plotfunc, clean_ui):
 def test_plot_fit_resid_ignores_ylog(getplot, plotfunc, clean_ui):
     """Do the plot_resid-family of routines ignore the ylog setting?"""
 
-    rprefs = getplot(recalc=False).plot_prefs
-    dprefs = ui.get_data_plot(recalc=False).plot_prefs
+    rprefs = getplot(recalc=False, copy=False).plot_prefs
+    dprefs = ui.get_data_plot(recalc=False, copy=False).plot_prefs
 
     setup_example(None)
 
@@ -1410,13 +1411,20 @@ def test_get_xxx_contour_prefs_behavior(ctype, clean_ui):
     got = preffunc()
     assert got["alpha"] is None
 
-    assert getfunc(recalc=False).contour_prefs["alpha"] is None
+    # The default for copy is True.
+    copied = getfunc(recalc=False)
+
+    kwargs = {"recalc": False, "copy": False}
+    assert getfunc(**kwargs).contour_prefs["alpha"] is None
 
     got["alpha"] = 0.5
 
-    assert getfunc(recalc=False).contour_prefs["alpha"] == pytest.approx(0.5)
-    assert getfunc(2, recalc=False).contour_prefs["alpha"] == pytest.approx(0.5)
-    assert getfunc("foo", recalc=False).contour_prefs["alpha"] == pytest.approx(0.5)
+    assert getfunc(**kwargs).contour_prefs["alpha"] == pytest.approx(0.5)
+    assert getfunc(2, **kwargs).contour_prefs["alpha"] == pytest.approx(0.5)
+    assert getfunc("foo", **kwargs).contour_prefs["alpha"] == pytest.approx(0.5)
+
+    # The copied preferences is still None
+    assert copied.contour_prefs["alpha"] is None
 
 
 @pytest.mark.parametrize("session", [BaseSession, AstroSession])

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Sequence
 from configparser import ConfigParser
-import copy
+from copy import deepcopy
 import copyreg as copy_reg
 from dataclasses import dataclass
 import importlib
@@ -397,6 +397,12 @@ def calc_multiplot_size(rows, cols, nplots):
         nrows = get(ncols)
 
     return nrows, ncols
+
+
+def cpy(obj: T, copy: bool) -> T:
+    """Return the object or a copy of it."""
+
+    return deepcopy(obj) if copy else obj
 
 
 ###############################################################################
@@ -821,7 +827,8 @@ class FitStore:
 
 def get_components_helper(getfunc: Callable[..., Plot],
                           model: Model,
-                          idval: IdType) -> MultiPlot:
+                          idval: IdType
+                          ) -> MultiPlot:
     """Handle get_source/model_components_plot.
 
     Iterate through each term in the source model.
@@ -832,8 +839,8 @@ def get_components_helper(getfunc: Callable[..., Plot],
     for cpt in cpts:
         # Copy over the plot as otherwise they will all be set
         # to the last cpt.
-        plotobj = getfunc(id=idval, model=cpt, recalc=True)
-        out.add(copy.deepcopy(plotobj))
+        plotobj = getfunc(id=idval, model=cpt, recalc=True, copy=True)
+        out.add(plotobj)
 
     out.title = "Component plot"
     return out
@@ -4294,7 +4301,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
         data = self.get_data(fromid)
-        data = copy.deepcopy(data)
+        data = deepcopy(data)
         self.set_data(toid, data)
 
     # DOC-TODO: this does not delete the source expression;
@@ -10011,17 +10018,22 @@ class Session(NoNewAttributesAfterInit):
         lrplot = self.get_pvalue_plot(null_model=null_model, alt_model=alt_model,
                                       conv_model=conv_model, id=id, otherids=otherids,
                                       num=num, bins=bins, numcores=numcores,
-                                      recalc=not replot)
+                                      recalc=not replot, copy=False)
         self._plot(lrplot, overplot=overplot, clearwindow=clearwindow,
                    **kwargs)
 
-    def get_pvalue_plot(self, null_model=None, alt_model=None, conv_model=None,
+    def get_pvalue_plot(self,
+                        null_model=None,
+                        alt_model=None,
+                        conv_model=None,
                         id: IdType = 1,
                         otherids: IdTypes = (),
                         num: int = 500,
                         bins: int = 25,
                         numcores: int | None = None,
-                        recalc: bool = False):
+                        recalc: bool = False,
+                        copy: bool = True
+                        ):
         """Return the data used by plot_pvalue.
 
         Access the data arrays and preferences defining the histogram plot
@@ -10030,6 +10042,10 @@ class Session(NoNewAttributesAfterInit):
         model using faked data with Poisson noise. Data returned includes the
         likelihood ratio computed using the observed data, and the p-value,
         used to reject or accept the null model.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         .. versionchanged:: 4.17.0
            The "wstat" statistic can now be used with this routine.
@@ -10059,6 +10075,10 @@ class Session(NoNewAttributesAfterInit):
            The default value (``False``) means that the results from the
            last call to `plot_pvalue` or `get_pvalue_plot` are
            returned. If ``True``, the values are re-calculated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -10092,7 +10112,7 @@ class Session(NoNewAttributesAfterInit):
 
         lrplot = self._lrplot
         if not recalc:
-            return lrplot
+            return cpy(lrplot, copy)
 
         if null_model is None:
             raise TypeError("null model cannot be None")
@@ -10116,7 +10136,7 @@ class Session(NoNewAttributesAfterInit):
 
         lrplot.prepare(ratios=results.ratios, bins=bins,
                        niter=num, lr=results.lr, ppp=results.ppp)
-        return lrplot
+        return cpy(lrplot, copy)
 
     #
     # Sampling functions
@@ -12286,11 +12306,9 @@ class Session(NoNewAttributesAfterInit):
         nids = len(idvals)
         plots = []
         for idx, idval in enumerate(reversed(idvals), 1):
-            plot = getfunc(id=idval, recalc=recalc, **kwargs)
-            if idx == nids:
-                plots.append(plot)
-            else:
-                plots.append(copy.deepcopy(plot))
+            copyarg = idx != nids
+            plot = getfunc(id=idval, recalc=recalc, copy=copyarg, **kwargs)
+            plots.append(plot)
 
         # Add the plots to the MultiPlot but fix the order.
         #
@@ -12325,8 +12343,14 @@ class Session(NoNewAttributesAfterInit):
 
     def get_data_plot(self,
                       id: IdType | None = None,
-                      recalc: bool = True):
+                      recalc: bool = True,
+                      copy: bool = True
+                      ):
         """Return the data used by plot_data.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12337,6 +12361,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `plot_data` (or `get_data_plot`) are returned, otherwise
            the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12374,7 +12402,7 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(data, self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     # DOC-TODO: discussion of preferences needs better handling
     # of how it interacts with the chosen plot backend.
@@ -12410,14 +12438,62 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        The meaning of the fields depend on the chosen plot backend.
-        A value of ``None`` means to use the default value for that
-        attribute, or not to use that setting.
-
         The "fit" argument can not be used, even though there is a
         get_fit_plot call. Either use the "data" or "model" arguments
         to access the desired plot type, or use get_fit_plot() and
         access the dataplot and modelplot attributes directly.
+
+        The meaning of the fields depend on the chosen plot backend.
+        A value of ``None`` means to use the default value for that
+        attribute, or not to use that setting.
+
+        The following preferences are recognized by the matplotlib
+        backend:
+
+        ``alpha``
+           The transparency value used to draw the line or symbol,
+           where 0 is fully transparent and 1 is fully opaque.
+
+        ``barsabove``
+           The barsabove argument for the matplotlib errorbar function.
+
+        ``capsize``
+           The capsize argument for the matplotlib errorbar function.
+
+        ``color``
+           The color to use (will be over-ridden by more-specific
+           options below).
+
+        ``ecolor``
+           The color to draw error bars.
+
+        ``linestyle``
+           How should the line connecting the data points be drawn.
+
+        ``marker``
+           What style is used for the symbols.
+
+        ``markerfacecolor``
+           What color to draw the symbol representing the data points.
+
+        ``markersize``
+           What size is the symbol drawn.
+
+        ``xerrorbars``
+           Should error bars be drawn for the X axis.
+
+        ``xlog``
+           Should the X axis be drawn with a logarithmic scale? This
+           field can also be changed with the `set_xlog` and
+           `set_xlinear` functions.
+
+        ``yerrorbars``
+           Should error bars be drawn for the Y axis.
+
+        ``ylog``
+           Should the Y axis be drawn with a logarithmic scale? This
+           field can also be changed with the `set_ylog` and
+           `set_ylinear` functions.
 
         Examples
         --------
@@ -12448,15 +12524,17 @@ class Session(NoNewAttributesAfterInit):
             raise ArgumentErr(f"Use 'data' or 'model' instead of '{plottype}'")
 
         get = getattr(self, f"get_{ptype}_plot")
-        plotobj = get(id, recalc=False, **kwargs)
+        plotobj = get(id, recalc=False, copy=False, **kwargs)
         return get_plot_prefs(plotobj)
 
     def get_data_plot_prefs(self,
-                            id: IdType | None = None) -> PrefsType:
+                            id: IdType | None = None
+                            ) -> PrefsType:
         """Return the preferences for plot_data.
 
         The plot preferences may depend on the data set,
-        so it is now an optional argument.
+        so it is now an optional argument. The `get_plot_prefs`
+        routine should be used instead.
 
         .. versionchanged:: 4.12.2
            The id argument has been given.
@@ -12481,65 +12559,12 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        The meaning of the fields depend on the chosen plot backend.
-        A value of ``None`` means to use the default value for that
-        attribute, unless indicated otherwise. These preferences
-        are used by the following commands: `plot_data`, `plot_bkg`,
-        `plot_ratio`, and the "fit" variants, such as `plot_fit`,
-        `plot_fit_resid`, and `plot_bkg_fit`.
+        These preferences are used by the following commands:
+        `plot_data`, `plot_bkg`, `plot_ratio`, and the "fit" variants,
+        such as `plot_fit`, `plot_fit_resid`, and `plot_bkg_fit`.
 
-        The following preferences are recognized by the matplotlib
-        backend:
-
-        ``alpha``
-           The transparency value used to draw the line or symbol,
-           where 0 is fully transparent and 1 is fully opaque.
-
-        ``barsabove``
-           The barsabove argument for the matplotlib errorbar function.
-
-        ``capsize``
-           The capsize argument for the matplotlib errorbar function.
-
-        ``color``
-           The color to use (will be over-ridden by more-specific
-           options below). The default is ``None``.
-
-        ``ecolor``
-           The color to draw error bars. The default is ``None``.
-
-        ``linestyle``
-           How should the line connecting the data points be drawn.
-           The default is 'None', which means no line is drawn.
-
-        ``marker``
-           What style is used for the symbols. The default is ``'.'``
-           which indicates a point.
-
-        ``markerfacecolor``
-           What color to draw the symbol representing the data points.
-           The default is ``None``.
-
-        ``markersize``
-           What size is the symbol drawn. The default is ``None``.
-
-        ``xerrorbars``
-           Should error bars be drawn for the X axis. The default is
-           ``False``.
-
-        ``xlog``
-           Should the X axis be drawn with a logarithmic scale? The
-           default is ``False``. This field can also be changed with the
-           `set_xlog` and `set_xlinear` functions.
-
-        ``yerrorbars``
-           Should error bars be drawn for the Y axis. The default is
-           ``True``.
-
-        ``ylog``
-           Should the Y axis be drawn with a logarithmic scale? The
-           default is ``False``. This field can also be changed with the
-           `set_ylog` and `set_ylinear` functions.
+        The preferences recognized by the matplotlib backend are the
+        same as for `get_plot_prefs`.
 
         Examples
         --------
@@ -12553,14 +12578,20 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self.get_data_plot(id, recalc=False)
+        plotobj = self.get_data_plot(id, recalc=False, copy=False)
         return get_plot_prefs(plotobj)
 
     # also in sherpa.astro.utils (copies this docstring)
     def get_model_plot(self,
                        id: IdType | None = None,
-                       recalc: bool = True):
+                       recalc: bool = True,
+                       copy: bool = True
+                       ):
         """Return the data used to create the model plot.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12571,6 +12602,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `plot_model` (or `get_model_plot`) are returned, otherwise
            the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12602,13 +12637,19 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(data, self.get_model(id), self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     # also in sherpa.astro.utils (does not copy this docstring)
     def get_source_plot(self,
                         id: IdType | None = None,
-                        recalc: bool = True):
+                        recalc: bool = True,
+                        copy: bool = True
+                        ):
         """Return the data used to create the source plot.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12619,6 +12660,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `plot_source` (or `get_source_plot`) are returned, otherwise
            the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12675,10 +12720,19 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(data, self.get_source(idval), self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
-    def get_model_component_plot(self, id, model=None, recalc: bool = True):
+    def get_model_component_plot(self,
+                                 id,
+                                 model=None,
+                                 recalc: bool = True,
+                                 copy: bool = True
+                                 ):
         """Return the data used to create the model-component plot.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12691,6 +12745,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `plot_model_component` (or `get_model_component_plot`)
            are returned, otherwise the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12748,10 +12806,10 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(data, model, self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_model_components_plot(self,
-                                  id: IdType | None = None
+                                  id: IdType | None = None,
                                   ) -> MultiPlot:
         """Return the data used by plot_model_components.
 
@@ -12797,8 +12855,17 @@ class Session(NoNewAttributesAfterInit):
                                      model=model, idval=idval)
 
     # sherpa.astro.utils version copies this docstring
-    def get_source_component_plot(self, id, model=None, recalc: bool = True):
+    def get_source_component_plot(self,
+                                  id,
+                                  model=None,
+                                  recalc: bool = True,
+                                  copy: bool = True
+                                  ):
         """Return the data used by plot_source_component.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -12811,6 +12878,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `plot_source_component` (or `get_source_component_plot`)
            are returned, otherwise the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -12872,7 +12943,7 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(data, model, self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_source_components_plot(self,
                                    id: IdType | None = None
@@ -12920,11 +12991,14 @@ class Session(NoNewAttributesAfterInit):
         return get_components_helper(self.get_source_component_plot,
                                      model=model, idval=idval)
 
-    def get_model_plot_prefs(self, id: IdType | None = None) -> PrefsType:
+    def get_model_plot_prefs(self,
+                             id: IdType | None = None
+                             ) -> PrefsType:
         """Return the preferences for plot_model.
 
         The plot preferences may depend on the data set,
-        so it is now an optional argument.
+        so it is now an optional argument. The `get_plot_prefs`
+        routine should be used instead.
 
         .. versionchanged:: 4.12.2
            The id argument has been given.
@@ -12949,15 +13023,13 @@ class Session(NoNewAttributesAfterInit):
 
         Notes
         -----
-        The meaning of the fields depend on the chosen plot backend.
-        A value of ``None`` means to use the default value for that
-        attribute, unless indicated otherwise. These preferences are
-        used by the following commands: `plot_model`, `plot_ratio`,
-        `plot_bkg_model`, and the "fit" variants, such as `plot_fit`,
-        `plot_fit_resid`, and `plot_bkg_fit`.
+        These preferences are used by the following commands:
+        `plot_model`, `plot_ratio`, `plot_bkg_model`, and the "fit"
+        variants, such as `plot_fit`, `plot_fit_resid`, and
+        `plot_bkg_fit`.
 
         The preferences recognized by the matplotlib backend are the
-        same as for `get_data_plot_prefs`.
+        same as for `get_plot_prefs`.
 
         Examples
         --------
@@ -12970,12 +13042,14 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self.get_model_plot(id, recalc=False)
+        plotobj = self.get_model_plot(id, recalc=False, copy=False)
         return get_plot_prefs(plotobj)
 
     def get_fit_plot(self,
                      id: IdType | None = None,
-                     recalc: bool = True):
+                     recalc: bool = True,
+                     copy: bool = True
+                     ):
         """Return the data used to create the fit plot.
 
         Parameters
@@ -12987,6 +13061,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `plot_fit` (or `get_fit_plot`) are returned, otherwise
            the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -13036,16 +13114,22 @@ class Session(NoNewAttributesAfterInit):
 
         plotobj = self._plot_types["fit"][0]
         if recalc:
-            dataobj = self.get_data_plot(id, recalc=recalc)
-            modelobj = self.get_model_plot(id, recalc=recalc)
+            dataobj = self.get_data_plot(id, recalc=recalc, copy=copy)
+            modelobj = self.get_model_plot(id, recalc=recalc, copy=copy)
             plotobj.prepare(dataobj, modelobj)
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_resid_plot(self,
                        id: IdType | None = None,
-                       recalc: bool = True):
+                       recalc: bool = True,
+                       copy: bool = True
+                       ):
         """Return the data used by plot_resid.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -13056,6 +13140,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `plot_resid` (or `get_resid_plot`) are returned, otherwise
            the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -13116,12 +13204,18 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(data, self.get_model(id), self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_delchi_plot(self,
                         id: IdType | None = None,
-                        recalc: bool = True):
+                        recalc: bool = True,
+                        copy: bool = True
+                        ):
         """Return the data used by plot_delchi.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -13132,6 +13226,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `plot_delchi` (or `get_delchi_plot`) are returned, otherwise
            the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -13193,12 +13291,18 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(data, self.get_model(id), self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_chisqr_plot(self,
                         id: IdType | None = None,
-                        recalc: bool = True):
+                        recalc: bool = True,
+                        copy: bool = True
+                        ):
         """Return the data used by plot_chisqr.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -13270,12 +13374,18 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(data, self.get_model(id), self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_ratio_plot(self,
                        id: IdType | None = None,
-                       recalc: bool = True):
+                       recalc: bool = True,
+                       copy: bool = True
+                       ):
         """Return the data used by plot_ratio.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -13286,6 +13396,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `plot_ratio` (or `get_ratio_plot`) are returned, otherwise
            the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -13347,12 +13461,18 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(data, self.get_model(id), self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_data_contour(self,
                          id: IdType | None = None,
-                         recalc: bool = True):
+                         recalc: bool = True,
+                         copy: bool = True
+                         ):
         """Return the data used by contour_data.
+
+        .. versionchanged:: 4.19.0
+           The contour object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -13363,6 +13483,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `contour_data` (or `get_data_contour`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the contour object copied before being returned? If so then
+           the contour attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -13398,11 +13522,12 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_contour_prefs(self,
                           contourtype: str,
-                          id: IdType | None = None) -> PrefsType:
+                          id: IdType | None = None
+                          ) -> PrefsType:
         """Return the preferences for the given contour type.
 
         .. versionadded:: 4.16.0
@@ -13460,7 +13585,7 @@ class Session(NoNewAttributesAfterInit):
             raise ArgumentErr("Use 'data' or 'model' instead of 'fit'")
 
         get = getattr(self, f"get_{ctype}_contour")
-        return get(id, recalc=False).contour_prefs
+        return get(id, recalc=False, copy=False).contour_prefs
 
     def get_data_contour_prefs(self) -> PrefsType:
         """Return the preferences for contour_data.
@@ -13510,12 +13635,18 @@ class Session(NoNewAttributesAfterInit):
         >>> contour_data()
 
         """
-        return self.get_data_contour(recalc=False).contour_prefs
+        return self.get_data_contour(recalc=False, copy=False).contour_prefs
 
     def get_model_contour(self,
                           id: IdType | None = None,
-                          recalc: bool = True):
+                          recalc: bool = True,
+                          copy: bool = True
+                          ):
         """Return the data used by contour_model.
+
+        .. versionchanged:: 4.19.0
+           The contour object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -13526,6 +13657,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `contour_model` (or `get_model_contour`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the contour object copied before being returned? If so then
+           the contour attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -13561,12 +13696,18 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_source_contour(self,
                            id: IdType | None = None,
-                           recalc: bool = True):
+                           recalc: bool = True,
+                           copy: bool = True
+                           ):
         """Return the data used by contour_source.
+
+        .. versionchanged:: 4.19.0
+           The contour object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -13577,6 +13718,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `contour_source` (or `get_source_contour`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the contour object copied before being returned? If so then
+           the contour attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -13612,7 +13757,7 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_source(id), self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_model_contour_prefs(self) -> PrefsType:
         """Return the preferences for contour_model.
@@ -13662,12 +13807,18 @@ class Session(NoNewAttributesAfterInit):
         >>> contour_model(overcontour=True)
 
         """
-        return self.get_model_contour(recalc=False).contour_prefs
+        return self.get_model_contour(recalc=False, copy=False).contour_prefs
 
     def get_fit_contour(self,
                         id: IdType | None = None,
-                        recalc: bool = True):
+                        recalc: bool = True,
+                        copy: bool = True
+                        ):
         """Return the data used by contour_fit.
+
+        .. versionchanged:: 4.19.0
+           The contour object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -13678,6 +13829,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `contour_fit` (or `get_fit_contour`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the contour object copied before being returned? If so then
+           the contour attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -13715,16 +13870,23 @@ class Session(NoNewAttributesAfterInit):
 
         plotobj = self._contour_types["fit"]
         if recalc:
-            dataobj = self.get_data_contour(id, recalc=recalc)
-            modelobj = self.get_model_contour(id, recalc=recalc)
+            kwargs = {"recalc": recalc, "copy": False}
+            dataobj = self.get_data_contour(id, **kwargs)
+            modelobj = self.get_model_contour(id, **kwargs)
             plotobj.prepare(dataobj, modelobj)
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_resid_contour(self,
                           id: IdType | None = None,
-                          recalc: bool = True):
+                          recalc: bool = True,
+                          copy: bool = True
+                          ):
         """Return the data used by contour_resid.
+
+        .. versionchanged:: 4.19.0
+           The contour object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -13735,6 +13897,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `contour_resid` (or `get_resid_contour`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the contour object copied before being returned? If so then
+           the contour attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -13771,12 +13937,18 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_ratio_contour(self,
                           id: IdType | None = None,
-                          recalc: bool = True):
+                          recalc: bool = True,
+                          copy: bool = True
+                          ):
         """Return the data used by contour_ratio.
+
+        .. versionchanged:: 4.19.0
+           The contour object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -13787,6 +13959,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `contour_ratio` (or `get_ratio_contour`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the contour object copied before being returned? If so then
+           the contour attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -13823,12 +13999,18 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(self.get_data(id), self.get_model(id), self.get_stat())
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_psf_contour(self,
                         id: IdType | None = None,
-                        recalc: bool = True):
+                        recalc: bool = True,
+                        copy: bool = True
+                        ):
         """Return the data used by contour_psf.
+
+        .. versionchanged:: 4.19.0
+           The contour object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -13839,6 +14021,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `contour_psf` (or `get_psf_contour`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the contour object copied before being returned? If so then
+           the contour attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -13870,12 +14056,18 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(self.get_psf(id), self.get_data(id))
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_kernel_contour(self,
                            id: IdType | None = None,
-                           recalc: bool = True):
+                           recalc: bool = True,
+                           copy: bool = True
+                           ):
         """Return the data used by contour_kernel.
+
+        .. versionchanged:: 4.19.0
+           The contour object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -13886,6 +14078,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `contour_kernel` (or `get_kernel_contour`) are returned,
            otherwise the data is re-generated.
+        copy : bool, optional
+           Is the contour object copied before being returned? If so then
+           the contour attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -13918,12 +14114,18 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(self.get_psf(id), self.get_data(id))
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_psf_plot(self,
                      id: IdType | None = None,
-                     recalc: bool = True):
+                     recalc: bool = True,
+                     copy: bool = True
+                     ):
         """Return the data used by plot_psf.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -13934,6 +14136,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `plot_psf` (or `get_psf_plot`) are returned, otherwise
            the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -13964,12 +14170,18 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(self.get_psf(id), self.get_data(id))
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_kernel_plot(self,
                         id: IdType | None = None,
-                        recalc: bool = True):
+                        recalc: bool = True,
+                        copy: bool = True
+                        ):
         """Return the data used by plot_kernel.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -13980,6 +14192,10 @@ class Session(NoNewAttributesAfterInit):
            If ``False`` then the results from the last call to
            `plot_kernel` (or `get_kernel_plot`) are returned, otherwise
            the data is re-generated.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -14010,7 +14226,7 @@ class Session(NoNewAttributesAfterInit):
         if recalc:
             plotobj.prepare(self.get_psf(id), self.get_data(id))
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     #
     # Line plots
@@ -14021,7 +14237,8 @@ class Session(NoNewAttributesAfterInit):
                     rows: int | None = None,
                     cols: int | None = None,
                     ids: IdType | IdTypes | None = None,
-                    **kwargs) -> None:
+                    **kwargs
+                    ) -> None:
         """Handle the plot() or contour() call.
 
         The arguments are split up into groups - a "command" followed
@@ -14116,6 +14333,9 @@ class Session(NoNewAttributesAfterInit):
         # Store the per plot-area positional arguments in plots and
         # the keyword arguments in stores.
         #
+        # The following could avoid the deepcopy calls once all plot
+        # and contour calls accept a copy argument.
+        #
         plots = []
         stores = []
         largs = list(args)
@@ -14199,15 +14419,17 @@ class Session(NoNewAttributesAfterInit):
                not isinstance(getargs[0], str) and \
                isinstance(getargs[0], Iterable):
 
-                def getid(id, recalc=True):
-                    return getfunc(id, *getargs[1:], recalc=True)
+                def getid(id, recalc=True, copy=True):
+                    # Ignore the copy argument
+                    return getfunc(id, *getargs[1:], recalc=True,
+                                   copy=True)
 
                 plotobj = self._get_plot_objects(getargs[0], getid,
                                                  recalc=True)
-                plots.append(copy.deepcopy(plotobj))
+                plots.append(plotobj)
 
             else:
-                plots.append(copy.deepcopy(getfunc(*getargs)))
+                plots.append(getfunc(*getargs, copy=True))
 
         nplots = len(plots)
 
@@ -14276,7 +14498,7 @@ class Session(NoNewAttributesAfterInit):
                 # Take the general options (general_store) and then
                 # apply the per-plot (local_store) arguments.
                 #
-                store = copy.deepcopy(general_store)
+                store = deepcopy(general_store)
                 store.update(local_store)
                 plotfunc(plot, **store)
 
@@ -15400,7 +15622,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        def get(id, recalc=False):
+        def get(id, recalc=False, copy=True):
             # Check there is a model for this dataset.
             mdl = self._models.get(id, None)
             if mdl is not None:
@@ -15408,7 +15630,7 @@ class Session(NoNewAttributesAfterInit):
                                     f" is set for dataset {id}. "
                                     "You should use plot_model instead.")
 
-            return self.get_source_plot(id, recalc=recalc)
+            return self.get_source_plot(id, recalc=recalc, copy=copy)
 
         plotobj = self._get_plot_objects(id, get, recalc=not replot)
         self._plot(plotobj, overplot=overplot,
@@ -16431,15 +16653,28 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self.get_pdf_plot()
+        plotobj = self.get_pdf_plot(copy=False)
         if not replot:
             plotobj.prepare(points, bins, normed, xlabel, name)
 
         self._plot(plotobj, overplot=overplot,
                    clearwindow=clearwindow, **kwargs)
 
-    def get_pdf_plot(self):
+    def get_pdf_plot(self,
+                     copy: bool = True
+                     ):
         """Return the data used to plot the last PDF.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
+
+        Parameters
+        ----------
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -16453,7 +16688,7 @@ class Session(NoNewAttributesAfterInit):
         plot_pdf : Plot the probability density function of an array.
 
         """
-        return self._pdfplot
+        return cpy(self._pdfplot, copy)
 
     def plot_cdf(self,
                  points: ArrayType,
@@ -16867,7 +17102,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self.get_data_contour(id, recalc=not replot)
+        plotobj = self.get_data_contour(id, recalc=not replot, copy=False)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
     def contour_model(self,
@@ -16918,7 +17153,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self.get_model_contour(id, recalc=not replot)
+        plotobj = self.get_model_contour(id, recalc=not replot, copy=False)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
     def contour_source(self,
@@ -16968,7 +17203,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self.get_source_contour(id, recalc=not replot)
+        plotobj = self.get_source_contour(id, recalc=not replot, copy=False)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
     def contour_fit(self,
@@ -17017,7 +17252,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self.get_fit_contour(id, recalc=not replot)
+        plotobj = self.get_fit_contour(id, recalc=not replot, copy=False)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
     def contour_resid(self,
@@ -17065,7 +17300,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self.get_resid_contour(id, recalc=not replot)
+        plotobj = self.get_resid_contour(id, recalc=not replot, copy=False)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
     def contour_ratio(self,
@@ -17113,7 +17348,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self.get_ratio_contour(id, recalc=not replot)
+        plotobj = self.get_ratio_contour(id, recalc=not replot, copy=False)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
     def contour_psf(self,
@@ -17149,7 +17384,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self.get_psf_contour(id, recalc=not replot)
+        plotobj = self.get_psf_contour(id, recalc=not replot, copy=False)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
     def contour_kernel(self,
@@ -17185,7 +17420,7 @@ class Session(NoNewAttributesAfterInit):
 
         """
 
-        plotobj = self.get_kernel_contour(id, recalc=not replot)
+        plotobj = self.get_kernel_contour(id, recalc=not replot, copy=False)
         self._contour(plotobj, overcontour=overcontour, **kwargs)
 
     def contour_fit_resid(self,
@@ -17231,8 +17466,8 @@ class Session(NoNewAttributesAfterInit):
         """
 
         recalc = not replot
-        plot1obj = self.get_fit_contour(id, recalc=recalc)
-        plot2obj = self.get_resid_contour(id, recalc=recalc)
+        plot1obj = self.get_fit_contour(id, recalc=recalc, copy=False)
+        plot2obj = self.get_resid_contour(id, recalc=recalc, copy=False)
 
         # This does not use _jointplot because the X axis is not
         # obviously shared between the two plots.
@@ -17267,7 +17502,8 @@ class Session(NoNewAttributesAfterInit):
                      delv: float | None = None,
                      fac: float = 1,
                      log: bool = False,
-                     numcores: int | None = None):
+                     numcores: int | None = None
+                     ):
         """Return the interval-projection object.
 
         This returns (and optionally calculates) the data used to
@@ -17514,7 +17750,8 @@ class Session(NoNewAttributesAfterInit):
                      log=(False, False),
                      sigma=(1, 2, 3),
                      levels=None,
-                     numcores: int | None = None):
+                     numcores: int | None = None
+                     ):
         """Return the region-projection object.
 
         This returns (and optionally calculates) the data used to
@@ -17655,7 +17892,8 @@ class Session(NoNewAttributesAfterInit):
                     log=(False, False),
                     sigma=(1, 2, 3),
                     levels=None,
-                    numcores: int | None = None):
+                    numcores: int | None = None
+                    ):
         """Return the region-uncertainty object.
 
         This returns (and optionally calculates) the data used to

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -12257,7 +12257,7 @@ class Session(NoNewAttributesAfterInit):
 
     def _get_plot_objects(self,
                           ids: IdType | IdTypes | None,
-                          getfunc: Callable[..., Plot | HistogramPlot],
+                          getfunc: Callable[..., Plot | HistogramPlot | sherpa.plot.Contour],
                           *,
                           recalc: bool = True,
                           **kwargs
@@ -13467,7 +13467,7 @@ class Session(NoNewAttributesAfterInit):
                          id: IdType | None = None,
                          recalc: bool = True,
                          copy: bool = True
-                         ):
+                         ) -> sherpa.plot.DataContour:
         """Return the data used by contour_data.
 
         .. versionchanged:: 4.19.0
@@ -13641,7 +13641,7 @@ class Session(NoNewAttributesAfterInit):
                           id: IdType | None = None,
                           recalc: bool = True,
                           copy: bool = True
-                          ):
+                          ) -> sherpa.plot.ModelContour:
         """Return the data used by contour_model.
 
         .. versionchanged:: 4.19.0
@@ -13702,7 +13702,7 @@ class Session(NoNewAttributesAfterInit):
                            id: IdType | None = None,
                            recalc: bool = True,
                            copy: bool = True
-                           ):
+                           ) -> sherpa.plot.SourceContour:
         """Return the data used by contour_source.
 
         .. versionchanged:: 4.19.0
@@ -13813,7 +13813,7 @@ class Session(NoNewAttributesAfterInit):
                         id: IdType | None = None,
                         recalc: bool = True,
                         copy: bool = True
-                        ):
+                        ) -> sherpa.plot.FitContour:
         """Return the data used by contour_fit.
 
         .. versionchanged:: 4.19.0
@@ -13881,7 +13881,7 @@ class Session(NoNewAttributesAfterInit):
                           id: IdType | None = None,
                           recalc: bool = True,
                           copy: bool = True
-                          ):
+                          ) -> sherpa.plot.ResidContour:
         """Return the data used by contour_resid.
 
         .. versionchanged:: 4.19.0
@@ -13943,7 +13943,7 @@ class Session(NoNewAttributesAfterInit):
                           id: IdType | None = None,
                           recalc: bool = True,
                           copy: bool = True
-                          ):
+                          ) -> sherpa.plot.RatioContour:
         """Return the data used by contour_ratio.
 
         .. versionchanged:: 4.19.0
@@ -14005,7 +14005,7 @@ class Session(NoNewAttributesAfterInit):
                         id: IdType | None = None,
                         recalc: bool = True,
                         copy: bool = True
-                        ):
+                        ) -> sherpa.plot.PSFContour:
         """Return the data used by contour_psf.
 
         .. versionchanged:: 4.19.0
@@ -14062,7 +14062,7 @@ class Session(NoNewAttributesAfterInit):
                            id: IdType | None = None,
                            recalc: bool = True,
                            copy: bool = True
-                           ):
+                           ) -> sherpa.plot.PSFKernelContour:
         """Return the data used by contour_kernel.
 
         .. versionchanged:: 4.19.0
@@ -14120,7 +14120,7 @@ class Session(NoNewAttributesAfterInit):
                      id: IdType | None = None,
                      recalc: bool = True,
                      copy: bool = True
-                     ):
+                     ) -> sherpa.plot.PSFContour:
         """Return the data used by plot_psf.
 
         .. versionchanged:: 4.19.0
@@ -14176,7 +14176,7 @@ class Session(NoNewAttributesAfterInit):
                         id: IdType | None = None,
                         recalc: bool = True,
                         copy: bool = True
-                        ):
+                        ) -> sherpa.plot.PSFKernelContour:
         """Return the data used by plot_kernel.
 
         .. versionchanged:: 4.19.0
@@ -18632,7 +18632,7 @@ class Session(NoNewAttributesAfterInit):
     def get_data_image(self,
                        id: IdType | None = None,
                        copy: bool = True
-                       ):
+                       ) -> sherpa.image.DataImage:
         """Return the data used by image_data.
 
         .. versionchanged:: 4.19.0
@@ -18686,7 +18686,7 @@ class Session(NoNewAttributesAfterInit):
     def get_model_image(self,
                         id: IdType | None = None,
                         copy: bool = True
-                        ):
+                        ) -> sherpa.image.ModelImage:
         """Return the data used by image_model.
 
         Evaluate the source expression for the image pixels -
@@ -18748,7 +18748,7 @@ class Session(NoNewAttributesAfterInit):
     def get_source_image(self,
                          id: IdType | None = None,
                          copy: bool = True
-                         ):
+                         ) -> sherpa.image.SourceImage:
         """Return the data used by image_source.
 
         Evaluate the source expression for the image pixels - without
@@ -18806,7 +18806,7 @@ class Session(NoNewAttributesAfterInit):
                                   id,
                                   model=None,
                                   copy: bool = True
-                                  ):
+                                  ) -> sherpa.image.ComponentModelImage:
         """Return the data used by image_model_component.
 
         .. versionchanged:: 4.19.0
@@ -18883,7 +18883,7 @@ class Session(NoNewAttributesAfterInit):
                                    id,
                                    model=None,
                                    copy: bool = True
-                                   ):
+                                   ) -> sherpa.image.ComponentSourceImage:
         """Return the data used by image_source_component.
 
         .. versionchanged:: 4.19.0
@@ -18954,7 +18954,7 @@ class Session(NoNewAttributesAfterInit):
     def get_ratio_image(self,
                         id: IdType | None = None,
                         copy: bool = True
-                        ):
+                        ) -> sherpa.image.RatioImage:
         """Return the data used by image_ratio.
 
         .. versionchanged:: 4.19.0
@@ -19008,7 +19008,7 @@ class Session(NoNewAttributesAfterInit):
     def get_resid_image(self,
                         id: IdType | None = None,
                         copy: bool = True
-                        ):
+                        ) -> sherpa.image.ResidImage:
         """Return the data used by image_resid.
 
         .. versionchanged:: 4.19.0
@@ -19062,7 +19062,7 @@ class Session(NoNewAttributesAfterInit):
     def get_psf_image(self,
                       id: IdType | None = None,
                       copy: bool = True
-                      ):
+                      ) -> sherpa.image.PSFImage:
         """Return the data used by image_psf.
 
         .. versionchanged:: 4.19.0
@@ -19113,7 +19113,7 @@ class Session(NoNewAttributesAfterInit):
     def get_kernel_image(self,
                          id: IdType | None = None,
                          copy: bool = True
-                         ):
+                         ) -> sherpa.image.PSFKernelImage:
         """Return the data used by image_kernel.
 
         .. versionchanged:: 4.19.0

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -17502,7 +17502,8 @@ class Session(NoNewAttributesAfterInit):
                      delv: float | None = None,
                      fac: float = 1,
                      log: bool = False,
-                     numcores: int | None = None
+                     numcores: int | None = None,
+                     copy: bool = True
                      ):
         """Return the interval-projection object.
 
@@ -17511,6 +17512,10 @@ class Session(NoNewAttributesAfterInit):
         parameter is `False` (the default value) then all other parameters
         are ignored and the results of the last `int_proj` call are
         returned.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         .. versionchanged:: 4.16.1
            The log parameter can now be set to `True`.
@@ -17559,6 +17564,10 @@ class Session(NoNewAttributesAfterInit):
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -17612,7 +17621,7 @@ class Session(NoNewAttributesAfterInit):
                             fac=fac, log=log, numcores=numcores)
             plotobj.calc(fit, par, self._methods)
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     # DOC-NOTE: Check that this works (since get_int_proj may not) when
     # recalc=True
@@ -17627,7 +17636,9 @@ class Session(NoNewAttributesAfterInit):
                     delv: float | None = None,
                     fac: float = 1,
                     log: bool = False,
-                    numcores: int | None = None):
+                    numcores: int | None = None,
+                    copy: bool = True
+                    ):
         """Return the interval-uncertainty object.
 
         This returns (and optionally calculates) the data used to
@@ -17635,6 +17646,10 @@ class Session(NoNewAttributesAfterInit):
         parameter is `False` (the default value) then all other parameters
         are ignored and the results of the last `int_unc` call are
         returned.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         .. versionchanged:: 4.16.1
            The log parameter can now be set to `True`.
@@ -17679,6 +17694,10 @@ class Session(NoNewAttributesAfterInit):
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -17733,7 +17752,7 @@ class Session(NoNewAttributesAfterInit):
                             numcores=numcores)
             plotobj.calc(fit, par)
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_reg_proj(self,
                      par0: str | Parameter | None = None,
@@ -17750,7 +17769,8 @@ class Session(NoNewAttributesAfterInit):
                      log=(False, False),
                      sigma=(1, 2, 3),
                      levels=None,
-                     numcores: int | None = None
+                     numcores: int | None = None,
+                     copy: bool = True
                      ):
         """Return the region-projection object.
 
@@ -17759,6 +17779,10 @@ class Session(NoNewAttributesAfterInit):
         parameter is `False` (the default value) then all other parameters
         are ignored and the results of the last `reg_proj` call are
         returned.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         .. versionchanged:: 4.16.1
            The log parameter can now be set to `True` for one or both
@@ -17816,6 +17840,10 @@ class Session(NoNewAttributesAfterInit):
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -17876,7 +17904,7 @@ class Session(NoNewAttributesAfterInit):
                             numcores=numcores)
             plotobj.calc(fit, par0, par1, self._methods)
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     def get_reg_unc(self,
                     par0: str | Parameter | None = None,
@@ -17892,7 +17920,8 @@ class Session(NoNewAttributesAfterInit):
                     log=(False, False),
                     sigma=(1, 2, 3),
                     levels=None,
-                    numcores: int | None = None
+                    numcores: int | None = None,
+                    copy: bool = True
                     ):
         """Return the region-uncertainty object.
 
@@ -17901,6 +17930,10 @@ class Session(NoNewAttributesAfterInit):
         parameter is `False` (the default value) then all other parameters
         are ignored and the results of the last `reg_unc` call are
         returned.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         .. versionchanged:: 4.16.1
            The log parameter can now be set to `True` for one or both
@@ -17958,6 +17991,10 @@ class Session(NoNewAttributesAfterInit):
         numcores : optional
            The number of CPU cores to use. The default is to use all
            the cores on the machine.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -18019,7 +18056,7 @@ class Session(NoNewAttributesAfterInit):
                             numcores=numcores)
             plotobj.calc(fit, par0, par1)
 
-        return plotobj
+        return cpy(plotobj, copy)
 
     # DOC-NOTE: I am not convinced I have fac described correctly
     # DOC-NOTE: same synopsis as int_unc

--- a/sherpa/ui/utils.py
+++ b/sherpa/ui/utils.py
@@ -18630,14 +18630,24 @@ class Session(NoNewAttributesAfterInit):
     #
 
     def get_data_image(self,
-                       id: IdType | None = None):
+                       id: IdType | None = None,
+                       copy: bool = True
+                       ):
         """Return the data used by image_data.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
         id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -18671,21 +18681,31 @@ class Session(NoNewAttributesAfterInit):
         imageobj = self._image_types['data']
         data = self.get_data(id)
         imageobj.prepare_image(data)
-        return imageobj
+        return cpy(imageobj, copy)
 
     def get_model_image(self,
-                        id: IdType | None = None):
+                        id: IdType | None = None,
+                        copy: bool = True
+                        ):
         """Return the data used by image_model.
 
         Evaluate the source expression for the image pixels -
         including any PSF convolution defined by `set_psf` - and
         return the results.
 
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
+
         Parameters
         ----------
         id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -18721,23 +18741,32 @@ class Session(NoNewAttributesAfterInit):
         data = self.get_data(id)
         model = self.get_model(id)
         imageobj.prepare_image(data, model)
-        return imageobj
-
+        return cpy(imageobj, copy)
 
     # DOC-TODO: it looks like get_source_image doesn't raise DataErr with
     # a non-2D data set
     def get_source_image(self,
-                         id: IdType | None = None):
+                         id: IdType | None = None,
+                         copy: bool = True
+                         ):
         """Return the data used by image_source.
 
         Evaluate the source expression for the image pixels - without
         any PSF convolution - and return the results.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
         id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -18771,10 +18800,18 @@ class Session(NoNewAttributesAfterInit):
         data = self.get_data(id)
         source = self.get_source(id)
         imageobj.prepare_image(data, source)
-        return imageobj
+        return cpy(imageobj, copy)
 
-    def get_model_component_image(self, id, model=None):
+    def get_model_component_image(self,
+                                  id,
+                                  model=None,
+                                  copy: bool = True
+                                  ):
         """Return the data used by image_model_component.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -18783,6 +18820,10 @@ class Session(NoNewAttributesAfterInit):
            used, as returned by `get_default_id`.
         model : str or sherpa.models.model.Model instance
            The component to display (the name, if a string).
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -18836,10 +18877,18 @@ class Session(NoNewAttributesAfterInit):
         imageobj = self._image_types['model_component']
         data = self.get_data(id)
         imageobj.prepare_image(data, model)
-        return imageobj
+        return cpy(imageobj, copy)
 
-    def get_source_component_image(self, id, model=None):
+    def get_source_component_image(self,
+                                   id,
+                                   model=None,
+                                   copy: bool = True
+                                   ):
         """Return the data used by image_source_component.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
@@ -18848,6 +18897,10 @@ class Session(NoNewAttributesAfterInit):
            used, as returned by `get_default_id`.
         model : str or sherpa.models.model.Model instance
            The component to display (the name, if a string).
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -18896,17 +18949,27 @@ class Session(NoNewAttributesAfterInit):
         imageobj = self._image_types['source_component']
         data = self.get_data(id)
         imageobj.prepare_image(data, model)
-        return imageobj
+        return cpy(imageobj, copy)
 
     def get_ratio_image(self,
-                        id: IdType | None = None):
+                        id: IdType | None = None,
+                        copy: bool = True
+                        ):
         """Return the data used by image_ratio.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
         id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -18940,17 +19003,27 @@ class Session(NoNewAttributesAfterInit):
         data = self.get_data(id)
         model = self.get_model(id)
         imageobj.prepare_image(data, model)
-        return imageobj
+        return cpy(imageobj, copy)
 
     def get_resid_image(self,
-                        id: IdType | None = None):
+                        id: IdType | None = None,
+                        copy: bool = True
+                        ):
         """Return the data used by image_resid.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
         id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -18984,17 +19057,27 @@ class Session(NoNewAttributesAfterInit):
         data = self.get_data(id)
         model = self.get_model(id)
         imageobj.prepare_image(data, model)
-        return imageobj
+        return cpy(imageobj, copy)
 
     def get_psf_image(self,
-                      id: IdType | None = None):
+                      id: IdType | None = None,
+                      copy: bool = True
+                      ):
         """Return the data used by image_psf.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
         id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -19025,17 +19108,27 @@ class Session(NoNewAttributesAfterInit):
         psf = self.get_psf(id)
         data = self.get_data(id)
         imageobj.prepare_image(psf, data)
-        return imageobj
+        return cpy(imageobj, copy)
 
     def get_kernel_image(self,
-                         id: IdType | None = None):
+                         id: IdType | None = None,
+                         copy: bool = True
+                         ):
         """Return the data used by image_kernel.
+
+        .. versionchanged:: 4.19.0
+           The plot object is now copied by default. To get the previous
+           behaviour set the ``copy`` attribute to ``False``.
 
         Parameters
         ----------
         id : int, str, or None, optional
            The data set. If not given then the default identifier is
            used, as returned by `get_default_id`.
+        copy : bool, optional
+           Is the plot object copied before being returned? If so then
+           the plot attributes will not be changed by multiple calls
+           to this routine.
 
         Returns
         -------
@@ -19066,7 +19159,7 @@ class Session(NoNewAttributesAfterInit):
         psf = self.get_psf(id)
         data = self.get_data(id)
         imageobj.prepare_image(psf, data)
-        return imageobj
+        return cpy(imageobj, copy)
 
     #
     # Images


### PR DESCRIPTION
# Summary

Change the routines to get the plot, contour, and image display objects so that they are copied by default to address user confusion. Fix #2424.

# Details

This is related to

- issue #2424 
- issue #2500 (tangentially)

The aim is to add the `copy: bool = True` default keyword argument to the `get_xxx_plot/contour/image` calls. When set (the default) then the plot object is copied. This means that the internal `Session` field storing the data - normally the `_plot_types`/`_contour_types`/`_image_types` dictionary but some cases have an explicit attribute - is copied, which means

1. repeated calls will result in new objects, which is what the user is going to assume (given some of the docstrings)
2. if the user does want to change the "actual" object then they need to set `copy=False` or - preferably - to use `get_plot_prefs`.

These changes are made for all cases (plot, contour, and image) to provide a consistent experience.

I will note I'd like users to use routines like `calc_model` to get the data  - rather than extract it from the plot - but this is not always possible or easy, and this is an already working alternative.

# Example

Before this change:

```
>>> from sherpa import ui
WARNING: imaging routines will not be available,
failed to import sherpa.image.ds9_backend due to
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
>>> ui.load_arrays(1, [1, 2, 3], [10, 20, 30])
>>> ui.load_arrays(2, [4, 5, 6], [100, 90, 70])
>>> p1 = ui.get_data_plot(1)
>>> p2 = ui.get_data_plot(2)
>>> print(p1.y)
[100 90 70]
>>> print(p2.y)
[100  90  70]
```

The two objects are the same, which is not what the user is likely to expects. After this change:

```
>>> from sherpa import ui
WARNING: imaging routines will not be available,
failed to import sherpa.image.ds9_backend due to
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
>>> ui.load_arrays(1, [1, 2, 3], [10, 20, 30])
>>> ui.load_arrays(2, [4, 5, 6], [100, 90, 70])
>>> p1 = ui.get_data_plot(1)
>>> p2 = ui.get_data_plot(2)
>>> print(p1.y)
[10 20 30]
>>> print(p2.y)
[100  90  70]
```

Users who used to do

```
get_data_plot().plot_prefs["alpha"] = 0.5
```

will now have to say 

```
get_data_plot(copy=False).plot_prefs["alpha"] = 0.5
```

(or `.histo_prefs`) but we really want them to say

```
get_plot_prefs("data")["alpha"] = 0.5
```

instead (and this doesn't change here). However, `get_plot_prefs` is relatively new and we used to only have `get_data_plot_prefs` and `get_model_plot_prefs` so users used to have to use the `get_xxx_plot().plot_prefs...` approach.