### PR TITLE
Change how constants are referenced

### DIFF
--- a/sherpa/include/sherpa/astro/models.hh
+++ b/sherpa/include/sherpa/astro/models.hh
@@ -1,5 +1,6 @@
 //
-//  Copyright (C) 2007, 2020, 2021  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2020, 2021, 2026
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -25,6 +26,18 @@
 
 #include "Faddeeva.hh"
 
+#define SMP_MAX   sherpa::constants::smp_max< DataType >()
+#define PI        sherpa::constants::pi< DataType >()
+#define TWOPI     sherpa::constants::twopi< DataType >()
+#define SQRT_PI   sherpa::constants::sqrt_pi< DataType >()
+
+#define H_KEV     sherpa::constants::h_kev< DataType >()
+#define C_KM      sherpa::constants::c_km< DataType >()
+#define C_ANG     sherpa::constants::c_ang< DataType >()
+#define TWO_H_OVER_C_SQUARED \
+  sherpa::constants::two_h_over_c_squared< DataType >()
+#define H_OVER_K  sherpa::constants::h_over_k< DataType >()
+
 namespace sherpa { namespace astro { namespace models {
 
 
@@ -40,7 +53,7 @@ namespace sherpa { namespace astro { namespace models {
     double sigma = fwhm_g / std::sqrt(8 * log(2));
     std::complex<double> arg = (x - p[2]) + gamma * std::complex<double>(0,1);
     arg /= sigma * std::sqrt(2);
-    val = p[3] * Faddeeva::w(arg).real() / (sigma * std::sqrt(2 * PI));
+    val = p[3] * Faddeeva::w(arg).real() / (sigma * std::sqrt(TWOPI));
     return EXIT_SUCCESS;
 
   }

--- a/sherpa/include/sherpa/constants.hh
+++ b/sherpa/include/sherpa/constants.hh
@@ -1,5 +1,6 @@
 // 
-//  Copyright (C) 2008  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2008, 2026
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -123,29 +124,6 @@ namespace sherpa { namespace constants {
 
 
 }  }  /* namespace constants, namespace sherpa */
-
-
-#ifndef _SHERPA_CONST
-#define _SHERPA_CONST(name)	sherpa::constants::name< DataType >()
-#endif
-
-#define SMP_MIN			_SHERPA_CONST(smp_min)
-#define SMP_MAX			_SHERPA_CONST(smp_max)
-#define LOGTEN			_SHERPA_CONST(logten)
-#define PI			_SHERPA_CONST(pi)
-#define TWOPI			_SHERPA_CONST(twopi)
-#define H_ERG			_SHERPA_CONST(h_erg)
-#define E_EV			_SHERPA_CONST(e_ev)
-#define H_KEV			_SHERPA_CONST(h_kev)
-#define C_KM			_SHERPA_CONST(c_km)
-#define C_CM			_SHERPA_CONST(c_cm)
-#define C_ANG			_SHERPA_CONST(c_ang)
-#define K			_SHERPA_CONST(k)
-#define TWO_H_OVER_C_SQUARED	_SHERPA_CONST(two_h_over_c_squared)
-#define H_OVER_K		_SHERPA_CONST(h_over_k)
-#define GFACTOR			_SHERPA_CONST(gfactor)
-#define SQRT_GFACTOR		_SHERPA_CONST(sqrt_gfactor)
-#define SQRT_PI			_SHERPA_CONST(sqrt_pi)
 
 
 /*

--- a/sherpa/include/sherpa/model_extension.hh
+++ b/sherpa/include/sherpa/model_extension.hh
@@ -1,5 +1,5 @@
 // 
-//  Copyright (C) 2007, 2016, 2019, 2020, 2023
+//  Copyright (C) 2007, 2016, 2019, 2020, 2023, 2026
 //  Smithsonian Astrophysical Observatory
 //
 //

--- a/sherpa/include/sherpa/models.hh
+++ b/sherpa/include/sherpa/models.hh
@@ -1,5 +1,6 @@
 //
-//  Copyright (C) 2007, 2020, 2021  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2007, 2020, 2021, 2026
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -23,6 +24,14 @@
 #include <algorithm>
 #include <sherpa/utils.hh>
 #include <sherpa/constants.hh>
+
+#define SMP_MIN        sherpa::constants::smp_min< DataType >()
+#define PI             sherpa::constants::pi< DataType >()
+#define TWOPI          sherpa::constants::twopi< DataType >()
+#define SQRT_PI        sherpa::constants::sqrt_pi< DataType >()
+#define LOGTEN         sherpa::constants::logten< DataType >()
+#define GFACTOR        sherpa::constants::gfactor< DataType >()
+#define SQRT_GFACTOR   sherpa::constants::sqrt_gfactor< DataType >()
 
 namespace sherpa { namespace models {
 

--- a/sherpa/include/sherpa/utils.hh
+++ b/sherpa/include/sherpa/utils.hh
@@ -1,5 +1,6 @@
 //
-//  Copyright (C) 2008, 2021  Smithsonian Astrophysical Observatory
+//  Copyright (C) 2008, 2021, 2026
+//  Smithsonian Astrophysical Observatory
 //
 //
 //  This program is free software; you can redistribute it and/or modify
@@ -52,6 +53,7 @@
 #define SQRT(x)			std::sqrt(x)
 #define TAN(x)			std::tan(x)
 
+#define TWOPI   sherpa::constants::twopi< DataType >()
 
 namespace sherpa { namespace utils {
 
@@ -240,11 +242,11 @@ namespace sherpa { namespace utils {
     DataType deltaY = x1 - p[2];
     DataType p_four = p[4];
     if( p[3] != 0 ) {
-      while( p_four >= 2*PI ) {
-	p_four -= 2*PI;
+      while( p_four >= TWOPI ) {
+	p_four -= TWOPI;
       }
       while( p_four < 0.0 ) {
-	p_four += 2*PI;
+	p_four += TWOPI;
       }
       DataType cosTheta = COS(p_four);
       DataType sinTheta = SIN(p_four);
@@ -282,11 +284,11 @@ namespace sherpa { namespace utils {
       return EXIT_FAILURE;
     }
 
-    while( theta >= 2*PI ) {
-      theta -= 2*PI;
+    while( theta >= TWOPI ) {
+      theta -= TWOPI;
     }
     while( theta < 0.0 ) {
-      theta += 2*PI;
+      theta += TWOPI;
     }
     DataType cosTheta = COS(theta);
     DataType sinTheta = SIN(theta);
@@ -320,11 +322,11 @@ namespace sherpa { namespace utils {
   //   DataType deltaY = x1 - p[2];
   //   DataType p_four = p[4];
   //   if( p[3] != 0 ) {
-  //     while( p_four >= 2*PI ) {
-  // 	p_four -= 2*PI;
+  //     while( p_four >= TWOPI ) {
+  // 	p_four -= TWOPI;
   //     }
   //     while( p_four < 0.0 ) {
-  // 	p_four += 2*PI;
+  // 	p_four += TWOPI;
   //     }
   //     DataType cosTheta = COS(p_four);
   //     DataType sinTheta = SIN(p_four);


### PR DESCRIPTION
# Summary

Change how the constants are referenced by the extension modules. There is no functional change.

# Details

Prior to this commit the constants.hh file provided a number of macros to reference the symbols the class creates. However, this pollutes the "identifier table", which can cause problems with including OTS code. So far this has not been a problem, but XSPEC 12.13.0 now has a struct field called "K" which interfers with the "K" macro defined in constants.hh - e.g. 
- issue #2515.

Since the macros are

- just convenience symbols,
- not always taken advantage of,
- and are not always used

this commit moves them to the code that actually needs them. It does lead to a little bit of duplication, but I think it's useful to know just what ones are being used.

Some code has been updated to take advantage of these identifiers, mainly replace 2*PI with TWOPI.