### PR TITLE
BUILD: support clangxx 23.1

### DIFF
--- a/sherpa/utils/src/_psf.cc
+++ b/sherpa/utils/src/_psf.cc
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2007, 2016, 2018, 2020-2021, 2025
+//  Copyright (C) 2007, 2016, 2018, 2020-2021, 2025-2026
 //  Smithsonian Astrophysical Observatory
 //
 //
@@ -25,6 +25,7 @@
 #include <vector>
 #include <sstream>
 #include <iostream>
+#include <algorithm>
 
 extern "C" {
 


### PR DESCRIPTION
# Summary

Ensure that clangxx 23.1 can be used to build Sherpa.

# Details

Make sure that algorithm is included to pick up std::lower_bound. It's not obvious to me why clangxx 23.1 started to worry about this.